### PR TITLE
409/jitsi jwt auth

### DIFF
--- a/api/src/config.rs
+++ b/api/src/config.rs
@@ -52,6 +52,14 @@ pub enum TranslatorConfig {
 }
 
 #[derive(Clone, Debug, Deserialize)]
+pub struct JitsiConfig {
+    pub jwt_app_id: String,
+    pub jwt_app_secret: String,
+    pub jwt_accepted_issuers: String,
+    pub jwt_accepted_audiences: String,
+}
+
+#[derive(Clone, Debug, Deserialize)]
 pub struct ComhairleConfig {
     pub database_url: String,
     pub jwt_secret: String,
@@ -68,4 +76,5 @@ pub struct ComhairleConfig {
     pub enable_rate_limiting: bool,
     pub heyform_url: String,
     pub polis_url: String,
+    pub jitsi: Option<JitsiConfig>,
 }

--- a/api/src/config.rs
+++ b/api/src/config.rs
@@ -55,6 +55,7 @@ pub enum TranslatorConfig {
 pub struct JitsiConfig {
     pub jwt_app_id: String,
     pub jwt_app_secret: String,
+    pub jwt_sub: String,
     pub jwt_accepted_issuers: String,
     pub jwt_accepted_audiences: String,
 }

--- a/api/src/config.rs
+++ b/api/src/config.rs
@@ -52,7 +52,7 @@ pub enum TranslatorConfig {
 }
 
 #[derive(Clone, Debug, Deserialize)]
-pub struct JitsiConfig {
+pub struct VideoCallConfig {
     pub jwt_app_id: String,
     pub jwt_app_secret: String,
     pub jwt_sub: String,
@@ -77,5 +77,5 @@ pub struct ComhairleConfig {
     pub enable_rate_limiting: bool,
     pub heyform_url: String,
     pub polis_url: String,
-    pub jitsi: Option<JitsiConfig>,
+    pub video_call_service: Option<VideoCallConfig>,
 }

--- a/api/src/error.rs
+++ b/api/src/error.rs
@@ -41,6 +41,9 @@ pub enum ComhairleError {
     #[error("No bot service configured")]
     NoBotServiceConfigured,
 
+    #[error("No video service configured")]
+    NoVideoServiceConfigured,
+
     #[error("HeyForm error: {0}")]
     HeyFormError(#[from] HeyFormError),
 
@@ -235,6 +238,9 @@ pub enum ComhairleError {
 
     #[error("Conversation already live")]
     ConversationAlreadyLive,
+
+    #[error("Event missing video_meeting_id")]
+    NoVideoMeetingId,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -256,7 +256,5 @@ pub async fn setup_server(state: Arc<ComhairleState>) -> Result<Router<()>, Comh
         fs::write("open-api-spec.json", json.as_bytes()).await?;
     }
 
-    println!("Config ${:#?}", state.config);
-
     Ok(app)
 }

--- a/api/src/models/event.rs
+++ b/api/src/models/event.rs
@@ -338,7 +338,7 @@ pub async fn list(
 }
 
 #[instrument(err(Debug))]
-pub async fn get_by_id(db: &PgPool, id: &Uuid, locale: &str) -> Result<Event, ComhairleError> {
+pub async fn get_by_id(db: &PgPool, id: &Uuid) -> Result<Event, ComhairleError> {
     let query = Query::select()
         .columns(DEFAULT_COLUMNS.map(|col| (EventIden::Table, col)))
         .from(EventIden::Table)

--- a/api/src/routes/auth.rs
+++ b/api/src/routes/auth.rs
@@ -15,7 +15,7 @@ use axum::{
 };
 use axum_extra::extract::cookie::{Cookie, CookieJar, SameSite};
 use bon::builder;
-use chrono::{Duration, TimeDelta};
+use chrono::TimeDelta;
 use jsonwebtoken::{decode, encode, DecodingKey, EncodingKey, Header, TokenData, Validation};
 use rand_core::OsRng;
 use regex::Regex;
@@ -244,7 +244,7 @@ pub fn generate_jwt<T: Serialize>(
     sub: Option<String>,
 ) -> String {
     let expiration = chrono::Utc::now()
-        .checked_add_signed(duration.unwrap_or_else(|| Duration::hours(24)))
+        .checked_add_signed(duration.unwrap_or_else(|| chrono::Duration::hours(24)))
         .expect("valid timestamp")
         .timestamp() as usize;
 
@@ -292,7 +292,7 @@ async fn signup(
         .user(&user)
         .secret(&state.config.jwt_secret)
         .custom_claims(claims)
-        .duration(Duration::minutes(15))
+        .duration(chrono::Duration::minutes(15))
         .call();
     let verify_link = format!(
         "{}/auth/verify-user?token={}",
@@ -447,7 +447,7 @@ async fn resend_verification_email(
         .user(&user)
         .secret(&state.config.jwt_secret)
         .custom_claims(claims)
-        .duration(Duration::minutes(15))
+        .duration(chrono::Duration::minutes(15))
         .call();
     let verify_link = format!("{}/auth/verify-user?token={}", state.config.domain, token);
     state
@@ -514,7 +514,7 @@ async fn password_reset_create(
         .user(&user)
         .secret(&state.config.jwt_secret)
         .custom_claims(claims)
-        .duration(Duration::minutes(15))
+        .duration(chrono::Duration::minutes(15))
         .call();
     let reset_link = format!(
         "{}/auth/password-reset/update?token={}",
@@ -1845,7 +1845,11 @@ mod tests {
         let claims = EmailLinkClaims {
             email: Some(email.to_string()),
         };
-        let token = generate_jwt(&user, claims, &state.config.jwt_secret, None);
+        let token = generate_jwt()
+            .user(&user)
+            .secret(&state.config.jwt_secret)
+            .custom_claims(claims)
+            .call();
 
         // Try to reset with weak password
         let weak_password = "weak";

--- a/api/src/routes/auth.rs
+++ b/api/src/routes/auth.rs
@@ -219,10 +219,13 @@ pub struct SessionClaims {
 
 /// JWT Claims
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(bound = "T: Serialize + DeserializeOwned")]
+#[serde(
+    bound(serialize = "T: Serialize"),
+    bound(deserialize = "T: DeserializeOwned")
+)]
 pub struct Claims<T>
 where
-    T: Serialize + DeserializeOwned,
+    T: Serialize,
 {
     sub: String,
     exp: usize,
@@ -233,7 +236,7 @@ where
 
 /// Generate JWT
 #[builder]
-pub fn generate_jwt<T: Serialize + DeserializeOwned>(
+pub fn generate_jwt<T: Serialize>(
     user: &User,
     secret: &str,
     custom_claims: T,

--- a/api/src/routes/auth.rs
+++ b/api/src/routes/auth.rs
@@ -14,7 +14,8 @@ use axum::{
     RequestPartsExt,
 };
 use axum_extra::extract::cookie::{Cookie, CookieJar, SameSite};
-use chrono::TimeDelta;
+use bon::builder;
+use chrono::{Duration, TimeDelta};
 use jsonwebtoken::{decode, encode, DecodingKey, EncodingKey, Header, TokenData, Validation};
 use rand_core::OsRng;
 use regex::Regex;
@@ -231,19 +232,21 @@ where
 }
 
 /// Generate JWT
+#[builder]
 pub fn generate_jwt<T: Serialize + DeserializeOwned>(
     user: &User,
-    custom_claims: T,
     secret: &str,
-    custom_duration: Option<TimeDelta>,
+    custom_claims: T,
+    duration: Option<TimeDelta>,
+    sub: Option<String>,
 ) -> String {
     let expiration = chrono::Utc::now()
-        .checked_add_signed(custom_duration.unwrap_or_else(|| chrono::Duration::hours(24)))
+        .checked_add_signed(duration.unwrap_or_else(|| Duration::hours(24)))
         .expect("valid timestamp")
         .timestamp() as usize;
 
     let claims = Claims {
-        sub: user.id.to_string(),
+        sub: sub.unwrap_or(user.id.to_string()),
         exp: expiration,
         id: user.id.to_string(),
         details: custom_claims,
@@ -282,12 +285,12 @@ async fn signup(
     let claims = EmailLinkClaims {
         email: user.email.clone(),
     };
-    let verification_token = generate_jwt(
-        &user,
-        claims,
-        &state.config.jwt_secret,
-        Some(chrono::Duration::minutes(15)),
-    );
+    let verification_token = generate_jwt()
+        .user(&user)
+        .secret(&state.config.jwt_secret)
+        .custom_claims(claims)
+        .duration(Duration::minutes(15))
+        .call();
     let verify_link = format!(
         "{}/auth/verify-user?token={}",
         state.config.domain, verification_token
@@ -301,7 +304,11 @@ async fn signup(
         email_verified: user.email_verified,
         roles: Vec::new(),
     };
-    let session_token = generate_jwt(&user, claims, &state.config.jwt_secret, None);
+    let session_token = generate_jwt()
+        .user(&user)
+        .secret(&state.config.jwt_secret)
+        .custom_claims(claims)
+        .call();
     let cookie = Cookie::build((AUTH_KEY, session_token))
         .path("/")
         .secure(true)
@@ -326,7 +333,11 @@ async fn signup_annon(
         email_verified: user.email_verified,
         roles: Vec::new(),
     };
-    let token = generate_jwt(&user, claims, &state.config.jwt_secret, None);
+    let token = generate_jwt()
+        .user(&user)
+        .secret(&state.config.jwt_secret)
+        .custom_claims(claims)
+        .call();
 
     let cookie = Cookie::build((AUTH_KEY, token))
         .path("/")
@@ -368,7 +379,11 @@ async fn login(
         email_verified: user.email_verified,
         roles: Vec::new(),
     };
-    let token = generate_jwt(&user.clone(), claims, &state.config.jwt_secret, None);
+    let token = generate_jwt()
+        .user(&user)
+        .secret(&state.config.jwt_secret)
+        .custom_claims(claims)
+        .call();
     let cookie = Cookie::build((AUTH_KEY, token))
         .path("/")
         .secure(true)
@@ -399,7 +414,11 @@ async fn login_annon(
         email_verified: user.email_verified,
         roles: Vec::new(),
     };
-    let token = generate_jwt(&user.clone(), claims, &state.config.jwt_secret, None);
+    let token = generate_jwt()
+        .user(&user)
+        .secret(&state.config.jwt_secret)
+        .custom_claims(claims)
+        .call();
     let cookie = Cookie::build((AUTH_KEY, token))
         .path("/")
         .secure(true)
@@ -421,12 +440,12 @@ async fn resend_verification_email(
     let claims = EmailLinkClaims {
         email: user.email.clone(),
     };
-    let token = generate_jwt(
-        &user,
-        claims,
-        &state.config.jwt_secret,
-        Some(chrono::Duration::minutes(15)),
-    );
+    let token = generate_jwt()
+        .user(&user)
+        .secret(&state.config.jwt_secret)
+        .custom_claims(claims)
+        .duration(Duration::minutes(15))
+        .call();
     let verify_link = format!("{}/auth/verify-user?token={}", state.config.domain, token);
     state
         .mailer
@@ -463,12 +482,11 @@ async fn verify_email_token(
         email_verified: updated_user.email_verified,
         roles: Vec::new(),
     };
-    let session_token = generate_jwt(
-        &updated_user.clone(),
-        claims,
-        &state.config.jwt_secret,
-        None,
-    );
+    let session_token = generate_jwt()
+        .user(&updated_user.clone())
+        .secret(&state.config.jwt_secret)
+        .custom_claims(claims)
+        .call();
     let cookie = Cookie::build((AUTH_KEY, session_token.clone()))
         .path("/")
         .secure(true)
@@ -489,12 +507,12 @@ async fn password_reset_create(
     let claims = EmailLinkClaims {
         email: user.email.clone(),
     };
-    let token = generate_jwt(
-        &user,
-        claims,
-        &state.config.jwt_secret,
-        Some(chrono::Duration::minutes(15)),
-    );
+    let token = generate_jwt()
+        .user(&user)
+        .secret(&state.config.jwt_secret)
+        .custom_claims(claims)
+        .duration(Duration::minutes(15))
+        .call();
     let reset_link = format!(
         "{}/auth/password-reset/update?token={}",
         state.config.domain, token
@@ -1094,7 +1112,11 @@ mod tests {
             email_verified: user.email_verified,
             roles: Vec::new(),
         };
-        let token = generate_jwt(&user, claims, secret, None);
+        let token = generate_jwt()
+            .user(&user)
+            .secret(secret)
+            .custom_claims(claims)
+            .call();
         let (status, user, _) = session.verify_email_token(&app, token).await?;
         let user: UserDto = serde_json::from_value(user)?;
 
@@ -1138,7 +1160,11 @@ mod tests {
             email_verified: user.email_verified,
             roles: Vec::new(),
         };
-        let token = generate_jwt(&user, claims, secret, None);
+        let token = generate_jwt()
+            .user(&user)
+            .secret(secret)
+            .custom_claims(claims)
+            .call();
         let (status, _, _) = session.verify_email_token(&app, token).await?;
 
         assert_eq!(
@@ -1186,7 +1212,11 @@ mod tests {
             email_verified: user.email_verified,
             roles: Vec::new(),
         };
-        let token = generate_jwt(&user, claims, secret, None);
+        let token = generate_jwt()
+            .user(&user)
+            .secret(secret)
+            .custom_claims(claims)
+            .call();
         let (status, _, _) = session.verify_email_token(&app, token).await?;
 
         assert_eq!(status, StatusCode::CONFLICT, "user email already verified");
@@ -1499,7 +1529,11 @@ mod tests {
         let claims = EmailLinkClaims {
             email: Some(email.to_string()),
         };
-        let token = generate_jwt(&user, claims, &secret, None);
+        let token = generate_jwt()
+            .user(&user)
+            .secret(&secret)
+            .custom_claims(claims)
+            .call();
 
         let updated_password = "UpdatedPassword123!";
         let (reset_status, _, _) = session
@@ -1557,7 +1591,11 @@ mod tests {
         let claims = EmailLinkClaims {
             email: Some(email.to_string()),
         };
-        let token = generate_jwt(&user, claims, &secret, None);
+        let token = generate_jwt()
+            .user(&user)
+            .secret(&secret)
+            .custom_claims(claims)
+            .call();
         let (status, _, _) = session
             .password_reset_update(&app, &token, "foo", "bar")
             .await?;
@@ -1598,7 +1636,11 @@ mod tests {
             organization_id: None,
         };
         let claims = EmailLinkClaims { email: None };
-        let token = generate_jwt(&user, claims, &secret, None);
+        let token = generate_jwt()
+            .user(&user)
+            .secret(&secret)
+            .custom_claims(claims)
+            .call();
         let password = "updated_password";
         let (status, _, _) = session
             .password_reset_update(&app, &token, password, password)

--- a/api/src/routes/events.rs
+++ b/api/src/routes/events.rs
@@ -174,7 +174,8 @@ struct VideoEventJwtContext {
 
 #[derive(Serialize, Deserialize, Debug)]
 struct VideoEventJwtUser {
-    name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
     id: String,
 }
 
@@ -185,15 +186,14 @@ async fn get_jwt(
     RequiredUser(user): RequiredUser,
 ) -> Result<(StatusCode, Json<JwtResponse>), ComhairleError> {
     let event = event::get_by_id(&state.db, &event_id).await?;
-    // TODO: error variant
-    let video_meeting_id = event.video_meeting_id.ok_or(ComhairleError::CorruptedData(
-        "Missing video meeting id".to_string(),
-    ))?;
+    let video_meeting_id = event
+        .video_meeting_id
+        .ok_or(ComhairleError::NoVideoMeetingId)?;
     let jwt_config = &state
         .config
         .jitsi
         .as_ref()
-        .ok_or(ComhairleError::NoBotUserSession)?; // TODO: error variant
+        .ok_or(ComhairleError::NoVideoServiceConfigured)?;
 
     let claims = VideoEventJwtClaims {
         iss: jwt_config.jwt_app_id.clone(), // TODO:
@@ -201,7 +201,7 @@ async fn get_jwt(
         room: video_meeting_id.to_string(),
         context: VideoEventJwtContext {
             user: VideoEventJwtUser {
-                name: user.clone().username.unwrap_or("".to_string()),
+                name: user.clone().username,
                 id: user.clone().id.to_string(),
             },
         },
@@ -212,7 +212,7 @@ async fn get_jwt(
         .secret(&jwt_config.jwt_app_secret)
         .custom_claims(claims)
         .duration(chrono::Duration::hours(1))
-        .sub("jitsi.comhairle.scot".to_string())
+        .sub(jwt_config.jwt_sub.clone())
         .call();
 
     Ok((StatusCode::OK, Json(JwtResponse { jwt })))

--- a/api/src/routes/events.rs
+++ b/api/src/routes/events.rs
@@ -159,24 +159,24 @@ struct JwtResponse {
     jwt: String,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
-struct VideoEventJwtClaims {
-    iss: String,
-    aud: String,
-    room: String,
-    context: VideoEventJwtContext,
+#[derive(Serialize, Debug)]
+struct VideoEventJwtClaims<'a> {
+    iss: &'a str,
+    aud: &'a str,
+    room: &'a str,
+    context: VideoEventJwtContext<'a>,
+}
+
+#[derive(Serialize, Debug)]
+struct VideoEventJwtContext<'a> {
+    user: VideoEventJwtUser<'a>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-struct VideoEventJwtContext {
-    user: VideoEventJwtUser,
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-struct VideoEventJwtUser {
+struct VideoEventJwtUser<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
-    name: Option<String>,
-    id: String,
+    name: Option<&'a str>,
+    id: &'a str,
 }
 
 #[instrument(err(Debug), skip(state))]
@@ -196,13 +196,13 @@ async fn get_jwt(
         .ok_or(ComhairleError::NoVideoServiceConfigured)?;
 
     let claims = VideoEventJwtClaims {
-        iss: jwt_config.jwt_app_id.clone(), // TODO:
-        aud: jwt_config.jwt_app_id.clone(),
-        room: video_meeting_id.to_string(),
+        iss: &jwt_config.jwt_app_id,
+        aud: &jwt_config.jwt_app_id,
+        room: &video_meeting_id.to_string(),
         context: VideoEventJwtContext {
             user: VideoEventJwtUser {
-                name: user.clone().username,
-                id: user.clone().id.to_string(),
+                name: user.username.as_deref(),
+                id: &user.id.to_string(),
             },
         },
     };
@@ -212,7 +212,7 @@ async fn get_jwt(
         .secret(&jwt_config.jwt_app_secret)
         .custom_claims(claims)
         .duration(chrono::Duration::hours(1))
-        .sub(jwt_config.jwt_sub.clone())
+        .sub(jwt_config.jwt_sub.to_owned())
         .call();
 
     Ok((StatusCode::OK, Json(JwtResponse { jwt })))

--- a/api/src/routes/events.rs
+++ b/api/src/routes/events.rs
@@ -189,15 +189,15 @@ async fn get_jwt(
     let video_meeting_id = event
         .video_meeting_id
         .ok_or(ComhairleError::NoVideoMeetingId)?;
-    let jwt_config = &state
+    let video_call_config = &state
         .config
-        .jitsi
+        .video_call_service
         .as_ref()
         .ok_or(ComhairleError::NoVideoServiceConfigured)?;
 
     let claims = VideoEventJwtClaims {
-        iss: &jwt_config.jwt_app_id,
-        aud: &jwt_config.jwt_app_id,
+        iss: &video_call_config.jwt_app_id,
+        aud: &video_call_config.jwt_app_id,
         room: &video_meeting_id.to_string(),
         context: VideoEventJwtContext {
             user: VideoEventJwtUser {
@@ -209,10 +209,10 @@ async fn get_jwt(
 
     let jwt = generate_jwt()
         .user(&user)
-        .secret(&jwt_config.jwt_app_secret)
+        .secret(&video_call_config.jwt_app_secret)
         .custom_claims(claims)
         .duration(chrono::Duration::hours(1))
-        .sub(jwt_config.jwt_sub.to_owned())
+        .sub(video_call_config.jwt_sub.to_owned())
         .call();
 
     Ok((StatusCode::OK, Json(JwtResponse { jwt })))

--- a/api/src/routes/events.rs
+++ b/api/src/routes/events.rs
@@ -24,7 +24,7 @@ use crate::{
         pagination::{PageOptions, PaginatedResults},
     },
     routes::{
-        auth::{is_user_admin, RequiredAdminUser, RequiredUser},
+        auth::{generate_jwt, is_user_admin, RequiredAdminUser, RequiredUser},
         events::dto::{EventDto, LocalizedEventDto},
         translations::LocaleExtractor,
     },
@@ -78,7 +78,7 @@ async fn get(
     RequiredUser(user): RequiredUser,
     LocaleExtractor(locale): LocaleExtractor,
 ) -> Result<(StatusCode, Json<EventResponse>), ComhairleError> {
-    let event = event::get_by_id(&state.db, &event_id, &locale).await?;
+    let event = event::get_by_id(&state.db, &event_id).await?;
 
     let should_return_with_translations =
         query.with_translations && is_user_admin(&user, &state.config);
@@ -154,6 +154,70 @@ async fn delete(
     Ok((StatusCode::OK, Json(event)))
 }
 
+#[derive(Serialize, JsonSchema, Debug)]
+struct JwtResponse {
+    jwt: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct VideoEventJwtClaims {
+    iss: String,
+    aud: String,
+    room: String,
+    context: VideoEventJwtContext,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct VideoEventJwtContext {
+    user: VideoEventJwtUser,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct VideoEventJwtUser {
+    name: String,
+    id: String,
+}
+
+#[instrument(err(Debug), skip(state))]
+async fn get_jwt(
+    State(state): State<Arc<ComhairleState>>,
+    Path((_conversation_id, event_id)): Path<(Uuid, Uuid)>,
+    RequiredUser(user): RequiredUser,
+) -> Result<(StatusCode, Json<JwtResponse>), ComhairleError> {
+    let event = event::get_by_id(&state.db, &event_id).await?;
+    // TODO: error variant
+    let video_meeting_id = event.video_meeting_id.ok_or(ComhairleError::CorruptedData(
+        "Missing video meeting id".to_string(),
+    ))?;
+    let jwt_config = &state
+        .config
+        .jitsi
+        .as_ref()
+        .ok_or(ComhairleError::NoBotUserSession)?; // TODO: error variant
+
+    let claims = VideoEventJwtClaims {
+        iss: jwt_config.jwt_app_id.clone(), // TODO:
+        aud: jwt_config.jwt_app_id.clone(),
+        room: video_meeting_id.to_string(),
+        context: VideoEventJwtContext {
+            user: VideoEventJwtUser {
+                name: user.clone().username.unwrap_or("".to_string()),
+                id: user.clone().id.to_string(),
+            },
+        },
+    };
+
+    let jwt = generate_jwt()
+        .user(&user)
+        .secret(&jwt_config.jwt_app_secret)
+        .custom_claims(claims)
+        .duration(chrono::Duration::hours(1))
+        .sub("jitsi.comhairle.scot".to_string())
+        .call();
+
+    Ok((StatusCode::OK, Json(JwtResponse { jwt })))
+}
+
 pub fn router(state: Arc<ComhairleState>) -> ApiRouter {
     ApiRouter::new()
         .api_route("/", get_with(list, |op| {
@@ -202,6 +266,16 @@ pub fn router(state: Arc<ComhairleState>) -> ApiRouter {
                     .description("Delete an event")
                     .security_requirement("JWT")
                     .response::<200, Json<EventDto>>()
+
+        }))
+        .api_route("/{event_id}/auth", 
+            get_with(get_jwt, |op| {
+                op.id("GetEventJWT")
+                    .tag("Events")
+                    .summary("Get a auth JWT for an event")
+                    .description("Get a auth JWT for an event")
+                    .security_requirement("JWT")
+                    .response::<200, Json<JwtResponse>>()
 
         }))
         .with_state(state)

--- a/ui/packages/api-client/src/api.ts
+++ b/ui/packages/api-client/src/api.ts
@@ -1072,6 +1072,8 @@ export const PartialEvent = z
   .partial()
   .passthrough();
 export type PartialEvent = z.infer<typeof PartialEvent>;
+export const JwtResponse = z.object({ jwt: z.string() }).passthrough();
+export type JwtResponse = z.infer<typeof JwtResponse>;
 export const EventAttendanceDto = z
   .object({
     createdAt: z.string().datetime({ offset: true }),
@@ -1380,6 +1382,7 @@ export const schemas = {
   EventWithTranslations,
   EventResponse,
   PartialEvent,
+  JwtResponse,
   EventAttendanceDto,
   PaginatedResults_for_EventAttendanceDto,
   CreateEventAttendanceRequest,
@@ -1967,6 +1970,14 @@ curl -X POST \
     description: `Delete an event attendance by id`,
     requestFormat: "json",
     response: EventAttendanceDto,
+  },
+  {
+    method: "get",
+    path: "/conversation/:conversation_id/events/:event_id/auth",
+    alias: "GetEventJWT",
+    description: `Get a auth JWT for an event`,
+    requestFormat: "json",
+    response: z.object({ jwt: z.string() }).passthrough(),
   },
   {
     method: "get",

--- a/ui/packages/comhairle/src/lib/components/JitsiMeet/JitsiMeet.svelte
+++ b/ui/packages/comhairle/src/lib/components/JitsiMeet/JitsiMeet.svelte
@@ -24,7 +24,7 @@
 	}
 
 	let {
-		domain = env.PUBLIC_JITSI_DOMAIN ?? 'video.comhairle.scot',
+		domain = env.PUBLIC_JITSI_DOMAIN ?? 'jitsi.comhairle.scot',
 		roomName,
 		displayName = '',
 		email = '',

--- a/ui/packages/comhairle/src/lib/components/JitsiMeet/JitsiMeet.svelte
+++ b/ui/packages/comhairle/src/lib/components/JitsiMeet/JitsiMeet.svelte
@@ -8,7 +8,7 @@
 		roomName: string;
 		displayName?: string;
 		email?: string;
-		jwt?: string;
+		jwt: string;
 		width?: string | number;
 		height?: string | number;
 		startWithAudioMuted?: boolean;
@@ -28,7 +28,7 @@
 		roomName,
 		displayName = '',
 		email = '',
-		jwt = '',
+		jwt,
 		width = '100%',
 		height = '100%',
 		startWithAudioMuted = false,

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
@@ -10,10 +10,11 @@
 	let conversationId = $derived(data.conversationId);
 	let eventId = $derived(data.eventId);
 	let event = $derived(data.event);
+	let jwt = $derived(data.jwt);
 	let apiAttendances = $derived(data.attendances);
 	let user = $derived(data.user);
 
-	let roomName = $derived(`comhairle-event-${eventId}`);
+	let roomName = $derived(event?.videoMeetingId);
 
 	let jitsiApi: any = $state(null);
 	let panelOpen = $state(false);
@@ -164,6 +165,7 @@
 		<div class="relative min-h-0 min-w-0 flex-1">
 			<JitsiMeet
 				{roomName}
+				{jwt}
 				onApiReady={handleApiReady}
 				onParticipantJoined={handleParticipantJoined}
 				onParticipantLeft={handleParticipantLeft}

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.ts
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.ts
@@ -6,12 +6,13 @@ export const load: PageLoad = async ({ parent, params }) => {
 	const { conversation_id, event_id } = params;
 
 	try {
-		const [event, attendancesResult] = await Promise.all([
+		const [event, attendancesResult, authRes] = await Promise.all([
 			api.GetEvent({ params: { conversation_id, event_id } }),
 			api.ListEventAttendances({
 				params: { conversation_id, event_id },
 				queries: { limit: 200 }
-			})
+			}),
+			api.GetEventJWT({ params: { conversation_id, event_id } })
 		]);
 
 		return {
@@ -19,6 +20,7 @@ export const load: PageLoad = async ({ parent, params }) => {
 			eventId: event_id,
 			event: event as LocalizedEventDto,
 			attendances: attendancesResult.records as EventAttendanceDto[],
+			jwt: authRes.jwt,
 			user
 		};
 	} catch (e) {

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.ts
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.ts
@@ -30,7 +30,8 @@ export const load: PageLoad = async ({ parent, params }) => {
 			eventId: event_id,
 			event: null,
 			attendances: [] as EventAttendanceDto[],
-			user
+			user,
+			jwt: ''
 		};
 	}
 };


### PR DESCRIPTION
Actions:

- refactor of `generate_jwt` to use builder pattern
- jitsi jwt route with required claims
- config update
- update frontend to use jwt authentication

