### PR TITLE
fix: progress bar not advancing in preview mode

### DIFF
--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/workflow/[workflow_id]/s/[workflow_step_id]/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/workflow/[workflow_id]/s/[workflow_step_id]/+page.svelte
@@ -42,10 +42,12 @@
 	let sortedSteps = $derived([...workflowSteps].sort((a, b) => a.stepOrder - b.stepOrder));
 
 	let actualCurrentStep = $derived(
-		sortedSteps.find((ws) => {
-			const progress = userProgress.find((p) => p.workflowStepId === ws.id);
-			return progress?.status !== 'done';
-		}) ?? null
+		conversation.isLive
+			? (sortedSteps.find((ws) => {
+					const progress = userProgress.find((p) => p.workflowStepId === ws.id);
+					return progress?.status !== 'done';
+				}) ?? null)
+			: workflowStep
 	);
 
 	let isRevisiting = $derived(


### PR DESCRIPTION
**Cause:** 
In preview mode, we skip SetUserProgress API calls. But the step progress bar was deriving the "current step" from userProgress data(which is always empty in preview). So it always showed step 1 as current, no matter which step you were actually on.

**Fix:**
- In preview mode, use the step being viewed as the current step instead of computing it from (empty) progress data. Steps before it now correctly show as completed. 

- Zero change to the live/launched conversation path.