### PR TITLE
Conversation template card dark mode

### DIFF
--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/new/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/new/+page.svelte
@@ -17,7 +17,6 @@
 
 	let { data } = $props();
 
-
 	const form = superForm(data.form, {
 		SPA: true,
 		validators: zodClient(NewConversationSchema),
@@ -46,7 +45,7 @@
 					supported_languages: ['en'],
 					is_public: false,
 					is_live: false,
-					is_invite_only: false,
+					is_invite_only: false
 				};
 
 				let conversation = await apiClient.CreateConversation(fullConversation);
@@ -124,7 +123,7 @@
 	<div class="m:grid-cols-3 grid h-auto w-full grid-cols-2 gap-4">
 		<Card.Root
 			class={selectedWorkflowTemplate === 'empty'
-				? 'cursor-pointer bg-green-100'
+				? 'bg-primary text-primary-foreground cursor-pointer'
 				: 'cursor-pointer'}
 			onclick={() => (selectedWorkflowTemplate = 'empty')}
 		>
@@ -138,7 +137,7 @@
 
 		<Card.Root
 			class={selectedWorkflowTemplate === 'learn_polis'
-				? 'cursor-pointer bg-green-100'
+				? 'bg-primary text-primary-foreground cursor-pointer'
 				: 'cursor-pointer'}
 			onclick={() => (selectedWorkflowTemplate = 'learn_polis')}
 		>
@@ -153,7 +152,7 @@
 
 		<Card.Root
 			class={selectedWorkflowTemplate === 'learn_survey'
-				? 'cursor-pointer bg-green-100'
+				? 'bg-primary text-primary-foreground cursor-pointer'
 				: 'cursor-pointer'}
 			onclick={() => (selectedWorkflowTemplate = 'learn_survey')}
 		>
@@ -168,7 +167,7 @@
 
 		<Card.Root
 			class={selectedWorkflowTemplate === 'learn_survey_polis'
-				? 'cursor-pointer bg-green-100'
+				? 'bg-primary text-primary-foreground cursor-pointer'
 				: 'cursor-pointer'}
 			onclick={() => (selectedWorkflowTemplate = 'learn_survey_polis')}
 		>


### PR DESCRIPTION
Actions:

+ adjust colours for selected conversation template card

Motivation:

+ colours didn't work in dark mode

Previously:
<img width="1185" height="890" alt="screenshot_2026-03-10_16-05-03" src="https://github.com/user-attachments/assets/81a30846-10b9-43dc-9fe9-38a5e8cdff78" />

Updated to:
<img width="1465" height="1001" alt="screenshot_2026-03-10_16-05-29" src="https://github.com/user-attachments/assets/84a77574-16da-4c08-8a76-1c831545d3e6" />
