### PR TITLE
Visual fix: add padding to step descriptions

### DIFF
--- a/ui/packages/comhairle/src/lib/components/StepSelector.svelte
+++ b/ui/packages/comhairle/src/lib/components/StepSelector.svelte
@@ -149,7 +149,7 @@
 		{:else}
 			<span
 				class={cn(
-					'text-sm leading-5 font-medium',
+					'px-3 text-sm leading-5 font-medium',
 					step.status === 'completed-locked'
 						? 'text-muted-foreground/60'
 						: 'text-foreground'


### PR DESCRIPTION
Before:
<img width="1174" height="270" alt="image" src="https://github.com/user-attachments/assets/01205566-6cbb-4f38-b67a-dff970ed769d" />

After:
<img width="1049" height="329" alt="2026-03-23_13-48-51" src="https://github.com/user-attachments/assets/dd256604-f604-422e-a147-60eb95555a4c" />
