### PR TITLE
Remove top margin of embed container because we already have a lot of spacing in the metadata

### DIFF
--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/workflow/[workflow_id]/s/[workflow_step_id]/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/workflow/[workflow_id]/s/[workflow_step_id]/+page.svelte
@@ -185,7 +185,7 @@
 						>Skip this step</Button
 					>
 				{/if}
-				<div class="my-10 w-full grow">
+				<div class="mb-10 w-full grow">
 					{#if toolConfig.type === Learn.TOOL_NAME}
 						<Learn.UserUI
 							onDone={stepComplete}


### PR DESCRIPTION
this is adding too much negative space imo

<img width="1135" height="753" alt="image" src="https://github.com/user-attachments/assets/bdbd0db3-0c90-4e50-817f-81139b762144" />
