### PR TITLE
Video call state

### DIFF
--- a/api/src/error.rs
+++ b/api/src/error.rs
@@ -1,6 +1,7 @@
 use crate::{
     tools::polis::PolisError, transcription_service::error::TranscriptionServiceError,
-    translation_service::error::TranslationError, wiki_poll_service::error::WikiPollServiceError,
+    translation_service::error::TranslationError, websockets::error::WebsocketError,
+    wiki_poll_service::error::WikiPollServiceError,
 };
 use aide::OperationIo;
 use axum::{
@@ -208,6 +209,9 @@ pub enum ComhairleError {
 
     #[error("WebSocket send error: {0}")]
     WebSocketSendError(String),
+
+    #[error("WebSocket handler error: {0}")]
+    WebSocketHandlerError(Box<WebsocketError>),
 
     #[error("Serialization error: {0}")]
     SerializationError(String),

--- a/api/src/websockets.rs
+++ b/api/src/websockets.rs
@@ -1,3 +1,4 @@
+pub mod error;
 pub mod handlers;
 pub mod messages;
 pub mod routes;
@@ -113,13 +114,19 @@ pub trait WebSocketMessageHandler: Send + Sync {
     /// # Returns
     ///
     /// - `Ok(())` if the message was handled successfully
-    /// - `Err(ComhairleError)` if an error occurred
+    /// - `Err(WebsocketError)` if an error occurred
+    ///
+    /// # Implementation Note
+    ///
+    /// Each handler can define its own error type and convert it to WebsocketError
+    /// using the `?` operator or `.map_err(Into::into)`, since each handler's error
+    /// type implements `Into<WebsocketError>` via the `#[from]` attribute.
     async fn handle_message(
         &self,
         message: &WebSocketMessage,
         connection: &WebSocketConnection,
         state: &Arc<ComhairleState>,
-    ) -> Result<(), ComhairleError>;
+    ) -> Result<(), crate::websockets::error::WebsocketError>;
 }
 
 static NEXT_CONNECTION_ID: AtomicUsize = AtomicUsize::new(1);
@@ -649,7 +656,10 @@ async fn route_to_handler(
 
     if let Some(domain) = domain {
         if let Some(handler) = state.websockets.get_handler(domain) {
-            handler.handle_message(message, connection, state).await?;
+            handler
+                .handle_message(message, connection, state)
+                .await
+                .map_err(|e| ComhairleError::WebSocketHandlerError(Box::new(e)))?;
             return Ok(true);
         }
     }

--- a/api/src/websockets.rs
+++ b/api/src/websockets.rs
@@ -53,7 +53,8 @@ use crate::{
 /// use std::sync::Arc;
 /// use comhairle::websockets::{WebSocketMessageHandler, WebSocketConnection};
 /// use comhairle::websockets::messages::WebSocketMessage;
-/// use comhairle::{ComhairleState, error::ComhairleError};
+/// use comhairle::websockets::error::WebsocketError;
+/// use comhairle::ComhairleState;
 ///
 /// pub struct ChatHandler;
 ///
@@ -68,7 +69,7 @@ use crate::{
 ///         message: &WebSocketMessage,
 ///         connection: &WebSocketConnection,
 ///         state: &Arc<ComhairleState>,
-///     ) -> Result<(), ComhairleError> {
+///     ) -> Result<(), WebsocketError> {
 ///         match message {
 ///             WebSocketMessage::Custom { event, data } if event.starts_with("chat:") => {
 ///                 // Handle chat messages
@@ -76,7 +77,8 @@ use crate::{
 ///                     event: "chat:response".to_string(),
 ///                     data: serde_json::json!({"status": "received"}),
 ///                 };
-///                 connection.send_message(&response).await?;
+///                 // Ignore send errors in this example
+///                 let _ = connection.send_message(&response).await;
 ///             }
 ///             _ => {}
 ///         }

--- a/api/src/websockets/error.rs
+++ b/api/src/websockets/error.rs
@@ -1,0 +1,26 @@
+use thiserror::Error;
+
+use crate::websockets::handlers::{
+    notifications::NotificationWSError, video_call::VideoCallWSError, workflow::WorkflowWSError,
+};
+
+#[derive(Error, Debug)]
+pub enum WebsocketError {
+    #[error("Video Call Error: {0}")]
+    VideoCallError(#[from] VideoCallWSError),
+
+    #[error("Notification Error: {0}")]
+    NotificationError(#[from] NotificationWSError),
+
+    #[error("Workflow Error: {0}")]
+    WorkflowError(#[from] WorkflowWSError),
+
+    #[error("WebSocket send error: {0}")]
+    SendError(String),
+
+    #[error("Serialization error: {0}")]
+    SerializationError(String),
+
+    #[error("Database error: {0}")]
+    DatabaseError(String),
+}

--- a/api/src/websockets/handlers/mod.rs
+++ b/api/src/websockets/handlers/mod.rs
@@ -1,2 +1,3 @@
 pub mod notifications;
+pub mod video_call;
 pub mod workflow;

--- a/api/src/websockets/handlers/notifications.rs
+++ b/api/src/websockets/handlers/notifications.rs
@@ -5,7 +5,6 @@ use tracing::info;
 use uuid::Uuid;
 
 use crate::{
-    error::ComhairleError,
     models::{notification, notification_delivery},
     websockets::{
         error::WebsocketError, messages::WebSocketMessage, WebSocketConnection,
@@ -15,7 +14,19 @@ use crate::{
 };
 
 #[derive(Error, Debug)]
-pub enum NotificationWSError {}
+pub enum NotificationWSError {
+    #[error("Invalid or missing delivery ID")]
+    InvalidDeliveryId,
+
+    #[error("User not authorized to access this notification")]
+    Unauthorized,
+
+    #[error("Database error: {0}")]
+    DatabaseError(String),
+
+    #[error("Failed to send WebSocket message: {0}")]
+    SendError(String),
+}
 
 /// Handler for notification-related WebSocket messages.
 ///
@@ -129,7 +140,7 @@ impl NotificationMessageHandler {
         title: &str,
         message: &str,
         level: &str,
-    ) -> Result<(), ComhairleError> {
+    ) -> Result<(), NotificationWSError> {
         let ws_message = WebSocketMessage::Custom {
             event: "notification:new".to_string(),
             data: serde_json::json!({
@@ -140,7 +151,11 @@ impl NotificationMessageHandler {
             }),
         };
 
-        let sent_count = state.websockets.send_to_user(user_id, &ws_message).await?;
+        let sent_count = state
+            .websockets
+            .send_to_user(user_id, &ws_message)
+            .await
+            .map_err(|e| NotificationWSError::SendError(e.to_string()))?;
 
         if sent_count > 0 {
             info!(
@@ -212,7 +227,7 @@ impl NotificationMessageHandler {
         notification_type: notification::NotificationType,
         context_type: notification::NotificationContextType,
         context_id: Option<&Uuid>,
-    ) -> Result<notification::Notification, ComhairleError> {
+    ) -> Result<notification::Notification, NotificationWSError> {
         // Create the notification in the database
         let new_notification = notification::CreateNotification {
             title: title.to_string(),
@@ -222,7 +237,9 @@ impl NotificationMessageHandler {
             context_id: context_id.copied(),
         };
 
-        let created_notification = notification::create(&state.db, &new_notification).await?;
+        let created_notification = notification::create(&state.db, &new_notification)
+            .await
+            .map_err(|e| NotificationWSError::DatabaseError(e.to_string()))?;
 
         // Create delivery record
         let delivery = notification_delivery::CreateNotificationDelivery {
@@ -231,7 +248,9 @@ impl NotificationMessageHandler {
             delivery_method: Some(notification_delivery::DeliveryMethod::InApp),
         };
 
-        let _created_delivery = notification_delivery::create(&state.db, &delivery).await?;
+        let _created_delivery = notification_delivery::create(&state.db, &delivery)
+            .await
+            .map_err(|e| NotificationWSError::DatabaseError(e.to_string()))?;
 
         // Send via WebSocket if user is connected
         Self::send_notification_to_user(
@@ -264,19 +283,19 @@ impl WebSocketMessageHandler for NotificationMessageHandler {
             WebSocketMessage::Custom { event, data } if event.starts_with("notification:") => {
                 match event.as_str() {
                     "notification:mark_read" => {
-                        self.handle_mark_read(data, connection, state).await
+                        self.handle_mark_read(data, connection, state).await?
                     }
                     "notification:mark_all_read" => {
-                        self.handle_mark_all_read(connection, state).await
+                        self.handle_mark_all_read(connection, state).await?
                     }
                     "notification:get_unread_count" => {
-                        self.handle_get_unread_count(connection, state).await
+                        self.handle_get_unread_count(connection, state).await?
                     }
                     _ => {
                         info!("Unhandled notification event: {}", event);
-                        Ok(())
                     }
                 }
+                Ok(())
             }
             _ => Ok(()),
         }
@@ -289,24 +308,24 @@ impl NotificationMessageHandler {
         data: &serde_json::Value,
         connection: &WebSocketConnection,
         state: &Arc<ComhairleState>,
-    ) -> Result<(), WebsocketError> {
+    ) -> Result<(), NotificationWSError> {
         let delivery_id = data["delivery_id"]
             .as_str()
             .and_then(|s| Uuid::parse_str(s).ok())
-            .ok_or_else(|| WebsocketError::DatabaseError("Missing or invalid delivery_id".into()))?;
+            .ok_or(NotificationWSError::InvalidDeliveryId)?;
 
         // Verify the delivery belongs to this user
         let delivery = notification_delivery::get_by_id(&state.db, &delivery_id)
             .await
-            .map_err(|e| WebsocketError::DatabaseError(e.to_string()))?;
+            .map_err(|e| NotificationWSError::DatabaseError(e.to_string()))?;
         if delivery.user_id != connection.user.id {
-            return Err(WebsocketError::DatabaseError("User not authorized".into()));
+            return Err(NotificationWSError::Unauthorized);
         }
 
         // Mark as read
         notification_delivery::mark_as_read(&state.db, &delivery_id, chrono::Utc::now())
             .await
-            .map_err(|e| WebsocketError::DatabaseError(e.to_string()))?;
+            .map_err(|e| NotificationWSError::DatabaseError(e.to_string()))?;
 
         // Send confirmation back
         let response = WebSocketMessage::Custom {
@@ -319,7 +338,7 @@ impl NotificationMessageHandler {
         connection
             .send_message(&response)
             .await
-            .map_err(|e| WebsocketError::SendError(e.to_string()))?;
+            .map_err(|e| NotificationWSError::SendError(e.to_string()))?;
 
         // Also send updated unread count
         self.send_unread_count(connection, state).await?;
@@ -336,7 +355,7 @@ impl NotificationMessageHandler {
         &self,
         connection: &WebSocketConnection,
         state: &Arc<ComhairleState>,
-    ) -> Result<(), WebsocketError> {
+    ) -> Result<(), NotificationWSError> {
         // Mark all as read for this user
         let updated_deliveries = notification_delivery::mark_all_as_read_for_user(
             &state.db,
@@ -344,7 +363,7 @@ impl NotificationMessageHandler {
             chrono::Utc::now(),
         )
         .await
-        .map_err(|e| WebsocketError::DatabaseError(e.to_string()))?;
+        .map_err(|e| NotificationWSError::DatabaseError(e.to_string()))?;
 
         // Send confirmation back
         let response = WebSocketMessage::Custom {
@@ -357,7 +376,7 @@ impl NotificationMessageHandler {
         connection
             .send_message(&response)
             .await
-            .map_err(|e| WebsocketError::SendError(e.to_string()))?;
+            .map_err(|e| NotificationWSError::SendError(e.to_string()))?;
 
         // Also send updated unread count (should be 0)
         self.send_unread_count(connection, state).await?;
@@ -375,7 +394,7 @@ impl NotificationMessageHandler {
         &self,
         connection: &WebSocketConnection,
         state: &Arc<ComhairleState>,
-    ) -> Result<(), WebsocketError> {
+    ) -> Result<(), NotificationWSError> {
         self.send_unread_count(connection, state).await
     }
 
@@ -383,11 +402,11 @@ impl NotificationMessageHandler {
         &self,
         connection: &WebSocketConnection,
         state: &Arc<ComhairleState>,
-    ) -> Result<(), WebsocketError> {
+    ) -> Result<(), NotificationWSError> {
         let count =
             notification_delivery::get_unread_count_for_user(&state.db, &connection.user.id)
                 .await
-                .map_err(|e| WebsocketError::DatabaseError(e.to_string()))?;
+                .map_err(|e| NotificationWSError::DatabaseError(e.to_string()))?;
 
         let response = WebSocketMessage::Custom {
             event: "notification:unread_count".to_string(),
@@ -398,7 +417,7 @@ impl NotificationMessageHandler {
         connection
             .send_message(&response)
             .await
-            .map_err(|e| WebsocketError::SendError(e.to_string()))?;
+            .map_err(|e| NotificationWSError::SendError(e.to_string()))?;
 
         Ok(())
     }

--- a/api/src/websockets/handlers/notifications.rs
+++ b/api/src/websockets/handlers/notifications.rs
@@ -1,14 +1,21 @@
 use async_trait::async_trait;
 use std::sync::Arc;
+use thiserror::Error;
 use tracing::info;
 use uuid::Uuid;
 
 use crate::{
     error::ComhairleError,
     models::{notification, notification_delivery},
-    websockets::{messages::WebSocketMessage, WebSocketConnection, WebSocketMessageHandler},
+    websockets::{
+        error::WebsocketError, messages::WebSocketMessage, WebSocketConnection,
+        WebSocketMessageHandler,
+    },
     ComhairleState,
 };
+
+#[derive(Error, Debug)]
+pub enum NotificationWSError {}
 
 /// Handler for notification-related WebSocket messages.
 ///
@@ -252,7 +259,7 @@ impl WebSocketMessageHandler for NotificationMessageHandler {
         message: &WebSocketMessage,
         connection: &WebSocketConnection,
         state: &Arc<ComhairleState>,
-    ) -> Result<(), ComhairleError> {
+    ) -> Result<(), WebsocketError> {
         match message {
             WebSocketMessage::Custom { event, data } if event.starts_with("notification:") => {
                 match event.as_str() {
@@ -282,20 +289,24 @@ impl NotificationMessageHandler {
         data: &serde_json::Value,
         connection: &WebSocketConnection,
         state: &Arc<ComhairleState>,
-    ) -> Result<(), ComhairleError> {
+    ) -> Result<(), WebsocketError> {
         let delivery_id = data["delivery_id"]
             .as_str()
             .and_then(|s| Uuid::parse_str(s).ok())
-            .ok_or_else(|| ComhairleError::BadRequest("Missing or invalid delivery_id".into()))?;
+            .ok_or_else(|| WebsocketError::DatabaseError("Missing or invalid delivery_id".into()))?;
 
         // Verify the delivery belongs to this user
-        let delivery = notification_delivery::get_by_id(&state.db, &delivery_id).await?;
+        let delivery = notification_delivery::get_by_id(&state.db, &delivery_id)
+            .await
+            .map_err(|e| WebsocketError::DatabaseError(e.to_string()))?;
         if delivery.user_id != connection.user.id {
-            return Err(ComhairleError::UserNotAuthorized);
+            return Err(WebsocketError::DatabaseError("User not authorized".into()));
         }
 
         // Mark as read
-        notification_delivery::mark_as_read(&state.db, &delivery_id, chrono::Utc::now()).await?;
+        notification_delivery::mark_as_read(&state.db, &delivery_id, chrono::Utc::now())
+            .await
+            .map_err(|e| WebsocketError::DatabaseError(e.to_string()))?;
 
         // Send confirmation back
         let response = WebSocketMessage::Custom {
@@ -305,7 +316,10 @@ impl NotificationMessageHandler {
                 "success": true,
             }),
         };
-        connection.send_message(&response).await?;
+        connection
+            .send_message(&response)
+            .await
+            .map_err(|e| WebsocketError::SendError(e.to_string()))?;
 
         // Also send updated unread count
         self.send_unread_count(connection, state).await?;
@@ -322,14 +336,15 @@ impl NotificationMessageHandler {
         &self,
         connection: &WebSocketConnection,
         state: &Arc<ComhairleState>,
-    ) -> Result<(), ComhairleError> {
+    ) -> Result<(), WebsocketError> {
         // Mark all as read for this user
         let updated_deliveries = notification_delivery::mark_all_as_read_for_user(
             &state.db,
             &connection.user.id,
             chrono::Utc::now(),
         )
-        .await?;
+        .await
+        .map_err(|e| WebsocketError::DatabaseError(e.to_string()))?;
 
         // Send confirmation back
         let response = WebSocketMessage::Custom {
@@ -339,7 +354,10 @@ impl NotificationMessageHandler {
                 "success": true,
             }),
         };
-        connection.send_message(&response).await?;
+        connection
+            .send_message(&response)
+            .await
+            .map_err(|e| WebsocketError::SendError(e.to_string()))?;
 
         // Also send updated unread count (should be 0)
         self.send_unread_count(connection, state).await?;
@@ -357,7 +375,7 @@ impl NotificationMessageHandler {
         &self,
         connection: &WebSocketConnection,
         state: &Arc<ComhairleState>,
-    ) -> Result<(), ComhairleError> {
+    ) -> Result<(), WebsocketError> {
         self.send_unread_count(connection, state).await
     }
 
@@ -365,10 +383,11 @@ impl NotificationMessageHandler {
         &self,
         connection: &WebSocketConnection,
         state: &Arc<ComhairleState>,
-    ) -> Result<(), ComhairleError> {
+    ) -> Result<(), WebsocketError> {
         let count =
             notification_delivery::get_unread_count_for_user(&state.db, &connection.user.id)
-                .await?;
+                .await
+                .map_err(|e| WebsocketError::DatabaseError(e.to_string()))?;
 
         let response = WebSocketMessage::Custom {
             event: "notification:unread_count".to_string(),
@@ -376,7 +395,10 @@ impl NotificationMessageHandler {
                 "count": count,
             }),
         };
-        connection.send_message(&response).await?;
+        connection
+            .send_message(&response)
+            .await
+            .map_err(|e| WebsocketError::SendError(e.to_string()))?;
 
         Ok(())
     }

--- a/api/src/websockets/handlers/video_call.rs
+++ b/api/src/websockets/handlers/video_call.rs
@@ -1,0 +1,726 @@
+use std::{
+    collections::HashMap,
+    sync::{Arc, RwLock},
+};
+
+use async_trait::async_trait;
+use rand::seq::SliceRandom;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use tracing::info;
+use uuid::Uuid;
+
+use crate::{
+    models::users::User,
+    websockets::{messages::WebSocketMessage, WebSocketConnection, WebSocketMessageHandler},
+    ComhairleState,
+};
+
+/// Represents a participant in a video call.
+///
+/// Contains the user information and their role in the call (e.g., moderator, facilitator, participant).
+#[derive(Serialize, Deserialize, Debug)]
+pub struct VideoCallParticipant {
+    user: User,
+    role: String,
+}
+
+/// Represents a breakout room assignment with a list of participant UUIDs.
+///
+/// Used to organize participants into smaller groups during a video call.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct BreakoutRoomAssignments {
+    pub participants: Vec<Uuid>,
+}
+
+/// Complete state of a video call.
+///
+/// Contains all information about the call including participants, status,
+/// breakout room assignments, and current agenda progress.
+#[derive(Serialize, Debug)]
+pub struct VideoCallState {
+    /// Unique identifier for the video call
+    pub video_call_id: Uuid,
+    /// Current status of the call (Waiting, InProgress, or Ended)
+    pub status: VideoCallStatus,
+    /// Map of participant user IDs to their participant data
+    pub participants: HashMap<Uuid, VideoCallParticipant>,
+    /// List of breakout room assignments
+    pub breakout_rooms: Vec<BreakoutRoomAssignments>,
+    /// Jitsi meeting room identifier
+    pub jitsi_call_id: Uuid,
+    /// Current step in the agenda (0-indexed)
+    pub current_agenda_step: u32,
+}
+
+/// WebSocket message handler for video call events.
+///
+/// Manages the state of all active video calls and handles incoming
+/// WebSocket messages related to video call operations.
+pub struct VideoCallMessageHandler {
+    /// Thread-safe map of event IDs to their video call states
+    pub video_calls: RwLock<HashMap<Uuid, VideoCallState>>,
+}
+
+/// Status of a video call.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub enum VideoCallStatus {
+    /// Call is waiting to start
+    Waiting,
+    /// Call is currently in progress
+    InProgress,
+    /// Call has ended
+    Ended,
+}
+
+/// Errors that can occur during video call WebSocket operations.
+#[derive(Debug, Error)]
+pub enum VideoCallWSError {
+    #[error("User is not participating in this call")]
+    UserNotOnCall,
+
+    #[error("Wrong message format {0}")]
+    IncorrectMessageFormat(#[from] serde_json::Error),
+
+    #[error("Failed to get event id")]
+    FailedToDeserializeEventId,
+
+    #[error("No event specified. Please provide an event_id")]
+    NoEventSpecified,
+
+    #[error("Failed to get lock on room")]
+    FailedToGetLockOnRoom,
+
+    #[error("User is not authorized to change call state")]
+    UnauthorizedStateChange,
+}
+
+impl VideoCallState {
+    /// Creates a new video call state with default values.
+    ///
+    /// # Arguments
+    ///
+    /// * `video_call_id` - Unique identifier for this video call
+    /// * `jitsi_call_id` - Jitsi meeting room identifier
+    ///
+    /// # Returns
+    ///
+    /// A new `VideoCallState` initialized with:
+    /// - Status: `Waiting`
+    /// - No participants
+    /// - No breakout rooms
+    /// - Agenda step: 0
+    pub fn new(video_call_id: Uuid, jitsi_call_id: Uuid) -> Self {
+        Self {
+            status: VideoCallStatus::Waiting,
+            participants: HashMap::new(),
+            video_call_id,
+            jitsi_call_id,
+            current_agenda_step: 0,
+            breakout_rooms: vec![],
+        }
+    }
+}
+
+/// Data structure for user join events.
+#[derive(Serialize, Deserialize)]
+struct UserJoinData {
+    pub event_id: Uuid,
+}
+
+/// Data structure for user leave events.
+#[derive(Serialize, Deserialize)]
+struct UserLeaveData {
+    pub event_id: Uuid,
+}
+
+/// Data structure for setting the current agenda item.
+#[derive(Serialize, Deserialize)]
+struct SetAgendaItemData {
+    pub event_id: Uuid,
+    pub agenda_item: u32,
+}
+
+/// Data structure for broadcasting messages to call participants.
+#[derive(Serialize, Deserialize, Debug)]
+struct BroadcastMessageData {
+    pub event_id: Uuid,
+    pub message: String,
+}
+
+/// Data structure for changing the call state.
+#[derive(Serialize, Deserialize, Debug)]
+struct ChangeCallStateData {
+    pub event_id: Uuid,
+    pub status: VideoCallStatus,
+}
+
+/// Data structure for assigning participants to breakout rooms.
+#[derive(Serialize, Deserialize, Debug)]
+struct AssignBreakoutRoomsData {
+    pub event_id: Uuid,
+    pub max_users_per_room: usize,
+}
+
+impl VideoCallMessageHandler {
+    /// Creates a new video call message handler with an empty call registry.
+    pub fn new() -> Self {
+        Self {
+            video_calls: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Executes a function with read-only access to a video call state.
+    ///
+    /// This method acquires a read lock on the video calls registry and provides
+    /// safe read-only access to the requested call state through a closure.
+    ///
+    /// # Arguments
+    ///
+    /// * `event_id` - The UUID of the event/call to access
+    /// * `f` - Closure that receives a reference to the `VideoCallState`
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(Some(R))` - The closure was executed and returned a value
+    /// * `Ok(None)` - The event_id was not found in the registry
+    /// * `Err(VideoCallWSError)` - Failed to acquire the read lock
+    pub fn with_video_call_state<F, R>(
+        &self,
+        event_id: &Uuid,
+        f: F,
+    ) -> Result<Option<R>, VideoCallWSError>
+    where
+        F: FnOnce(&VideoCallState) -> R,
+    {
+        let video_calls = self
+            .video_calls
+            .read()
+            .map_err(|_| VideoCallWSError::FailedToGetLockOnRoom)?;
+        Ok(video_calls.get(event_id).map(f))
+    }
+
+    /// Executes a function with mutable access to a video call state.
+    ///
+    /// This method acquires a write lock on the video calls registry and provides
+    /// safe mutable access to the requested call state through a closure.
+    ///
+    /// # Arguments
+    ///
+    /// * `event_id` - The UUID of the event/call to access
+    /// * `f` - Closure that receives a mutable reference to the `VideoCallState`
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(Some(R))` - The closure was executed and returned a value
+    /// * `Ok(None)` - The event_id was not found in the registry
+    /// * `Err(VideoCallWSError)` - Failed to acquire the write lock
+    pub fn with_video_call_state_mut<F, R>(
+        &self,
+        event_id: &Uuid,
+        f: F,
+    ) -> Result<Option<R>, VideoCallWSError>
+    where
+        F: FnOnce(&mut VideoCallState) -> R,
+    {
+        let mut video_calls = self
+            .video_calls
+            .write()
+            .map_err(|_| VideoCallWSError::FailedToGetLockOnRoom)?;
+        Ok(video_calls.get_mut(event_id).map(f))
+    }
+
+    /// Sets the current agenda item for a video call.
+    ///
+    /// Updates the `current_agenda_step` field of the call state and broadcasts
+    /// the updated state to all participants.
+    ///
+    /// # Arguments
+    ///
+    /// * `event_id` - The UUID of the event/call
+    /// * `data` - JSON data containing the new agenda item number
+    /// * `_connection` - WebSocket connection of the requesting user (unused)
+    /// * `state` - Application state for broadcasting
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - JSON deserialization fails
+    /// - Failed to acquire lock on the call state
+    /// - Broadcasting the state fails
+    pub async fn set_agenda_item(
+        &self,
+        event_id: &Uuid,
+        data: &serde_json::Value,
+        _connection: &WebSocketConnection,
+        state: &Arc<ComhairleState>,
+    ) -> Result<(), VideoCallWSError> {
+        let agenda_update: SetAgendaItemData = serde_json::from_value(data.clone())?;
+
+        self.with_video_call_state_mut(event_id, |call_state| {
+            call_state.current_agenda_step = agenda_update.agenda_item
+        })?;
+
+        self.broadcast_state(event_id, state).await?;
+
+        Ok(())
+    }
+
+    /// Broadcasts a custom message to all participants in a video call.
+    ///
+    /// Only moderators and facilitators are authorized to broadcast messages.
+    /// The message is sent to all participants in the call via WebSocket.
+    ///
+    /// # Arguments
+    ///
+    /// * `event_id` - The UUID of the event/call
+    /// * `data` - JSON data containing the message to broadcast
+    /// * `connection` - WebSocket connection of the user sending the message
+    /// * `state` - Application state for sending messages
+    ///
+    /// # Authorization
+    ///
+    /// Only users with role "moderator" or "facilitator" can broadcast messages.
+    /// Other users' broadcast attempts are silently ignored.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if JSON deserialization fails or lock acquisition fails.
+    pub async fn broadcast_message(
+        &self,
+        event_id: &Uuid,
+        data: &serde_json::Value,
+        connection: &WebSocketConnection,
+        state: &Arc<ComhairleState>,
+    ) -> Result<(), VideoCallWSError> {
+        let broadcast_data: BroadcastMessageData = serde_json::from_value(data.clone())?;
+
+        // Extract participant user IDs and check authorization synchronously
+        let participant_ids = self
+            .with_video_call_state(event_id, |call| {
+                // Check if the sender is authorized to broadcast
+                if let Some(sender) = call.participants.get(&connection.user.id) {
+                    if sender.role == "moderator" || sender.role == "facilitator" {
+                        // Return all participant user IDs
+                        return Some(call.participants.keys().copied().collect::<Vec<Uuid>>());
+                    }
+                }
+                None
+            })?
+            .flatten();
+
+        // If authorized, broadcast to all participants
+        if let Some(participant_ids) = participant_ids {
+            let message = WebSocketMessage::Custom {
+                event: "video_call:message".into(),
+                data: serde_json::json!({
+                    "message": broadcast_data.message
+                }),
+            };
+
+            // Send to each participant
+            for user_id in participant_ids {
+                let _ = state.websockets.send_to_user(&user_id, &message).await;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Handles a user joining a video call.
+    ///
+    /// This method:
+    /// 1. Verifies the user is registered for the event
+    /// 2. Adds them to the participants list
+    /// 3. Auto-assigns them to a breakout room if rooms exist
+    /// 4. Sends the current call state to the joining user
+    /// 5. Broadcasts the updated state to all participants
+    ///
+    /// # Arguments
+    ///
+    /// * `_event_id` - The UUID of the event (unused, extracted from data)
+    /// * `data` - JSON data containing the event_id
+    /// * `connection` - WebSocket connection of the joining user
+    /// * `state` - Application state for database access and broadcasting
+    ///
+    /// # Auto-Assignment to Breakout Rooms
+    ///
+    /// If breakout rooms have been configured and the user is not already
+    /// assigned to a room, they will be automatically assigned to the room
+    /// with the fewest participants.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - JSON deserialization fails
+    /// - User is not registered for the event
+    /// - Failed to acquire lock on the call state
+    /// - Broadcasting fails
+    pub async fn handle_user_join(
+        &self,
+        _event_id: &Uuid,
+        data: &serde_json::Value,
+        connection: &WebSocketConnection,
+        state: &Arc<ComhairleState>,
+    ) -> Result<(), VideoCallWSError> {
+        let join_data: UserJoinData = serde_json::from_value(data.clone())?;
+
+        // Verify the user is registered for this event
+        let attendance = crate::models::event_attendance::get_by_event_and_user(
+            &state.db,
+            &join_data.event_id,
+            &connection.user.id,
+        )
+        .await
+        .map_err(|_| VideoCallWSError::UserNotOnCall)?;
+
+        let role = attendance.role;
+        let user_id = connection.user.id;
+        let user = connection.user.clone();
+
+        // Add the participant to the video call and auto-assign to breakout room if needed
+        self.with_video_call_state_mut(&join_data.event_id, |call| {
+            call.participants
+                .insert(user_id, VideoCallParticipant { user, role });
+
+            // If breakout rooms exist, auto-assign the user to a room
+            if !call.breakout_rooms.is_empty() {
+                // Check if user is already in a breakout room
+                let already_assigned = call
+                    .breakout_rooms
+                    .iter()
+                    .any(|room| room.participants.contains(&user_id));
+
+                if !already_assigned {
+                    // Find the room with the fewest participants
+                    if let Some((room_index, _)) = call
+                        .breakout_rooms
+                        .iter()
+                        .enumerate()
+                        .min_by_key(|(_, room)| room.participants.len())
+                    {
+                        // Add user to the room with the fewest participants
+                        call.breakout_rooms[room_index].participants.push(user_id);
+                    }
+                }
+            }
+        })?;
+
+        // Send the current state directly to the joining user
+        let call_state = self
+            .with_video_call_state(&join_data.event_id, |call| serde_json::to_value(call).ok())?
+            .flatten();
+
+        if let Some(call_state) = call_state {
+            let message = WebSocketMessage::Custom {
+                event: "video_call:state_update".into(),
+                data: call_state,
+            };
+            let _ = state.websockets.send_to_user(&user_id, &message).await;
+        }
+
+        // Broadcast the updated state to all participants
+        self.broadcast_state(&join_data.event_id, state).await?;
+
+        Ok(())
+    }
+
+    /// Handles a user leaving a video call.
+    ///
+    /// Removes the user from the participants list and broadcasts the
+    /// updated state to all remaining participants.
+    ///
+    /// # Arguments
+    ///
+    /// * `_event_id` - The UUID of the event (unused, extracted from data)
+    /// * `data` - JSON data containing the event_id
+    /// * `connection` - WebSocket connection of the leaving user
+    /// * `state` - Application state for broadcasting
+    ///
+    /// # Note
+    ///
+    /// This method does not remove the user from breakout room assignments.
+    /// The user will remain in the breakout room assignments list even after leaving.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - JSON deserialization fails
+    /// - Failed to acquire lock on the call state
+    /// - Broadcasting fails
+    pub async fn handle_user_leave(
+        &self,
+        _event_id: &Uuid,
+        data: &serde_json::Value,
+        connection: &WebSocketConnection,
+        state: &Arc<ComhairleState>,
+    ) -> Result<(), VideoCallWSError> {
+        let leave_data: UserLeaveData = serde_json::from_value(data.clone())?;
+
+        let user_id = connection.user.id;
+
+        // Remove the participant from the video call
+        self.with_video_call_state_mut(&leave_data.event_id, |call| {
+            call.participants.remove(&user_id);
+        })?;
+
+        self.broadcast_state(&leave_data.event_id, state).await?;
+
+        Ok(())
+    }
+
+    /// Changes the status of a video call.
+    ///
+    /// Only moderators and facilitators are authorized to change the call state.
+    /// The state can be changed between Waiting, InProgress, and Ended.
+    ///
+    /// # Arguments
+    ///
+    /// * `_event_id` - The UUID of the event (unused, extracted from data)
+    /// * `data` - JSON data containing the event_id and new status
+    /// * `connection` - WebSocket connection of the user requesting the change
+    /// * `state` - Application state for broadcasting
+    ///
+    /// # Authorization
+    ///
+    /// Only users with role "moderator" or "facilitator" can change call state.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - JSON deserialization fails
+    /// - User is not authorized (`UnauthorizedStateChange`)
+    /// - Failed to acquire lock on the call state
+    /// - Broadcasting fails
+    pub async fn change_call_state(
+        &self,
+        _event_id: &Uuid,
+        data: &serde_json::Value,
+        connection: &WebSocketConnection,
+        state: &Arc<ComhairleState>,
+    ) -> Result<(), VideoCallWSError> {
+        let state_data: ChangeCallStateData = serde_json::from_value(data.clone())?;
+
+        let user_id = connection.user.id;
+        let new_status = state_data.status;
+
+        // Check authorization and update the call state
+        let authorized = self
+            .with_video_call_state_mut(&state_data.event_id, |call| {
+                // Check if the user is authorized (moderator or facilitator)
+                if let Some(participant) = call.participants.get(&user_id) {
+                    if participant.role == "moderator" || participant.role == "facilitator" {
+                        call.status = new_status;
+                        return true;
+                    }
+                }
+                false
+            })?
+            .unwrap_or(false);
+
+        if !authorized {
+            return Err(VideoCallWSError::UnauthorizedStateChange);
+        }
+
+        self.broadcast_state(&state_data.event_id, state).await?;
+
+        Ok(())
+    }
+
+    /// Randomly assigns all participants to breakout rooms.
+    ///
+    /// Only moderators and facilitators are authorized to assign breakout rooms.
+    /// Participants are randomly shuffled and then divided into rooms based on
+    /// the specified maximum users per room.
+    ///
+    /// # Arguments
+    ///
+    /// * `_event_id` - The UUID of the event (unused, extracted from data)
+    /// * `data` - JSON data containing event_id and max_users_per_room
+    /// * `connection` - WebSocket connection of the user requesting the assignment
+    /// * `state` - Application state for broadcasting
+    ///
+    /// # Algorithm
+    ///
+    /// 1. Collects all current participant IDs
+    /// 2. Randomly shuffles the participants
+    /// 3. Divides them into chunks of `max_users_per_room` size
+    /// 4. Creates a `BreakoutRoomAssignments` for each chunk
+    ///
+    /// If there are 13 participants and `max_users_per_room` is 5, this will create
+    /// 3 rooms: two with 5 participants and one with 3 participants.
+    ///
+    /// # Authorization
+    ///
+    /// Only users with role "moderator" or "facilitator" can assign breakout rooms.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - JSON deserialization fails
+    /// - User is not authorized (`UnauthorizedStateChange`)
+    /// - Failed to acquire lock on the call state
+    /// - Broadcasting fails
+    pub async fn assign_breakout_rooms(
+        &self,
+        _event_id: &Uuid,
+        data: &serde_json::Value,
+        connection: &WebSocketConnection,
+        state: &Arc<ComhairleState>,
+    ) -> Result<(), VideoCallWSError> {
+        let assignment_data: AssignBreakoutRoomsData = serde_json::from_value(data.clone())?;
+
+        let user_id = connection.user.id;
+        let max_users = assignment_data.max_users_per_room;
+
+        // Check authorization and assign breakout rooms
+        let authorized = self
+            .with_video_call_state_mut(&assignment_data.event_id, |call| {
+                // Check if the user is authorized (moderator or facilitator)
+                if let Some(participant) = call.participants.get(&user_id) {
+                    if participant.role == "moderator" || participant.role == "facilitator" {
+                        // Collect all participant IDs
+                        let mut participant_ids: Vec<Uuid> =
+                            call.participants.keys().copied().collect();
+
+                        // Shuffle participants randomly
+                        let mut rng = rand::thread_rng();
+                        participant_ids.shuffle(&mut rng);
+
+                        // Divide into rooms with max_users_per_room
+                        let breakout_rooms: Vec<BreakoutRoomAssignments> = participant_ids
+                            .chunks(max_users)
+                            .map(|chunk| BreakoutRoomAssignments {
+                                participants: chunk.to_vec(),
+                            })
+                            .collect();
+
+                        call.breakout_rooms = breakout_rooms;
+                        return true;
+                    }
+                }
+                false
+            })?
+            .unwrap_or(false);
+
+        if !authorized {
+            return Err(VideoCallWSError::UnauthorizedStateChange);
+        }
+
+        self.broadcast_state(&assignment_data.event_id, state)
+            .await?;
+
+        Ok(())
+    }
+
+    /// Broadcasts the current video call state to all participants.
+    ///
+    /// This is a convenience method used internally to synchronize state across
+    /// all connected clients. The complete state (including participants, status,
+    /// breakout rooms, and agenda step) is serialized and sent to each participant.
+    ///
+    /// # Arguments
+    ///
+    /// * `event_id` - The UUID of the event/call to broadcast
+    /// * `state` - Application state for sending WebSocket messages
+    ///
+    /// # Called Automatically
+    ///
+    /// This method is automatically called after:
+    /// - A user joins or leaves the call
+    /// - The call state changes (Waiting → InProgress → Ended)
+    /// - Breakout rooms are assigned
+    /// - The agenda item is updated
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - Failed to acquire lock on the call state
+    /// - Call state not found for the given event_id
+    /// - Serialization fails
+    pub async fn broadcast_state(
+        &self,
+        event_id: &Uuid,
+        state: &Arc<ComhairleState>,
+    ) -> Result<(), VideoCallWSError> {
+        // Extract the current state and participant IDs
+        let (participant_ids, call_state) = self
+            .with_video_call_state(event_id, |call| {
+                let ids: Vec<Uuid> = call.participants.keys().copied().collect();
+                // Serialize the state within the closure while we have the lock
+                let serialized = serde_json::to_value(call).ok()?;
+                Some((ids, serialized))
+            })?
+            .flatten()
+            .ok_or(VideoCallWSError::FailedToGetLockOnRoom)?;
+
+        // Broadcast the state to all participants
+        let message = WebSocketMessage::Custom {
+            event: "video_call:state_update".into(),
+            data: call_state,
+        };
+
+        for user_id in participant_ids {
+            let _ = state.websockets.send_to_user(&user_id, &message).await;
+        }
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl WebSocketMessageHandler for VideoCallMessageHandler {
+    fn domain(&self) -> &str {
+        "video_call"
+    }
+
+    async fn handle_message(
+        &self,
+        message: &WebSocketMessage,
+        connection: &WebSocketConnection,
+        state: &Arc<ComhairleState>,
+    ) -> Result<(), crate::websockets::error::WebsocketError> {
+        match message {
+            WebSocketMessage::Custom { event, data } if event.starts_with("video_call:") => {
+                let event_id: Uuid = serde_json::from_value(
+                    data.get("event_id")
+                        .ok_or(VideoCallWSError::NoEventSpecified)?
+                        .clone(),
+                )
+                .map_err(|_| VideoCallWSError::FailedToDeserializeEventId)?;
+
+                match event.as_str() {
+                    "video_call:user_joined" => {
+                        self.handle_user_join(&event_id, data, connection, state)
+                            .await?
+                    }
+                    "video_call:user_left" => {
+                        self.handle_user_leave(&event_id, data, connection, state)
+                            .await?
+                    }
+                    "video_call:change_state" => {
+                        self.change_call_state(&event_id, data, connection, state)
+                            .await?
+                    }
+                    "video_call:assign_breakout_rooms" => {
+                        self.assign_breakout_rooms(&event_id, data, connection, state)
+                            .await?
+                    }
+                    "video_call:set_agenda_item" => {
+                        self.set_agenda_item(&event_id, data, connection, state)
+                            .await?
+                    }
+                    "video_call:send_message" => {
+                        self.broadcast_message(&event_id, data, connection, state)
+                            .await?
+                    }
+                    _ => {
+                        info!("Unhandled video call event: {}", event);
+                    }
+                }
+                Ok(())
+            }
+            _ => Ok(()),
+        }
+    }
+}

--- a/api/src/websockets/handlers/video_call.rs
+++ b/api/src/websockets/handlers/video_call.rs
@@ -151,7 +151,7 @@ struct BroadcastMessageData {
 
 /// Data structure for changing the call state.
 #[derive(Serialize, Deserialize, Debug)]
-struct ChangeCallStateData {
+struct ChangeCallStatusData {
     pub event_id: Uuid,
     pub status: VideoCallStatus,
 }
@@ -499,14 +499,14 @@ impl VideoCallMessageHandler {
     /// - User is not authorized (`UnauthorizedStateChange`)
     /// - Failed to acquire lock on the call state
     /// - Broadcasting fails
-    pub async fn change_call_state(
+    pub async fn change_call_status(
         &self,
         _event_id: &Uuid,
         data: &serde_json::Value,
         connection: &WebSocketConnection,
         state: &Arc<ComhairleState>,
     ) -> Result<(), VideoCallWSError> {
-        let state_data: ChangeCallStateData = serde_json::from_value(data.clone())?;
+        let state_data: ChangeCallStatusData = serde_json::from_value(data.clone())?;
 
         let user_id = connection.user.id;
         let new_status = state_data.status;
@@ -706,7 +706,7 @@ impl WebSocketMessageHandler for VideoCallMessageHandler {
                             .await?
                     }
                     "video_call:change_state" => {
-                        self.change_call_state(&event_id, data, connection, state)
+                        self.change_call_status(&event_id, data, connection, state)
                             .await?
                     }
                     "video_call:assign_breakout_rooms" => {

--- a/api/src/websockets/handlers/video_call.rs
+++ b/api/src/websockets/handlers/video_call.rs
@@ -11,18 +11,19 @@ use tracing::info;
 use uuid::Uuid;
 
 use crate::{
-    models::users::User,
     websockets::{messages::WebSocketMessage, WebSocketConnection, WebSocketMessageHandler},
     ComhairleState,
 };
 
 /// Represents a participant in a video call.
 ///
-/// Contains the user information and their role in the call (e.g., moderator, facilitator, participant).
-#[derive(Serialize, Deserialize, Debug)]
+/// Contains minimal user information and their role in the call (e.g., moderator, facilitator, participant).
+/// Email addresses and other sensitive data are not included for privacy reasons.
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct VideoCallParticipant {
-    user: User,
-    role: String,
+    pub user_id: Uuid,
+    pub username: Option<String>,
+    pub role: String,
 }
 
 /// Represents a breakout room assignment with a list of participant UUIDs.
@@ -376,12 +377,18 @@ impl VideoCallMessageHandler {
 
         let role = attendance.role;
         let user_id = connection.user.id;
-        let user = connection.user.clone();
+        let username = connection.user.username.clone();
 
         // Add the participant to the video call and auto-assign to breakout room if needed
         self.with_video_call_state_mut(&join_data.event_id, |call| {
-            call.participants
-                .insert(user_id, VideoCallParticipant { user, role });
+            call.participants.insert(
+                user_id,
+                VideoCallParticipant {
+                    user_id,
+                    username,
+                    role,
+                },
+            );
 
             // If breakout rooms exist, auto-assign the user to a room
             if !call.breakout_rooms.is_empty() {

--- a/api/src/websockets/handlers/workflow.rs
+++ b/api/src/websockets/handlers/workflow.rs
@@ -1,12 +1,15 @@
 use async_trait::async_trait;
 use std::sync::Arc;
+use thiserror::Error;
 use tracing::info;
 
 use crate::{
-    error::ComhairleError,
-    websockets::{messages::WebSocketMessage, WebSocketConnection, WebSocketMessageHandler},
+    websockets::{error::WebsocketError, messages::WebSocketMessage, WebSocketConnection, WebSocketMessageHandler},
     ComhairleState,
 };
+
+#[derive(Error, Debug)]
+pub enum WorkflowWSError {}
 
 /// Handler for workflow-related WebSocket messages.
 ///
@@ -80,7 +83,7 @@ impl WebSocketMessageHandler for WorkflowMessageHandler {
         message: &WebSocketMessage,
         connection: &WebSocketConnection,
         state: &Arc<ComhairleState>,
-    ) -> Result<(), ComhairleError> {
+    ) -> Result<(), WebsocketError> {
         match message {
             WebSocketMessage::UserStartedWorkflowStep { workflow_step_id } => {
                 self.handle_workflow_step_started(workflow_step_id, connection, state)
@@ -108,8 +111,8 @@ impl WorkflowMessageHandler {
         &self,
         workflow_step_id: &uuid::Uuid,
         connection: &WebSocketConnection,
-        state: &Arc<ComhairleState>,
-    ) -> Result<(), ComhairleError> {
+        _state: &Arc<ComhairleState>,
+    ) -> Result<(), WebsocketError> {
         info!(
             "User {} started workflow step {}",
             connection.user.id, workflow_step_id
@@ -153,7 +156,7 @@ impl WorkflowMessageHandler {
         workflow_step_id: &uuid::Uuid,
         connection: &WebSocketConnection,
         _state: &Arc<ComhairleState>,
-    ) -> Result<(), ComhairleError> {
+    ) -> Result<(), WebsocketError> {
         info!(
             "User {} finished workflow step {}",
             connection.user.id, workflow_step_id
@@ -178,7 +181,10 @@ impl WorkflowMessageHandler {
                 "completed": true,
             }),
         };
-        connection.send_message(&response).await?;
+        connection
+            .send_message(&response)
+            .await
+            .map_err(|e| WebsocketError::SendError(e.to_string()))?;
 
         Ok(())
     }
@@ -188,7 +194,7 @@ impl WorkflowMessageHandler {
         workflow_step_id: &uuid::Uuid,
         connection: &WebSocketConnection,
         _state: &Arc<ComhairleState>,
-    ) -> Result<(), ComhairleError> {
+    ) -> Result<(), WebsocketError> {
         info!(
             "User {} is idle on workflow step {}",
             connection.user.id, workflow_step_id
@@ -206,7 +212,7 @@ impl WorkflowMessageHandler {
         data: &serde_json::Value,
         connection: &WebSocketConnection,
         _state: &Arc<ComhairleState>,
-    ) -> Result<(), ComhairleError> {
+    ) -> Result<(), WebsocketError> {
         info!(
             "Custom workflow event '{}' from user {}: {:?}",
             event, connection.user.id, data

--- a/api/src/websockets/setup.rs
+++ b/api/src/websockets/setup.rs
@@ -3,7 +3,10 @@ use tracing::info;
 
 use crate::ComhairleState;
 
-use super::handlers::{notifications::NotificationMessageHandler, workflow::WorkflowMessageHandler};
+use super::handlers::{
+    notifications::NotificationMessageHandler, video_call::VideoCallMessageHandler,
+    workflow::WorkflowMessageHandler,
+};
 
 /// Register all WebSocket message handlers with the application state.
 ///
@@ -20,6 +23,10 @@ use super::handlers::{notifications::NotificationMessageHandler, workflow::Workf
 /// - **WorkflowMessageHandler**: Handles workflow progress tracking
 ///   - Domain: `"workflow"`
 ///   - Events: `user_started_workflow_step`, `user_finished_workflow_step`, etc.
+///
+/// - **VideoCallMessageHandler**: Handles video call state and interactions
+///   - Domain: `"video_call"`
+///   - Events: `video_call:user_joined`, `video_call:user_left`, `video_call:change_state`, etc.
 ///
 /// # Adding New Handlers
 ///
@@ -61,6 +68,10 @@ pub fn register_handlers(state: &Arc<ComhairleState>) {
     // Register workflow handler
     let workflow_handler = Arc::new(WorkflowMessageHandler::new());
     state.websockets.register_handler(workflow_handler);
+
+    // Register video call handler
+    let video_call_handler = Arc::new(VideoCallMessageHandler::new());
+    state.websockets.register_handler(video_call_handler);
 
     info!("WebSocket message handlers registered successfully");
 }

--- a/ui/packages/comhairle/src/lib/services/videoCallService.svelte.ts
+++ b/ui/packages/comhairle/src/lib/services/videoCallService.svelte.ts
@@ -1,0 +1,183 @@
+import { ws } from '$lib/api/websockets.svelte';
+
+// Types matching backend structures
+export type VideoCallStatus = 'Waiting' | 'InProgress' | 'Ended';
+
+export interface VideoCallParticipant {
+	user: {
+		id: string;
+		username: string;
+		email: string;
+	};
+	role: string;
+}
+
+export interface BreakoutRoomAssignments {
+	participants: string[];
+}
+
+export interface VideoCallState {
+	video_call_id: string;
+	status: VideoCallStatus;
+	participants: Record<string, VideoCallParticipant>;
+	breakout_rooms: BreakoutRoomAssignments[];
+	jitsi_call_id: string;
+	current_agenda_step: number;
+}
+
+export interface BroadcastMessage {
+	message: string;
+}
+
+export class VideoCallService {
+	private _currentCallState = $state<VideoCallState | null>(null);
+	private _lastBroadcastMessage = $state<string | null>(null);
+	private isListening = false;
+
+	constructor() {
+		this.setupListeners();
+	}
+
+	get currentCallState(): VideoCallState | null {
+		return this._currentCallState;
+	}
+
+	get lastBroadcastMessage(): string | null {
+		return this._lastBroadcastMessage;
+	}
+
+	get isInCall(): boolean {
+		return this._currentCallState !== null;
+	}
+
+	get participants(): VideoCallParticipant[] {
+		if (!this._currentCallState) return [];
+		return Object.values(this._currentCallState.participants);
+	}
+
+	get breakoutRooms(): BreakoutRoomAssignments[] {
+		return this._currentCallState?.breakout_rooms ?? [];
+	}
+
+	get currentAgendaStep(): number {
+		return this._currentCallState?.current_agenda_step ?? 0;
+	}
+
+	get callStatus(): VideoCallStatus | null {
+		return this._currentCallState?.status ?? null;
+	}
+
+	private setupListeners() {
+		if (this.isListening) return;
+		this.isListening = true;
+
+		// Listen for video call events from server
+		ws.on('custom', (payload) => {
+			if (payload.event === 'video_call:state_update') {
+				this.handleStateUpdate(payload.data as VideoCallState);
+			} else if (payload.event === 'video_call:message') {
+				this.handleBroadcastMessage(payload.data as BroadcastMessage);
+			}
+		});
+	}
+
+	private handleStateUpdate(state: VideoCallState) {
+		console.log('Video call state updated:', state);
+		this._currentCallState = state;
+	}
+
+	private handleBroadcastMessage(data: BroadcastMessage) {
+		console.log('Received broadcast message:', data.message);
+		this._lastBroadcastMessage = data.message;
+	}
+
+	// User joins a video call
+	joinCall(eventId: string) {
+		ws.sendCustom('video_call:user_joined', {
+			event_id: eventId
+		});
+	}
+
+	// User leaves a video call
+	leaveCall(eventId: string) {
+		ws.sendCustom('video_call:user_left', {
+			event_id: eventId
+		});
+		// Clear local state when leaving
+		this._currentCallState = null;
+	}
+
+	// Change the call state (moderator/facilitator only)
+	changeCallState(eventId: string, status: VideoCallStatus) {
+		ws.sendCustom('video_call:change_state', {
+			event_id: eventId,
+			status
+		});
+	}
+
+	// Assign participants to breakout rooms (moderator/facilitator only)
+	assignBreakoutRooms(eventId: string, maxUsersPerRoom: number) {
+		ws.sendCustom('video_call:assign_breakout_rooms', {
+			event_id: eventId,
+			max_users_per_room: maxUsersPerRoom
+		});
+	}
+
+	// Set the current agenda item (moderator/facilitator only)
+	setAgendaItem(eventId: string, agendaItem: number) {
+		ws.sendCustom('video_call:set_agenda_item', {
+			event_id: eventId,
+			agenda_item: agendaItem
+		});
+	}
+
+	// Broadcast a message to all participants (moderator/facilitator only)
+	broadcastMessage(eventId: string, message: string) {
+		ws.sendCustom('video_call:send_message', {
+			event_id: eventId,
+			message
+		});
+	}
+
+	// Helper to check if current user is in a specific breakout room
+	getUserBreakoutRoom(userId: string): number | null {
+		if (!this._currentCallState) return null;
+
+		for (let i = 0; i < this._currentCallState.breakout_rooms.length; i++) {
+			if (this._currentCallState.breakout_rooms[i].participants.includes(userId)) {
+				return i;
+			}
+		}
+		return null;
+	}
+
+	// Helper to get participants in a specific breakout room
+	getBreakoutRoomParticipants(roomIndex: number): VideoCallParticipant[] {
+		if (!this._currentCallState || roomIndex >= this._currentCallState.breakout_rooms.length) {
+			return [];
+		}
+
+		const room = this._currentCallState.breakout_rooms[roomIndex];
+		return room.participants
+			.map((userId) => this._currentCallState!.participants[userId])
+			.filter(Boolean);
+	}
+
+	// Helper to check if user has moderator/facilitator role
+	isAuthorized(userId: string): boolean {
+		if (!this._currentCallState) return false;
+
+		const participant = this._currentCallState.participants[userId];
+		if (!participant) return false;
+
+		return participant.role === 'moderator' || participant.role === 'facilitator';
+	}
+
+	// Clear last broadcast message
+	clearLastMessage() {
+		this._lastBroadcastMessage = null;
+	}
+}
+
+// Singleton instance
+export const videoCallService = new VideoCallService();

--- a/ui/packages/comhairle/src/lib/services/videoCallService.svelte.ts
+++ b/ui/packages/comhairle/src/lib/services/videoCallService.svelte.ts
@@ -4,11 +4,8 @@ import { ws } from '$lib/api/websockets.svelte';
 export type VideoCallStatus = 'Waiting' | 'InProgress' | 'Ended';
 
 export interface VideoCallParticipant {
-	user: {
-		id: string;
-		username: string;
-		email: string;
-	};
+	user_id: string;
+	username: string | null;
 	role: string;
 }
 


### PR DESCRIPTION
Adds a websocket service for video calls to coordinate a given call. There is a backend implementation and a frontend service that work together

It syncs the room state to all participants automatically 
It gives events for users joining / leaving 
It automatically generate breakout rooms and gives a function to regenerate them if needed. 
It allows the moderator to start the call / end the call 
It allows the moderator to set the current agenda item.