### PR TITLE
Fix: Content renderer should show bulletpoints for rich text in step metadata

### DIFF
--- a/ui/packages/comhairle/src/lib/components/RichTextEditor/ContentRenderer/ContentRenderer.svelte
+++ b/ui/packages/comhairle/src/lib/components/RichTextEditor/ContentRenderer/ContentRenderer.svelte
@@ -3,6 +3,7 @@
 	import { Editor } from '@tiptap/core';
 	import { detectContentType } from '$lib/utils/contentDetection';
 	import { getBaseExtensions, getEditorProps } from '../editorConfig';
+	import '../editor-content.css';
 
 	type Props = {
 		content?: string;

--- a/ui/packages/comhairle/src/lib/components/RichTextEditor/RichTextEditor.svelte
+++ b/ui/packages/comhairle/src/lib/components/RichTextEditor/RichTextEditor.svelte
@@ -6,7 +6,6 @@
 	import { ListItem } from '@tiptap/extension-list-item';
 	import { TextStyle } from '@tiptap/extension-text-style';
 	import { Underline } from '@tiptap/extension-underline';
-	import { TextAlign } from '@tiptap/extension-text-align';
 	import EditorToolbar from './EditorToolbar.svelte';
 	import { CONTENT_TYPES, type ContentType, type ActiveStates } from '$lib/components/RichTextEditor/types';
 	import { detectContentType } from '$lib/utils/contentDetection';
@@ -87,9 +86,6 @@
 				TextStyle,
 				ListItem,
 				Underline,
-				TextAlign.configure({
-					types: ['heading', 'paragraph']
-				}),
 				// Shared base extensions
 				...getBaseExtensions({ mode: 'editor' })
 			],

--- a/ui/packages/comhairle/src/lib/components/RichTextEditor/editor-content.css
+++ b/ui/packages/comhairle/src/lib/components/RichTextEditor/editor-content.css
@@ -33,8 +33,14 @@
 	line-height: 1.6;
 }
 
-.tiptap ul,
+.tiptap ul {
+	list-style-type: disc;
+	padding-left: 1.5rem;
+	margin: 0.5rem 0;
+}
+
 .tiptap ol {
+	list-style-type: decimal;
 	padding-left: 1.5rem;
 	margin: 0.5rem 0;
 }

--- a/ui/packages/comhairle/src/lib/components/RichTextEditor/editorConfig.ts
+++ b/ui/packages/comhairle/src/lib/components/RichTextEditor/editorConfig.ts
@@ -1,6 +1,7 @@
 import { StarterKit } from '@tiptap/starter-kit';
 import { Link } from '@tiptap/extension-link';
 import { Image } from '@tiptap/extension-image';
+import { TextAlign } from '@tiptap/extension-text-align';
 import { Markdown } from '@tiptap/markdown';
 import { Iframe } from '$lib/components/RichTextEditor/extensions/iframe';
 import type { Extensions } from '@tiptap/core';
@@ -42,6 +43,9 @@ export function getBaseExtensions(options: EditorConfigOptions): Extensions {
 			HTMLAttributes: EDITOR_HTML_ATTRIBUTES.image
 		}),
 		Iframe,
+		TextAlign.configure({
+			types: ['heading', 'paragraph']
+		}),
 		StarterKit.configure({
 			heading: {
 				levels: [1, 2, 3, 4, 5, 6]

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/+layout.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/+layout.svelte
@@ -50,6 +50,7 @@
 			</h2>
 			<Button
 				href={`/conversations/${conversation.id}/preview`}
+				target="_blank"
 				class="bg-blue-200 px-8 py-3 text-sm text-black"
 			>
 				Preview


### PR DESCRIPTION
Before:
<img width="411" height="254" alt="image" src="https://github.com/user-attachments/assets/e1e84649-b4f6-4e92-8c27-f6b35829d540" />


After:
<img width="386" height="303" alt="image" src="https://github.com/user-attachments/assets/cb66f99d-80d7-44b6-a9d8-edc7c61a253a" />


Additional things: 
- open preview in a new tab (as mentioned by @shuyanglin)
- found and fixed a similar bug with center and right text alignment 