### PR TITLE
213 api client types

### DIFF
--- a/ui/packages/api-client/src/api.ts
+++ b/ui/packages/api-client/src/api.ts
@@ -3,6 +3,7 @@ import {
   Zodios,
   type ZodiosOptions,
   type ZodiosInstance,
+  type ZodiosEndpointDefinitions,
 } from "@zodios/core";
 import { z } from "zod";
 
@@ -1534,7 +1535,7 @@ export const schemas: Record<string, z.ZodType<any>> = {
   ComhairleServices,
 };
 
-const endpoints: ReturnType<typeof makeApi> = makeApi([
+const endpoints = makeApi([
   {
     method: "get",
     path: "/auth/current_user",
@@ -1806,6 +1807,14 @@ Use a raw HTTP request and process the response body incrementally.`,
         schema: z.object({ question: z.string() }).passthrough(),
       },
     ],
+    response: z.void(),
+  },
+  {
+    method: "get",
+    path: "/conversation/:conversation_id/contacts/export",
+    alias: "ExportConversationContacts",
+    description: `Exports a CSV file containing all users who have opted in to receive email updates for this conversation`,
+    requestFormat: "json",
     response: z.void(),
   },
   {
@@ -3369,7 +3378,7 @@ This struct contains optional fields that can be updated on a TextTranslation re
     requestFormat: "json",
     response: WebSocketStats,
   },
-]);
+] as const satisfies ZodiosEndpointDefinitions);
 
 export const api: ZodiosInstance<typeof endpoints> = new Zodios(endpoints);
 

--- a/ui/packages/api-client/src/template.hbs
+++ b/ui/packages/api-client/src/template.hbs
@@ -1,4 +1,4 @@
-import { makeApi, Zodios, type ZodiosOptions, type ZodiosInstance } from "@zodios/core";
+import { makeApi, Zodios, type ZodiosOptions, type ZodiosInstance, type ZodiosEndpointDefinitions } from "@zodios/core";
 import { z } from "zod";
 
 {{#if imports}}
@@ -21,7 +21,7 @@ export const schemas: Record<string, z.ZodType<any>> = {
 };
 {{/ifNotEmptyObj}}
 
-const endpoints: ReturnType<typeof makeApi> = makeApi([
+const endpoints = makeApi([
 {{#each endpoints}}
 	{
 		method: "{{method}}",
@@ -73,7 +73,7 @@ const endpoints: ReturnType<typeof makeApi> = makeApi([
 		{{/if}}
 	},
 {{/each}}
-]);
+] as const satisfies ZodiosEndpointDefinitions);
 
 export const {{options.apiClientName}}: ZodiosInstance<typeof endpoints> = new Zodios({{#if options.baseUrl}}"{{options.baseUrl}}", {{/if}}endpoints);
 


### PR DESCRIPTION
Actions:

+ change explicit type of `endpoints` in api client template to use satisfies

Motivation:

+ allow inferred types to work around serialization limit
+ explicit type breaks typing of client methods resulting in not autocomplete or type checking of method params