### PR TITLE
9 adjust publish action and package json to publish to npm instead of…

### DIFF
--- a/.github/workflows/publish-api-client.yml
+++ b/.github/workflows/publish-api-client.yml
@@ -13,7 +13,6 @@ jobs:
     environment: base 
     permissions:
       contents: read
-      packages: write
     steps:
       -
         name: Checkout
@@ -23,7 +22,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
-          registry-url: https://npm.pkg.github.com/
+          registry-url: https://registry.npmjs.org/
       -
         name: Set version from tag
         run: |
@@ -32,7 +31,7 @@ jobs:
         working-directory: ui/packages/api-client
       -
         name: Publish
-        run: npm publish
+        run: npm publish --access public
         working-directory: ui/packages/api-client
         env:
-          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/ui/packages/api-client/package.json
+++ b/ui/packages/api-client/package.json
@@ -5,9 +5,6 @@
 	"type": "module",
 	"main": "dist/api.js",
 	"types": "dist/api.d.ts",
-	"publishConfig": {
-		"registry": "https://npm.pkg.github.com/"
-	},
 	"scripts": {
 		"generateAPI": "openapi-zod-client \"../../../open-api-spec.json\" -o src/api.ts -t src/template.hbs",
 		"ts": "tsc",


### PR DESCRIPTION
Adjust `publish-api-client` workflow and package.json for api-client to publish to npm registry instead of github packages