### PR TITLE
Polis embed: show seed statements in a different color

### DIFF
--- a/ui/packages/comhairle/messages/ar.json
+++ b/ui/packages/comhairle/messages/ar.json
@@ -134,7 +134,7 @@
 	"polis_voted_everything": "لقد صوّتت على كل شيء. شكراً لك!",
 	"polis_come_back_later": "عد لاحقاً لمعرفة ما إذا تمت إضافة آراء جديدة.",
 	"polis_error_description": "لم نتمكن من تحميل الآراء الآن. قد تكون هذه مشكلة مؤقتة.",
-	"polis_seed_statement": "هذا رأي تأسيسي",
+	"polis_seed_statement": "مقدم من مالك المحادثة",
 	"password_updated_successfully": "تم تحديث كلمة المرور بنجاح",
 	"password_updated_successfully_body": "تم تغيير كلمة المرور الخاصة بك. يمكنك الاستمرار في استخدام التطبيق.",
 	"continue_to_home": "المتابعة إلى الصفحة الرئيسية"

--- a/ui/packages/comhairle/messages/ar.json
+++ b/ui/packages/comhairle/messages/ar.json
@@ -134,6 +134,7 @@
 	"polis_voted_everything": "لقد صوّتت على كل شيء. شكراً لك!",
 	"polis_come_back_later": "عد لاحقاً لمعرفة ما إذا تمت إضافة آراء جديدة.",
 	"polis_error_description": "لم نتمكن من تحميل الآراء الآن. قد تكون هذه مشكلة مؤقتة.",
+	"polis_seed_statement": "هذا رأي تأسيسي",
 	"password_updated_successfully": "تم تحديث كلمة المرور بنجاح",
 	"password_updated_successfully_body": "تم تغيير كلمة المرور الخاصة بك. يمكنك الاستمرار في استخدام التطبيق.",
 	"continue_to_home": "المتابعة إلى الصفحة الرئيسية"

--- a/ui/packages/comhairle/messages/cy.json
+++ b/ui/packages/comhairle/messages/cy.json
@@ -134,6 +134,7 @@
 	"polis_voted_everything": "Rydych wedi pleidleisio ar bopeth. Diolch!",
 	"polis_come_back_later": "Dewch yn ôl yn hwyrach i weld a yw barnau newydd wedi'u hychwanegu.",
 	"polis_error_description": "Nid oeddem yn gallu llwytho'r datganiadau ar hyn o bryd. Efallai mai mater dros dro yw hwn.",
+	"polis_seed_statement": "Datganiad hadau yw hwn",
 	"password_updated_successfully": "Diweddarwyd y cyfrinair yn llwyddiannus",
 	"password_updated_successfully_body": "Mae eich cyfrinair wedi'i newid. Gallwch barhau i ddefnyddio'r rhaglen.",
 	"continue_to_home": "Parhau i'r hafan"

--- a/ui/packages/comhairle/messages/cy.json
+++ b/ui/packages/comhairle/messages/cy.json
@@ -134,7 +134,7 @@
 	"polis_voted_everything": "Rydych wedi pleidleisio ar bopeth. Diolch!",
 	"polis_come_back_later": "Dewch yn ôl yn hwyrach i weld a yw barnau newydd wedi'u hychwanegu.",
 	"polis_error_description": "Nid oeddem yn gallu llwytho'r datganiadau ar hyn o bryd. Efallai mai mater dros dro yw hwn.",
-	"polis_seed_statement": "Datganiad hadau yw hwn",
+	"polis_seed_statement": "Cyflwynwyd gan berchennog y sgwrs",
 	"password_updated_successfully": "Diweddarwyd y cyfrinair yn llwyddiannus",
 	"password_updated_successfully_body": "Mae eich cyfrinair wedi'i newid. Gallwch barhau i ddefnyddio'r rhaglen.",
 	"continue_to_home": "Parhau i'r hafan"

--- a/ui/packages/comhairle/messages/en.json
+++ b/ui/packages/comhairle/messages/en.json
@@ -139,6 +139,7 @@
 	"polis_voted_everything": "You have voted on everything. Thank you!",
 	"polis_come_back_later": "Come back later to see if new statements have been added.",
 	"polis_error_description": "We couldn't load the statements right now. This may be a temporary issue.",
