### PR TITLE
fix: redirect users back to conversation after signup

### DIFF
--- a/ui/packages/comhairle/src/lib/urls.ts
+++ b/ui/packages/comhairle/src/lib/urls.ts
@@ -1,59 +1,79 @@
-import { redirect } from "@sveltejs/kit"
-import { notifications } from "./notifications.svelte"
-import { goto } from "$app/navigation"
+import { redirect } from '@sveltejs/kit';
+import { notifications } from './notifications.svelte';
+import { goto } from '$app/navigation';
 
 export function conversation_url(conversation_id: string, isPreview: boolean = false) {
-	return `/conversations/${conversation_id}${isPreview ? "/preview" : ""}`
+	return `/conversations/${conversation_id}${isPreview ? '/preview' : ''}`;
 }
 
 export function manage_conversation_url(conversation_id: string) {
-	return `/admin/conversations/${conversation_id}/configure`
+	return `/admin/conversations/${conversation_id}/configure`;
 }
 
-export function workflow_url(conversation_id: string, workflow_id: string, isPreview: boolean = false) {
-	return conversation_url(conversation_id, isPreview) + `/workflow/${workflow_id}`
+export function workflow_url(
+	conversation_id: string,
+	workflow_id: string,
+	isPreview: boolean = false
+) {
+	return conversation_url(conversation_id, isPreview) + `/workflow/${workflow_id}`;
 }
 
-export function next_workflow_step_url(conversation_id: string, workflow_id: string, isPreview: boolean = false) {
-	return workflow_url(conversation_id, workflow_id, isPreview) + `/next`
+export function next_workflow_step_url(
+	conversation_id: string,
+	workflow_id: string,
+	isPreview: boolean = false
+) {
+	return workflow_url(conversation_id, workflow_id, isPreview) + `/next`;
 }
 
-export function thank_you_page(conversation_id: string, workflow_id: string, isPreview: boolean = false) {
-	return workflow_url(conversation_id, workflow_id, isPreview) + "/thank_you"
+export function thank_you_page(
+	conversation_id: string,
+	workflow_id: string,
+	isPreview: boolean = false
+) {
+	return workflow_url(conversation_id, workflow_id, isPreview) + '/thank_you';
 }
 
-export function workflow_step_url(conversation_id: string, workflow_id: string, workflow_step_id: string, isPreview: boolean = false) {
-	return workflow_url(conversation_id, workflow_id, isPreview) + `/s/${workflow_step_id}`
+export function workflow_step_url(
+	conversation_id: string,
+	workflow_id: string,
+	workflow_step_id: string,
+	isPreview: boolean = false
+) {
+	return workflow_url(conversation_id, workflow_id, isPreview) + `/s/${workflow_step_id}`;
 }
 
-export function report_url(conversation_id: string, workflow_id: string, isPreview: boolean = false) {
-	return conversation_url(conversation_id, isPreview) + "/report"
+export function report_url(
+	conversation_id: string,
+	workflow_id: string,
+	isPreview: boolean = false
+) {
+	return conversation_url(conversation_id, isPreview) + '/report';
 }
 
-// Redirect to the login page with a link back to the current 
+// Redirect to the login page with a link back to the current
 // context.
 export function loginRedirect(backTo: string, message?: string) {
 	if (message) {
-		notifications.addFlash({ message, priority: "INFO" });
+		notifications.addFlash({ message, priority: 'INFO' });
 	}
-	goto(`/auth/login?backTo=${backTo}`)
+	goto(`/auth/login?backTo=${encodeURIComponent(backTo)}`);
 }
 
-// Redirect to the signup page with a link back to the current 
+// Redirect to the signup page with a link back to the current
 // context.
 export function signupRedirect(backTo: string, message?: string) {
 	if (message) {
-		notifications.addFlash({ message, priority: "INFO" });
+		notifications.addFlash({ message, priority: 'INFO' });
 	}
-	goto(`/auth/signup?backTo=${backTo}`)
+	goto(`/auth/signup?backTo=${encodeURIComponent(backTo)}`);
 }
 
-// Redirect to the signup annon page with a link back to the current 
+// Redirect to the signup annon page with a link back to the current
 // context.
 export function signupAnnonRedirect(backTo: string, message?: string) {
 	if (message) {
-		notifications.addFlash({ message, priority: "INFO" });
+		notifications.addFlash({ message, priority: 'INFO' });
 	}
-	goto(`/auth/anonymous-signup?backTo=${backTo}`)
+	goto(`/auth/anonymous-signup?backTo=${encodeURIComponent(backTo)}`);
 }
-

--- a/ui/packages/comhairle/src/routes/(public)/auth/anonymous-login/login-form.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/auth/anonymous-login/login-form.svelte
@@ -16,7 +16,10 @@
 
 	const form = superForm(defaults(zod(annonLoginFormSchema)), {
 		validators: zodClient(annonLoginFormSchema),
-		onSubmit: attemptLogin
+		onSubmit: async ({ cancel }) => {
+			cancel();
+			await attemptLogin();
+		}
 	});
 
 	const { form: formData, enhance, message: errMessage, validateForm } = form;
@@ -106,8 +109,9 @@
 	<div class="flex flex-col gap-1">
 		<p class="text-muted-foreground text-base">
 			{m.dont_have_an_account_signup().split('?')[0]}?
-			<a href={`/auth/signup?backTo=${backTo ?? '/'}`} class="text-primary underline"
-				>{m.sign_up()}</a
+			<a
+				href={`/auth/signup?backTo=${encodeURIComponent(backTo ?? '/')}`}
+				class="text-primary underline">{m.sign_up()}</a
 			>
 		</p>
 	</div>

--- a/ui/packages/comhairle/src/routes/(public)/auth/anonymous-signup/+page.server.ts
+++ b/ui/packages/comhairle/src/routes/(public)/auth/anonymous-signup/+page.server.ts
@@ -1,11 +1,10 @@
 import { fail, redirect } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types.js';
-import { page } from '$app/state';
 
-export const load:PageServerLoad = ({url})=>{
-	let backTo = url.searchParams.get("backTo") ?? "/"
-	return {backTo}
-}
+export const load: PageServerLoad = ({ url }) => {
+	let backTo = url.searchParams.get('backTo') ?? '/';
+	return { backTo };
+};
 
 export const actions = {
 	default: async (evt) => {
@@ -19,7 +18,7 @@ export const actions = {
 			return fail(400, {});
 		}
 
-		let backTo = evt.url.searchParams.get("backTo") ?? "/"
-		redirect(302, `/auth/anonymous-signup/code?backTo=${backTo}`);
+		let backTo = evt.url.searchParams.get('backTo') ?? '/';
+		redirect(302, `/auth/anonymous-signup/code?backTo=${encodeURIComponent(backTo)}`);
 	}
 };

--- a/ui/packages/comhairle/src/routes/(public)/auth/anonymous-signup/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/auth/anonymous-signup/+page.svelte
@@ -53,8 +53,9 @@
 		<div class="flex flex-col gap-1 font-light">
 			<p class="text-muted-foreground text-base">
 				{m.already_have_an_account_login().split('?')[0]}?
-				<a href={`/auth/login?backTo=${data.backTo ?? '/'}`} class="text-primary underline"
-					>{m.login()}</a
+				<a
+					href={`/auth/login?backTo=${encodeURIComponent(data.backTo ?? '/')}`}
+					class="text-primary underline">{m.login()}</a
 				>
 			</p>
 			<p class="text-muted-foreground text-base">

--- a/ui/packages/comhairle/src/routes/(public)/auth/anonymous-signup/code/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/auth/anonymous-signup/code/+page.svelte
@@ -94,7 +94,7 @@
 					Download
 				</Button>
 				<Button
-					href="/conversations"
+					href={backTo}
 					variant="outline"
 					size="lg"
 					class="hover:bg-background/70 h-12"

--- a/ui/packages/comhairle/src/routes/(public)/auth/login/login-form.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/auth/login/login-form.svelte
@@ -17,7 +17,10 @@
 	const form = superForm(defaults(zod(loginFormSchema)), {
 		validators: zodClient(loginFormSchema),
 		taintedMessage: false,
-		onSubmit: attemptLogin
+		onSubmit: async ({ cancel }) => {
+			cancel();
+			await attemptLogin();
+		}
 	});
 
 	let responseMessage = $state(null);
@@ -121,7 +124,7 @@
 		</LoadingButton>
 
 		<Button
-			href={resolve(`/auth/anonymous-login?backTo=${backTo ?? '/'}`)}
+			href={resolve(`/auth/anonymous-login?backTo=${encodeURIComponent(backTo ?? '/')}`)}
 			variant="outline"
 			size="lg"
 			class="h-12 w-full px-7 lg:w-auto"
@@ -137,7 +140,7 @@
 		<p class="text-muted-foreground text-base">
 			{m.dont_have_an_account_signup().split('?')[0]}?
 			<a
-				href={resolve(`/auth/signup?backTo=${backTo ?? '/'}`)}
+				href={resolve(`/auth/signup?backTo=${encodeURIComponent(backTo ?? '/')}`)}
 				class="text-primary underline"
 			>
 				{m.sign_up()}

--- a/ui/packages/comhairle/src/routes/(public)/auth/signup/signup-form.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/auth/signup/signup-form.svelte
@@ -18,7 +18,10 @@
 	const form = superForm(defaults(zod(signupFormSchema)), {
 		validators: zodClient(signupFormSchema),
 		taintedMessage: false,
-		onSubmit: attemptLogin
+		onSubmit: async ({ cancel }) => {
+			cancel();
+			await attemptLogin();
+		}
 	});
 
 	let { form: formData, validateForm, enhance } = form;
@@ -38,7 +41,9 @@
 					if (user.auth_type === 'annon') {
 						await goto(backTo ?? '/');
 					} else {
-						await goto('/auth/verification-message');
+						await goto(
+							`/auth/verification-message?backTo=${encodeURIComponent(backTo ?? '/')}`
+						);
 					}
 				} catch (e) {
 					responseMessage = e.response.data.err;
@@ -133,7 +138,7 @@
 		</LoadingButton>
 
 		<Button
-			href={`/auth/anonymous-signup?backTo=${backTo}`}
+			href={`/auth/anonymous-signup?backTo=${encodeURIComponent(backTo ?? '/')}`}
 			variant="outline"
 			size="lg"
 			class="h-12 w-full px-7 lg:w-auto"
@@ -145,7 +150,10 @@
 	<div class="flex flex-col gap-1 font-light">
 		<p class="text-muted-foreground text-base">
 			{m.already_have_an_account_login().split('?')[0]}?
-			<a href={`/auth/login?backTo=${backTo}`} class="text-primary underline">{m.login()}</a>
+			<a
+				href={`/auth/login?backTo=${encodeURIComponent(backTo ?? '/')}`}
+				class="text-primary underline">{m.login()}</a
+			>
 		</p>
 		<p class="text-muted-foreground text-base">
 			{m.agree_to_tos()}

--- a/ui/packages/comhairle/src/routes/(public)/auth/verification-message/+page.server.ts
+++ b/ui/packages/comhairle/src/routes/(public)/auth/verification-message/+page.server.ts
@@ -1,0 +1,8 @@
+import type { PageServerLoad } from './$types.js';
+
+export const load: PageServerLoad = async ({ url }) => {
+	let backTo = url.searchParams.get('backTo') ?? '/';
+	return {
+		backTo
+	};
+};

--- a/ui/packages/comhairle/src/routes/(public)/auth/verification-message/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/auth/verification-message/+page.svelte
@@ -12,6 +12,6 @@
 
 <div class="flex min-h-screen w-full flex-col">
 	<AuthGradient showLogo={false} mode="full">
-		<VerificationMessage user={data.user} />
+		<VerificationMessage user={data.user} backTo={data.backTo} />
 	</AuthGradient>
 </div>

--- a/ui/packages/comhairle/src/routes/(public)/auth/verification-message/verification-message.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/auth/verification-message/verification-message.svelte
@@ -4,7 +4,7 @@
 	import * as m from '$lib/paraglide/messages';
 	import { Button } from '$lib/components/ui/button';
 
-	let { user } = $props();
+	let { user, backTo }: { user: any; backTo?: string } = $props();
 
 	let responseMessage: string | null = $state(null);
 
@@ -52,10 +52,14 @@
 		</p>
 
 		<div class="flex flex-col items-center gap-3 pt-2 sm:flex-row">
-			<Button href="/auth/login" variant="default" size="lg">
+			<Button
+				href={`/auth/login?backTo=${encodeURIComponent(backTo ?? '/')}`}
+				variant="default"
+				size="lg"
+			>
 				{m.back_to_login()}
 			</Button>
-			<Button href="/" variant="outline" size="lg">
+			<Button href={backTo ?? '/'} variant="outline" size="lg">
 				{m.go_home()}
 			</Button>
 		</div>

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/+page.svelte
@@ -22,7 +22,7 @@
 	let firstWorkflowPath = $derived(`${url}/workflow/${firstWorkflow.id}/next`);
 
 	async function redirectToLogin() {
-		loginRedirect(url.toString(), 'Login to join the conversation');
+		loginRedirect(url.pathname, 'Login to join the conversation');
 	}
 
 	// Register a new annon user, sign them up for
@@ -39,7 +39,7 @@
 	}
 
 	async function redirectToSignIn() {
-		signupRedirect(url.toString(), 'Signup to join the conversation');
+		signupRedirect(url.pathname, 'Signup to join the conversation');
 	}
 
 	async function registerUser() {


### PR DESCRIPTION
**the problem**
user clicks "take part" on a conversation → gets sent to signup → creates account → lands on homepage instead of the conversation they wanted to join

**ze fix**
added a backTo query param (that used to be there until I changed it recently - oops - sorry)

main change:
anonymous signup code page now uses backTo instead of hardcoded /conversations link

also did while i was here:
1. url-encoded backTo everywhere to prevent query string weirdness
2. switched from full urls to pathnames for cleaner params
3. threaded backTo through verification flow for non-anon signups
4. bonus**: login/signup forms now submit on enter key

is this overkill?
could simplify to only encode at entry points but then:
- breaks if someone adds a direct link without using helpers
- server-side redirects still need manual encoding anyway
- auth is critical, better paranoid than debugging "works 99% of the time" bugs

thoughts? keep it paranoid or simplify?