### PR TITLE
Change navbar breakpoint from custom to explicit 900px

### DIFF
--- a/ui/packages/comhairle/src/lib/components/NavBar.svelte
+++ b/ui/packages/comhairle/src/lib/components/NavBar.svelte
@@ -81,7 +81,7 @@
 		</div>
 
 		<!-- Desktop Navigation -->
-		<div class="navbar:flex hidden gap-3">
+		<div class="hidden gap-3 min-[900px]:flex">
 			{#each links as link (link.href)}
 				<Button
 					href={link.href}
@@ -94,7 +94,7 @@
 			{/each}
 		</div>
 
-		<div class="navbar:flex hidden items-center gap-x-4">
+		<div class="hidden items-center gap-x-4 min-[900px]:flex">
 			<LocaleSwitcher
 				class="data-[placeholder]:text-primary-foreground rounded-full border border-none bg-transparent py-5 text-base shadow-xs hover:bg-white/10"
 			/>
@@ -113,7 +113,7 @@
 		</div>
 
 		<!-- Mobile Navigation -->
-		<div class="navbar:hidden">
+		<div class="min-[900px]:hidden">
 			<Drawer.Root bind:open={isOpen} direction="bottom">
 				<Drawer.Trigger>
 					<Button variant="nav" size="icon">


### PR DESCRIPTION
For some reason this was caused by the cuttom breakpoint I added :/
Will investigate further, but for now to fix quickly, I've hardcoded the max container size

<img width="1098" height="845" alt="image" src="https://github.com/user-attachments/assets/2674194c-56a7-4bc7-b70b-80a77d1edc87" />
<img width="748" height="836" alt="image" src="https://github.com/user-attachments/assets/60c10687-e0e8-418d-8e04-d043fc182944" />