+	"polis_seed_statement": "This is a seed statement",
 	"password_updated_successfully": "Password updated successfully",
 	"password_updated_successfully_body": "Your password has been changed. Use your new password to log in next time.",
 	"continue_to_home": "Continue to Home"

--- a/ui/packages/comhairle/messages/en.json
+++ b/ui/packages/comhairle/messages/en.json
@@ -139,7 +139,7 @@
 	"polis_voted_everything": "You have voted on everything. Thank you!",
 	"polis_come_back_later": "Come back later to see if new statements have been added.",
 	"polis_error_description": "We couldn't load the statements right now. This may be a temporary issue.",
-	"polis_seed_statement": "This is a seed statement",
+	"polis_seed_statement": "Submitted by conversation owner",
 	"password_updated_successfully": "Password updated successfully",
 	"password_updated_successfully_body": "Your password has been changed. Use your new password to log in next time.",
 	"continue_to_home": "Continue to Home"

--- a/ui/packages/comhairle/messages/es.json
+++ b/ui/packages/comhairle/messages/es.json
@@ -134,7 +134,7 @@
 	"polis_voted_everything": "Has votado sobre todo. ¡Gracias!",
 	"polis_come_back_later": "Vuelve más tarde para ver si se han añadido nuevas opiniones.",
 	"polis_error_description": "No pudimos cargar las opiniones en este momento. Puede ser un problema temporal.",
-	"polis_seed_statement": "Esta es una opinión semilla",
+	"polis_seed_statement": "Enviado por el propietario de la conversación",
 	"password_updated_successfully": "Contraseña actualizada correctamente",
 	"password_updated_successfully_body": "Tu contraseña ha sido cambiada. Puedes continuar usando la aplicación.",
 	"continue_to_home": "Continuar al inicio"

--- a/ui/packages/comhairle/messages/es.json
+++ b/ui/packages/comhairle/messages/es.json
@@ -134,6 +134,7 @@
 	"polis_voted_everything": "Has votado sobre todo. ¡Gracias!",
 	"polis_come_back_later": "Vuelve más tarde para ver si se han añadido nuevas opiniones.",
 	"polis_error_description": "No pudimos cargar las opiniones en este momento. Puede ser un problema temporal.",
+	"polis_seed_statement": "Esta es una opinión semilla",
 	"password_updated_successfully": "Contraseña actualizada correctamente",
 	"password_updated_successfully_body": "Tu contraseña ha sido cambiada. Puedes continuar usando la aplicación.",
 	"continue_to_home": "Continuar al inicio"

--- a/ui/packages/comhairle/messages/fr.json
+++ b/ui/packages/comhairle/messages/fr.json
@@ -132,6 +132,7 @@
 	"polis_voted_everything": "Vous avez voté sur tout. Merci !",
 	"polis_come_back_later": "Revenez plus tard pour voir si de nouvelles opinions ont été ajoutées.",
 	"polis_error_description": "Nous n'avons pas pu charger les opinions pour le moment. Il peut s'agir d'un problème temporaire.",
+	"polis_seed_statement": "Ceci est une opinion de départ",
 	"password_updated_successfully": "Mot de passe mis à jour avec succès",
 	"password_updated_successfully_body": "Votre mot de passe a été modifié. Vous pouvez continuer à utiliser l'application.",
 	"continue_to_home": "Continuer vers l'accueil"

--- a/ui/packages/comhairle/messages/fr.json
+++ b/ui/packages/comhairle/messages/fr.json
@@ -132,7 +132,7 @@
 	"polis_voted_everything": "Vous avez voté sur tout. Merci !",
 	"polis_come_back_later": "Revenez plus tard pour voir si de nouvelles opinions ont été ajoutées.",
 	"polis_error_description": "Nous n'avons pas pu charger les opinions pour le moment. Il peut s'agir d'un problème temporaire.",
-	"polis_seed_statement": "Ceci est une opinion de départ",
+	"polis_seed_statement": "Soumis par le propriétaire de la conversation",
 	"password_updated_successfully": "Mot de passe mis à jour avec succès",
 	"password_updated_successfully_body": "Votre mot de passe a été modifié. Vous pouvez continuer à utiliser l'application.",
 	"continue_to_home": "Continuer vers l'accueil"

