### PR TITLE
Fix navbar causing page to scroll sideways on tablets

### DIFF
--- a/ui/packages/comhairle/src/lib/components/NavBar.svelte
+++ b/ui/packages/comhairle/src/lib/components/NavBar.svelte
@@ -81,7 +81,7 @@
 		</div>
 
 		<!-- Desktop Navigation -->
-		<div class="hidden gap-3 md:flex">
+		<div class="navbar:flex hidden gap-3">
 			{#each links as link (link.href)}
 				<Button
 					href={link.href}
@@ -94,7 +94,7 @@
 			{/each}
 		</div>
 
-		<div class="hidden items-center gap-x-4 md:flex">
+		<div class="navbar:flex hidden items-center gap-x-4">
 			<LocaleSwitcher
 				class="data-[placeholder]:text-primary-foreground rounded-full border border-none bg-transparent py-5 text-base shadow-xs hover:bg-white/10"
 			/>
@@ -112,8 +112,9 @@
 			<ProfileMenu {user} />
 		</div>
 
+		<!-- 900 px -->
 		<!-- Mobile Navigation -->
-		<div class="md:hidden">
+		<div class="navbar:hidden">
 			<Drawer.Root bind:open={isOpen} direction="bottom">
 				<Drawer.Trigger>
 					<Button variant="nav" size="icon">

--- a/ui/packages/comhairle/src/lib/components/NavBar.svelte
+++ b/ui/packages/comhairle/src/lib/components/NavBar.svelte
@@ -112,7 +112,6 @@
 			<ProfileMenu {user} />
 		</div>
 
-		<!-- 900 px -->
 		<!-- Mobile Navigation -->
 		<div class="navbar:hidden">
 			<Drawer.Root bind:open={isOpen} direction="bottom">

--- a/ui/packages/comhairle/src/lib/styles/comhairle-themes.css
+++ b/ui/packages/comhairle/src/lib/styles/comhairle-themes.css
@@ -459,6 +459,7 @@
 }
 
 @theme {
+	--breakpoint-navbar: 900px;
 	--radius: 0.5rem;
 	--radius-xs: calc(0.5rem - 6px);
 	--radius-sm: calc(0.5rem - 4px);


### PR DESCRIPTION
Solution:
add custom breakpoint for navbar (900px)

Follow ups?
Potentially we want a different design for a "reduced" navbar? But might be an overkill at the moment