### PR TITLE
Add password update success dialog and fix form validation bug

### DIFF
--- a/ui/packages/comhairle/messages/ar.json
+++ b/ui/packages/comhairle/messages/ar.json
@@ -132,5 +132,8 @@
 	"polis_do_you_want_to_continue": "هل تريد المتابعة؟",
 	"polis_continue_voting": "متابعة التصويت",
 	"polis_voted_everything": "لقد صوّتت على كل شيء. شكراً لك!",
-	"polis_come_back_later": "عد لاحقاً لمعرفة ما إذا تمت إضافة آراء جديدة."
+	"polis_come_back_later": "عد لاحقاً لمعرفة ما إذا تمت إضافة آراء جديدة.",
+	"password_updated_successfully": "تم تحديث كلمة المرور بنجاح",
+	"password_updated_successfully_body": "تم تغيير كلمة المرور الخاصة بك. يمكنك الاستمرار في استخدام التطبيق.",
+	"continue_to_home": "المتابعة إلى الصفحة الرئيسية"
 }

--- a/ui/packages/comhairle/messages/cy.json
+++ b/ui/packages/comhairle/messages/cy.json
@@ -132,5 +132,8 @@
 	"polis_do_you_want_to_continue": "Ydych chi am barhau?",
 	"polis_continue_voting": "Parhau i bleidleisio",
 	"polis_voted_everything": "Rydych wedi pleidleisio ar bopeth. Diolch!",
-	"polis_come_back_later": "Dewch yn ôl yn hwyrach i weld a yw barnau newydd wedi'u hychwanegu."
+	"polis_come_back_later": "Dewch yn ôl yn hwyrach i weld a yw barnau newydd wedi'u hychwanegu.",
+	"password_updated_successfully": "Diweddarwyd y cyfrinair yn llwyddiannus",
+	"password_updated_successfully_body": "Mae eich cyfrinair wedi'i newid. Gallwch barhau i ddefnyddio'r rhaglen.",
+	"continue_to_home": "Parhau i'r hafan"
 }

--- a/ui/packages/comhairle/messages/en.json
+++ b/ui/packages/comhairle/messages/en.json
@@ -137,5 +137,8 @@
 	"polis_do_you_want_to_continue": "Do you want to continue?",
 	"polis_continue_voting": "Continue voting",
 	"polis_voted_everything": "You have voted on everything. Thank you!",
-	"polis_come_back_later": "Come back later to see if new statements have been added."
+	"polis_come_back_later": "Come back later to see if new statements have been added.",
+	"password_updated_successfully": "Password updated successfully",
+	"password_updated_successfully_body": "Your password has been changed. Use your new password to log in next time.",
+	"continue_to_home": "Continue to Home"
 }

--- a/ui/packages/comhairle/messages/es.json
+++ b/ui/packages/comhairle/messages/es.json
@@ -132,5 +132,8 @@
 	"polis_do_you_want_to_continue": "¿Quieres continuar?",
 	"polis_continue_voting": "Seguir votando",
 	"polis_voted_everything": "Has votado sobre todo. ¡Gracias!",
-	"polis_come_back_later": "Vuelve más tarde para ver si se han añadido nuevas opiniones."
+	"polis_come_back_later": "Vuelve más tarde para ver si se han añadido nuevas opiniones.",
+	"password_updated_successfully": "Contraseña actualizada correctamente",
+	"password_updated_successfully_body": "Tu contraseña ha sido cambiada. Puedes continuar usando la aplicación.",
+	"continue_to_home": "Continuar al inicio"
 }

--- a/ui/packages/comhairle/messages/fr.json
+++ b/ui/packages/comhairle/messages/fr.json
@@ -130,5 +130,8 @@
 	"polis_do_you_want_to_continue": "Voulez-vous continuer ?",
 	"polis_continue_voting": "Continuer à voter",
 	"polis_voted_everything": "Vous avez voté sur tout. Merci !",