--- a/ui/packages/comhairle/messages/gd.json
+++ b/ui/packages/comhairle/messages/gd.json
@@ -134,7 +134,7 @@
 	"polis_voted_everything": "Tha thu air bhòtadh air a h-uile rud. Tapadh leat!",
 	"polis_come_back_later": "Thig air ais nas fhaide air adhart gus faicinn a bheil beachdan ùra air an cur ris.",
 	"polis_error_description": "Cha b' urrainn dhuinn na h-aithrisean a luchdachadh an-dràsta. Dh'fhaodadh gur e duilgheadas sealach a th' ann.",
-	"polis_seed_statement": "Is e aithris sìol a tha seo",
+	"polis_seed_statement": "Air a chur a-steach le neach-stiùiridh a' chòmhraidh",
 	"password_updated_successfully": "Chaidh am facal-faire ùrachadh gu soirbheachail",
 	"password_updated_successfully_body": "Chaidh am facal-faire agad atharrachadh. Faodaidh tu leantainn air adhart a' cleachdadh na h-aplacaid.",
 	"continue_to_home": "Lean air adhart chun dachaigh"

--- a/ui/packages/comhairle/messages/gd.json
+++ b/ui/packages/comhairle/messages/gd.json
@@ -134,6 +134,7 @@
 	"polis_voted_everything": "Tha thu air bhòtadh air a h-uile rud. Tapadh leat!",
 	"polis_come_back_later": "Thig air ais nas fhaide air adhart gus faicinn a bheil beachdan ùra air an cur ris.",
 	"polis_error_description": "Cha b' urrainn dhuinn na h-aithrisean a luchdachadh an-dràsta. Dh'fhaodadh gur e duilgheadas sealach a th' ann.",
+	"polis_seed_statement": "Is e aithris sìol a tha seo",
 	"password_updated_successfully": "Chaidh am facal-faire ùrachadh gu soirbheachail",
 	"password_updated_successfully_body": "Chaidh am facal-faire agad atharrachadh. Faodaidh tu leantainn air adhart a' cleachdadh na h-aplacaid.",
 	"continue_to_home": "Lean air adhart chun dachaigh"

--- a/ui/packages/comhairle/messages/pt.json
+++ b/ui/packages/comhairle/messages/pt.json
@@ -134,7 +134,7 @@
 	"polis_voted_everything": "Você votou em tudo. Obrigado!",
 	"polis_come_back_later": "Volte mais tarde para ver se novas opiniões foram adicionadas.",
 	"polis_error_description": "Não foi possível carregar as opiniões neste momento. Pode ser um problema temporário.",
-	"polis_seed_statement": "Esta é uma opinião semente",
+	"polis_seed_statement": "Enviado pelo proprietário da conversa",
 	"password_updated_successfully": "Senha atualizada com sucesso",
 	"password_updated_successfully_body": "Sua senha foi alterada. Você pode continuar usando o aplicativo.",
 	"continue_to_home": "Continuar para a página inicial"

--- a/ui/packages/comhairle/messages/pt.json
+++ b/ui/packages/comhairle/messages/pt.json
@@ -134,6 +134,7 @@
 	"polis_voted_everything": "Você votou em tudo. Obrigado!",
 	"polis_come_back_later": "Volte mais tarde para ver se novas opiniões foram adicionadas.",
 	"polis_error_description": "Não foi possível carregar as opiniões neste momento. Pode ser um problema temporário.",
+	"polis_seed_statement": "Esta é uma opinião semente",
 	"password_updated_successfully": "Senha atualizada com sucesso",
 	"password_updated_successfully_body": "Sua senha foi alterada. Você pode continuar usando o aplicativo.",
 	"continue_to_home": "Continuar para a página inicial"

--- a/ui/packages/comhairle/messages/zh.json
+++ b/ui/packages/comhairle/messages/zh.json
@@ -133,6 +133,7 @@
 	"polis_voted_everything": "您已对所有内容投票。谢谢！",
 	"polis_come_back_later": "稍后再来查看是否有新的意见被添加。",
 	"polis_error_description": "我们目前无法加载意见。这可能是一个临时问题。",
+	"polis_seed_statement": "这是一个种子意见",
 	"password_updated_successfully": "密码更新成功",
 	"password_updated_successfully_body": "您的密码已更改。您可以继续使用该应用程序。",
 	"continue_to_home": "继续前往首页"

--- a/ui/packages/comhairle/messages/zh.json
+++ b/ui/packages/comhairle/messages/zh.json
@@ -133,7 +133,7 @@
 	"polis_voted_everything": "您已对所有内容投票。谢谢！",
 	"polis_come_back_later": "稍后再来查看是否有新的意见被添加。",
 	"polis_error_description": "我们目前无法加载意见。这可能是一个临时问题。",
