### PR TITLE
Fix: conversation state not updating when switching between conversations

### DIFF
--- a/frontend/src/routes/(admin)/admin/conversations/[conversation_id]/configure/+page.svelte
+++ b/frontend/src/routes/(admin)/admin/conversations/[conversation_id]/configure/+page.svelte
@@ -35,6 +35,13 @@
 	$effect(() => {
 		primaryLanguage = data.conversation.primaryLocale ?? 'en';
 		supportedLanguages = data.conversation.supportedLanguages ?? ['en'];
+		$form.title = data.conversation.title;
+		$form.shortDescription = data.conversation.shortDescription;
+		$form.description = data.conversation.description;
+		$form.imageUrl = data.conversation.imageUrl;
+		$form.isPublic = data.conversation.isPublic;
+		$form.isInviteOnly = data.conversation.isInviteOnly;
+		$form.autoLogin = data.workflows[0]?.autoLogin;
 	});
 
 	function updateFormForLanguage(newLanguage: string) {


### PR DESCRIPTION
**Root cause:** 
superForm() is called once at component init with data.conversation values baked in. When you navigate to a different conversation, the load function re-runs and data updates, but the superForm store keeps the old values since it was never told to update.

**Fix:** 
Extended the $effect to also sync all form fields whenever data.conversation changes