### PR TITLE
95 polis client refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1312,6 +1312,7 @@ dependencies = [
  "clap",
  "comhairle-macros",
  "config",
+ "cookie",
  "dashmap",
  "dotenvy",
  "enum_dispatch",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -105,6 +105,7 @@ tracing-test = "0.2.5"
 dotenvy = "0.15.7"
 fake = { version = "4", features = ["chrono", "derive", "uuid"] }
 enum_dispatch = "0.3.13"
+cookie = "0.18.1"
 
 [dev-dependencies]
 fake = { version = "4", features = ["derive"] }

--- a/api/src/tools/polis.rs
+++ b/api/src/tools/polis.rs
@@ -175,7 +175,7 @@ pub async fn launch(
     .await?;
 
     // Login as live config user
-    client
+    let live_auth_cookies = client
         .login(&WikiPollLogin {
             email: live_poll_config.admin_user.clone(),
             password: live_poll_config.admin_password.clone(),
@@ -186,7 +186,7 @@ pub async fn launch(
 
     for comment in seed_statements {
         client
-            .post_seed_comment(&comment.txt, &live_poll_config.poll_id)
+            .post_seed_comment(&comment.txt, &live_poll_config.poll_id, &live_auth_cookies)
             .await?;
     }
 
@@ -199,13 +199,13 @@ async fn polis_setup(
     client: &Arc<dyn WikiPollService>,
 ) -> Result<PolisToolConfig, ComhairleError> {
     let (email, password) = client.create_random_admin_user().await?;
-    client
+    let auth_cookies = client
         .login(&WikiPollLogin {
             email: email.clone(),
             password: password.clone(),
         })
         .await?;
-    let poll_id = client.create_poll().await?;
+    let poll_id = client.create_poll(&auth_cookies).await?;
 
     Ok(PolisToolConfig {
         server_url: polis_url.to_string(),

--- a/api/src/wiki_poll_service.rs
+++ b/api/src/wiki_poll_service.rs
@@ -16,12 +16,13 @@ pub trait WikiPollService: Send + Sync {
 
     async fn login(&self, login: &WikiPollLogin) -> Result<String, WikiPollServiceError>;
 
-    async fn create_poll(&self) -> Result<String, WikiPollServiceError>;
+    async fn create_poll(&self, auth_cookies: &str) -> Result<String, WikiPollServiceError>;
 
     async fn post_seed_comment(
         &self,
         comment: &str,
         poll_id: &str,
+        auth_cookies: &str,
     ) -> Result<String, WikiPollServiceError>;
 
     async fn get_comments(
@@ -65,7 +66,7 @@ impl MockWikiPollService {
             .returning(|_| Box::pin(async move { Ok("wiki_poll_auth_cookie".to_string()) }));
         wiki_poll_service
             .expect_create_poll()
-            .returning(|| Box::pin(async move { Ok("test_poll_id".to_string()) }));
+            .returning(|_| Box::pin(async move { Ok("test_poll_id".to_string()) }));
         wiki_poll_service.expect_get_comments().returning(|_| {
             Box::pin(async move {
                 Ok(vec![WikiPollComment {
@@ -75,56 +76,5 @@ impl MockWikiPollService {
         });
 
         wiki_poll_service
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use sqlx::PgPool;
-
-    use crate::test_helpers::test_state;
-
-    use super::*;
-
-    #[sqlx::test]
-    #[ignore]
-    async fn login(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
-        let state = test_state().db(pool).call()?;
-        let login = WikiPollLogin {
-            email: "xVHTX2@comhairle.com".into(),
-            password: "GNgTWJ".into(),
-        };
-        state.wiki_poll_service.login(&login).await?;
-        Ok(())
-    }
-
-    #[sqlx::test]
-    #[ignore]
-    async fn create_poll(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
-        let state = test_state().db(pool).call()?;
-
-        let login = WikiPollLogin {
-            email: "LtILIo@comhairle.com".into(),
-            password: "sa1d3v".into(),
-        };
-        state.wiki_poll_service.login(&login).await?;
-
-        state.wiki_poll_service.create_poll().await?;
-        Ok(())
-    }
-
-    #[sqlx::test]
-    #[ignore]
-    async fn sign_up_and_create_poll(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
-        let state = test_state().db(pool).call()?;
-        let (email, password) = state.wiki_poll_service.create_random_admin_user().await?;
-
-        let login = WikiPollLogin { email, password };
-
-        state.wiki_poll_service.login(&login).await?;
-
-        let _ = state.wiki_poll_service.create_poll().await?;
-
-        Ok(())
     }
 }

--- a/api/src/wiki_poll_service/polis_service.rs
+++ b/api/src/wiki_poll_service/polis_service.rs
@@ -1,6 +1,10 @@
 use async_trait::async_trait;
+use cookie::Cookie;
 use rand::{distributions::Alphanumeric, Rng};
-use reqwest::{header::SET_COOKIE, Client};
+use reqwest::{
+    header::{COOKIE, SET_COOKIE},
+    Client,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use tracing::{instrument, warn};
@@ -19,7 +23,7 @@ pub struct PolisClient {
 
 impl PolisClient {
     pub fn new(base_url: &str) -> Self {
-        let client = Client::builder().cookie_store(true).build().unwrap();
+        let client = Client::new();
         Self {
             client,
             base_url: base_url.to_string(),
@@ -72,6 +76,27 @@ impl WikiPollService for PolisClient {
         Ok((new_user.email, new_user.password))
     }
 
+    /// Authenticates with the Polis API and returns the session cookies required
+    /// for subsequent admin requests.
+    ///
+    /// The `Set-Cookie` headers returned by the login response are parsed and
+    /// reformatted into a single `Cookie` header value, stripping attributes
+    /// such as `Max-Age`, `Domain`, and `Expires` which are only valid in
+    /// server responses.
+    ///
+    /// # Example
+    ///
+    /// Given login response headers:
+    /// ```text
+    /// set-cookie: token2=abcd; Max-Age=31536000; Domain=...
+    /// set-cookie: uid2=abcd; Max-Age=31536000; Domain=...
+    /// set-cookie: e=1; Max-Age=31536000; Domain=...
+    /// ```
+    ///
+    /// The returned string will be:
+    /// ```text
+    /// token2=abcd; uid2=abcd; e=1
+    /// ```
     async fn login(&self, login: &WikiPollLogin) -> Result<String, WikiPollServiceError> {
         let url = format!("https://{}/api/v3/auth/login", self.base_url);
         let resp = self
@@ -82,26 +107,29 @@ impl WikiPollService for PolisClient {
             .await
             .map_err(|_| PolisError::FailedToLogin)?;
 
-        let cookie = resp
+        let cookies = resp
             .headers()
-            .get(SET_COOKIE)
-            .ok_or(PolisError::FailedToLogin)?
-            .to_str()
-            .map_err(|_| PolisError::FailedToLogin)?
-            .to_owned();
+            .get_all(SET_COOKIE)
+            .iter()
+            .filter_map(|v| v.to_str().ok())
+            .filter_map(|v| Cookie::parse(v).ok())
+            .map(|c| format!("{}={}", c.name(), c.value()))
+            .collect::<Vec<_>>()
+            .join("; ");
 
         let _ = resp
             .json::<LoginResp>()
             .await
             .map_err(|_| PolisError::FailedToLogin)?;
 
-        Ok(cookie)
+        Ok(cookies)
     }
 
-    async fn create_poll(&self) -> Result<String, WikiPollServiceError> {
+    async fn create_poll(&self, auth_cookies: &str) -> Result<String, WikiPollServiceError> {
         let new_poll = self
             .client
             .post(format!("https://{}/api/v3/conversations", self.base_url))
+            .header(COOKIE, auth_cookies)
             .send()
             .await
             .map_err(|e| {
@@ -122,13 +150,19 @@ impl WikiPollService for PolisClient {
         &self,
         comment: &str,
         poll_id: &str,
+        auth_cookies: &str,
     ) -> Result<String, WikiPollServiceError> {
-        let post_json =
-            json!({"txt":comment,"pid":"mypid","conversation_id":poll_id,"is_seed":true});
+        let post_json = json!({
+            "txt": comment,
+            "pid": "mypid",
+            "conversation_id": poll_id,
+            "is_seed": true
+        });
 
         let resp = self
             .client
             .post(format!("https://{}/api/v3/comments", self.base_url))
+            .header(COOKIE, auth_cookies)
             .json(&post_json)
             .send()
             .await
@@ -187,4 +221,101 @@ pub struct LoginResp {
     pub uid: u32,
     pub email: String,
     pub token: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::wiki_poll_service::polis_service::PolisClient;
+
+    use super::*;
+
+    #[tokio::test]
+    #[ignore]
+    async fn login() -> Result<(), Box<dyn std::error::Error>> {
+        let client = PolisClient::new("polis.comhairle.scot");
+        let login = WikiPollLogin {
+            email: "cJIc2EPhHL@comhairle.com".into(),
+            password: "f8QYSX9U9x".into(),
+        };
+        client.login(&login).await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn create_poll() -> Result<(), Box<dyn std::error::Error>> {
+        let client = PolisClient::new("polis.comhairle.scot");
+
+        let login = WikiPollLogin {
+            email: "cJIc2EPhHL@comhairle.com".into(),
+            password: "f8QYSX9U9x".into(),
+        };
+        let cookies = client.login(&login).await?;
+
+        let _result = client.create_poll(&cookies).await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn sign_up_and_create_poll() -> Result<(), Box<dyn std::error::Error>> {
+        let client = PolisClient::new("polis.comhairle.scot");
+        let (email, password) = client.create_random_admin_user().await?;
+        println!("{email} {password}");
+
+        let login = WikiPollLogin { email, password };
+
+        let cookies = client.login(&login).await?;
+
+        let resp = client.create_poll(&cookies).await?;
+        println!("{resp:#?}");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn post_seed_comment() -> Result<(), Box<dyn std::error::Error>> {
+        let client = PolisClient::new("polis.comhairle.scot");
+        let (email, password) = client.create_random_admin_user().await?;
+        println!("{email} {password}");
+
+        let login = WikiPollLogin { email, password };
+
+        let cookies = client.login(&login).await?;
+
+        let poll_id = client.create_poll(&cookies).await?;
+
+        let _response = client
+            .post_seed_comment("test_seed_comment", &poll_id, &cookies)
+            .await?;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    #[ignore]
+    async fn get_comments() -> Result<(), Box<dyn std::error::Error>> {
+        let client = PolisClient::new("polis.comhairle.scot");
+        let (email, password) = client.create_random_admin_user().await?;
+        println!("{email} {password}");
+
+        let login = WikiPollLogin { email, password };
+
+        let cookies = client.login(&login).await?;
+
+        let poll_id = client.create_poll(&cookies).await?;
+
+        client
+            .post_seed_comment("test_seed_comment_1", &poll_id, &cookies)
+            .await?;
+        client
+            .post_seed_comment("test_seed_comment_2", &poll_id, &cookies)
+            .await?;
+
+        let _comments = client.get_comments(&poll_id).await?;
+
+        Ok(())
+    }
 }


### PR DESCRIPTION
Actions:

+ refactor wiki_poll_service and polis client implementation to not rely on reqwest cookie_store but instead return formatted auth cookie and directly pass to subsequent polis admin requests to be added as a Cookie header
+ update polis client tests to make real requests but mark as ignored

Motivation:

+ reliance on reqwest cookie_store automatically picking up auth cookies from login response could create a potential race condition on subsequent requests at scale
+ use real requests in polis client tests to correctly test auth flow