### PR TITLE
fix dark mode for translatable popup

### DIFF
--- a/ui/packages/comhairle/src/lib/components/Translation/TranslatableField.svelte
+++ b/ui/packages/comhairle/src/lib/components/Translation/TranslatableField.svelte
@@ -319,7 +319,7 @@
 	>
 		<Dialog.Content class="max-h-[90vh] min-w-[70vw] rounded-xl p-12" showCloseButton={false}>
 			<Dialog.Header class="flex flex-row items-center justify-between pr-0">
-				<Dialog.Title class="justify-start text-3xl leading-8 font-semibold text-black">
+				<Dialog.Title class="justify-start text-3xl leading-8 font-semibold text-foreground">
 					{dialogTitle}
 				</Dialog.Title>
 				<button

--- a/ui/packages/comhairle/src/lib/components/Translation/TranslationEditor.svelte
+++ b/ui/packages/comhairle/src/lib/components/Translation/TranslationEditor.svelte
@@ -223,7 +223,7 @@
 			{#if editorType === 'rich'}
 				<RichTextEditor value={sourceContent} onChange={handleSourceChange} {minHeight} {maxHeight} />
 			{:else}
-				<div class="rounded-lg border bg-white overflow-hidden">
+				<div class="rounded-lg border bg-white dark:bg-input/30 overflow-hidden">
 					<textarea
 						class="w-full resize-none border-none outline-none p-4 text-sm leading-5 bg-transparent"
 						style="min-height: {minHeight};"
@@ -256,7 +256,7 @@
 						{maxHeight}
 					/>
 				{:else}
-					<div class="rounded-xl border bg-white overflow-hidden">
+					<div class="rounded-xl border bg-white dark:bg-input/30 overflow-hidden">
 						<textarea
 							class="w-full resize-none border-none outline-none p-4 text-sm leading-5 bg-transparent"
 							style="min-height: {minHeight};"
@@ -303,7 +303,7 @@
 						{maxHeight}
 					/>
 				{:else}
-					<div class="rounded-xl border-1 bg-white overflow-hidden">
+					<div class="rounded-xl border bg-white dark:bg-input/30 overflow-hidden">
 						<textarea
 							class="w-full resize-none border-none outline-none p-4 text-sm leading-5 bg-transparent"
 							style="min-height: {minHeight};"


### PR DESCRIPTION
Previously:
<img width="1208" height="762" alt="screenshot_2026-03-02_12-46-10" src="https://github.com/user-attachments/assets/01f77632-3c1d-48b5-8c46-599e9c1f0c7a" />
<img width="1257" height="744" alt="screenshot_2026-03-02_12-46-05" src="https://github.com/user-attachments/assets/a583079f-7813-4881-8578-65eecb0432b0" />
<img width="1233" height="686" alt="screenshot_2026-03-02_12-46-01" src="https://github.com/user-attachments/assets/9877f2ca-637f-44f2-9f7f-2403bafdbe1c" />

Updated to:
<img width="1152" height="659" alt="screenshot_2026-03-02_12-58-38" src="https://github.com/user-attachments/assets/1a7cdd79-506d-4928-b584-fc927961d0dd" />