-	"polis_come_back_later": "Revenez plus tard pour voir si de nouvelles opinions ont été ajoutées."
+	"polis_come_back_later": "Revenez plus tard pour voir si de nouvelles opinions ont été ajoutées.",
+	"password_updated_successfully": "Mot de passe mis à jour avec succès",
+	"password_updated_successfully_body": "Votre mot de passe a été modifié. Vous pouvez continuer à utiliser l'application.",
+	"continue_to_home": "Continuer vers l'accueil"
 }

--- a/ui/packages/comhairle/messages/gd.json
+++ b/ui/packages/comhairle/messages/gd.json
@@ -132,5 +132,8 @@
 	"polis_do_you_want_to_continue": "A bheil thu airson leantainn air adhart?",
 	"polis_continue_voting": "Lean air adhart a' bhòtadh",
 	"polis_voted_everything": "Tha thu air bhòtadh air a h-uile rud. Tapadh leat!",
-	"polis_come_back_later": "Thig air ais nas fhaide air adhart gus faicinn a bheil beachdan ùra air an cur ris."
+	"polis_come_back_later": "Thig air ais nas fhaide air adhart gus faicinn a bheil beachdan ùra air an cur ris.",
+	"password_updated_successfully": "Chaidh am facal-faire ùrachadh gu soirbheachail",
+	"password_updated_successfully_body": "Chaidh am facal-faire agad atharrachadh. Faodaidh tu leantainn air adhart a' cleachdadh na h-aplacaid.",
+	"continue_to_home": "Lean air adhart chun dachaigh"
 }

--- a/ui/packages/comhairle/messages/pt.json
+++ b/ui/packages/comhairle/messages/pt.json
@@ -132,5 +132,8 @@
 	"polis_do_you_want_to_continue": "Deseja continuar?",
 	"polis_continue_voting": "Continuar votando",
 	"polis_voted_everything": "Você votou em tudo. Obrigado!",
-	"polis_come_back_later": "Volte mais tarde para ver se novas opiniões foram adicionadas."
+	"polis_come_back_later": "Volte mais tarde para ver se novas opiniões foram adicionadas.",
+	"password_updated_successfully": "Senha atualizada com sucesso",
+	"password_updated_successfully_body": "Sua senha foi alterada. Você pode continuar usando o aplicativo.",
+	"continue_to_home": "Continuar para a página inicial"
 }

--- a/ui/packages/comhairle/messages/zh.json
+++ b/ui/packages/comhairle/messages/zh.json
@@ -131,5 +131,8 @@
 	"polis_do_you_want_to_continue": "您想继续吗？",
 	"polis_continue_voting": "继续投票",
 	"polis_voted_everything": "您已对所有内容投票。谢谢！",
-	"polis_come_back_later": "稍后再来查看是否有新的意见被添加。"
+	"polis_come_back_later": "稍后再来查看是否有新的意见被添加。",
+	"password_updated_successfully": "密码更新成功",
+	"password_updated_successfully_body": "您的密码已更改。您可以继续使用该应用程序。",
+	"continue_to_home": "继续前往首页"
 }

--- a/ui/packages/comhairle/src/lib/components/UserDetailsForm/UserDetailsForm.svelte
+++ b/ui/packages/comhairle/src/lib/components/UserDetailsForm/UserDetailsForm.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import * as Form from '$lib/components/ui/form';
+	import * as Dialog from '$lib/components/ui/dialog';
 	import { Input } from '$lib/components/ui/input';
 	import { PasswordInput } from '$lib/components/ui/password-input';
 	import { Button } from '$lib/components/ui/button';
@@ -10,6 +11,8 @@
 	import { userDetailsSchema } from './schema';
 	import type { User } from '@crownshy/api-client/api';
 	import { onMount } from 'svelte';