-	"polis_seed_statement": "这是一个种子意见",
+	"polis_seed_statement": "由对话所有者提交",
 	"password_updated_successfully": "密码更新成功",
 	"password_updated_successfully_body": "您的密码已更改。您可以继续使用该应用程序。",
 	"continue_to_home": "继续前往首页"

--- a/ui/packages/comhairle/src/lib/styles/comhairle-themes.css
+++ b/ui/packages/comhairle/src/lib/styles/comhairle-themes.css
@@ -83,6 +83,9 @@
 	--auth-gradient-2: #7cb342;
 	--auth-gradient-3: #4a6d23;
 	--auth-gradient-4: #2a3d18;
+
+	--seed-highlight: #6b9b3a;
+	--seed-highlight-bg: #6b9b3a1a;
 }
 
 .dark {
@@ -140,6 +143,9 @@
 	--chat-text: var(--foreground);
 	--chat-text-muted: var(--chat-neutral);
 	--chat-bubble: var(--card);
+
+	--seed-highlight: #7cb342;
+	--seed-highlight-bg: #7cb34226;
 }
 
 /* Scottish Government Theme */
@@ -188,6 +194,9 @@
 	--auth-gradient-2: #06b6d4;
 	--auth-gradient-3: #4b92ec;
 	--auth-gradient-4: #1e3a5f;
+
+	--seed-highlight: #16a34a;
+	--seed-highlight-bg: #16a34a1a;
 
 	--font-sans: Inter, sans-serif;
 	--font-serif: Merriweather, serif;
@@ -263,6 +272,9 @@
 	--auth-gradient-2: #0891b2;
 	--auth-gradient-3: #3b7ed0;
 	--auth-gradient-4: #142d4f;
+
+	--seed-highlight: #4ade80;
+	--seed-highlight-bg: #4ade8026;
 
 	--chat-primary-light: color-mix(in oklch, var(--chat-primary), black 50%);
 	--chat-primary-lighter: color-mix(in oklch, var(--chat-primary), black 75%);
@@ -370,6 +382,9 @@
 	--auth-gradient-2: #9492c7;
 	--auth-gradient-3: #88c6ec;
 	--auth-gradient-4: #444749;
+
+	--seed-highlight: #90c46b;
+	--seed-highlight-bg: #90c46b1a;
 }
 
 [data-theme='waves'].dark {
@@ -456,6 +471,9 @@
 	--auth-gradient-2: #9492c7;
 	--auth-gradient-3: #88c6ec;
 	--auth-gradient-4: #444749;
+
+	--seed-highlight: #90c46b;
+	--seed-highlight-bg: #90c46b1a;
 }
 
 @theme {
@@ -529,6 +547,9 @@
 	--color-chat-text: var(--chat-text);
 	--color-chat-text-muted: var(--chat-text-muted);
 	--color-chat-bubble: var(--chat-bubble);
+
+	--color-seed-highlight: var(--seed-highlight);
+	--color-seed-highlight-bg: var(--seed-highlight-bg);
 
 	--font-sans: var(--font-sans);
 	--font-mono: var(--font-mono);

--- a/ui/packages/comhairle/src/lib/tools/polis/PolisApi.ts
+++ b/ui/packages/comhairle/src/lib/tools/polis/PolisApi.ts
@@ -2,6 +2,7 @@ export type PolisStatement = {
 	txt: string;
 	tid: number;
 	is_meta: boolean;
+	is_seed: boolean;
 	is_seen: boolean;
 	lang: string | undefined;
 	remaining: number;

--- a/ui/packages/comhairle/src/lib/tools/polis/PolisEmbed.svelte
+++ b/ui/packages/comhairle/src/lib/tools/polis/PolisEmbed.svelte
@@ -11,8 +11,10 @@
 		ChevronRight,
 		MessageSquare,
 		AlertTriangle,
-		RefreshCw
+		RefreshCw,
+		Info
 	} from 'lucide-svelte';
+	import * as Tooltip from '$lib/components/ui/tooltip';
 	import PolisApi, { type PolisApiState, type PolisStatement } from './PolisApi';
 	import { getVoteData, incrementVotes } from './polisVoteStore';
 	import * as m from '$lib/paraglide/messages';
@@ -207,12 +209,32 @@
 						</div>
 					</div>
 				{:else if polisCurrentStatement}
-					<p
-						class="text-card-foreground text-xl leading-9 font-normal sm:text-3xl"
+					<div
+						class="flex rounded-lg transition-colors {polisCurrentStatement.is_seed
+							? 'bg-seed-highlight-bg px-4 py-3'
+							: ''}"
 						in:fly={{ y: 20, duration: 500, easing: cubicOut }}
 					>
