### PR TITLE
5 conversation ragflow resource names

### DIFF
--- a/api/src/models/conversation.rs
+++ b/api/src/models/conversation.rs
@@ -600,11 +600,11 @@ pub async fn create(
     .await?;
 
     let (_, knowledge_base) = bot_service
-        .create_knowledge_base(conversation.title.clone(), None)
+        .create_knowledge_base(conversation_id.to_string(), None)
         .await?;
 
     let create_chat = CreateChatRequest {
-        name: conversation.title.clone(),
+        name: conversation_id.to_string(),
         knowledge_base_ids: Some(vec![config.default_knowledge_base_id.clone()]),
         prompt: Some(ComhairlePrompt {
             llm_prompt: Some(DEFAULT_CHAT_PROMPT.to_string()),


### PR DESCRIPTION
Actions:

+ use conversation_id for ragflow resource names when creating a new conversation

Motivation:

+ uuid guarantees against uniquenees, which is required for ragflow names
+ if using conversation title and conversation title is updated then the name ragflow resource no longer matches