### PR TITLE
83/revisit steps

### DIFF
--- a/api/migrations/20260319162002_add_can_revisit_column_to_workflow_step.sql
+++ b/api/migrations/20260319162002_add_can_revisit_column_to_workflow_step.sql
@@ -1,0 +1,3 @@
+-- Add can_revisit column to workflow step table
+ALTER TABLE workflow_step
+ADD COLUMN can_revisit BOOLEAN DEFAULT false;

--- a/api/src/models/workflow_step.rs
+++ b/api/src/models/workflow_step.rs
@@ -400,8 +400,8 @@ pub async fn list_localized(
 pub struct LocalizedWorkflowStepWithProgress {
     #[sqlx(flatten)]
     #[serde(flatten)]
-    step: LocalizedWorkflowStep,
-    status: ProgressStatus,
+    pub step: LocalizedWorkflowStep,
+    pub status: ProgressStatus,
 }
 
 #[instrument(err(Debug))]
@@ -733,11 +733,31 @@ mod tests {
             .await?;
 
         let steps = list_localized_with_progress(&pool, &workflow.id, "en", &user.id).await?;
-        assert_eq!(steps[0].status, ProgressStatus::Done, "incorrect first step progess status");
-        assert_eq!(steps[1].status, ProgressStatus::InProgress, "incorrect second step progess status");
-        assert_eq!(steps[2].status, ProgressStatus::NotStarted, "incorrect third step progess status");
-        assert_eq!(steps[3].status, ProgressStatus::NotStarted, "incorrect fourth step progess status");
-        assert_eq!(steps[4].status, ProgressStatus::NotStarted, "incorrect fifth step progess status");
+        assert_eq!(
+            steps[0].status,
+            ProgressStatus::Done,
+            "incorrect first step progess status"
+        );
+        assert_eq!(
+            steps[1].status,
+            ProgressStatus::InProgress,
+            "incorrect second step progess status"
+        );
+        assert_eq!(
+            steps[2].status,
+            ProgressStatus::NotStarted,
+            "incorrect third step progess status"
+        );
+        assert_eq!(
+            steps[3].status,
+            ProgressStatus::NotStarted,
+            "incorrect fourth step progess status"
+        );
+        assert_eq!(
+            steps[4].status,
+            ProgressStatus::NotStarted,
+            "incorrect fifth step progess status"
+        );
 
         Ok(())
     }

--- a/api/src/models/workflow_step.rs
+++ b/api/src/models/workflow_step.rs
@@ -40,6 +40,7 @@ pub struct WorkflowStep {
     pub description: TextContentId,
     pub is_offline: bool,
     pub required: bool,
+    pub can_revisit: bool,
     #[partially(transparent)]
     pub tool_config: Option<ToolConfig>,
     pub preview_tool_config: ToolConfig,
@@ -49,7 +50,7 @@ pub struct WorkflowStep {
     pub updated_at: DateTime<Utc>,
 }
 
-const DEFAULT_COLUMNS: [WorkflowStepIden; 12] = [
+const DEFAULT_COLUMNS: [WorkflowStepIden; 13] = [
     WorkflowStepIden::Id,
     WorkflowStepIden::Name,
     WorkflowStepIden::WorkflowId,
@@ -57,6 +58,7 @@ const DEFAULT_COLUMNS: [WorkflowStepIden; 12] = [
     WorkflowStepIden::ActivationRule,
     WorkflowStepIden::Description,
     WorkflowStepIden::IsOffline,
+    WorkflowStepIden::CanRevisit,
     WorkflowStepIden::ToolConfig,
     WorkflowStepIden::PreviewToolConfig,
     WorkflowStepIden::Required,
@@ -173,7 +175,9 @@ impl PartialWorkflowStep {
         if let Some(value) = &self.activation_rule {
             values.push((WorkflowStepIden::ActivationRule, value.into()))
         };
-
+        if let Some(value) = &self.can_revisit {
+            values.push((WorkflowStepIden::CanRevisit, (*value).into()))
+        };
         if let Some(value) = &self.tool_config {
             values.push((WorkflowStepIden::ToolConfig, value.into()))
         };
@@ -561,4 +565,54 @@ pub async fn get_current_active_step_for_user_localised(
         .await?;
 
     Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use crate::{
+        models::model_test_helpers::{get_random_conversation_id, setup_default_app_and_session},
+        routes::{workflow_steps::dto::WorkflowStepDto, workflows::dto::WorkflowDto},
+    };
+
+    use super::*;
+    use std::error::Error;
+
+    #[sqlx::test]
+    async fn should_update_can_revisit_field(pool: PgPool) -> Result<(), Box<dyn Error>> {
+        let (app, mut session) = setup_default_app_and_session(&pool).await?;
+        let conversation_id = get_random_conversation_id(&app, &mut session).await?;
+        let (_, workflow_res, _) = session
+            .create_random_workflow(&app, &conversation_id.to_string())
+            .await?;
+        let workflow: WorkflowDto = serde_json::from_value(workflow_res)?;
+        let steps_res = session
+            .create_random_workflow_steps(
+                &app,
+                &conversation_id.to_string(),
+                &workflow.id.to_string(),
+                1,
+            )
+            .await?;
+        let step: WorkflowStepDto = serde_json::from_value(steps_res.first().unwrap().to_owned())?;
+
+        assert!(!step.can_revisit, "incorrect can_revisit before update");
+
+        let (_, value, _) = session
+            .put(
+                &app,
+                &format!(
+                    "/conversation/{}/workflow/{}/workflow_step/{}",
+                    conversation_id, workflow.id, step.id
+                ),
+                json!({ "can_revisit": true }).to_string().into(),
+            )
+            .await?;
+        let step: WorkflowStepDto = serde_json::from_value(value)?;
+
+        assert!(step.can_revisit, "incorrect can_revisit after update");
+
+        Ok(())
+    }
 }

--- a/api/src/models/workflow_step.rs
+++ b/api/src/models/workflow_step.rs
@@ -1,14 +1,15 @@
 use std::sync::Arc;
 
 use crate::models::translations::{new_translation, TextContentId, TextFormat};
+use crate::models::users::UserIden;
 use crate::tools::ToolConfigSanitize;
 use crate::ComhairleState;
 use chrono::{DateTime, Utc};
 use comhairle_macros::{DbJsonBEnum, Translatable};
 use partially::Partial;
 use schemars::JsonSchema;
-use sea_query::PostgresQueryBuilder;
 use sea_query::{enum_def, Expr, Order, Query};
+use sea_query::{JoinType, PostgresQueryBuilder};
 use sea_query_binder::SqlxBinder;
 use serde::{Deserialize, Serialize};
 use sqlx::PgConnection;
@@ -367,7 +368,8 @@ pub async fn list(db: &PgPool, workflow_id: &Uuid) -> Result<Vec<WorkflowStep>, 
     Ok(workflow_steps)
 }
 
-pub async fn list_localised(
+#[instrument(err(Debug))]
+pub async fn list_localized(
     db: &PgPool,
     workflow_id: &Uuid,
     locale: &str,
@@ -390,6 +392,55 @@ pub async fn list_localised(
     let workflow_steps = sqlx::query_as_with::<_, LocalizedWorkflowStep, _>(&sql, values)
         .fetch_all(db)
         .await?;
+
+    Ok(workflow_steps)
+}
+
+#[derive(Serialize, Deserialize, JsonSchema, Debug, FromRow)]
+pub struct LocalizedWorkflowStepWithProgress {
+    #[sqlx(flatten)]
+    #[serde(flatten)]
+    step: LocalizedWorkflowStep,
+    status: ProgressStatus,
+}
+
+#[instrument(err(Debug))]
+pub async fn list_localized_with_progress(
+    db: &PgPool,
+    workflow_id: &Uuid,
+    locale: &str,
+    user_id: &Uuid,
+) -> Result<Vec<LocalizedWorkflowStepWithProgress>, ComhairleError> {
+    let query = Query::select()
+        .from(WorkflowStepIden::Table)
+        .columns(DEFAULT_COLUMNS.map(|col| (WorkflowStepIden::Table, col)))
+        .column((UserProgressIden::Table, UserProgressIden::Status))
+        .join(
+            JoinType::InnerJoin,
+            UserProgressIden::Table,
+            Expr::col((WorkflowStepIden::Table, WorkflowStepIden::Id))
+                .equals((UserProgressIden::Table, UserProgressIden::WorkflowStepId)),
+        )
+        .join(
+            JoinType::InnerJoin,
+            UserIden::Table,
+            Expr::col((UserIden::Table, UserIden::Id))
+                .equals((UserProgressIden::Table, UserProgressIden::UserId)),
+        )
+        .and_where(
+            Expr::col((WorkflowStepIden::Table, WorkflowStepIden::WorkflowId)).eq(*workflow_id),
+        )
+        .and_where(Expr::col((UserIden::Table, UserIden::Id)).eq(*user_id))
+        .order_by(
+            (WorkflowStepIden::Table, WorkflowStepIden::StepOrder),
+            Order::Asc,
+        )
+        .to_owned();
+
+    let (sql, values) = LocalizedWorkflowStep::query_to_localisation(query, locale)
+        .build_sqlx(PostgresQueryBuilder);
+
+    let workflow_steps = sqlx::query_as_with(&sql, values).fetch_all(db).await?;
 
     Ok(workflow_steps)
 }
@@ -569,11 +620,16 @@ pub async fn get_current_active_step_for_user_localised(
 
 #[cfg(test)]
 mod tests {
-    use serde_json::json;
-
     use crate::{
-        models::model_test_helpers::{get_random_conversation_id, setup_default_app_and_session},
-        routes::{workflow_steps::dto::WorkflowStepDto, workflows::dto::WorkflowDto},
+        models::{
+            self,
+            model_test_helpers::{get_random_conversation_id, setup_default_app_and_session},
+            users::User,
+            workflow,
+        },
+        routes::{
+            auth::SignupRequest, workflow_steps::dto::WorkflowStepDto, workflows::dto::WorkflowDto,
+        },
     };
 
     use super::*;
@@ -599,19 +655,89 @@ mod tests {
 
         assert!(!step.can_revisit, "incorrect can_revisit before update");
 
-        let (_, value, _) = session
-            .put(
-                &app,
-                &format!(
-                    "/conversation/{}/workflow/{}/workflow_step/{}",
-                    conversation_id, workflow.id, step.id
-                ),
-                json!({ "can_revisit": true }).to_string().into(),
-            )
-            .await?;
-        let step: WorkflowStepDto = serde_json::from_value(value)?;
+        let step = update(
+            &pool,
+            &step.id,
+            &workflow.id,
+            &PartialWorkflowStep {
+                can_revisit: Some(true),
+                ..Default::default()
+            },
+        )
+        .await?;
 
         assert!(step.can_revisit, "incorrect can_revisit after update");
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn should_list_localized_steps(pool: PgPool) -> Result<(), Box<dyn Error>> {
+        let (app, mut session) = setup_default_app_and_session(&pool).await?;
+        let conversation_id = get_random_conversation_id(&app, &mut session).await?;
+        let (_, workflow_res, _) = session
+            .create_random_workflow(&app, &conversation_id.to_string())
+            .await?;
+        let workflow: WorkflowDto = serde_json::from_value(workflow_res)?;
+        let _ = session
+            .create_random_workflow_steps(
+                &app,
+                &conversation_id.to_string(),
+                &workflow.id.to_string(),
+                5,
+            )
+            .await?;
+
+        let steps = list_localized(&pool, &workflow.id, "en").await?;
+
+        assert_eq!(steps.len(), 5, "incorrect number of steps");
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn should_list_localized_steps_with_user_progress(
+        pool: PgPool,
+    ) -> Result<(), Box<dyn Error>> {
+        let (app, mut session) = setup_default_app_and_session(&pool).await?;
+        let conversation_id = get_random_conversation_id(&app, &mut session).await?;
+        let (_, workflow_res, _) = session
+            .create_random_workflow(&app, &conversation_id.to_string())
+            .await?;
+        let workflow: WorkflowDto = serde_json::from_value(workflow_res)?;
+        let steps = session
+            .create_random_workflow_steps(
+                &app,
+                &conversation_id.to_string(),
+                &workflow.id.to_string(),
+                5,
+            )
+            .await?;
+        let first_step: WorkflowStepDto = serde_json::from_value(steps.first().unwrap().clone())?;
+        let second_step: WorkflowStepDto = serde_json::from_value(steps.get(1).unwrap().clone())?;
+        let user = models::users::create_user(
+            &SignupRequest {
+                username: "test_user".to_string(),
+                password: "test_pw".to_string(),
+                avatar_url: None,
+                email: "test_email".to_string(),
+            },
+            &pool,
+        )
+        .await?;
+        workflow::register_user(&pool, &workflow.id, &user).await?;
+
+        models::user_progress::update(&pool, &user.id, &first_step.id, ProgressStatus::Done)
+            .await?;
+        models::user_progress::update(&pool, &user.id, &second_step.id, ProgressStatus::InProgress)
+            .await?;
+
+        let steps = list_localized_with_progress(&pool, &workflow.id, "en", &user.id).await?;
+        assert_eq!(steps[0].status, ProgressStatus::Done, "incorrect first step progess status");
+        assert_eq!(steps[1].status, ProgressStatus::InProgress, "incorrect second step progess status");
+        assert_eq!(steps[2].status, ProgressStatus::NotStarted, "incorrect third step progess status");
+        assert_eq!(steps[3].status, ProgressStatus::NotStarted, "incorrect fourth step progess status");
+        assert_eq!(steps[4].status, ProgressStatus::NotStarted, "incorrect fifth step progess status");
 
         Ok(())
     }

--- a/api/src/routes/workflow_steps.rs
+++ b/api/src/routes/workflow_steps.rs
@@ -197,7 +197,7 @@ async fn list_workflows_step(
         ))
     } else {
         let mut workflow_steps =
-            workflow_step::list_localised(&state.db, &workflow_id, &locale).await?;
+            workflow_step::list_localized(&state.db, &workflow_id, &locale).await?;
         if !conversation_owner {
             for workflow_step in workflow_steps.iter_mut() {
                 workflow_step.sanatize();

--- a/api/src/routes/workflow_steps.rs
+++ b/api/src/routes/workflow_steps.rs
@@ -18,7 +18,9 @@ use uuid::Uuid;
 
 use crate::models::workflow_step::{LocalizedWorkflowStep, WorkflowStepWithTranslations};
 use crate::routes::translations::LocaleExtractor;
-use crate::routes::workflow_steps::dto::{LocalizedWorkflowStepDto, WorkflowStepDto};
+use crate::routes::workflow_steps::dto::{
+    LocalizedWorkflowStepDto, LocalizedWorkflowStepWithProgressDto, WorkflowStepDto,
+};
 use crate::routes::workflows::{SourcePathCtx, WorkflowPathCtx, WorkflowRouterContext};
 use crate::tools::ToolConfig;
 use crate::{
@@ -31,10 +33,13 @@ use super::auth::{is_user_admin, RequiredAdminUser, RequiredUser};
 use crate::models::{self, conversation, user_participation};
 use axum::extract::{FromRequestParts, Query};
 
-#[derive(Deserialize, JsonSchema, Debug)]
-pub struct GetWorkflowStepsQuery {
-    #[serde(rename = "withTranslations", default)]
-    pub with_translations: bool,
+#[derive(Deserialize, JsonSchema, Debug, Default)]
+#[serde(rename_all = "camelCase")]
+struct GetWorkflowStepsQuery {
+    #[serde(default)]
+    with_translations: bool,
+    #[serde(default)]
+    with_user_progress: bool,
 }
 
 #[derive(Serialize, JsonSchema)]
@@ -47,8 +52,9 @@ pub enum WorkflowStepResponse {
 #[derive(Serialize, JsonSchema)]
 #[serde(untagged)]
 pub enum WorkflowStepsListResponse {
-    Localized(Vec<LocalizedWorkflowStepDto>),
     WithTranslations(Vec<WorkflowStepWithTranslations>),
+    WithUserProgress(Vec<LocalizedWorkflowStepWithProgressDto>),
+    Localized(Vec<LocalizedWorkflowStepDto>),
 }
 
 pub mod dto;
@@ -195,6 +201,20 @@ async fn list_workflows_step(
                 steps_with_translations,
             )),
         ))
+    } else if query.with_user_progress {
+        let steps_with_progress =
+            workflow_step::list_localized_with_progress(&state.db, &workflow_id, &locale, &user.id)
+                .await?
+                .into_iter()
+                .map(Into::into)
+                .collect();
+
+        Ok((
+            StatusCode::OK,
+            Json(WorkflowStepsListResponse::WithUserProgress(
+                steps_with_progress,
+            )),
+        ))
     } else {
         let mut workflow_steps =
             workflow_step::list_localized(&state.db, &workflow_id, &locale).await?;
@@ -271,7 +291,13 @@ pub fn router(state: Arc<ComhairleState>, ctx: WorkflowRouterContext) -> ApiRout
             get_with(list_workflows_step, |op| {
                 op.id(&format!("List{ctx}WorkflowSteps"))
                     .tag("Workflow step")
-                    .summary("List the workflow steps associated with this workflow. Use withTranslations=true to get translation data.")
+                    .summary("List workflow steps.")
+                    .description(
+                        "
+List the workflow steps associated with this workflow.\n
+Use query param withTranslations=true to get the translation data for each step.\n
+Use query param withUserProgress=true to get the active user's progress status for each step.",
+                    )
                     .security_requirement("JWT")
                     .response::<200, Json<WorkflowStepsListResponse>>()
             }),

--- a/api/src/routes/workflow_steps/dto.rs
+++ b/api/src/routes/workflow_steps/dto.rs
@@ -40,6 +40,7 @@ pub struct WorkflowStepDto {
     pub description: TextContentId,
     pub is_offline: bool,
     pub required: bool,
+    pub can_revisit: bool,
     pub tool_config: Option<ToolConfig>,
     pub preview_tool_config: ToolConfig,
 }
@@ -73,6 +74,7 @@ pub struct LocalizedWorkflowStepDto {
     pub description: String,
     pub is_offline: bool,
     pub required: bool,
+    pub can_revisit: bool,
     pub tool_config: Option<ToolConfig>,
     pub preview_tool_config: ToolConfig,
 }
@@ -88,6 +90,7 @@ impl From<WorkflowStep> for WorkflowStepDto {
             description: w.description,
             is_offline: w.is_offline,
             required: w.required,
+            can_revisit: w.can_revisit,
             tool_config: w.tool_config,
             preview_tool_config: w.preview_tool_config,
         }
@@ -105,6 +108,7 @@ impl From<LocalizedWorkflowStep> for LocalizedWorkflowStepDto {
             description: w.description,
             is_offline: w.is_offline,
             required: w.required,
+            can_revisit: w.can_revisit,
             tool_config: w.tool_config,
             preview_tool_config: w.preview_tool_config,
         }

--- a/api/src/routes/workflow_steps/dto.rs
+++ b/api/src/routes/workflow_steps/dto.rs
@@ -5,7 +5,10 @@ use uuid::Uuid;
 use crate::{
     models::{
         translations::TextContentId,
-        workflow_step::{ActivationRule, LocalizedWorkflowStep, WorkflowStep},
+        user_progress::ProgressStatus,
+        workflow_step::{
+            ActivationRule, LocalizedWorkflowStep, LocalizedWorkflowStepWithProgress, WorkflowStep,
+        },
     },
     schema_helpers::{example_localized_text, example_uuid},
     tools::ToolConfig,
@@ -79,6 +82,43 @@ pub struct LocalizedWorkflowStepDto {
     pub preview_tool_config: ToolConfig,
 }
 
+/// Data transfer object (public API representation) for a LocalizedWorkflowStepWithProgress.
+/// It represents a `workflow_step` row with localized fields and additionally includes
+/// the active user's progress status for the step for convenience on the frontend.
+///
+/// This DTO is returned by workflow step related endpoints and is safe to expose
+/// to clients. It intentionally omits fields such as:
+///
+/// * `created_at`
+/// * `updated_at`
+///
+/// It includes localized `String` values for translatable fields:
+///
+/// * `name`
+/// * `description`
+///
+/// Serialized to JSON using camelCase field names for frontend (JavaScript) compatibility.
+#[derive(Serialize, Deserialize, JsonSchema, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct LocalizedWorkflowStepWithProgressDto {
+    #[schemars(example = "example_uuid")]
+    pub id: Uuid,
+    #[schemars(example = "example_uuid")]
+    pub workflow_id: Uuid,
+    #[schemars(example = "example_localized_text")]
+    pub name: String,
+    pub step_order: i32,
+    pub activation_rule: ActivationRule,
+    #[schemars(example = "example_localized_text")]
+    pub description: String,
+    pub is_offline: bool,
+    pub required: bool,
+    pub can_revisit: bool,
+    pub tool_config: Option<ToolConfig>,
+    pub preview_tool_config: ToolConfig,
+    pub progress_status: ProgressStatus,
+}
+
 impl From<WorkflowStep> for WorkflowStepDto {
     fn from(w: WorkflowStep) -> Self {
         Self {
@@ -111,6 +151,25 @@ impl From<LocalizedWorkflowStep> for LocalizedWorkflowStepDto {
             can_revisit: w.can_revisit,
             tool_config: w.tool_config,
             preview_tool_config: w.preview_tool_config,
+        }
+    }
+}
+
+impl From<LocalizedWorkflowStepWithProgress> for LocalizedWorkflowStepWithProgressDto {
+    fn from(w: LocalizedWorkflowStepWithProgress) -> Self {
+        Self {
+            id: w.step.id,
+            workflow_id: w.step.workflow_id,
+            name: w.step.name,
+            step_order: w.step.step_order,
+            activation_rule: w.step.activation_rule,
+            description: w.step.description,
+            is_offline: w.step.is_offline,
+            required: w.step.required,
+            can_revisit: w.step.can_revisit,
+            tool_config: w.step.tool_config,
+            preview_tool_config: w.step.preview_tool_config,
+            progress_status: w.status,
         }
     }
 }

--- a/api/src/test_helpers.rs
+++ b/api/src/test_helpers.rs
@@ -638,12 +638,12 @@ impl UserSession {
         app: &Router,
         conversation_id: &str,
         workflow_id: &str,
-        _no: i32,
+        no: i32,
     ) -> Result<Vec<Value>, Box<dyn Error>> {
         let url = format!("/conversation/{conversation_id}/workflow/{workflow_id}/workflow_step");
         let mut workflow_steps: Vec<serde_json::Value> = vec![];
         // Create a bunch of steps
-        for no in 0..10 {
+        for no in 0..no {
             let (_, step, _) = self
                 .post(
                     app,

--- a/ui/packages/api-client/src/api.ts
+++ b/ui/packages/api-client/src/api.ts
@@ -645,22 +645,6 @@ export const UserParticipation = z
   })
   .passthrough();
 export type UserParticipation = z.infer<typeof UserParticipation>;
-export const LocalizedWorkflowStepDto = z
-  .object({
-    activationRule: ActivationRule,
-    canRevisit: z.boolean(),
-    description: z.string(),
-    id: z.string().uuid(),
-    isOffline: z.boolean(),
-    name: z.string(),
-    previewToolConfig: ToolConfig,
-    required: z.boolean(),
-    stepOrder: z.number().int(),
-    toolConfig: z.union([ToolConfig, z.null()]).optional(),
-    workflowId: z.string().uuid(),
-  })
-  .passthrough();
-export type LocalizedWorkflowStepDto = z.infer<typeof LocalizedWorkflowStepDto>;
 export const Translation2 = z
   .object({
     textContent: TextContentDto,
@@ -693,9 +677,47 @@ export const WorkflowStepWithTranslations = z
 export type WorkflowStepWithTranslations = z.infer<
   typeof WorkflowStepWithTranslations
 >;
+export const ProgressStatus = z.enum(["not_started", "in_progress", "done"]);
+export type ProgressStatus = z.infer<typeof ProgressStatus>;
+export const LocalizedWorkflowStepWithProgressDto = z
+  .object({
+    activationRule: ActivationRule,
+    canRevisit: z.boolean(),
+    description: z.string(),
+    id: z.string().uuid(),
+    isOffline: z.boolean(),
+    name: z.string(),
+    previewToolConfig: ToolConfig,
+    progressStatus: ProgressStatus,
+    required: z.boolean(),
+    stepOrder: z.number().int(),
+    toolConfig: z.union([ToolConfig, z.null()]).optional(),
+    workflowId: z.string().uuid(),
+  })
+  .passthrough();
+export type LocalizedWorkflowStepWithProgressDto = z.infer<
+  typeof LocalizedWorkflowStepWithProgressDto
+>;
+export const LocalizedWorkflowStepDto = z
+  .object({
+    activationRule: ActivationRule,
+    canRevisit: z.boolean(),
+    description: z.string(),
+    id: z.string().uuid(),
+    isOffline: z.boolean(),
+    name: z.string(),
+    previewToolConfig: ToolConfig,
+    required: z.boolean(),
+    stepOrder: z.number().int(),
+    toolConfig: z.union([ToolConfig, z.null()]).optional(),
+    workflowId: z.string().uuid(),
+  })
+  .passthrough();
+export type LocalizedWorkflowStepDto = z.infer<typeof LocalizedWorkflowStepDto>;
 export const WorkflowStepsListResponse = z.union([
-  z.array(LocalizedWorkflowStepDto),
   z.array(WorkflowStepWithTranslations),
+  z.array(LocalizedWorkflowStepWithProgressDto),
+  z.array(LocalizedWorkflowStepDto),
 ]);
 export type WorkflowStepsListResponse = z.infer<
   typeof WorkflowStepsListResponse
@@ -766,8 +788,6 @@ export const PartialWorkflowStep = z
   .partial()
   .passthrough();
 export type PartialWorkflowStep = z.infer<typeof PartialWorkflowStep>;
-export const ProgressStatus = z.enum(["not_started", "in_progress", "done"]);
-export type ProgressStatus = z.infer<typeof ProgressStatus>;
 export const UserProgressDto = z
   .object({
     id: z.string().uuid(),
@@ -1332,16 +1352,17 @@ export const schemas = {
   WorkflowStepStats,
   WorkflowStats,
   UserParticipation,
-  LocalizedWorkflowStepDto,
   Translation2,
   WorkflowStepTranslations,
   WorkflowStepWithTranslations,
+  ProgressStatus,
+  LocalizedWorkflowStepWithProgressDto,
+  LocalizedWorkflowStepDto,
   WorkflowStepsListResponse,
   ToolSetup,
   CreateWorkflowStep,
   WorkflowStepDto,
   PartialWorkflowStep,
-  ProgressStatus,
   UserProgressDto,
   InviteType,
   LoginBehaviour,
@@ -2026,10 +2047,21 @@ curl -X POST \
     method: "get",
     path: "/conversation/:conversation_id/events/:event_id/workflows/:workflow_id/workflow_steps",
     alias: "ListEventWorkflowSteps",
+    description: `
+List the workflow steps associated with this workflow.
+
+Use query param withTranslations&#x3D;true to get the translation data for each step.
+
+Use query param withUserProgress&#x3D;true to get the active user&#x27;s progress status for each step.`,
     requestFormat: "json",
     parameters: [
       {
         name: "withTranslations",
+        type: "Query",
+        schema: z.boolean().optional().default(false),
+      },
+      {
+        name: "withUserProgress",
         type: "Query",
         schema: z.boolean().optional().default(false),
       },
@@ -2379,10 +2411,21 @@ curl -X POST \
     method: "get",
     path: "/conversation/:conversation_id/workflow/:workflow_id/workflow_step",
     alias: "ListConversationWorkflowSteps",
+    description: `
+List the workflow steps associated with this workflow.
+
+Use query param withTranslations&#x3D;true to get the translation data for each step.
+
+Use query param withUserProgress&#x3D;true to get the active user&#x27;s progress status for each step.`,
     requestFormat: "json",
     parameters: [
       {
         name: "withTranslations",
+        type: "Query",
+        schema: z.boolean().optional().default(false),
+      },
+      {
+        name: "withUserProgress",
         type: "Query",
         schema: z.boolean().optional().default(false),
       },

--- a/ui/packages/api-client/src/api.ts
+++ b/ui/packages/api-client/src/api.ts
@@ -597,6 +597,7 @@ export type ToolConfig = z.infer<typeof ToolConfig>;
 export const WorkflowStep = z
   .object({
     activation_rule: ActivationRule,
+    can_revisit: z.boolean(),
     created_at: z.string().datetime({ offset: true }),
     description: z.string().uuid(),
     id: z.string().uuid(),
@@ -647,6 +648,7 @@ export type UserParticipation = z.infer<typeof UserParticipation>;
 export const LocalizedWorkflowStepDto = z
   .object({
     activationRule: ActivationRule,
+    canRevisit: z.boolean(),
     description: z.string(),
     id: z.string().uuid(),
     isOffline: z.boolean(),
@@ -673,6 +675,7 @@ export type WorkflowStepTranslations = z.infer<typeof WorkflowStepTranslations>;
 export const WorkflowStepWithTranslations = z
   .object({
     activationRule: ActivationRule,
+    canRevisit: z.boolean(),
     createdAt: z.string().datetime({ offset: true }),
     description: z.string(),
     id: z.string().uuid(),
@@ -735,6 +738,7 @@ export type CreateWorkflowStep = z.infer<typeof CreateWorkflowStep>;
 export const WorkflowStepDto = z
   .object({
     activationRule: ActivationRule,
+    canRevisit: z.boolean(),
     description: z.string().uuid(),
     id: z.string().uuid(),
     isOffline: z.boolean(),
@@ -750,6 +754,7 @@ export type WorkflowStepDto = z.infer<typeof WorkflowStepDto>;
 export const PartialWorkflowStep = z
   .object({
     activation_rule: z.union([ActivationRule, z.null()]),
+    can_revisit: z.union([z.boolean(), z.null()]),
     description: z.union([z.string(), z.null()]),
     is_offline: z.union([z.boolean(), z.null()]),
     name: z.union([z.string(), z.null()]),

--- a/ui/packages/comhairle/src/lib/components/CommonStepConfig/CommonStepConfig.svelte
+++ b/ui/packages/comhairle/src/lib/components/CommonStepConfig/CommonStepConfig.svelte
@@ -15,6 +15,7 @@
 	import TranslatableField from '$lib/components/Translation/TranslatableField.svelte';
 	import { useDebounce } from 'runed';
 	import { getTextInLocale } from '$lib/components/Translation/translationUtils';
+	import { camelToSnakeCase } from '$lib/utils/snakeCaseKeys';
 
 	type Props = {
 		conversation_id: string;
@@ -42,7 +43,8 @@
 
 	let name = $state(step?.name ?? '');
 	let description = $state('');
-	let required = $state(step?.required ?? false);
+	let required = $derived(step?.required ?? false);
+	let revisitable = $derived(step?.canRevisit ?? false);
 
 	$effect(() => {
 		name = getTextInLocale(step?.translations?.name, primaryLocale, step?.name ?? '');
@@ -56,14 +58,10 @@
 		);
 	});
 
-	$effect(() => {
-		required = step?.required ?? false;
-	});
-
-	const debouncedUpdateRequired = useDebounce(async (checked: boolean) => {
+	const debouncedUpdateRequired = useDebounce(async (checked: boolean, field: string) => {
 		try {
 			await apiClient.UpdateConversationWorkflowStep(
-				{ required: checked },
+				{ [camelToSnakeCase(field)]: checked },
 				{
 					params: {
 						conversation_id,
@@ -74,13 +72,12 @@
 			);
 			await invalidateAll();
 		} catch (e) {
-			notifications.send({ message: 'Failed to update required status', priority: 'ERROR' });
+			notifications.send({ message: `Failed to update ${field} status`, priority: 'ERROR' });
 		}
 	}, 500);
 
-	function handleRequiredChange(checked: boolean) {
-		required = checked;
-		debouncedUpdateRequired(checked);
+	function handleSwitchChange(checked: boolean, field: string) {
+		debouncedUpdateRequired(checked, field);
 	}
 </script>
 
@@ -111,7 +108,7 @@
 		</Dialog.Trigger>
 
 		<Dialog.Content class="flex max-h-[90vh] min-w-[70vw] flex-col rounded-xl p-0">
-			<Dialog.Header class="flex-shrink-0 border-b p-6 pb-4">
+			<Dialog.Header class="shrink-0 border-b p-6 pb-4">
 				<Dialog.Title class="text-2xl">Edit Step Metadata</Dialog.Title>
 				<Dialog.Description>
 					Configure the name and description shown to participants.
@@ -160,9 +157,22 @@
 			</ScrollArea.Root>
 
 			<!-- Fixed footer with required toggle -->
-			<div class="bg-muted/30 flex-shrink-0 border-t p-6">
+			<div class="bg-muted/30 flex shrink-0 flex-col gap-4 border-t p-6">
 				<div class="flex items-center gap-2">
-					<Switch checked={required} onCheckedChange={handleRequiredChange} />
+					<Switch
+						checked={revisitable}
+						onCheckedChange={(value) => handleSwitchChange(value, 'canRevisit')}
+					/>
+					<Label class="text-base">Revisitable step</Label>
+					<span class="text-muted-foreground ml-2 text-sm"
+						>(Can users revisit this step?)</span
+					>
+				</div>
+				<div class="flex items-center gap-2">
+					<Switch
+						checked={required}
+						onCheckedChange={(value) => handleSwitchChange(value, 'required')}
+					/>
 					<Label class="text-base">Required step</Label>
 					<span class="text-muted-foreground ml-2 text-sm"
 						>(Can users skip this step?)</span


### PR DESCRIPTION
Actions:

- migration to add can_revisit column to workflow_step table
- model update to allow can_revisit to be updated
- admin toggle on workflow step metadata to update can_revisit
- functionality to return workflow steps with active user's progress status for convenience

Motiviation:

- allow steps to be marked as revisitable