-						{polisCurrentStatement.txt}
-					</p>
+						{#if polisCurrentStatement.is_seed}
+							<div class="mr-2 flex items-center gap-1.5 self-start">
+								<Tooltip.Provider>
+									<Tooltip.Root>
+										<Tooltip.Trigger
+											class="text-seed-highlight hover:text-seed-highlight/80 inline-flex cursor-help items-center gap-1 text-xs font-medium transition-colors"
+										>
+											<Info class="h-3.5 w-3.5" />
+										</Tooltip.Trigger>
+										<Tooltip.Content>
+											{m.polis_seed_statement()}
+										</Tooltip.Content>
+									</Tooltip.Root>
+								</Tooltip.Provider>
+							</div>
+						{/if}
+						<p class="text-card-foreground text-xl leading-9 font-normal sm:text-3xl">
+							{polisCurrentStatement.txt}
+						</p>
+					</div>
 				{/if}
 			</div>
 

--- a/ui/packages/comhairle/src/lib/tools/polis/PolisEmbed.svelte
+++ b/ui/packages/comhairle/src/lib/tools/polis/PolisEmbed.svelte
@@ -11,10 +11,8 @@
 		ChevronRight,
 		MessageSquare,
 		AlertTriangle,
-		RefreshCw,
-		Info
+		RefreshCw
 	} from 'lucide-svelte';
-	import * as Tooltip from '$lib/components/ui/tooltip';
 	import PolisApi, { type PolisApiState, type PolisStatement } from './PolisApi';
 	import { getVoteData, incrementVotes } from './polisVoteStore';
 	import * as m from '$lib/paraglide/messages';
@@ -209,28 +207,17 @@
 						</div>
 					</div>
 				{:else if polisCurrentStatement}
+					{#if polisCurrentStatement.is_seed}
+						<p class="text-seed-highlight mb-1 text-right text-xs font-medium">
+							{m.polis_seed_statement()}
+						</p>
+					{/if}
 					<div
-						class="flex rounded-lg transition-colors {polisCurrentStatement.is_seed
-							? 'bg-seed-highlight-bg px-4 py-3'
+						class="border-seed-highlight rounded-lg transition-colors {polisCurrentStatement.is_seed
+							? 'bg-seed-highlight-bg border-seed-highlight border px-4 py-3'
 							: ''}"
 						in:fly={{ y: 20, duration: 500, easing: cubicOut }}
 					>
-						{#if polisCurrentStatement.is_seed}
-							<div class="mr-2 flex items-center gap-1.5 self-start">
-								<Tooltip.Provider>
-									<Tooltip.Root>
-										<Tooltip.Trigger
-											class="text-seed-highlight hover:text-seed-highlight/80 inline-flex cursor-help items-center gap-1 text-xs font-medium transition-colors"
-										>
-											<Info class="h-3.5 w-3.5" />
-										</Tooltip.Trigger>
-										<Tooltip.Content>
-											{m.polis_seed_statement()}
-										</Tooltip.Content>
-									</Tooltip.Root>
-								</Tooltip.Provider>
-							</div>
-						{/if}
 						<p class="text-card-foreground text-xl leading-9 font-normal sm:text-3xl">
 							{polisCurrentStatement.txt}
 						</p>


### PR DESCRIPTION
Motivation:
visually distinguish seed statements from user-submitted statements in Polis voting interface

Actions:
+ add `--seed-highlight` and `--seed-highlight-bg` CSS variables to all themes (maybe we can reuse an existing variable?)
+ add `is_seed` field to PolisStatement type
+ render seed statement indicator with info icon and tooltip in PolisEmbed
+ apply seed highlight background styling to seed statements


<img width="782" height="738" alt="image" src="https://github.com/user-attachments/assets/b48ac22d-14ff-41d0-a97a-97238b93e66f" />
<img width="1135" height="686" alt="image" src="https://github.com/user-attachments/assets/34a6191d-15ca-4038-bd1a-f0287a5e5e17" />
