### PR TITLE
Websocket refactor

### DIFF
--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -109,13 +109,21 @@ async fn main() -> Result<(), Box<dyn Error>> {
         bulk_storage_service: Arc::new(bulk_storage_service),
     });
 
+    // Register WebSocket message handlers
+    comhairle::websockets::setup::register_handlers(&state);
+
     let app = setup_server(state.clone()).await?;
 
     let server_future = async move {
         // run our app with hyper
         let listener = tokio::net::TcpListener::bind("0.0.0.0:3000").await.unwrap();
         tracing::info!("listening on {}", listener.local_addr().unwrap());
-        axum::serve(listener, app).await.unwrap();
+        axum::serve(
+            listener,
+            app.into_make_service_with_connect_info::<std::net::SocketAddr>(),
+        )
+        .await
+        .unwrap();
     };
 
     let process_document_worker = WorkerBuilder::new("process_document_job")

--- a/api/src/routes/conversations.rs
+++ b/api/src/routes/conversations.rs
@@ -284,6 +284,21 @@ async fn send_notification_to_participants(
     let created_deliveries =
         notification_delivery_model::create_bulk(&state.db, &deliveries).await?;
 
+    // Send WebSocket notifications to connected users
+    let notification_level = notification.notification_type.to_string();
+
+    for delivery in &created_deliveries {
+        let _ = crate::websockets::handlers::notifications::NotificationMessageHandler::send_notification_to_user(
+            &state,
+            &delivery.user_id,
+            &notification.id,
+            &notification.title,
+            &notification.content,
+            &notification_level,
+        )
+        .await;
+    }
+
     Ok((
         StatusCode::CREATED,
         Json(SendEmailNotificationResponse {

--- a/api/src/routes/notifications.rs
+++ b/api/src/routes/notifications.rs
@@ -80,6 +80,16 @@ pub async fn mark_notification_as_read(
     let updated_delivery =
         notification_delivery::mark_as_read(&state.db, &delivery_id, Utc::now()).await?;
 
+    // Send updated unread count via WebSocket
+    let unread_count = notification_delivery::get_unread_count_for_user(&state.db, &user.id).await?;
+    let ws_message = crate::websockets::messages::WebSocketMessage::Custom {
+        event: "notification:unread_count".to_string(),
+        data: serde_json::json!({
+            "count": unread_count,
+        }),
+    };
+    let _ = state.websockets.send_to_user(&user.id, &ws_message).await;
+
     Ok((StatusCode::OK, Json(updated_delivery)))
 }
 
@@ -92,6 +102,16 @@ pub async fn mark_all_notifications_as_read(
     // Mark all unread notifications as read for this user
     let updated_deliveries =
         notification_delivery::mark_all_as_read_for_user(&state.db, &user.id, Utc::now()).await?;
+
+    // Send updated unread count via WebSocket (should be 0)
+    let unread_count = notification_delivery::get_unread_count_for_user(&state.db, &user.id).await?;
+    let ws_message = crate::websockets::messages::WebSocketMessage::Custom {
+        event: "notification:unread_count".to_string(),
+        data: serde_json::json!({
+            "count": unread_count,
+        }),
+    };
+    let _ = state.websockets.send_to_user(&user.id, &ws_message).await;
 
     Ok((
         StatusCode::OK,

--- a/api/src/websockets.rs
+++ b/api/src/websockets.rs
@@ -1,5 +1,7 @@
+pub mod handlers;
 pub mod messages;
 pub mod routes;
+pub mod setup;
 
 use std::sync::{
     atomic::{AtomicUsize, Ordering},
@@ -18,7 +20,7 @@ use futures_util::{SinkExt, StreamExt};
 use messages::{NotificationLevel, WebSocketMessage};
 use std::net::SocketAddr;
 use tokio::sync::mpsc;
-use tracing::{error, info, warn};
+use tracing::{error, info, instrument, warn};
 use uuid::Uuid;
 
 #[cfg(test)]
@@ -29,6 +31,92 @@ use async_trait::async_trait;
 use crate::{
     error::ComhairleError, models::users::User, routes::auth::RequiredUser, ComhairleState,
 };
+
+/// Trait for handling domain-specific WebSocket messages.
+///
+/// Implement this trait to create handlers for specific message domains.
+/// Handlers are registered with the WebSocket service and automatically receive
+/// messages that match their domain.
+///
+/// # Message Routing
+///
+/// Messages are routed to handlers based on their type or event prefix:
+/// - `UserStartedWorkflowStep`, `UserFinishedWorkflowStep`, `UserIdle` → domain "workflow"
+/// - `Custom { event: "notification:xyz", ... }` → domain "notification"
+/// - `Custom { event: "my_domain:xyz", ... }` → domain "my_domain"
+///
+/// # Example
+///
+/// ```rust
+/// use async_trait::async_trait;
+/// use std::sync::Arc;
+///
+/// pub struct ChatHandler;
+///
+/// #[async_trait]
+/// impl WebSocketMessageHandler for ChatHandler {
+///     fn domain(&self) -> &str {
+///         "chat"
+///     }
+///
+///     async fn handle_message(
+///         &self,
+///         message: &WebSocketMessage,
+///         connection: &WebSocketConnection,
+///         state: &Arc<ComhairleState>,
+///     ) -> Result<(), ComhairleError> {
+///         match message {
+///             WebSocketMessage::Custom { event, data } if event.starts_with("chat:") => {
+///                 // Handle chat messages
+///                 let response = WebSocketMessage::Custom {
+///                     event: "chat:response".to_string(),
+///                     data: serde_json::json!({"status": "received"}),
+///                 };
+///                 connection.send_message(&response).await?;
+///             }
+///             _ => {}
+///         }
+///         Ok(())
+///     }
+/// }
+///
+/// // Register the handler
+/// state.websockets.register_handler(Arc::new(ChatHandler));
+/// ```
+#[async_trait]
+pub trait WebSocketMessageHandler: Send + Sync {
+    /// Returns the domain/service identifier this handler manages.
+    ///
+    /// The domain is used to route messages to the appropriate handler.
+    /// Common domains include "notification", "workflow", "chat", etc.
+    fn domain(&self) -> &str;
+
+    /// Handle an incoming WebSocket message.
+    ///
+    /// This method is called when a message matching this handler's domain is received.
+    /// The handler can:
+    /// - Query the database via `state.db`
+    /// - Send responses via `connection.send_message()`
+    /// - Broadcast to other users via `state.websockets`
+    /// - Access user information via `connection.user`
+    ///
+    /// # Parameters
+    ///
+    /// - `message`: The parsed WebSocket message
+    /// - `connection`: Information about the sender's connection
+    /// - `state`: Application state (database, services, etc.)
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(())` if the message was handled successfully
+    /// - `Err(ComhairleError)` if an error occurred
+    async fn handle_message(
+        &self,
+        message: &WebSocketMessage,
+        connection: &WebSocketConnection,
+        state: &Arc<ComhairleState>,
+    ) -> Result<(), ComhairleError>;
+}
 
 static NEXT_CONNECTION_ID: AtomicUsize = AtomicUsize::new(1);
 
@@ -88,12 +176,13 @@ impl WebSocketConnection {
 
 pub type ConnectionMap = Arc<DashMap<ConnectionId, WebSocketConnection>>;
 pub type UserConnectionMap = Arc<DashMap<Uuid, Vec<ConnectionId>>>;
+pub type HandlerRegistry = Arc<DashMap<String, Arc<dyn WebSocketMessageHandler>>>;
 
 #[derive(Clone)]
-
 pub struct ComhairleWebSocketService {
     pub connections: ConnectionMap,
     pub user_connections: UserConnectionMap,
+    pub handlers: HandlerRegistry,
 }
 
 #[async_trait]
@@ -127,6 +216,13 @@ pub trait WebSocketService: Send + Sync {
     fn get_user_connection_count(&self, user_id: &Uuid) -> usize;
 
     fn get_connected_user_ids(&self) -> Vec<Uuid>;
+
+    // Handler registry methods
+    fn register_handler(&self, handler: Arc<dyn WebSocketMessageHandler>);
+
+    fn unregister_handler(&self, domain: &str) -> Option<Arc<dyn WebSocketMessageHandler>>;
+
+    fn get_handler(&self, domain: &str) -> Option<Arc<dyn WebSocketMessageHandler>>;
 }
 
 #[cfg(test)]
@@ -154,6 +250,9 @@ impl MockWebSocketService {
         websockets
             .expect_get_connected_user_ids()
             .returning(Vec::new);
+        websockets.expect_register_handler().returning(|_| ());
+        websockets.expect_unregister_handler().returning(|_| None);
+        websockets.expect_get_handler().returning(|_| None);
         websockets
     }
 }
@@ -163,6 +262,7 @@ impl ComhairleWebSocketService {
         Self {
             connections: Arc::new(DashMap::new()),
             user_connections: Arc::new(DashMap::new()),
+            handlers: Arc::new(DashMap::new()),
         }
     }
 }
@@ -318,8 +418,41 @@ impl WebSocketService for ComhairleWebSocketService {
             .map(|entry| *entry.key())
             .collect()
     }
+
+    /// Register a message handler for a specific domain.
+    ///
+    /// Handlers are routed messages based on their domain. Multiple handlers
+    /// cannot be registered for the same domain - the last one wins.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// let handler = Arc::new(MyHandler::new());
+    /// state.websockets.register_handler(handler);
+    /// ```
+    fn register_handler(&self, handler: Arc<dyn WebSocketMessageHandler>) {
+        let domain = handler.domain().to_string();
+        info!("Registering WebSocket handler for domain: {}", domain);
+        self.handlers.insert(domain, handler);
+    }
+
+    /// Unregister a message handler for a specific domain.
+    ///
+    /// Returns the removed handler if one was registered for this domain.
+    fn unregister_handler(&self, domain: &str) -> Option<Arc<dyn WebSocketMessageHandler>> {
+        info!("Unregistering WebSocket handler for domain: {}", domain);
+        self.handlers.remove(domain).map(|(_, handler)| handler)
+    }
+
+    /// Get a handler for a specific domain.
+    ///
+    /// Returns `None` if no handler is registered for this domain.
+    fn get_handler(&self, domain: &str) -> Option<Arc<dyn WebSocketMessageHandler>> {
+        self.handlers.get(domain).map(|entry| entry.value().clone())
+    }
 }
 
+#[instrument(skip(state, ws))]
 pub async fn websocket_handler(
     ws: WebSocketUpgrade,
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
@@ -327,8 +460,10 @@ pub async fn websocket_handler(
     RequiredUser(user): RequiredUser,
 ) -> Response {
     info!(
-        "WebSocket connection from {}, user: {:?}",
-        addr, user.username
+        "WebSocket connection from {}, user: {} (id: {})",
+        addr,
+        user.username.as_deref().unwrap_or("anonymous"),
+        user.id
     );
 
     ws.on_upgrade(move |socket| handle_websocket(socket, user, addr, state))
@@ -420,38 +555,31 @@ async fn handle_websocket(
 async fn handle_websocket_message(
     msg: Message,
     connection: &WebSocketConnection,
-    _state: &Arc<ComhairleState>,
+    state: &Arc<ComhairleState>,
 ) -> Result<(), ComhairleError> {
     match msg {
         Message::Text(text) => {
             if let Ok(ws_message) = serde_json::from_str::<WebSocketMessage>(&text) {
-                match ws_message {
+                // Handle core protocol messages
+                match &ws_message {
                     WebSocketMessage::Ping { timestamp } => {
-                        let pong = WebSocketMessage::Pong { timestamp };
+                        let pong = WebSocketMessage::Pong {
+                            timestamp: *timestamp,
+                        };
                         connection.send_message(&pong).await?;
+                        return Ok(());
                     }
-                    WebSocketMessage::Custom { event, data } => {
-                        info!(
-                            "Received custom event '{}' from connection {:?}: {}",
-                            event, connection.id, data
-                        );
-                        // Handle custom events here
-                    }
-                    WebSocketMessage::UserStartedWorkflowStep { workflow_step_id } => {
-                        info!("User started workflow step {}", workflow_step_id);
-                    }
-                    WebSocketMessage::UserFinishedWorkflowStep { workflow_step_id } => {
-                        info!("User finished workflow step {}", workflow_step_id);
-                    }
-                    WebSocketMessage::UserIdle { workflow_step_id } => {
-                        info!("User idle on {workflow_step_id}");
-                    }
-                    _ => {
-                        info!(
-                            "Received message from connection {:?}: {:?}",
-                            connection.id, ws_message
-                        );
-                    }
+                    _ => {}
+                }
+
+                // Route message to registered handlers based on message type
+                let handled = route_to_handler(&ws_message, connection, state).await?;
+
+                if !handled {
+                    info!(
+                        "Unhandled message from connection {:?}: {:?}",
+                        connection.id, ws_message
+                    );
                 }
             } else {
                 info!(
@@ -481,4 +609,45 @@ async fn handle_websocket_message(
     }
 
     Ok(())
+}
+
+/// Route a message to the appropriate registered handler based on message type or event prefix.
+///
+/// # Routing Rules
+///
+/// - `UserStartedWorkflowStep`, `UserFinishedWorkflowStep`, `UserIdle` → domain "workflow"
+/// - `Custom { event: "domain:action", ... }` → extracts "domain" from event prefix
+/// - Other message types → not routed (handled by core protocol)
+///
+/// # Returns
+///
+/// - `Ok(true)` if a handler was found and executed
+/// - `Ok(false)` if no handler was found for this message
+/// - `Err(ComhairleError)` if the handler execution failed
+async fn route_to_handler(
+    message: &WebSocketMessage,
+    connection: &WebSocketConnection,
+    state: &Arc<ComhairleState>,
+) -> Result<bool, ComhairleError> {
+    // Determine domain from message type
+    let domain = match message {
+        WebSocketMessage::UserStartedWorkflowStep { .. }
+        | WebSocketMessage::UserFinishedWorkflowStep { .. }
+        | WebSocketMessage::UserIdle { .. } => Some("workflow"),
+        WebSocketMessage::Custom { event, .. } => {
+            // For custom messages, extract domain from event prefix if present
+            // Format: "domain:event_name" or just use the event as-is
+            event.split(':').next()
+        }
+        _ => None,
+    };
+
+    if let Some(domain) = domain {
+        if let Some(handler) = state.websockets.get_handler(domain) {
+            handler.handle_message(message, connection, state).await?;
+            return Ok(true);
+        }
+    }
+
+    Ok(false)
 }

--- a/api/src/websockets.rs
+++ b/api/src/websockets.rs
@@ -47,9 +47,12 @@ use crate::{
 ///
 /// # Example
 ///
-/// ```rust
+/// ```rust,no_run
 /// use async_trait::async_trait;
 /// use std::sync::Arc;
+/// use comhairle::websockets::{WebSocketMessageHandler, WebSocketConnection};
+/// use comhairle::websockets::messages::WebSocketMessage;
+/// use comhairle::{ComhairleState, error::ComhairleError};
 ///
 /// pub struct ChatHandler;
 ///
@@ -81,6 +84,7 @@ use crate::{
 /// }
 ///
 /// // Register the handler
+/// # let state: Arc<ComhairleState> = unimplemented!();
 /// state.websockets.register_handler(Arc::new(ChatHandler));
 /// ```
 #[async_trait]
@@ -426,7 +430,8 @@ impl WebSocketService for ComhairleWebSocketService {
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```rust,ignore
+    /// // Assuming you have a handler implementation:
     /// let handler = Arc::new(MyHandler::new());
     /// state.websockets.register_handler(handler);
     /// ```

--- a/api/src/websockets/handlers/mod.rs
+++ b/api/src/websockets/handlers/mod.rs
@@ -1,0 +1,2 @@
+pub mod notifications;
+pub mod workflow;

--- a/api/src/websockets/handlers/notifications.rs
+++ b/api/src/websockets/handlers/notifications.rs
@@ -33,10 +33,14 @@ use crate::{
 ///
 /// # Example Usage
 ///
-/// ```rust
-/// use crate::websockets::handlers::notifications::NotificationMessageHandler;
-/// use crate::models::notification::{NotificationType, NotificationContextType};
+/// ```rust,no_run
+/// # use std::sync::Arc;
+/// # use uuid::Uuid;
+/// use comhairle::websockets::handlers::notifications::NotificationMessageHandler;
+/// use comhairle::models::notification::{NotificationType, NotificationContextType};
+/// # use comhairle::ComhairleState;
 ///
+/// # async fn example(state: Arc<ComhairleState>, user_id: Uuid, conversation_id: Uuid) -> Result<(), Box<dyn std::error::Error>> {
 /// // Send a notification to a user (creates DB record + sends via WebSocket)
 /// NotificationMessageHandler::create_and_send_notification(
 ///     &state,
@@ -47,6 +51,8 @@ use crate::{
 ///     NotificationContextType::Conversation,
 ///     Some(&conversation_id),
 /// ).await?;
+/// # Ok(())
+/// # }
 /// ```
 ///
 /// # Registration
@@ -91,15 +97,23 @@ impl NotificationMessageHandler {
     ///
     /// # Example
     ///
-    /// ```rust
+    /// ```rust,no_run
+    /// # use std::sync::Arc;
+    /// # use uuid::Uuid;
+    /// # use comhairle::ComhairleState;
+    /// use comhairle::websockets::handlers::notifications::NotificationMessageHandler;
+    ///
+    /// # async fn example(state: Arc<ComhairleState>, user_id: Uuid, notification_id: Uuid) -> Result<(), Box<dyn std::error::Error>> {
     /// NotificationMessageHandler::send_notification_to_user(
     ///     &state,
     ///     &user_id,
-    ///     &notification.id,
+    ///     &notification_id,
     ///     "System Alert",
     ///     "Your session will expire in 5 minutes",
     ///     "warning",
     /// ).await?;
+    /// # Ok(())
+    /// # }
     /// ```
     pub async fn send_notification_to_user(
         state: &Arc<ComhairleState>,
@@ -162,9 +176,14 @@ impl NotificationMessageHandler {
     ///
     /// # Example
     ///
-    /// ```rust
-    /// use crate::models::notification::{NotificationType, NotificationContextType};
+    /// ```rust,no_run
+    /// # use std::sync::Arc;
+    /// # use uuid::Uuid;
+    /// # use comhairle::ComhairleState;
+    /// use comhairle::websockets::handlers::notifications::NotificationMessageHandler;
+    /// use comhairle::models::notification::{NotificationType, NotificationContextType};
     ///
+    /// # async fn example(state: Arc<ComhairleState>, recipient_id: Uuid, conversation_id: Uuid) -> Result<(), Box<dyn std::error::Error>> {
     /// // Notify user of a new conversation message
     /// let notification = NotificationMessageHandler::create_and_send_notification(
     ///     &state,
@@ -175,6 +194,8 @@ impl NotificationMessageHandler {
     ///     NotificationContextType::Conversation,
     ///     Some(&conversation_id),
     /// ).await?;
+    /// # Ok(())
+    /// # }
     /// ```
     pub async fn create_and_send_notification(
         state: &Arc<ComhairleState>,

--- a/api/src/websockets/handlers/notifications.rs
+++ b/api/src/websockets/handlers/notifications.rs
@@ -1,0 +1,362 @@
+use async_trait::async_trait;
+use std::sync::Arc;
+use tracing::info;
+use uuid::Uuid;
+
+use crate::{
+    error::ComhairleError,
+    models::{notification, notification_delivery},
+    websockets::{messages::WebSocketMessage, WebSocketConnection, WebSocketMessageHandler},
+    ComhairleState,
+};
+
+/// Handler for notification-related WebSocket messages.
+///
+/// This handler manages real-time notifications over WebSockets, providing:
+/// - Instant notification delivery to connected users
+/// - Bidirectional communication (client can mark notifications as read)
+/// - Reactive unread count updates
+/// - Graceful fallback to database-only storage for offline users
+///
+/// # Message Events
+///
+/// ## Server → Client
+/// - `notification:new` - New notification created
+/// - `notification:marked_read` - Confirmation that notification was marked as read
+/// - `notification:all_marked_read` - Confirmation that all notifications were marked as read
+/// - `notification:unread_count` - Current unread notification count
+///
+/// ## Client → Server
+/// - `notification:mark_read` - Request to mark a notification as read
+/// - `notification:mark_all_read` - Request to mark all notifications as read
+/// - `notification:get_unread_count` - Request current unread count
+///
+/// # Example Usage
+///
+/// ```rust
+/// use crate::websockets::handlers::notifications::NotificationMessageHandler;
+/// use crate::models::notification::{NotificationType, NotificationContextType};
+///
+/// // Send a notification to a user (creates DB record + sends via WebSocket)
+/// NotificationMessageHandler::create_and_send_notification(
+///     &state,
+///     &user_id,
+///     "New Message",
+///     "You have a new message from Alice",
+///     NotificationType::Info,
+///     NotificationContextType::Conversation,
+///     Some(&conversation_id),
+/// ).await?;
+/// ```
+///
+/// # Registration
+///
+/// This handler is automatically registered in `websockets::setup::register_handlers()`.
+pub struct NotificationMessageHandler;
+
+impl NotificationMessageHandler {
+    /// Create a new notification message handler.
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Send a notification to a specific user via WebSocket (low-level).
+    ///
+    /// This method sends a notification message to a user if they are currently connected.
+    /// It does NOT create the notification in the database or create a delivery record.
+    ///
+    /// # When to Use
+    ///
+    /// Use this method when:
+    /// - You've already created the notification and delivery records
+    /// - You want to manually control the database transaction
+    /// - You're re-sending an existing notification
+    ///
+    /// For most use cases, prefer [`create_and_send_notification`](#method.create_and_send_notification)
+    /// which handles both database storage and WebSocket delivery.
+    ///
+    /// # Parameters
+    ///
+    /// - `state`: Application state
+    /// - `user_id`: ID of the user to send the notification to
+    /// - `notification_id`: ID of the notification (for tracking)
+    /// - `title`: Notification title
+    /// - `message`: Notification message content
+    /// - `level`: Notification level ("info", "warning", "error", "success")
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(())` if the message was sent successfully or user is not connected
+    /// - `Err(ComhairleError)` if there was an error sending the message
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// NotificationMessageHandler::send_notification_to_user(
+    ///     &state,
+    ///     &user_id,
+    ///     &notification.id,
+    ///     "System Alert",
+    ///     "Your session will expire in 5 minutes",
+    ///     "warning",
+    /// ).await?;
+    /// ```
+    pub async fn send_notification_to_user(
+        state: &Arc<ComhairleState>,
+        user_id: &Uuid,
+        notification_id: &Uuid,
+        title: &str,
+        message: &str,
+        level: &str,
+    ) -> Result<(), ComhairleError> {
+        let ws_message = WebSocketMessage::Custom {
+            event: "notification:new".to_string(),
+            data: serde_json::json!({
+                "id": notification_id,
+                "title": title,
+                "message": message,
+                "level": level,
+            }),
+        };
+
+        let sent_count = state.websockets.send_to_user(user_id, &ws_message).await?;
+
+        if sent_count > 0 {
+            info!(
+                "Sent notification {} to user {} via WebSocket",
+                notification_id, user_id
+            );
+        } else {
+            info!(
+                "User {} not connected, notification {} stored in database only",
+                user_id, notification_id
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Create a notification, store it in the database, and send via WebSocket if connected.
+    ///
+    /// This is the recommended way to send notifications as it handles both:
+    /// 1. Persistent storage (database record + delivery record)
+    /// 2. Real-time delivery (WebSocket if user is connected)
+    ///
+    /// If the user is not currently connected, the notification is stored and will be
+    /// available when they next check their notifications via the REST API.
+    ///
+    /// # Parameters
+    ///
+    /// - `state`: Application state
+    /// - `user_id`: ID of the user to send the notification to
+    /// - `title`: Notification title
+    /// - `message`: Notification message content
+    /// - `notification_type`: Type of notification (Info, Warning, Error, Success)
+    /// - `context_type`: Context of the notification (Site, Conversation, etc.)
+    /// - `context_id`: Optional ID linking the notification to a specific entity
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(Notification)` with the created notification
+    /// - `Err(ComhairleError)` if database or WebSocket operations fail
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use crate::models::notification::{NotificationType, NotificationContextType};
+    ///
+    /// // Notify user of a new conversation message
+    /// let notification = NotificationMessageHandler::create_and_send_notification(
+    ///     &state,
+    ///     &recipient_id,
+    ///     "New Message",
+    ///     "Alice sent you a message in 'Project Discussion'",
+    ///     NotificationType::Info,
+    ///     NotificationContextType::Conversation,
+    ///     Some(&conversation_id),
+    /// ).await?;
+    /// ```
+    pub async fn create_and_send_notification(
+        state: &Arc<ComhairleState>,
+        user_id: &Uuid,
+        title: &str,
+        message: &str,
+        notification_type: notification::NotificationType,
+        context_type: notification::NotificationContextType,
+        context_id: Option<&Uuid>,
+    ) -> Result<notification::Notification, ComhairleError> {
+        // Create the notification in the database
+        let new_notification = notification::CreateNotification {
+            title: title.to_string(),
+            content: message.to_string(),
+            notification_type: Some(notification_type),
+            context_type: Some(context_type),
+            context_id: context_id.copied(),
+        };
+
+        let created_notification = notification::create(&state.db, &new_notification).await?;
+
+        // Create delivery record
+        let delivery = notification_delivery::CreateNotificationDelivery {
+            notification_id: created_notification.id,
+            user_id: *user_id,
+            delivery_method: Some(notification_delivery::DeliveryMethod::InApp),
+        };
+
+        let _created_delivery = notification_delivery::create(&state.db, &delivery).await?;
+
+        // Send via WebSocket if user is connected
+        Self::send_notification_to_user(
+            state,
+            user_id,
+            &created_notification.id,
+            title,
+            message,
+            &created_notification.notification_type.to_string(),
+        )
+        .await?;
+
+        Ok(created_notification)
+    }
+}
+
+#[async_trait]
+impl WebSocketMessageHandler for NotificationMessageHandler {
+    fn domain(&self) -> &str {
+        "notification"
+    }
+
+    async fn handle_message(
+        &self,
+        message: &WebSocketMessage,
+        connection: &WebSocketConnection,
+        state: &Arc<ComhairleState>,
+    ) -> Result<(), ComhairleError> {
+        match message {
+            WebSocketMessage::Custom { event, data } if event.starts_with("notification:") => {
+                match event.as_str() {
+                    "notification:mark_read" => {
+                        self.handle_mark_read(data, connection, state).await
+                    }
+                    "notification:mark_all_read" => {
+                        self.handle_mark_all_read(connection, state).await
+                    }
+                    "notification:get_unread_count" => {
+                        self.handle_get_unread_count(connection, state).await
+                    }
+                    _ => {
+                        info!("Unhandled notification event: {}", event);
+                        Ok(())
+                    }
+                }
+            }
+            _ => Ok(()),
+        }
+    }
+}
+
+impl NotificationMessageHandler {
+    async fn handle_mark_read(
+        &self,
+        data: &serde_json::Value,
+        connection: &WebSocketConnection,
+        state: &Arc<ComhairleState>,
+    ) -> Result<(), ComhairleError> {
+        let delivery_id = data["delivery_id"]
+            .as_str()
+            .and_then(|s| Uuid::parse_str(s).ok())
+            .ok_or_else(|| ComhairleError::BadRequest("Missing or invalid delivery_id".into()))?;
+
+        // Verify the delivery belongs to this user
+        let delivery = notification_delivery::get_by_id(&state.db, &delivery_id).await?;
+        if delivery.user_id != connection.user.id {
+            return Err(ComhairleError::UserNotAuthorized);
+        }
+
+        // Mark as read
+        notification_delivery::mark_as_read(&state.db, &delivery_id, chrono::Utc::now()).await?;
+
+        // Send confirmation back
+        let response = WebSocketMessage::Custom {
+            event: "notification:marked_read".to_string(),
+            data: serde_json::json!({
+                "delivery_id": delivery_id,
+                "success": true,
+            }),
+        };
+        connection.send_message(&response).await?;
+
+        // Also send updated unread count
+        self.send_unread_count(connection, state).await?;
+
+        info!(
+            "User {} marked notification {} as read",
+            connection.user.id, delivery_id
+        );
+
+        Ok(())
+    }
+
+    async fn handle_mark_all_read(
+        &self,
+        connection: &WebSocketConnection,
+        state: &Arc<ComhairleState>,
+    ) -> Result<(), ComhairleError> {
+        // Mark all as read for this user
+        let updated_deliveries = notification_delivery::mark_all_as_read_for_user(
+            &state.db,
+            &connection.user.id,
+            chrono::Utc::now(),
+        )
+        .await?;
+
+        // Send confirmation back
+        let response = WebSocketMessage::Custom {
+            event: "notification:all_marked_read".to_string(),
+            data: serde_json::json!({
+                "count": updated_deliveries.len(),
+                "success": true,
+            }),
+        };
+        connection.send_message(&response).await?;
+
+        // Also send updated unread count (should be 0)
+        self.send_unread_count(connection, state).await?;
+
+        info!(
+            "User {} marked {} notifications as read",
+            connection.user.id,
+            updated_deliveries.len()
+        );
+
+        Ok(())
+    }
+
+    async fn handle_get_unread_count(
+        &self,
+        connection: &WebSocketConnection,
+        state: &Arc<ComhairleState>,
+    ) -> Result<(), ComhairleError> {
+        self.send_unread_count(connection, state).await
+    }
+
+    async fn send_unread_count(
+        &self,
+        connection: &WebSocketConnection,
+        state: &Arc<ComhairleState>,
+    ) -> Result<(), ComhairleError> {
+        let count =
+            notification_delivery::get_unread_count_for_user(&state.db, &connection.user.id)
+                .await?;
+
+        let response = WebSocketMessage::Custom {
+            event: "notification:unread_count".to_string(),
+            data: serde_json::json!({
+                "count": count,
+            }),
+        };
+        connection.send_message(&response).await?;
+
+        Ok(())
+    }
+}

--- a/api/src/websockets/handlers/workflow.rs
+++ b/api/src/websockets/handlers/workflow.rs
@@ -33,12 +33,20 @@ use crate::{
 ///
 /// # Example
 ///
-/// ```rust
+/// ```rust,no_run
+/// # use std::sync::Arc;
+/// # use uuid::Uuid;
+/// # use comhairle::ComhairleState;
+/// use comhairle::websockets::messages::WebSocketMessage;
+///
+/// # async fn example(state: Arc<ComhairleState>, step_id: Uuid) -> Result<(), Box<dyn std::error::Error>> {
 /// // In your workflow step component/handler:
 /// let message = WebSocketMessage::UserStartedWorkflowStep {
 ///     workflow_step_id: step_id,
 /// };
 /// state.websockets.broadcast_to_all(&message).await?;
+/// # Ok(())
+/// # }
 /// ```
 ///
 /// # Database Integration

--- a/api/src/websockets/handlers/workflow.rs
+++ b/api/src/websockets/handlers/workflow.rs
@@ -1,0 +1,212 @@
+use async_trait::async_trait;
+use std::sync::Arc;
+use tracing::info;
+
+use crate::{
+    error::ComhairleError,
+    websockets::{messages::WebSocketMessage, WebSocketConnection, WebSocketMessageHandler},
+    ComhairleState,
+};
+
+/// Handler for workflow-related WebSocket messages.
+///
+/// This handler tracks user progress through workflows in real-time, including:
+/// - When users start/finish workflow steps
+/// - When users become idle on a step
+/// - Custom workflow events via the `workflow:` event prefix
+///
+/// # Message Types
+///
+/// ## Handled Message Types
+/// - `UserStartedWorkflowStep { workflow_step_id }` - User began a workflow step
+/// - `UserFinishedWorkflowStep { workflow_step_id }` - User completed a workflow step
+/// - `UserIdle { workflow_step_id }` - User is idle/inactive on a workflow step
+/// - `Custom { event: "workflow:*", ... }` - Custom workflow events
+///
+/// # Use Cases
+///
+/// - Track user progress through onboarding flows
+/// - Monitor activity on collaborative workflows
+/// - Trigger actions when users complete steps
+/// - Send reminders when users are idle
+/// - Broadcast step completion to other participants
+///
+/// # Example
+///
+/// ```rust
+/// // In your workflow step component/handler:
+/// let message = WebSocketMessage::UserStartedWorkflowStep {
+///     workflow_step_id: step_id,
+/// };
+/// state.websockets.broadcast_to_all(&message).await?;
+/// ```
+///
+/// # Database Integration
+///
+/// This handler can be extended to:
+/// - Record step start/completion times in `user_workflow_progress` table
+/// - Update workflow completion status
+/// - Track analytics/metrics
+/// - Trigger workflow-specific business logic
+///
+/// # Registration
+///
+/// This handler is automatically registered in `websockets::setup::register_handlers()`.
+pub struct WorkflowMessageHandler;
+
+impl WorkflowMessageHandler {
+    /// Create a new workflow message handler.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl WebSocketMessageHandler for WorkflowMessageHandler {
+    fn domain(&self) -> &str {
+        "workflow"
+    }
+
+    async fn handle_message(
+        &self,
+        message: &WebSocketMessage,
+        connection: &WebSocketConnection,
+        state: &Arc<ComhairleState>,
+    ) -> Result<(), ComhairleError> {
+        match message {
+            WebSocketMessage::UserStartedWorkflowStep { workflow_step_id } => {
+                self.handle_workflow_step_started(workflow_step_id, connection, state)
+                    .await
+            }
+            WebSocketMessage::UserFinishedWorkflowStep { workflow_step_id } => {
+                self.handle_workflow_step_finished(workflow_step_id, connection, state)
+                    .await
+            }
+            WebSocketMessage::UserIdle { workflow_step_id } => {
+                self.handle_user_idle(workflow_step_id, connection, state)
+                    .await
+            }
+            WebSocketMessage::Custom { event, data } if event.starts_with("workflow:") => {
+                self.handle_custom_workflow_event(event, data, connection, state)
+                    .await
+            }
+            _ => Ok(()),
+        }
+    }
+}
+
+impl WorkflowMessageHandler {
+    async fn handle_workflow_step_started(
+        &self,
+        workflow_step_id: &uuid::Uuid,
+        connection: &WebSocketConnection,
+        state: &Arc<ComhairleState>,
+    ) -> Result<(), ComhairleError> {
+        info!(
+            "User {} started workflow step {}",
+            connection.user.id, workflow_step_id
+        );
+
+        // Example: Query database to get workflow step details
+        // let _step = sqlx::query!(
+        //     "SELECT id, workflow_id FROM workflow_steps WHERE id = $1",
+        //     workflow_step_id
+        // )
+        // .fetch_optional(&state.db)
+        // .await?;
+
+        // Example: Update user progress in database
+        // sqlx::query!(
+        //     "INSERT INTO user_workflow_progress (user_id, workflow_step_id, started_at)
+        //      VALUES ($1, $2, NOW())
+        //      ON CONFLICT (user_id, workflow_step_id) DO UPDATE SET started_at = NOW()",
+        //     connection.user.id,
+        //     workflow_step_id
+        // )
+        // .execute(&state.db)
+        // .await?;
+
+        // Example: Broadcast to other users in the same workflow
+        // let broadcast_msg = WebSocketMessage::Custom {
+        //     event: "workflow:user_joined_step".to_string(),
+        //     data: serde_json::json!({
+        //         "user_id": connection.user.id,
+        //         "username": connection.user.username,
+        //         "workflow_step_id": workflow_step_id,
+        //     }),
+        // };
+        // state.websockets.broadcast_to_all(&broadcast_msg).await?;
+
+        Ok(())
+    }
+
+    async fn handle_workflow_step_finished(
+        &self,
+        workflow_step_id: &uuid::Uuid,
+        connection: &WebSocketConnection,
+        _state: &Arc<ComhairleState>,
+    ) -> Result<(), ComhairleError> {
+        info!(
+            "User {} finished workflow step {}",
+            connection.user.id, workflow_step_id
+        );
+
+        // Example: Update completion status in database
+        // sqlx::query!(
+        //     "UPDATE user_workflow_progress
+        //      SET completed_at = NOW()
+        //      WHERE user_id = $1 AND workflow_step_id = $2",
+        //     connection.user.id,
+        //     workflow_step_id
+        // )
+        // .execute(&state.db)
+        // .await?;
+
+        // Example: Send acknowledgment back to user
+        let response = WebSocketMessage::Custom {
+            event: "workflow:step_completed".to_string(),
+            data: serde_json::json!({
+                "workflow_step_id": workflow_step_id,
+                "completed": true,
+            }),
+        };
+        connection.send_message(&response).await?;
+
+        Ok(())
+    }
+
+    async fn handle_user_idle(
+        &self,
+        workflow_step_id: &uuid::Uuid,
+        connection: &WebSocketConnection,
+        _state: &Arc<ComhairleState>,
+    ) -> Result<(), ComhairleError> {
+        info!(
+            "User {} is idle on workflow step {}",
+            connection.user.id, workflow_step_id
+        );
+
+        // Example: Track idle time for analytics
+        // You could store this in database or send to analytics service
+
+        Ok(())
+    }
+
+    async fn handle_custom_workflow_event(
+        &self,
+        event: &str,
+        data: &serde_json::Value,
+        connection: &WebSocketConnection,
+        _state: &Arc<ComhairleState>,
+    ) -> Result<(), ComhairleError> {
+        info!(
+            "Custom workflow event '{}' from user {}: {:?}",
+            event, connection.user.id, data
+        );
+
+        // Handle custom workflow events here
+        // Example: "workflow:save_progress", "workflow:request_help", etc.
+
+        Ok(())
+    }
+}

--- a/api/src/websockets/setup.rs
+++ b/api/src/websockets/setup.rs
@@ -1,0 +1,65 @@
+use std::sync::Arc;
+use tracing::info;
+
+use crate::ComhairleState;
+
+use super::handlers::{notifications::NotificationMessageHandler, workflow::WorkflowMessageHandler};
+
+/// Register all WebSocket message handlers with the application state.
+///
+/// This function initializes and registers all domain-specific WebSocket message handlers.
+/// It should be called once during application startup, after the state is created but
+/// before the server starts accepting connections.
+///
+/// # Registered Handlers
+///
+/// - **NotificationMessageHandler**: Handles real-time notifications
+///   - Domain: `"notification"`
+///   - Events: `notification:new`, `notification:mark_read`, etc.
+///
+/// - **WorkflowMessageHandler**: Handles workflow progress tracking
+///   - Domain: `"workflow"`
+///   - Events: `user_started_workflow_step`, `user_finished_workflow_step`, etc.
+///
+/// # Adding New Handlers
+///
+/// To add a new handler:
+///
+/// 1. Create a handler struct implementing `WebSocketMessageHandler`
+/// 2. Import it in this module
+/// 3. Register it in this function:
+///
+/// ```rust
+/// let my_handler = Arc::new(MyHandler::new());
+/// state.websockets.register_handler(my_handler);
+/// ```
+///
+/// # Example
+///
+/// ```rust
+/// // In main.rs, after creating the application state:
+/// let state = Arc::new(ComhairleState { /* ... */ });
+///
+/// // Register all WebSocket handlers
+/// comhairle::websockets::setup::register_handlers(&state);
+///
+/// // Now start the server
+/// let app = setup_server(state.clone()).await?;
+/// ```
+///
+/// # Parameters
+///
+/// - `state`: The application state containing the WebSocket service
+pub fn register_handlers(state: &Arc<ComhairleState>) {
+    info!("Registering WebSocket message handlers");
+
+    // Register notification handler
+    let notification_handler = Arc::new(NotificationMessageHandler::new());
+    state.websockets.register_handler(notification_handler);
+
+    // Register workflow handler
+    let workflow_handler = Arc::new(WorkflowMessageHandler::new());
+    state.websockets.register_handler(workflow_handler);
+
+    info!("WebSocket message handlers registered successfully");
+}

--- a/api/src/websockets/setup.rs
+++ b/api/src/websockets/setup.rs
@@ -29,14 +29,15 @@ use super::handlers::{notifications::NotificationMessageHandler, workflow::Workf
 /// 2. Import it in this module
 /// 3. Register it in this function:
 ///
-/// ```rust
+/// ```rust,ignore
+/// // Example (assuming you have a MyHandler implementation):
 /// let my_handler = Arc::new(MyHandler::new());
 /// state.websockets.register_handler(my_handler);
 /// ```
 ///
 /// # Example
 ///
-/// ```rust
+/// ```rust,ignore
 /// // In main.rs, after creating the application state:
 /// let state = Arc::new(ComhairleState { /* ... */ });
 ///

--- a/ui/packages/comhairle/src/lib/api/websockets.svelte.ts
+++ b/ui/packages/comhairle/src/lib/api/websockets.svelte.ts
@@ -1,37 +1,200 @@
 import { browser } from '$app/environment';
+
+// Core types for base WebSocket service
+export type NotificationLevel = 'info' | 'warning' | 'error' | 'success';
+
+// Core message types - only protocol-level messages
+export type CoreWebSocketMessage =
+	| { type: 'ping'; payload: { timestamp: number } }
+	| { type: 'pong'; payload: { timestamp: number } }
+	| {
+			type: 'notification';
+			payload: { title: string; message: string; level: NotificationLevel };
+	  }
+	| { type: 'user_joined'; payload: { user_id: string; username?: string } }
+	| { type: 'user_left'; payload: { user_id: string; username?: string } }
+	| { type: 'broadcast'; payload: { message: string; from_user?: string } }
+	| { type: 'error'; payload: { code: string; message: string } }
+	| { type: 'custom'; payload: { event: string; data: any } };
+
+// Allow extension by other services
+export type WebSocketMessage = CoreWebSocketMessage | { type: string; payload: any };
+
+type MessageHandler = (message: WebSocketMessage) => void;
+type TypedMessageHandler<T extends WebSocketMessage['type']> = (
+	payload: Extract<WebSocketMessage, { type: T }>['payload']
+) => void;
+
 export class WSConnection {
-	socket: (WebSocket | null) = null;
-	connectionStatus: "pending" | "ready" = $state("pending")
+	socket: WebSocket | null = null;
+	connectionStatus = $state<'disconnected' | 'connecting' | 'connected' | 'error'>(
+		'disconnected'
+	);
+	reconnectAttempts = $state(0);
+
+	private messageHandlers: Set<MessageHandler> = new Set();
+	private typedHandlers: Map<string, Set<TypedMessageHandler<any>>> = new Map();
+	private reconnectTimeout: ReturnType<typeof setTimeout> | null = null;
+	private maxReconnectAttempts = 5;
+	private reconnectDelay = 1000;
+	private pingInterval: ReturnType<typeof setInterval> | null = null;
 
 	connect() {
-		if (browser) {
-
-			const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-			const host = window.location.host;
-			const token = document.cookie.split('; ').find(row => row.startsWith('access_token='))?.split('=')[1];
-			const url = `${protocol}//${host}/api/ws${token ? `?token=${token}` : ''}`;
-			this.socket = new WebSocket(url);
-			this.socket.onopen = () => {
-				console.log("Connection opened")
-			}
-			this.socket.onerror = (e) => {
-				console.log("WS error ", e)
-			}
+		if (!browser) {
+			console.log('WebSocket only available in browser');
+			return;
 		}
-		else {
-			console.log("on server side")
+
+		if (this.socket?.readyState === WebSocket.OPEN || this.connectionStatus === 'connecting') {
+			return;
+		}
+
+		this.connectionStatus = 'connecting';
+
+		// In development, bypass Vite proxy and connect directly to backend
+		// Cookies are sent automatically with WebSocket connections
+		const isDev = import.meta.env.DEV;
+		const url = isDev
+			? 'ws://localhost:3000/ws'
+			: `${window.location.protocol === 'https:' ? 'wss:' : 'ws:'}//${window.location.host}/api/ws`;
+
+		console.log(
+			'Connecting to WebSocket:',
+			url,
+			isDev ? '(dev - direct)' : '(prod - via proxy)'
+		);
+
+		this.socket = new WebSocket(url);
+
+		this.socket.onopen = () => {
+			console.log('WebSocket connection opened');
+			this.connectionStatus = 'connected';
+			this.reconnectAttempts = 0;
+			this.startPingInterval();
+		};
+
+		this.socket.onmessage = (event) => {
+			try {
+				const message: WebSocketMessage = JSON.parse(event.data);
+				console.log('WebSocket message received:', message);
+
+				// Call general message handlers
+				this.messageHandlers.forEach((handler) => handler(message));
+
+				// Call typed handlers for this message type
+				const handlers = this.typedHandlers.get(message.type);
+				if (handlers) {
+					handlers.forEach((handler) => handler(message.payload));
+				}
+
+				// Handle pong responses for ping
+				if (message.type === 'pong') {
+					console.log('Received pong');
+				}
+			} catch (error) {
+				console.error('Error parsing WebSocket message:', error);
+			}
+		};
+
+		this.socket.onerror = (error) => {
+			console.error('WebSocket error:', error);
+			this.connectionStatus = 'error';
+		};
+
+		this.socket.onclose = (event) => {
+			console.log('WebSocket connection closed:', event.code, event.reason);
+			this.connectionStatus = 'disconnected';
+			this.stopPingInterval();
+			this.attemptReconnect();
+		};
+	}
+
+	disconnect() {
+		if (this.reconnectTimeout) {
+			clearTimeout(this.reconnectTimeout);
+			this.reconnectTimeout = null;
+		}
+		this.stopPingInterval();
+		if (this.socket) {
+			this.socket.close();
+			this.socket = null;
+		}
+		this.connectionStatus = 'disconnected';
+	}
+
+	private attemptReconnect() {
+		if (this.reconnectAttempts >= this.maxReconnectAttempts) {
+			console.error('Max reconnection attempts reached');
+			return;
+		}
+
+		this.reconnectAttempts++;
+		const delay = this.reconnectDelay * Math.pow(2, this.reconnectAttempts - 1);
+		console.log(`Attempting to reconnect in ${delay}ms (attempt ${this.reconnectAttempts})`);
+
+		this.reconnectTimeout = setTimeout(() => {
+			this.connect();
+		}, delay);
+	}
+
+	private startPingInterval() {
+		this.pingInterval = setInterval(() => {
+			this.send({ type: 'ping', payload: { timestamp: Date.now() } });
+		}, 30000); // Ping every 30 seconds
+	}
+
+	private stopPingInterval() {
+		if (this.pingInterval) {
+			clearInterval(this.pingInterval);
+			this.pingInterval = null;
 		}
 	}
 
-	send(data: any) {
+	send(message: WebSocketMessage) {
 		if (this.socket && this.socket.readyState === WebSocket.OPEN) {
-			this.socket.send(JSON.stringify(data));
+			this.socket.send(JSON.stringify(message));
 		} else {
-			console.warn('WebSocket not open; retrying soon...');
-			setTimeout(() => this.send(data), 500);
+			console.warn('WebSocket not open; cannot send message');
 		}
+	}
+
+	// Subscribe to all messages
+	onMessage(handler: MessageHandler): () => void {
+		this.messageHandlers.add(handler);
+		return () => this.messageHandlers.delete(handler);
+	}
+
+	// Subscribe to specific message types
+	on<T extends WebSocketMessage['type']>(type: T, handler: TypedMessageHandler<T>): () => void {
+		if (!this.typedHandlers.has(type)) {
+			this.typedHandlers.set(type, new Set());
+		}
+		this.typedHandlers.get(type)!.add(handler);
+
+		return () => {
+			const handlers = this.typedHandlers.get(type);
+			if (handlers) {
+				handlers.delete(handler);
+				if (handlers.size === 0) {
+					this.typedHandlers.delete(type);
+				}
+			}
+		};
+	}
+
+	// Convenience methods for common message types
+	sendCustom(event: string, data: any) {
+		this.send({
+			type: 'custom',
+			payload: { event, data }
+		});
 	}
 }
 
-export const ws = new WSConnection()
-ws.connect()
+// Singleton instance - available everywhere
+export const ws = new WSConnection();
+
+// Auto-connect in browser
+if (browser) {
+	ws.connect();
+}

--- a/ui/packages/comhairle/src/lib/components/NavBar.svelte
+++ b/ui/packages/comhairle/src/lib/components/NavBar.svelte
@@ -23,8 +23,8 @@
 	import { afterNavigate } from '$app/navigation';
 	import { page } from '$app/state';
 	import { userInitials } from '$lib/utils';
-	import { apiClient } from '@crownshy/api-client/client';
 	import { Separator } from '$lib/components/ui/separator';
+	import { notificationService } from '$lib/services/notifications.svelte';
 
 	let links = [
 		{
@@ -51,22 +51,15 @@
 		isOpen = false;
 	});
 
+	$effect(() => {
+		console.log('Unread count ', notificationService.unreadCount);
+	});
+
 	let { user, isAdmin } = $props();
 
 	let user_initials = $derived(userInitials(user?.username ?? ''));
-	let notifications: number | undefined = $state();
 
 	const linkIcons = [Home, Info, MessageSquare, Shield];
-
-	$effect(() => {
-		if (!user) return;
-		async function checkNotifications() {
-			notifications = (await apiClient.GetUnreadNotificationsCount()).count;
-		}
-		checkNotifications();
-		const interval = setInterval(checkNotifications, 5000);
-		return () => clearInterval(interval);
-	});
 </script>
 
 <nav
@@ -177,8 +170,10 @@
 								>
 									<Bell class="text-muted-foreground size-5" />
 									{m.notifications()}
-									{#if notifications && notifications > 0}
-										<Badge class="ml-auto">{notifications}</Badge>
+									{#if notificationService.unreadCount > 0}
+										<Badge class="ml-auto"
+											>{notificationService.unreadCount}</Badge
+										>
 									{/if}
 								</Button>
 								<Button

--- a/ui/packages/comhairle/src/lib/notifications.svelte.ts
+++ b/ui/packages/comhairle/src/lib/notifications.svelte.ts
@@ -1,13 +1,15 @@
 import { toast, type ExternalToast } from 'svelte-sonner';
 export { Toaster as NotificationsToaster } from '$lib/components/ui/sonner';
-import { z } from 'zod'
+import { z } from 'zod';
 
 // Use to serialize and deserialize the flash notifications
-let FlashString: z.ZodType<Array<SendOpts>> = z.array(z.object({
-	message: z.string(),
-	priority: z.optional(z.enum(['INFO', 'WARNING', 'ERROR', 'SUCCESS'])),
-	duration: z.optional(z.number())
-}))
+let FlashString: z.ZodType<Array<SendOpts>> = z.array(
+	z.object({
+		message: z.string(),
+		priority: z.optional(z.enum(['INFO', 'WARNING', 'ERROR', 'SUCCESS'])),
+		duration: z.optional(z.number())
+	})
+);
 
 class NotificationsManager {
 	private static DEFAULT_DURATION = 60000;
@@ -20,14 +22,10 @@ class NotificationsManager {
 	}
 
 	public async listen() {
-		// TODO: implement
-
-		// // hacky testing snippet:
-		// let id = 0;
-		// setInterval(() => {
-		// 	++id;
-		// 	this.sendServerNotification(`server message ${id}`, `${id}`);
-		// }, 6000);
+		// Notification listening is now handled by the NotificationService
+		// which uses WebSockets. This method is kept for backwards compatibility
+		// but doesn't need to do anything as the service auto-initializes.
+		console.log('Notification listening is handled by WebSocket service');
 	}
 
 	private sendServerNotification(opts: SendServerNotificationOpts) {
@@ -44,21 +42,19 @@ class NotificationsManager {
 
 	// TODO this doesn't work when running on server side
 	// need to perhaps move to cookies to store and
-	// retrive the flash notifications 
+	// retrive the flash notifications
 	public addFlash(opts: SendOpts) {
 		try {
 			let flashString = sessionStorage.getItem('comhairle_flash_notfifications');
 			let flash;
 			if (flashString) {
-				flash = FlashString.parse(JSON.parse(flashString))
+				flash = FlashString.parse(JSON.parse(flashString));
+			} else {
+				flash = [opts];
 			}
-			else {
-				flash = [opts]
-			}
-			sessionStorage.setItem("comhairle_flash_notfifications", JSON.stringify(flash))
-		}
-		catch (e) {
-			console.warn("Failed to set session storage, probably on server")
+			sessionStorage.setItem('comhairle_flash_notfifications', JSON.stringify(flash));
+		} catch (e) {
+			console.warn('Failed to set session storage, probably on server');
 		}
 	}
 
@@ -66,12 +62,12 @@ class NotificationsManager {
 		if (!sessionStorage) return;
 		let flashString = sessionStorage.getItem('comhairle_flash_notfifications');
 		if (flashString) {
-			let flash = FlashString.parse(JSON.parse(flashString))
+			let flash = FlashString.parse(JSON.parse(flashString));
 			for (let message of flash) {
-				this.send(message)
+				this.send(message);
 			}
 		}
-		sessionStorage.removeItem("comhairle_flash_notfifications")
+		sessionStorage.removeItem('comhairle_flash_notfifications');
 	}
 
 	private async ack(id: string) {

--- a/ui/packages/comhairle/src/lib/profile/ProfileMenu.svelte
+++ b/ui/packages/comhairle/src/lib/profile/ProfileMenu.svelte
@@ -9,6 +9,8 @@
 	import { Badge } from '$lib/components/ui/badge';
 	import { Bell, LogOut, Settings, ChevronsUpDown } from 'lucide-svelte';
 	import ModeToggle from '$lib/components/ModeToggle.svelte';
+
+	import { notificationService } from '$lib/services/notifications.svelte';
 	import type { UserDto } from '@crownshy/api-client/api';
 
 	type Props = {
@@ -18,13 +20,6 @@
 	const { user, triggerVariant = 'outline' }: Props = $props();
 
 	let user_initials = $derived(userInitials(user?.username ?? ''));
-	let notifications: number | undefined = $state();
-
-	$effect(() => {
-		async function checkNotifications() {
-			notifications = (await apiClient.GetUnreadNotificationsCount()).count;
-		}
-	});
 </script>
 
 {#if user}
@@ -45,8 +40,8 @@
 					{user.username}
 				{/if}
 			</p>
-			{#if notifications && notifications > 0}
-				<Badge>{notifications}</Badge>
+			{#if notificationService.unreadCount > 0}
+				<Badge>{notificationService.unreadCount}</Badge>
 			{/if}
 			<ChevronsUpDown class="text-card-foreground size-3" />
 		</DropdownMenu.Trigger>
@@ -68,8 +63,8 @@
 				<DropdownMenu.Item>
 					<Button href="/notifications" type="submit" variant="ghost"
 						><Bell />Notifications
-						{#if notifications && notifications > 0}
-							<Badge>{notifications}</Badge>
+						{#if notificationService.unreadCount > 0}
+							<Badge>{notificationService.unreadCount}</Badge>
 						{/if}
 					</Button>
 				</DropdownMenu.Item>

--- a/ui/packages/comhairle/src/lib/services/notifications.svelte.ts
+++ b/ui/packages/comhairle/src/lib/services/notifications.svelte.ts
@@ -1,0 +1,112 @@
+import { ws } from '$lib/api/websockets.svelte';
+import { notifications, type NotificationPriorities } from '$lib/notifications.svelte';
+
+interface ServerNotification {
+	id: string;
+	title: string;
+	message: string;
+	level: string;
+}
+
+export class NotificationService {
+	private _unreadCount = $state(0);
+	private isListening = false;
+
+	constructor() {
+		this.setupListeners();
+		// Request initial count after a short delay to ensure WebSocket is connected
+		setTimeout(() => this.requestUnreadCount(), 100);
+	}
+
+	get unreadCount() {
+		return this._unreadCount;
+	}
+
+	private setupListeners() {
+		if (this.isListening) return;
+		this.isListening = true;
+
+		// Listen for new notifications from server
+		ws.on('custom', (payload) => {
+			if (payload.event === 'notification:new') {
+				this.handleNewNotification(payload.data as ServerNotification);
+			} else if (payload.event === 'notification:unread_count') {
+				this._unreadCount = payload.data.count;
+			} else if (payload.event === 'notification:marked_read') {
+				console.log('Notification marked as read:', payload.data);
+			} else if (payload.event === 'notification:all_marked_read') {
+				console.log('All notifications marked as read:', payload.data);
+				this._unreadCount = 0;
+			}
+		});
+
+		// Listen for regular notification messages
+		ws.on('notification', (payload) => {
+			this.handleNotificationMessage(payload);
+		});
+
+		// Request initial unread count when connected
+		this.requestUnreadCount();
+	}
+
+	private handleNewNotification(notification: ServerNotification) {
+		// Map backend level to frontend priority
+		const priority = this.mapLevelToPriority(notification.level);
+
+		// Show toast notification
+		notifications.send({
+			message: `${notification.title}: ${notification.message}`,
+			priority
+		});
+
+		// Increment unread count
+		this._unreadCount++;
+	}
+
+	private handleNotificationMessage(payload: { title: string; message: string; level: string }) {
+		const priority = this.mapLevelToPriority(payload.level);
+		notifications.send({
+			message: `${payload.title}: ${payload.message}`,
+			priority
+		});
+	}
+
+	private mapLevelToPriority(level: string): NotificationPriorities {
+		switch (level.toLowerCase()) {
+			case 'success':
+				return 'SUCCESS';
+			case 'warning':
+				return 'WARNING';
+			case 'error':
+				return 'ERROR';
+			case 'info':
+			default:
+				return 'INFO';
+		}
+	}
+
+	// Mark a notification as read
+	markAsRead(deliveryId: string) {
+		ws.sendCustom('notification:mark_read', {
+			delivery_id: deliveryId
+		});
+	}
+
+	// Mark all notifications as read
+	markAllAsRead() {
+		ws.sendCustom('notification:mark_all_read', {});
+	}
+
+	// Request current unread count
+	requestUnreadCount() {
+		if (ws.connectionStatus === 'connected') {
+			ws.sendCustom('notification:get_unread_count', {});
+		} else {
+			// Retry when connected
+			setTimeout(() => this.requestUnreadCount(), 1000);
+		}
+	}
+}
+
+// Singleton instance
+export const notificationService = new NotificationService();

--- a/ui/packages/comhairle/src/lib/services/workflow.svelte.ts
+++ b/ui/packages/comhairle/src/lib/services/workflow.svelte.ts
@@ -1,0 +1,194 @@
+import { ws, type WebSocketMessage } from '$lib/api/websockets.svelte';
+
+// Workflow-specific message types
+export type WorkflowWebSocketMessage =
+	| { type: 'user_started_workflow_step'; payload: { workflow_step_id: string } }
+	| { type: 'user_finished_workflow_step'; payload: { workflow_step_id: string } }
+	| { type: 'user_idle'; payload: { workflow_step_id: string } };
+
+export interface WorkflowStepActivity {
+	workflow_step_id: string;
+	user_id: string;
+	username?: string;
+	status: 'started' | 'finished' | 'idle';
+	timestamp: number;
+}
+
+export class WorkflowService {
+	// Track active users per workflow step
+	private activeUsers = $state<Map<string, Set<string>>>(new Map());
+
+	// Track the current user's active workflow step
+	currentWorkflowStep = $state<string | null>(null);
+
+	// History of workflow activities
+	activityLog = $state<WorkflowStepActivity[]>([]);
+
+	constructor() {
+		this.setupListeners();
+	}
+
+	private setupListeners() {
+		// Listen for all messages and filter for workflow-specific ones
+		ws.onMessage((message: WebSocketMessage) => {
+			switch (message.type) {
+				case 'user_started_workflow_step':
+					this.handleUserStarted(
+						(
+							message as WorkflowWebSocketMessage & {
+								type: 'user_started_workflow_step';
+							}
+						).payload.workflow_step_id
+					);
+					break;
+
+				case 'user_finished_workflow_step':
+					this.handleUserFinished(
+						(
+							message as WorkflowWebSocketMessage & {
+								type: 'user_finished_workflow_step';
+							}
+						).payload.workflow_step_id
+					);
+					break;
+
+				case 'user_idle':
+					this.handleUserIdle(
+						(message as WorkflowWebSocketMessage & { type: 'user_idle' }).payload
+							.workflow_step_id
+					);
+					break;
+
+				case 'user_joined':
+					console.log(
+						`User ${message.payload.username || message.payload.user_id} joined`
+					);
+					break;
+
+				case 'user_left':
+					console.log(`User ${message.payload.username || message.payload.user_id} left`);
+					break;
+
+				case 'broadcast':
+					console.log('Workflow broadcast:', message.payload.message);
+					break;
+			}
+		});
+	}
+
+	// Start a workflow step
+	startWorkflowStep(workflowStepId: string) {
+		// End previous step if exists
+		if (this.currentWorkflowStep) {
+			this.finishWorkflowStep(this.currentWorkflowStep);
+		}
+
+		this.currentWorkflowStep = workflowStepId;
+
+		// Send workflow-specific message through base WebSocket
+		ws.send({
+			type: 'user_started_workflow_step',
+			payload: { workflow_step_id: workflowStepId }
+		} as WorkflowWebSocketMessage);
+
+		console.log(`Started workflow step: ${workflowStepId}`);
+	}
+
+	// Finish a workflow step
+	finishWorkflowStep(workflowStepId: string) {
+		if (this.currentWorkflowStep === workflowStepId) {
+			this.currentWorkflowStep = null;
+		}
+
+		ws.send({
+			type: 'user_finished_workflow_step',
+			payload: { workflow_step_id: workflowStepId }
+		} as WorkflowWebSocketMessage);
+
+		console.log(`Finished workflow step: ${workflowStepId}`);
+	}
+
+	// Mark user as idle on a workflow step
+	markIdle(workflowStepId: string) {
+		ws.send({
+			type: 'user_idle',
+			payload: { workflow_step_id: workflowStepId }
+		} as WorkflowWebSocketMessage);
+
+		console.log(`Marked idle on workflow step: ${workflowStepId}`);
+	}
+
+	// Get active users for a specific workflow step
+	getActiveUsers(workflowStepId: string): number {
+		return this.activeUsers.get(workflowStepId)?.size || 0;
+	}
+
+	// Check if currently on a workflow step
+	isOnWorkflowStep(workflowStepId: string): boolean {
+		return this.currentWorkflowStep === workflowStepId;
+	}
+
+	// Private handlers for tracking state
+	private handleUserStarted(workflowStepId: string) {
+		if (!this.activeUsers.has(workflowStepId)) {
+			this.activeUsers.set(workflowStepId, new Set());
+		}
+		// You could track specific user IDs here if the backend sends them
+
+		this.activityLog.push({
+			workflow_step_id: workflowStepId,
+			user_id: 'unknown', // Backend would need to send this
+			status: 'started',
+			timestamp: Date.now()
+		});
+
+		// Keep only last 100 activities
+		if (this.activityLog.length > 100) {
+			this.activityLog = this.activityLog.slice(-100);
+		}
+	}
+
+	private handleUserFinished(workflowStepId: string) {
+		const users = this.activeUsers.get(workflowStepId);
+		if (users) {
+			// Would remove specific user if we tracked them
+			if (users.size === 0) {
+				this.activeUsers.delete(workflowStepId);
+			}
+		}
+
+		this.activityLog.push({
+			workflow_step_id: workflowStepId,
+			user_id: 'unknown',
+			status: 'finished',
+			timestamp: Date.now()
+		});
+
+		if (this.activityLog.length > 100) {
+			this.activityLog = this.activityLog.slice(-100);
+		}
+	}
+
+	private handleUserIdle(workflowStepId: string) {
+		this.activityLog.push({
+			workflow_step_id: workflowStepId,
+			user_id: 'unknown',
+			status: 'idle',
+			timestamp: Date.now()
+		});
+
+		if (this.activityLog.length > 100) {
+			this.activityLog = this.activityLog.slice(-100);
+		}
+	}
+
+	// Cleanup method to call when service is no longer needed
+	destroy() {
+		if (this.currentWorkflowStep) {
+			this.finishWorkflowStep(this.currentWorkflowStep);
+		}
+	}
+}
+
+// Singleton instance
+export const workflowService = new WorkflowService();

--- a/ui/packages/comhairle/vite.config.ts
+++ b/ui/packages/comhairle/vite.config.ts
@@ -1,8 +1,7 @@
-
 import { paraglideVitePlugin } from '@inlang/paraglide-js';
 import devtoolsJson from 'vite-plugin-devtools-json';
 
-import { defineConfig } from 'vite'
+import { defineConfig } from 'vite';
 import { sveltekit } from '@sveltejs/kit/vite';
 import tailwindcss from '@tailwindcss/vite';
 
@@ -14,26 +13,34 @@ export default defineConfig({
 		paraglideVitePlugin({
 			project: './project.inlang',
 			outdir: './src/lib/paraglide'
-		}),
+		})
 	],
 	server: {
 		proxy: {
 			'/api/ws': {
-				target: 'ws://localhost:3000',
+				target: 'http://localhost:3000',
+				ws: true,
 				changeOrigin: true,
 				rewrite: (path) => path.replace(/^\/api/, ''),
-				ws: true,
 				configure: (proxy, _options) => {
 					proxy.on('error', (err, _req, _res) => {
 						console.log('Websocket proxy error', err);
 					});
 					proxy.on('proxyReq', (proxyReq, req, _res) => {
-						console.log('Websocket Sending Request to the Target:', req.method, req.url);
+						console.log(
+							'Websocket Sending Request to the Target:',
+							req.method,
+							req.url
+						);
 					});
 					proxy.on('proxyRes', (proxyRes, req, _res) => {
-						console.log('Websocket Received Response from the Target:', proxyRes.statusCode, req.url);
+						console.log(
+							'Websocket Received Response from the Target:',
+							proxyRes.statusCode,
+							req.url
+						);
 					});
-				},
+				}
 			},
 			'/api': {
 				target: 'http://localhost:3000',
@@ -47,15 +54,13 @@ export default defineConfig({
 						console.log('Sending Request to the Target:', req.method, req.url);
 					});
 					proxy.on('proxyRes', (proxyRes, req, _res) => {
-						console.log('Received Response from the Target:', proxyRes.statusCode, req.url);
+						console.log(
+							'Received Response from the Target:',
+							proxyRes.statusCode,
+							req.url
+						);
 					});
-				},
-			},
-
-			"/proxy/polis": {
-				target: 'https://poliscommunity.crown-shy.com',
-				changeOrigin: false,
-				rewrite: (path) => path.replace(/^\/proxy\/polis/, '')
+				}
 			}
 		}
 	},

--- a/ui/packages/comhairle/vite.config.ts
+++ b/ui/packages/comhairle/vite.config.ts
@@ -24,21 +24,28 @@ export default defineConfig({
 				rewrite: (path) => path.replace(/^\/api/, ''),
 				configure: (proxy, _options) => {
 					proxy.on('error', (err, _req, _res) => {
-						console.log('Websocket proxy error', err);
+						console.error('❌ WebSocket proxy error:', err);
 					});
 					proxy.on('proxyReq', (proxyReq, req, _res) => {
 						console.log(
-							'Websocket Sending Request to the Target:',
+							'📤 WebSocket proxying:',
 							req.method,
-							req.url
+							req.url,
+							'→',
+							proxyReq.path
 						);
 					});
 					proxy.on('proxyRes', (proxyRes, req, _res) => {
-						console.log(
-							'Websocket Received Response from the Target:',
-							proxyRes.statusCode,
-							req.url
-						);
+						console.log('📥 WebSocket response:', proxyRes.statusCode, req.url);
+					});
+					proxy.on('upgrade', (req, socket, head) => {
+						console.log('⬆️  WebSocket upgrade:', req.url);
+					});
+					proxy.on('open', (proxySocket) => {
+						console.log('✅ WebSocket proxy connection opened');
+					});
+					proxy.on('close', (res, socket, head) => {
+						console.log('❌ WebSocket proxy connection closed');
 					});
 				}
 			},


### PR DESCRIPTION
This PR does a lot of work fixing up the websocket implementation 

We now have 
- A way to have different backend services that use the websocket connection 
- A setting up two services, one to monitor workflow processes another to manage notifications 
- A frontend service for websockets that creates a single connection but lets other systems hook into it 
- Frontend services for workflow monitoring and notifications 

The code is mostly refactored to use this with the exception of the workflow monitoring which is coming soon.  
