### PR TITLE
Step Progress Bar Navigation: Prevent users from proceeding before completing required

### DIFF
--- a/ui/packages/comhairle/src/lib/components/StepHeader.svelte
+++ b/ui/packages/comhairle/src/lib/components/StepHeader.svelte
@@ -10,6 +10,7 @@
 		estimatedMinutes?: number;
 		prevHref?: string;
 		onNext?: () => void;
+		nextDisabled?: boolean;
 	}
 
 	let {
@@ -19,7 +20,8 @@
 		description,
 		estimatedMinutes,
 		prevHref,
-		onNext
+		onNext,
+		nextDisabled = false
 	}: StepHeaderProps = $props();
 </script>
 
@@ -59,7 +61,7 @@
 				</p>
 			</div>
 
-			{#if onNext}
+			{#if onNext && !nextDisabled}
 				<button
 					onclick={onNext}
 					class="text-muted-foreground shrink-0 p-2"

--- a/ui/packages/comhairle/src/lib/tools/elicitation_bot/ElicitationBotEmbed.svelte
+++ b/ui/packages/comhairle/src/lib/tools/elicitation_bot/ElicitationBotEmbed.svelte
@@ -13,9 +13,17 @@
 		userId: string;
 		topic?: string;
 		onDone?: () => void;
+		onCanContinueChange?: (canContinue: boolean) => void;
 	};
 
-	let { conversationId, workflowStepId, userId, topic = 'this topic', onDone }: Props = $props();
+	let {
+		conversationId,
+		workflowStepId,
+		userId,
+		topic = 'this topic',
+		onDone,
+		onCanContinueChange
+	}: Props = $props();
 
 	function cleanBotContent(content: string): string {
 		return content.replace(/<br\s*\/?>/gi, '').trim();
@@ -28,6 +36,12 @@
 	let claims = $state<ExtractedClaim[]>([]);
 	let activeRequestId = $state<string | null>(null);
 	let claimModifications = $state<ClaimModification | null>(null);
+
+	let hasApprovedClaims = $derived(claims.some((c) => c.status === 'approved'));
+
+	$effect(() => {
+		onCanContinueChange?.(hasApprovedClaims);
+	});
 
 	onMount(async () => {
 		try {
@@ -244,6 +258,6 @@
 		onClaimEdit={handleClaimEdit}
 		onClaimRemove={handleClaimRemove}
 		onAddClaim={handleAddClaim}
-		onDone={onDone}
+		{onDone}
 	/>
 {/if}

--- a/ui/packages/comhairle/src/lib/tools/polis/PolisEmbed.svelte
+++ b/ui/packages/comhairle/src/lib/tools/polis/PolisEmbed.svelte
@@ -24,6 +24,7 @@
 		onDone: () => void;
 		requiredVotes?: number;
 		workflowStepId?: string;
+		onCanContinueChange?: (canContinue: boolean) => void;
 	};
 
 	let {
@@ -32,7 +33,8 @@
 		user_id,
 		onDone,
 		requiredVotes = 5,
-		workflowStepId = polis_id
+		workflowStepId = polis_id,
+		onCanContinueChange
 	}: Props = $props();
 
 	const stepId = workflowStepId;
@@ -84,6 +86,10 @@
 
 	const disabled = $derived(voteCooldown || waitingForNext);
 	const canContinue = $derived(hasMetThreshold);
+
+	$effect(() => {
+		onCanContinueChange?.(canContinue);
+	});
 
 	let anchoredRemaining = $state<number | null>(null);
 	let anchoredTotal = $state<number | null>(null);

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/workflow/[workflow_id]/s/[workflow_step_id]/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/workflow/[workflow_id]/s/[workflow_step_id]/+page.svelte
@@ -95,9 +95,23 @@
 	});
 
 	let currentNextAction = $state<(() => void) | undefined>(undefined);
+	let canProceed = $state(false);
+
+	$effect(() => {
+		const type = toolConfig.type;
+		if (type === Learn.TOOL_NAME || type === LivedExperience.TOOL_NAME) {
+			canProceed = true;
+		} else {
+			canProceed = false;
+		}
+	});
 
 	function handleNextAction(fn: () => void) {
 		currentNextAction = fn;
+	}
+
+	function handleCanContinueChange(value: boolean) {
+		canProceed = value;
 	}
 
 	function goToThankYouPage() {
@@ -175,6 +189,7 @@
 				description={workflowStep.description}
 				prevHref={prevStepHref}
 				onNext={currentNextAction ?? stepComplete}
+				nextDisabled={!canProceed}
 			/>
 		</div>
 
@@ -201,6 +216,7 @@
 							polis_url={toolConfig.server_url}
 							workflowStepId={workflowStep.id}
 							onDone={stepComplete}
+							onCanContinueChange={handleCanContinueChange}
 						/>
 					{/if}
 					{#if toolConfig.type === HeyForm.TOOL_NAME}
@@ -226,6 +242,7 @@
 								userId={user.id}
 								topic={toolConfig.topic}
 								onDone={stepComplete}
+								onCanContinueChange={handleCanContinueChange}
 							/>
 						{/key}
 					{/if}


### PR DESCRIPTION
We don't want users to be able to navigate out of steps before the minimum requirement has been satisfied. E.g:
Referring to this navigation
<img width="896" height="287" alt="image" src="https://github.com/user-attachments/assets/a4174d3d-3d96-482a-b701-fe9d2fcb9130" />


| Tool | Chevron | Logic |
|------|---------|-------|
| **Learn** | Always enabled | `canProceed = true` by default |
| **HeyForm** | Always disabled | `canProceed` stays `false`; iframe handles redirect |
| **Polis** | Disabled → enabled after vote threshold | Polis fires `onCanContinueChange(true)` once `hasMetThreshold` |
| **ElicitationBot** | Disabled → enabled after approving ≥1 claim | Fires `onCanContinueChange(true)` when `hasApprovedClaims` |


Actions:
+ add nextDisabled prop to StepHeader component to conditionally disable next button
+ add onCanContinueChange callback to PolisEmbed and ElicitationBotEmbed
+ track canProceed state in workflow step page based on tool type and embed callbacks
+ automatically enable proceed for Learn and LivedExperience (just for now, later we might want to add some recs)
+ disable next button when canProceed is false