+	import * as m from '$lib/paraglide/messages.js';
+	import { goto } from '$app/navigation';
 
 	let {
 		user
@@ -19,6 +22,7 @@
 
 	let loading = $state(false);
 	let saving = $state(false);
+	let showSuccessDialog = $state(false);
 
 	const form = superForm(
 		{
@@ -29,16 +33,19 @@
 		{
 			validators: zodClient(userDetailsSchema),
 			taintedMessage: false,
-			validationMethod: 'oninput',
-			onSubmit: saveUserDetails
+			validationMethod: 'onsubmit'
 		}
 	);
 
-	const { form: formData, enhance, validateForm, errors } = form;
+	const { form: formData, validateForm, errors } = form;
 
-	async function saveUserDetails() {
-		const result = await validateForm({ update: true });
-		if (!result.valid) return;
+	async function saveUserDetails(e: Event) {
+		e.preventDefault();
+		const result = await validateForm({ update: false });
+		if (!result.valid) {
+			$errors = result.errors;
+			return;
+		}
 
 		try {
 			saving = true;
@@ -65,14 +72,12 @@
 
 			const updatedUser = await apiClient.UpdateUserDetails(updateData);
 
-			// Clear password fields after successful update
+			// Clear validation errors first, then password fields
+			$errors = {};
 			$formData.password = '';
 			$formData.confirmPassword = '';
 
-			notifications.send({
-				message: 'User details updated successfully!',
-				priority: 'SUCCESS'
-			});
+			showSuccessDialog = true;
 		} catch (error: any) {
 			notifications.send({
 				message:
@@ -93,7 +98,7 @@
 		<p class="text-muted-foreground text-sm">Update your username and password here.</p>
 	</div>
 
-	<form method="POST" class="space-y-4" use:enhance>
+	<form method="POST" class="space-y-4" onsubmit={saveUserDetails}>
 		<Form.Field {form} name="username" class="space-y-2">
 			<Form.Control>
 				{#snippet children({ props })}
@@ -146,4 +151,18 @@
 			</Button>
 		</div>
 	</form>
+
+	<Dialog.Root bind:open={showSuccessDialog}>
+		<Dialog.Content class="sm:max-w-[425px]">
+			<Dialog.Header>
+				<Dialog.Title>{m.password_updated_successfully()}</Dialog.Title>
+				<Dialog.Description>
+					{m.password_updated_successfully_body()}
+				</Dialog.Description>
+			</Dialog.Header>
+			<Dialog.Footer>
+				<Button onclick={() => goto('/')}>{m.continue_to_home()}</Button>
+			</Dialog.Footer>
+		</Dialog.Content>
+	</Dialog.Root>
 </div>

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/new/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/new/+page.svelte
@@ -23,7 +23,7 @@
 		resetForm: false
 	});
 
-	const { form: formData, enhance, message: errMessage, validateForm } = form;
+	const { form: formData, enhance, message: errMessage, validateForm, errors } = form;
 
 	let submitting = $state(false);
 	let selectedWorkflowTemplate = $state('empty');
@@ -31,55 +31,60 @@
 	async function handleSubmit(e: Event) {
 		e.preventDefault();
 		submitting = true;
-		const result = await validateForm();
+		const result = await validateForm({ update: false });
 
-		if (result.valid) {
-			try {
-				let fullConversation = {
-					...result.data,
-					description:
-						'This should be a longer description about the conversation. It should introduce people to what is being discussed and outline-solid the actions that might be taken as a result of the conversation',
-					tags: [],
-					image_url: PlaceholderConvo,
-					primary_locale: 'en',
-					supported_languages: ['en'],
-					is_public: false,
-					is_live: false,
-					is_invite_only: false
-				};
+		if (!result.valid) {
+			// Only show errors when validation actually fails
+			$errors = result.errors;
+			submitting = false;
+			return;
+		}
 
-				let conversation = await apiClient.CreateConversation(fullConversation);
+		try {
+			let fullConversation = {
+				...result.data,
+				description:
+					'This should be a longer description about the conversation. It should introduce people to what is being discussed and outline-solid the actions that might be taken as a result of the conversation',
+				tags: [],
+				image_url: PlaceholderConvo,
+				primary_locale: 'en',
+				supported_languages: ['en'],
+				is_public: false,
+				is_live: false,
+				is_invite_only: false
+			};
 
-				let workflow = await apiClient.CreateConversationWorkflow(
-					{
-						name: 'Default Workflow',
-						description: 'The default workflow',
-						is_active: true,
-						is_public: true,
-						auto_login: false
-					},
-					{ params: { conversation_id: conversation.id } }
-				);
+			let conversation = await apiClient.CreateConversation(fullConversation);
 
-				//@ts-ignore
-				let template = workflow_templates[selectedWorkflowTemplate];
-				for (let step of template) {
-					await apiClient.CreateConversationWorkflowStep(step, {
-						params: {
-							conversation_id: conversation.id,
-							workflow_id: workflow.id
-						}
-					});
-				}
+			let workflow = await apiClient.CreateConversationWorkflow(
+				{
+					name: 'Default Workflow',
+					description: 'The default workflow',
+					is_active: true,
+					is_public: true,
+					auto_login: false
+				},
+				{ params: { conversation_id: conversation.id } }
+			);
 
-				notifications.addFlash({ message: 'Conversastion Created' });
-				await invalidateAll();
-
-				goto(manage_conversation_url(conversation.id));
-			} catch (e) {
-				console.warn(e);
-				notifications.send({ message: 'Something went wrong creating the conversation' });
+			//@ts-ignore
+			let template = workflow_templates[selectedWorkflowTemplate];
+			for (let step of template) {
+				await apiClient.CreateConversationWorkflowStep(step, {
+					params: {
+						conversation_id: conversation.id,
+						workflow_id: workflow.id
+					}
+				});
 			}
+
+			notifications.addFlash({ message: 'Conversastion Created' });
+			await invalidateAll();
+
+			goto(manage_conversation_url(conversation.id));
+		} catch (e) {
+			console.warn(e);
+			notifications.send({ message: 'Something went wrong creating the conversation' });
 		}
 	}
 </script>

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/new/+page.ts
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/new/+page.ts
@@ -1,15 +1,10 @@
-import { error } from '@sveltejs/kit';
-import { defaults, superValidate } from 'sveltekit-superforms';
+import { superValidate } from 'sveltekit-superforms';
 import { zod } from 'sveltekit-superforms/adapters';
-import { z } from 'zod';
-import NewConversationSchema  from "./NewConversationSchema"
+import NewConversationSchema from './NewConversationSchema';
 
-export const ssr=false;
+export const ssr = false;
 export const load = async () => {
-
-	const conversationData = defaults(zod(NewConversationSchema));
-
-	const form = await superValidate(conversationData, zod(NewConversationSchema));
+	const form = await superValidate(zod(NewConversationSchema), { errors: false });
 
 	return { form };
 };


### PR DESCRIPTION
Improve UX by not showing error messages on success + add a little confirmation dialog to show success.

**Before** (tiny notification at bottom right + big red message:
<img width="1471" height="1004" alt="image" src="https://github.com/user-attachments/assets/e69669b0-f98e-4cae-9122-db61ca3ef9e1" />

**After:** (dialog that the user has to dismiss or click button continue to home page + no red errors)
We might wanna refine the copy or the design, but it's a step towards better UX
<img width="1344" height="594" alt="image" src="https://github.com/user-attachments/assets/53602d33-58d3-4089-bbf8-1a16a4cabbf3" />


Bonus: When creating a conversation we used to clear out the fields and show red.. removed that too...
Before:
<img width="1453" height="916" alt="image" src="https://github.com/user-attachments/assets/1fcd00b2-6cd3-4342-a8c0-11e0ef87777e" />


After (only show errors when user clicks on "create")
<img width="1464" height="895" alt="image" src="https://github.com/user-attachments/assets/8a03c9dd-4fd3-46c4-8b1b-a4edd14810b0" />

----
### Actions:
+ add translations for password update success dialog across all languages
+ implement success dialog in UserDetailsForm to show after password update
+ clear validation errors before clearing password fields
+ fix form validation to only show errors on actual validation failures
+ prevent automatic error display on mount (form submission)

