### PR TITLE
Adjust footer responsive breakpoints and reorder copyright text

### DIFF
--- a/ui/packages/comhairle/src/lib/components/Footer.svelte
+++ b/ui/packages/comhairle/src/lib/components/Footer.svelte
@@ -55,7 +55,7 @@
 				<p class="text-sidebar-foreground/50 order-2 text-base font-normal md:order-1">
 					Copyright {new Date().getFullYear()} &copy; Crown Shy
 				</p>
-				<div class="flex flex-wrap items-center justify-center gap-8">
+				<div class="order-1 flex flex-wrap items-center justify-center gap-8 md:order-2">
 					{#each legalLinks as link (link.href)}
 						<a
 							href={link.href}

--- a/ui/packages/comhairle/src/lib/components/Footer.svelte
+++ b/ui/packages/comhairle/src/lib/components/Footer.svelte
@@ -27,10 +27,12 @@
 		<div class="flex w-full max-w-[1280px] flex-col gap-12 px-6">
 			<!-- Top row: Logo + Nav + Subscribe -->
 			<div
-				class="flex flex-col items-center gap-8 lg:h-[84px] lg:flex-row lg:justify-between"
+				class="flex flex-col items-center gap-8 md:h-[84px] md:flex-row md:justify-between"
 			>
 				<!-- Logo + Nav -->
-				<div class="flex flex-col items-center gap-6 lg:flex-1 lg:flex-row">
+				<div
+					class="flex flex-col items-center gap-6 md:flex-1 md:flex-row md:justify-between"
+				>
 					<ComhairleLogo color="text-sidebar-foreground" />
 					<nav class="flex flex-wrap items-center justify-center gap-8">
 						{#each navLinks as link (link.href)}
@@ -50,7 +52,7 @@
 
 			<!-- Bottom row: Copyright + Legal links -->
 			<div class="flex flex-col items-center gap-4 md:flex-row md:justify-between">
-				<p class="text-sidebar-foreground/50 text-base font-normal">
+				<p class="text-sidebar-foreground/50 order-2 text-base font-normal md:order-1">
 					Copyright {new Date().getFullYear()} &copy; Crown Shy
 				</p>
 				<div class="flex flex-wrap items-center justify-center gap-8">


### PR DESCRIPTION
Motivation:
improve responsive layout behavior at medium screen sizes

Actions:
+ change footer layout breakpoints from lg to md
+ add justify-between to logo/nav container on md screens
+ reorder copyright text to appear second on mobile, first on desktop

<img width="1497" height="410" alt="image" src="https://github.com/user-attachments/assets/b3d714c6-b812-4a63-827e-efcc2cb4121e" />
<img width="884" height="392" alt="image" src="https://github.com/user-attachments/assets/f10b7a53-0261-4c63-96df-ff02cd714456" />
<img width="550" height="400" alt="image" src="https://github.com/user-attachments/assets/c21bf7d0-b715-4baa-91f9-27f49e305f09" />


