### PR TITLE
Fix elicitation bot state 

### DIFF
--- a/frontend/src/lib/components/RichTextEditor/ContentRenderer/ContentRenderer.svelte
+++ b/frontend/src/lib/components/RichTextEditor/ContentRenderer/ContentRenderer.svelte
@@ -65,7 +65,7 @@
 		width: 100%;
 	}
 
-	:global(.content-renderer--minimal .tiptap) {
+	:global(.content-renderer .tiptap) {
 		min-height: unset;
 	}
 </style>

--- a/frontend/src/lib/tools/elicitation_bot/ElicitationBotChat.svelte
+++ b/frontend/src/lib/tools/elicitation_bot/ElicitationBotChat.svelte
@@ -28,7 +28,7 @@
 
 	const defaultOpeningMessage = {
 		id: '1',
-		content: `Hello, I am here to help you shape your views and opinions. What's your initial view about${topic}?`,
+		content: `Hello, I am here to help you shape your views and opinions. What's your initial view about ${topic}?`,
 		isBot: true,
 		timestamp: new Date()
 	};
@@ -36,10 +36,9 @@
 	let inputValue = $state('');
 	let scrollAreaRef: HTMLElement | null = $state(null);
 	let textareaRef: HTMLTextAreaElement | null = $state(null);
-	let [, ...messageHistory] = messages;
-	let chatMessages = $state<ElicitationMessage[]>([
+	let chatMessages = $derived<ElicitationMessage[]>([
 		defaultOpeningMessage,
-		...(messageHistory ?? [])
+		...messages.slice(1)
 	]);
 	let isMobile = $state(false);
 	let activeTab = $state('chat');


### PR DESCRIPTION
Motivation: Fix messages not showing after you send them.
Changes: 
- Use derived now to show messages
- Decrease gap between step description and content
- Add space in initial message

"Works on my machine" evidence:
<img width="863" height="711" alt="image" src="https://github.com/user-attachments/assets/85b8cc3d-cb22-46ab-96c0-e0d6d6e7e248" />
<img width="1218" height="1038" alt="image" src="https://github.com/user-attachments/assets/9f09099c-cd8e-4b7d-ac1c-db20f6d975c9" />
