### PR TITLE
Live Event UI: Full meeting flow with breakout rooms, agenda management, and facilitator controls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -704,9 +704,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-async"
-version = "1.2.14"
+version = "1.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffcaf626bdda484571968400c326a244598634dc75fd451325a54ad1a59acfc"
+checksum = "5cc50d0f63e714784b84223abd7abbc8577de8c35d699e0edd19f0a88a08ae13"
 dependencies = [
  "futures-util",
  "pin-project-lite",
@@ -2182,7 +2182,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3166,7 +3166,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "system-configuration 0.6.1",
  "tokio",
  "tower-service",
@@ -3830,7 +3830,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4499,7 +4499,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.36",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "thiserror 2.0.17",
  "tokio",
  "tracing",
@@ -4536,9 +4536,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5039,7 +5039,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6086,7 +6086,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/api/src/models/event.rs
+++ b/api/src/models/event.rs
@@ -192,6 +192,9 @@ impl PartialEvent {
         if let Some(value) = &self.signup_mode {
             values.push((EventIden::SignupMode, value.into()));
         }
+        if let Some(value) = &self.agenda {
+            values.push((EventIden::Agenda, value.into()));
+        }
 
         values
     }

--- a/api/src/models/event.rs
+++ b/api/src/models/event.rs
@@ -30,6 +30,7 @@ pub struct BreakoutRoomAgendaItem {
     pub instructions: String,
     pub estimated_time: u32,
     pub time_limit: Option<u32>,
+    pub max_per_room: Option<u32>,
 }
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema, Clone, PartialEq)]

--- a/api/src/routes/events.rs
+++ b/api/src/routes/events.rs
@@ -204,7 +204,7 @@ async fn get_jwt(
         .as_ref()
         .ok_or(ComhairleError::NoVideoServiceConfigured)?;
 
-    let is_moderator = attendance.role == "facilitator";
+    let is_moderator = attendance.role == "facilitator" || attendance.role == "moderator";
 
     let claims = VideoEventJwtClaims {
         iss: &video_call_config.jwt_app_id,

--- a/api/src/routes/events.rs
+++ b/api/src/routes/events.rs
@@ -195,7 +195,7 @@ async fn get_jwt(
         event_attendance::get_by_event_and_user(&state.db, &event_id, &user.id).await?;
 
     let event = event::get_by_id(&state.db, &event_id).await?;
-    let video_meeting_id = event
+    let _video_meeting_id = event
         .video_meeting_id
         .ok_or(ComhairleError::NoVideoMeetingId)?;
     let video_call_config = &state
@@ -214,7 +214,7 @@ async fn get_jwt(
             user: VideoEventJwtUser {
                 name: user.username.as_deref(),
                 id: &user.id.to_string(),
-                moderator: attendance.role == "facilitator",
+                moderator: is_moderator,
             },
         },
     };

--- a/api/src/routes/events.rs
+++ b/api/src/routes/events.rs
@@ -209,7 +209,7 @@ async fn get_jwt(
     let claims = VideoEventJwtClaims {
         iss: &video_call_config.jwt_app_id,
         aud: &video_call_config.jwt_app_id,
-        room: &video_meeting_id.to_string(),
+        room: "*",
         context: VideoEventJwtContext {
             user: VideoEventJwtUser {
                 name: user.username.as_deref(),

--- a/api/src/websockets/handlers/video_call.rs
+++ b/api/src/websockets/handlers/video_call.rs
@@ -193,6 +193,9 @@ struct ChangeCallStatusData {
 struct AssignBreakoutRoomsData {
     pub event_id: Uuid,
     pub max_users_per_room: usize,
+    /// When provided, use these explicit assignments instead of random chunking.
+    /// Each inner Vec is the list of user IDs for one breakout room.
+    pub room_assignments: Option<Vec<Vec<Uuid>>>,
 }
 
 /// Data structure for starting a breakout session.
@@ -750,21 +753,36 @@ impl VideoCallMessageHandler {
                 // Check if the user is authorized (moderator or facilitator)
                 if let Some(participant) = call.participants.get(&user_id) {
                     if participant.role == "moderator" || participant.role == "facilitator" {
-                        // Collect all participant IDs
-                        let mut participant_ids: Vec<Uuid> =
-                            call.participants.keys().copied().collect();
+                        let breakout_rooms = if let Some(ref explicit) = assignment_data.room_assignments {
+                            // Use explicit assignments, filtering to known participants
+                            explicit
+                                .iter()
+                                .map(|room_ids| BreakoutRoomAssignments {
+                                    participants: room_ids
+                                        .iter()
+                                        .filter(|id| call.participants.contains_key(id))
+                                        .copied()
+                                        .collect(),
+                                })
+                                .filter(|room| !room.participants.is_empty())
+                                .collect()
+                        } else {
+                            // Collect all participant IDs
+                            let mut participant_ids: Vec<Uuid> =
+                                call.participants.keys().copied().collect();
 
-                        // Shuffle participants randomly
-                        let mut rng = rand::thread_rng();
-                        participant_ids.shuffle(&mut rng);
+                            // Shuffle participants randomly
+                            let mut rng = rand::thread_rng();
+                            participant_ids.shuffle(&mut rng);
 
-                        // Divide into rooms with max_users_per_room
-                        let breakout_rooms: Vec<BreakoutRoomAssignments> = participant_ids
-                            .chunks(max_users)
-                            .map(|chunk| BreakoutRoomAssignments {
-                                participants: chunk.to_vec(),
-                            })
-                            .collect();
+                            // Divide into rooms with max_users_per_room
+                            participant_ids
+                                .chunks(max_users)
+                                .map(|chunk| BreakoutRoomAssignments {
+                                    participants: chunk.to_vec(),
+                                })
+                                .collect()
+                        };
 
                         call.breakout_rooms = breakout_rooms;
                         return true;

--- a/ui/packages/api-client/src/api.ts
+++ b/ui/packages/api-client/src/api.ts
@@ -1097,6 +1097,7 @@ export const BreakoutRoomAgendaItem = z
     instructions: z.string(),
     prompt: z.string(),
     time_limit: z.union([z.number(), z.null()]).optional(),
+    max_per_room: z.union([z.number().int().gte(0), z.null()]).optional(),
   })
   .passthrough();
 export type BreakoutRoomAgendaItem = z.infer<typeof BreakoutRoomAgendaItem>;

--- a/ui/packages/comhairle/src/lib/components/JitsiMeet/JitsiMeet.svelte
+++ b/ui/packages/comhairle/src/lib/components/JitsiMeet/JitsiMeet.svelte
@@ -15,12 +15,14 @@
 		startWithVideoMuted?: boolean;
 		configOverwrite?: Record<string, any>;
 		interfaceConfigOverwrite?: Record<string, any>;
+		loadingMessage?: string;
 		onApiReady?: (api: any) => void;
 		onReadyToClose?: () => void;
 		onParticipantJoined?: (participant: any) => void;
 		onParticipantLeft?: (participant: any) => void;
 		onVideoConferenceJoined?: (data: any) => void;
 		onVideoConferenceLeft?: (data: any) => void;
+		onBreakoutRoomsUpdated?: (rooms: Record<string, any>) => void;
 	}
 
 	let {
@@ -35,12 +37,14 @@
 		startWithVideoMuted = false,
 		configOverwrite = {},
 		interfaceConfigOverwrite = {},
+		loadingMessage = 'Connecting to meeting...',
 		onApiReady,
 		onReadyToClose,
 		onParticipantJoined,
 		onParticipantLeft,
 		onVideoConferenceJoined,
-		onVideoConferenceLeft
+		onVideoConferenceLeft,
+		onBreakoutRoomsUpdated
 	}: JitsiMeetProps = $props();
 
 	let containerEl: HTMLDivElement;
@@ -64,6 +68,14 @@
 	}
 
 	function initJitsi() {
+		console.log(
+			'[JITSI] initJitsi called for room:',
+			roomName,
+			'| jwt present:',
+			!!jwt,
+			'| jwt length:',
+			jwt?.length
+		);
 		const JitsiMeetExternalAPI = (window as any).JitsiMeetExternalAPI;
 		if (!JitsiMeetExternalAPI) {
 			error = 'JitsiMeetExternalAPI not available';
@@ -98,31 +110,47 @@
 		}
 
 		try {
+			console.log('[JITSI] Creating JitsiMeetExternalAPI:', {
+				domain,
+				roomName,
+				jwt: jwt ? jwt.substring(0, 50) + '...' : 'none'
+			});
 			api = new JitsiMeetExternalAPI(domain, options);
 
 			api.addListener('videoConferenceJoined', (data: any) => {
+				console.log('[JITSI] videoConferenceJoined:', data);
 				loading = false;
 				onVideoConferenceJoined?.(data);
 			});
 
 			api.addListener('readyToClose', () => {
+				console.log('[JITSI] readyToClose fired');
 				onReadyToClose?.();
 			});
 
 			api.addListener('participantJoined', (data: any) => {
+				console.log('[JITSI] participantJoined:', data);
 				onParticipantJoined?.(data);
 			});
 
 			api.addListener('participantLeft', (data: any) => {
+				console.log('[JITSI] participantLeft:', data);
 				onParticipantLeft?.(data);
 			});
 
 			api.addListener('videoConferenceLeft', (data: any) => {
+				console.log('[JITSI] videoConferenceLeft:', data);
 				onVideoConferenceLeft?.(data);
+			});
+
+			api.addListener('breakoutRoomsUpdated', (data: any) => {
+				console.log('[JITSI] breakoutRoomsUpdated:', data);
+				onBreakoutRoomsUpdated?.(data);
 			});
 
 			onApiReady?.(api);
 		} catch (e) {
+			console.error('[JITSI] Failed to initialize:', e);
 			error = e instanceof Error ? e.message : 'Failed to initialize Jitsi';
 			loading = false;
 		}
@@ -139,6 +167,7 @@
 			});
 
 		return () => {
+			console.log('[JITSI] onMount cleanup — disposing API for room:', roomName);
 			if (api) {
 				api.dispose();
 				api = null;
@@ -184,7 +213,7 @@
 				<div
 					class="border-primary h-8 w-8 animate-spin rounded-full border-4 border-t-transparent"
 				></div>
-				<span class="text-muted-foreground text-sm">Connecting to meeting...</span>
+				<span class="text-muted-foreground text-sm">{loadingMessage}</span>
 			</div>
 		</div>
 	{/if}

--- a/ui/packages/comhairle/src/lib/components/JitsiMeet/JitsiMeet.svelte
+++ b/ui/packages/comhairle/src/lib/components/JitsiMeet/JitsiMeet.svelte
@@ -23,6 +23,7 @@
 		onVideoConferenceJoined?: (data: any) => void;
 		onVideoConferenceLeft?: (data: any) => void;
 		onBreakoutRoomsUpdated?: (rooms: Record<string, any>) => void;
+		onModeratorStatusChanged?: (isModerator: boolean) => void;
 	}
 
 	let {
@@ -44,7 +45,8 @@
 		onParticipantLeft,
 		onVideoConferenceJoined,
 		onVideoConferenceLeft,
-		onBreakoutRoomsUpdated
+		onBreakoutRoomsUpdated,
+		onModeratorStatusChanged
 	}: JitsiMeetProps = $props();
 
 	let containerEl: HTMLDivElement;
@@ -67,6 +69,20 @@
 		});
 	}
 
+	function decodeJwt(token: string) {
+		try {
+			const parts = token.split('.');
+			if (parts.length !== 3) return null;
+			// Decode the payload (second part)
+			const payload = parts[1];
+			const decoded = atob(payload.replace(/-/g, '+').replace(/_/g, '/'));
+			return JSON.parse(decoded);
+		} catch (e) {
+			console.error('[JITSI] Failed to decode JWT:', e);
+			return null;
+		}
+	}
+
 	function initJitsi() {
 		console.log(
 			'[JITSI] initJitsi called for room:',
@@ -76,6 +92,14 @@
 			'| jwt length:',
 			jwt?.length
 		);
+
+		// Decode and log JWT claims
+		if (jwt) {
+			const claims = decodeJwt(jwt);
+			console.log('[JITSI] JWT Claims:', claims);
+			console.log('[JITSI] Moderator status in JWT:', claims?.context?.user?.moderator);
+		}
+
 		const JitsiMeetExternalAPI = (window as any).JitsiMeetExternalAPI;
 		if (!JitsiMeetExternalAPI) {
 			error = 'JitsiMeetExternalAPI not available';
@@ -117,8 +141,33 @@
 			});
 			api = new JitsiMeetExternalAPI(domain, options);
 
+			let localParticipantId: string | null = null;
+
 			api.addListener('videoConferenceJoined', (data: any) => {
+				console.log('[JITSI] ===== JOINED CONFERENCE =====');
 				console.log('[JITSI] videoConferenceJoined:', data);
+				console.log('[JITSI] Room name:', data.roomName);
+				console.log('[JITSI] Display name:', data.displayName);
+				console.log('[JITSI] Participant ID:', data.id);
+
+				// Store local participant ID
+				localParticipantId = data.id;
+
+				// Log the user's role/moderator status
+				const isModerator = api.isModeratorEnabled?.() ?? false;
+				const participantInfo = api.getParticipantsInfo?.();
+				console.log('[JITSI] Current user role:', {
+					isModerator,
+					displayName: data.displayName,
+					participantId: data.id,
+					participantInfo
+				});
+				console.log('[JITSI] ==============================');
+
+				// Notify parent of moderator status
+				console.log('[JITSI] Setting initial moderator status:', isModerator);
+				onModeratorStatusChanged?.(isModerator);
+
 				loading = false;
 				onVideoConferenceJoined?.(data);
 			});
@@ -139,13 +188,49 @@
 			});
 
 			api.addListener('videoConferenceLeft', (data: any) => {
+				console.log('[JITSI] ===== LEFT CONFERENCE =====');
 				console.log('[JITSI] videoConferenceLeft:', data);
+				console.log('[JITSI] Room name:', data.roomName);
+				console.log('[JITSI] ==========================');
 				onVideoConferenceLeft?.(data);
 			});
 
 			api.addListener('breakoutRoomsUpdated', (data: any) => {
-				console.log('[JITSI] breakoutRoomsUpdated:', data);
-				onBreakoutRoomsUpdated?.(data);
+				console.log('[JITSI] breakoutRoomsUpdated event received');
+				console.log('[JITSI] Data structure:', data);
+				const rooms = data?.rooms || data || {};
+				console.log('[JITSI] Parsed rooms:', rooms);
+				console.log('[JITSI] Room count:', Object.keys(rooms).length);
+				console.log(
+					'[JITSI] Room details:',
+					Object.values(rooms).map((r: any) => ({
+						id: r.id,
+						jid: r.jid,
+						name: r.name,
+						isMainRoom: r.isMainRoom
+					}))
+				);
+				onBreakoutRoomsUpdated?.(rooms);
+			});
+
+			api.addListener('participantRoleChanged', (data: any) => {
+				const isModeratorFromRole = data.role === 'moderator';
+				const isModeratorFromAPI = api.isModeratorEnabled?.() ?? false;
+				console.log('[JITSI] participantRoleChanged:', {
+					participantId: data.id,
+					role: data.role,
+					isLocalUser: data.id === localParticipantId,
+					localParticipantId,
+					isModeratorFromRole,
+					isModeratorFromAPI
+				});
+
+				// Only update moderator status if this is the local user's role changing
+				if (data.id === localParticipantId) {
+					console.log('[JITSI] Local user role changed to:', data.role);
+					// Use the role from the event, not isModeratorEnabled()
+					onModeratorStatusChanged?.(isModeratorFromRole);
+				}
 			});
 
 			onApiReady?.(api);

--- a/ui/packages/comhairle/src/lib/components/LiveEvent/AddTimeDialog.svelte
+++ b/ui/packages/comhairle/src/lib/components/LiveEvent/AddTimeDialog.svelte
@@ -1,0 +1,55 @@
+<script lang="ts">
+	import * as Dialog from '$lib/components/ui/dialog';
+	import Button from '$lib/components/ui/button/button.svelte';
+	import { X } from 'lucide-svelte';
+
+	interface Props {
+		open: boolean;
+		timeLeftFormatted: string;
+		onClose: () => void;
+		onAddTime: (minutes: number) => void;
+	}
+
+	let { open = $bindable(), timeLeftFormatted, onClose, onAddTime }: Props = $props();
+
+	function handleAdd(minutes: number) {
+		onAddTime(minutes);
+		open = false;
+	}
+</script>
+
+<Dialog.Root bind:open onOpenChange={(v) => !v && onClose()}>
+	<Dialog.Content class="max-w-xl rounded-3xl p-9">
+		<div class="flex flex-col items-center gap-7">
+			<h2 class="text-foreground text-2xl leading-7 font-semibold">Add time</h2>
+
+			<span class="text-muted-foreground text-xs leading-6 font-medium">
+				Time left {timeLeftFormatted}
+			</span>
+
+			<div class="flex w-full items-center justify-center gap-4">
+				<Button
+					variant="primaryDark"
+					class="h-12 px-5 text-base font-medium"
+					onclick={() => handleAdd(1)}
+				>
+					+1 minute
+				</Button>
+				<Button
+					variant="primaryDark"
+					class="h-12 px-5 text-base font-medium"
+					onclick={() => handleAdd(2)}
+				>
+					+2 minutes
+				</Button>
+				<Button
+					variant="primaryDark"
+					class="h-12 px-5 text-base font-medium"
+					onclick={() => handleAdd(5)}
+				>
+					+5 minutes
+				</Button>
+			</div>
+		</div>
+	</Dialog.Content>
+</Dialog.Root>

--- a/ui/packages/comhairle/src/lib/components/LiveEvent/AddTimeDialog.svelte
+++ b/ui/packages/comhairle/src/lib/components/LiveEvent/AddTimeDialog.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import * as Dialog from '$lib/components/ui/dialog';
 	import Button from '$lib/components/ui/button/button.svelte';
-	import { X } from 'lucide-svelte';
 
 	interface Props {
 		open: boolean;

--- a/ui/packages/comhairle/src/lib/components/LiveEvent/AgendaPanel.svelte
+++ b/ui/packages/comhairle/src/lib/components/LiveEvent/AgendaPanel.svelte
@@ -10,6 +10,7 @@
 		readOnly?: boolean;
 		onSetCurrent?: (index: number) => void;
 		onNext?: () => void;
+		onEndMeeting?: () => void;
 	}
 
 	let {
@@ -18,7 +19,8 @@
 		isModerator,
 		readOnly = false,
 		onSetCurrent,
-		onNext
+		onNext,
+		onEndMeeting
 	}: Props = $props();
 
 	let interactive = $derived(isModerator && !readOnly);
@@ -35,6 +37,7 @@
 	}
 
 	let hasNext = $derived(currentStep < items.length - 1);
+	let isLastItem = $derived(currentStep === items.length - 1 && items.length > 0);
 </script>
 
 <div class="flex h-full flex-col overflow-hidden">
@@ -55,14 +58,24 @@
 	<!-- Footer (fixed at bottom) -->
 	{#if interactive}
 		<div class="shrink-0 border-t p-4">
-			<Button
-				variant="primaryDark"
-				class="h-10 w-full text-sm font-medium"
-				onclick={() => onNext?.()}
-				disabled={!hasNext}
-			>
-				Next
-			</Button>
+			{#if isLastItem}
+				<Button
+					variant="destructive"
+					class="h-10 w-full text-sm font-medium"
+					onclick={() => onEndMeeting?.()}
+				>
+					End meeting
+				</Button>
+			{:else}
+				<Button
+					variant="primaryDark"
+					class="h-10 w-full text-sm font-medium"
+					onclick={() => onNext?.()}
+					disabled={!hasNext}
+				>
+					Next
+				</Button>
+			{/if}
 		</div>
 	{/if}
 </div>

--- a/ui/packages/comhairle/src/lib/components/LiveEvent/AgendaPanel.svelte
+++ b/ui/packages/comhairle/src/lib/components/LiveEvent/AgendaPanel.svelte
@@ -47,67 +47,7 @@
 	<div class="min-h-0 flex-1 overflow-y-auto p-4">
 		<div class="flex w-full flex-col gap-1.5">
 			{#each items as item, index (item.id)}
-				{@const status = getStatus(index)}
-				{#if status === 'done'}
-					<svelte:element
-						this={interactive ? 'button' : 'div'}
-						class="bg-muted-foreground/10 inline-flex w-full items-center overflow-hidden rounded-xl border px-3 py-4 text-left {interactive
-							? 'hover:bg-muted-foreground/20 cursor-pointer'
-							: ''}"
-						onclick={() => handleItemClick(index)}
-					>
-						<div class="flex items-center gap-2">
-							<div
-								class="bg-muted-foreground/20 flex h-6 w-6 shrink-0 items-center justify-center rounded-full"
-							>
-								<Check class="text-muted-foreground h-3 w-3" />
-							</div>
-							<span class="text-muted-foreground line-clamp-1 text-xs font-medium">
-								{item.title}
-							</span>
-						</div>
-					</svelte:element>
-				{:else if status === 'current'}
-					<svelte:element
-						this={interactive ? 'button' : 'div'}
-						class="bg-primary/30 flex w-full flex-col items-start justify-center rounded-xl px-3 py-4 shadow-sm {interactive
-							? 'cursor-pointer'
-							: ''}"
-						onclick={() => handleItemClick(index)}
-					>
-						<div class="inline-flex items-center gap-2">
-							<span
-								class="text-primary bg-background flex h-6 shrink-0 items-center rounded-full border px-2 text-xs font-medium"
-							>
-								Current
-							</span>
-							<span class="text-foreground line-clamp-2 text-xs font-semibold">
-								{item.title}
-							</span>
-						</div>
-					</svelte:element>
-				{:else}
-					<svelte:element
-						this={interactive ? 'button' : 'div'}
-						class="bg-background inline-flex w-full items-center overflow-hidden rounded-xl border px-3 py-4 text-left {interactive
-							? 'hover:bg-accent cursor-pointer'
-							: ''}"
-						onclick={() => handleItemClick(index)}
-					>
-						<div class="flex items-center gap-2">
-							<div
-								class="bg-primary/10 flex h-6 w-6 shrink-0 items-center justify-center rounded-full"
-							>
-								<span class="text-primary text-xs leading-6 font-medium">
-									{index + 1}
-								</span>
-							</div>
-							<span class="text-foreground line-clamp-2 text-xs font-medium">
-								{item.title}
-							</span>
-						</div>
-					</svelte:element>
-				{/if}
+				{@render agendaItem(item, index)}
 			{/each}
 		</div>
 	</div>
@@ -126,3 +66,51 @@
 		</div>
 	{/if}
 </div>
+
+{#snippet agendaItem(item: AgendaItem, index: number)}
+	{@const status = getStatus(index)}
+	{@const wrapperClass =
+		status === 'done'
+			? `bg-muted-foreground/10 inline-flex items-center overflow-hidden border ${interactive ? 'hover:bg-muted-foreground/20 cursor-pointer' : ''}`
+			: status === 'current'
+				? `bg-primary/30 flex flex-col items-start justify-center shadow-sm ${interactive ? 'cursor-pointer' : ''}`
+				: `bg-background inline-flex items-center overflow-hidden border ${interactive ? 'hover:bg-accent cursor-pointer' : ''}`}
+	<svelte:element
+		this={interactive ? 'button' : 'div'}
+		class="w-full rounded-xl px-3 py-4 text-left {wrapperClass}"
+		onclick={() => handleItemClick(index)}
+	>
+		<div class="{status === 'current' ? 'inline-flex' : 'flex'} items-center gap-2">
+			{#if status === 'done'}
+				<div
+					class="bg-muted-foreground/20 flex h-6 w-6 shrink-0 items-center justify-center rounded-full"
+				>
+					<Check class="text-muted-foreground h-3 w-3" />
+				</div>
+			{:else if status === 'current'}
+				<span
+					class="text-primary bg-background flex h-6 shrink-0 items-center rounded-full border px-2 text-xs font-medium"
+				>
+					Current
+				</span>
+			{:else}
+				<div
+					class="bg-primary/10 flex h-6 w-6 shrink-0 items-center justify-center rounded-full"
+				>
+					<span class="text-primary text-xs leading-6 font-medium">
+						{index + 1}
+					</span>
+				</div>
+			{/if}
+			<span
+				class="text-xs {status === 'done'
+					? 'text-muted-foreground line-clamp-1 font-medium'
+					: status === 'current'
+						? 'text-foreground line-clamp-2 font-semibold'
+						: 'text-foreground line-clamp-2 font-medium'}"
+			>
+				{item.title}
+			</span>
+		</div>
+	</svelte:element>
+{/snippet}

--- a/ui/packages/comhairle/src/lib/components/LiveEvent/AgendaPanel.svelte
+++ b/ui/packages/comhairle/src/lib/components/LiveEvent/AgendaPanel.svelte
@@ -1,0 +1,128 @@
+<script lang="ts">
+	import Button from '$lib/components/ui/button/button.svelte';
+	import { Check } from 'lucide-svelte';
+	import type { AgendaItem } from './types';
+
+	interface Props {
+		items: AgendaItem[];
+		currentStep: number;
+		isModerator: boolean;
+		readOnly?: boolean;
+		onSetCurrent?: (index: number) => void;
+		onNext?: () => void;
+	}
+
+	let {
+		items,
+		currentStep,
+		isModerator,
+		readOnly = false,
+		onSetCurrent,
+		onNext
+	}: Props = $props();
+
+	let interactive = $derived(isModerator && !readOnly);
+
+	function getStatus(index: number): 'done' | 'current' | 'upcoming' {
+		if (index < currentStep) return 'done';
+		if (index === currentStep) return 'current';
+		return 'upcoming';
+	}
+
+	function handleItemClick(index: number) {
+		if (!interactive) return;
+		onSetCurrent?.(index);
+	}
+
+	let hasNext = $derived(currentStep < items.length - 1);
+</script>
+
+<div class="flex h-full flex-col overflow-hidden">
+	<!-- Header -->
+	<div class="flex shrink-0 items-center justify-center px-5">
+		<h2 class="text-muted-foreground text-center text-xl leading-7 font-semibold">Agenda</h2>
+	</div>
+
+	<!-- Items (scrollable) -->
+	<div class="min-h-0 flex-1 overflow-y-auto p-4">
+		<div class="flex w-full flex-col gap-1.5">
+			{#each items as item, index (item.id)}
+				{@const status = getStatus(index)}
+				{#if status === 'done'}
+					<svelte:element
+						this={interactive ? 'button' : 'div'}
+						class="bg-muted-foreground/10 inline-flex w-full items-center overflow-hidden rounded-xl border px-3 py-4 text-left {interactive
+							? 'hover:bg-muted-foreground/20 cursor-pointer'
+							: ''}"
+						onclick={() => handleItemClick(index)}
+					>
+						<div class="flex items-center gap-2">
+							<div
+								class="bg-muted-foreground/20 flex h-6 w-6 shrink-0 items-center justify-center rounded-full"
+							>
+								<Check class="text-muted-foreground h-3 w-3" />
+							</div>
+							<span class="text-muted-foreground line-clamp-1 text-xs font-medium">
+								{item.title}
+							</span>
+						</div>
+					</svelte:element>
+				{:else if status === 'current'}
+					<svelte:element
+						this={interactive ? 'button' : 'div'}
+						class="bg-primary/30 flex w-full flex-col items-start justify-center rounded-xl px-3 py-4 shadow-sm {interactive
+							? 'cursor-pointer'
+							: ''}"
+						onclick={() => handleItemClick(index)}
+					>
+						<div class="inline-flex items-center gap-2">
+							<span
+								class="text-primary bg-background flex h-6 shrink-0 items-center rounded-full border px-2 text-xs font-medium"
+							>
+								Current
+							</span>
+							<span class="text-foreground line-clamp-2 text-xs font-semibold">
+								{item.title}
+							</span>
+						</div>
+					</svelte:element>
+				{:else}
+					<svelte:element
+						this={interactive ? 'button' : 'div'}
+						class="bg-background inline-flex w-full items-center overflow-hidden rounded-xl border px-3 py-4 text-left {interactive
+							? 'hover:bg-accent cursor-pointer'
+							: ''}"
+						onclick={() => handleItemClick(index)}
+					>
+						<div class="flex items-center gap-2">
+							<div
+								class="bg-primary/10 flex h-6 w-6 shrink-0 items-center justify-center rounded-full"
+							>
+								<span class="text-primary text-xs leading-6 font-medium">
+									{index + 1}
+								</span>
+							</div>
+							<span class="text-foreground line-clamp-2 text-xs font-medium">
+								{item.title}
+							</span>
+						</div>
+					</svelte:element>
+				{/if}
+			{/each}
+		</div>
+	</div>
+
+	<!-- Footer (fixed at bottom) -->
+	{#if interactive}
+		<div class="shrink-0 border-t p-4">
+			<Button
+				variant="primaryDark"
+				class="h-10 w-full text-sm font-medium"
+				onclick={() => onNext?.()}
+				disabled={!hasNext}
+			>
+				Next
+			</Button>
+		</div>
+	{/if}
+</div>

--- a/ui/packages/comhairle/src/lib/components/LiveEvent/AssistanceNoticeDialog.svelte
+++ b/ui/packages/comhairle/src/lib/components/LiveEvent/AssistanceNoticeDialog.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+	import * as Dialog from '$lib/components/ui/dialog';
+	import Button from '$lib/components/ui/button/button.svelte';
+	import { X } from 'lucide-svelte';
+
+	interface Props {
+		open: boolean;
+		participantName: string;
+		roomName: string;
+		roomIndex: number;
+		onClose: () => void;
+		onEnterRoom: (roomIndex: number) => void;
+	}
+
+	let {
+		open = $bindable(),
+		participantName,
+		roomName,
+		roomIndex,
+		onClose,
+		onEnterRoom
+	}: Props = $props();
+
+	function handleEnter() {
+		onEnterRoom(roomIndex);
+		open = false;
+	}
+</script>
+
+<Dialog.Root bind:open onOpenChange={(v) => !v && onClose()}>
+	<Dialog.Content class="max-w-xl rounded-3xl p-9">
+		<div class="flex flex-col items-center gap-7">
+			<h2 class="text-foreground text-2xl leading-7 font-semibold">Notice</h2>
+
+			<p class="text-foreground text-center text-lg leading-7 font-medium">
+				{participantName} from {roomName} requested help.
+			</p>
+
+			<div class="flex w-full items-center justify-center">
+				<Button
+					variant="primaryDark"
+					class="h-12 px-5 text-base font-medium"
+					onclick={handleEnter}
+				>
+					Enter {roomName}
+				</Button>
+			</div>
+		</div>
+	</Dialog.Content>
+</Dialog.Root>

--- a/ui/packages/comhairle/src/lib/components/LiveEvent/BreakoutEndingDialog.svelte
+++ b/ui/packages/comhairle/src/lib/components/LiveEvent/BreakoutEndingDialog.svelte
@@ -1,0 +1,47 @@
+<script lang="ts">
+	import * as Dialog from '$lib/components/ui/dialog';
+	import Button from '$lib/components/ui/button/button.svelte';
+	import { X } from 'lucide-svelte';
+
+	interface Props {
+		open: boolean;
+		secondsLeft: number;
+		onGoBack: () => void;
+	}
+
+	let { open = $bindable(), secondsLeft, onGoBack }: Props = $props();
+</script>
+
+<Dialog.Root bind:open>
+	<Dialog.Content class="max-w-md rounded-3xl p-9 sm:max-w-md" showCloseButton={false}>
+		<button
+			class="text-muted-foreground hover:text-foreground absolute top-6 right-6"
+			onclick={onGoBack}
+		>
+			<X class="h-5 w-5" />
+		</button>
+
+		<div class="flex flex-col items-center gap-7">
+			<h2 class="text-foreground text-2xl leading-7 font-semibold">Notice</h2>
+
+			<p class="text-foreground text-center text-lg leading-7 font-medium">
+				This breakout room has ended.<br />
+				Go back to the plenary room.
+			</p>
+
+			<p class="text-foreground text-center text-lg leading-7 font-medium">
+				in {secondsLeft} second{secondsLeft !== 1 ? 's' : ''}..
+			</p>
+
+			<div class="flex w-full justify-center">
+				<Button
+					variant="primaryDark"
+					class="h-12 px-6 text-base font-medium"
+					onclick={onGoBack}
+				>
+					Go back
+				</Button>
+			</div>
+		</div>
+	</Dialog.Content>
+</Dialog.Root>

--- a/ui/packages/comhairle/src/lib/components/LiveEvent/BreakoutEndingDialog.svelte
+++ b/ui/packages/comhairle/src/lib/components/LiveEvent/BreakoutEndingDialog.svelte
@@ -30,7 +30,7 @@
 			</p>
 
 			<p class="text-foreground text-center text-lg leading-7 font-medium">
-				in {secondsLeft} second{secondsLeft !== 1 ? 's' : ''}..
+				in {secondsLeft} second{secondsLeft !== 1 ? 's' : ''}.
 			</p>
 
 			<div class="flex w-full justify-center">

--- a/ui/packages/comhairle/src/lib/components/LiveEvent/BreakoutRoomsPanel.svelte
+++ b/ui/packages/comhairle/src/lib/components/LiveEvent/BreakoutRoomsPanel.svelte
@@ -158,12 +158,6 @@
 						{/if}
 					</button>
 					<div class="border-border h-6 border-l"></div>
-					<button
-						class="text-foreground hover:bg-muted flex flex-1 items-center justify-center gap-2 px-4 py-3 text-xs font-medium"
-					>
-						<AlignLeft class="h-4 w-4" />
-						View Transcription
-					</button>
 				</div>
 			</div>
 		{/each}

--- a/ui/packages/comhairle/src/lib/components/LiveEvent/BreakoutRoomsPanel.svelte
+++ b/ui/packages/comhairle/src/lib/components/LiveEvent/BreakoutRoomsPanel.svelte
@@ -1,13 +1,22 @@
 <script lang="ts">
 	import Button from '$lib/components/ui/button/button.svelte';
 	import type { BreakoutRoomDisplay } from './types';
-	import { PenLine, MoveUpRight, AlignLeft, Megaphone, Clock, CircleStop } from 'lucide-svelte';
+	import {
+		PenLine,
+		MoveUpRight,
+		AlignLeft,
+		Megaphone,
+		Clock,
+		CircleStop,
+		ArrowRightLeft
+	} from 'lucide-svelte';
 
 	interface Props {
 		rooms: BreakoutRoomDisplay[];
 		timeLeftFormatted: string;
 		isModerator: boolean;
 		onEnterRoom: (roomIndex: number) => void;
+		onMoveParticipant?: (userId: string, targetRoomIndex: number) => void;
 		onAddTime: () => void;
 		onEndSession: () => void;
 		onBroadcastMessage: () => void;
@@ -18,10 +27,23 @@
 		timeLeftFormatted,
 		isModerator,
 		onEnterRoom,
+		onMoveParticipant,
 		onAddTime,
 		onEndSession,
 		onBroadcastMessage
 	}: Props = $props();
+
+	/** User ID whose move-to-room picker is currently visible */
+	let moveTargetUserId = $state<string | null>(null);
+
+	function toggleMovePicker(userId: string) {
+		moveTargetUserId = moveTargetUserId === userId ? null : userId;
+	}
+
+	function handleMove(userId: string, targetRoomIndex: number) {
+		onMoveParticipant?.(userId, targetRoomIndex);
+		moveTargetUserId = null;
+	}
 
 	const avatarColors = [
 		'bg-blue-500',
@@ -75,19 +97,49 @@
 					</div>
 
 					<!-- Participant list -->
-					<div class="flex flex-wrap gap-x-5 gap-y-2">
-						{#each room.participants as p, i}
-							<div class="flex items-center gap-1.5">
-								<div
-									class="{avatarColors[
-										i % avatarColors.length
-									]} flex h-6 w-6 items-center justify-center rounded-full text-xs font-medium text-white uppercase"
-								>
-									{getInitial(p.username, p.user_id)}
+					<div class="flex flex-col gap-1.5">
+						{#each room.participants as p, i (p.user_id)}
+							<div class="flex flex-col">
+								<div class="flex items-center gap-1.5">
+									<div
+										class="{avatarColors[
+											i % avatarColors.length
+										]} flex h-6 w-6 items-center justify-center rounded-full text-xs font-medium text-white uppercase"
+									>
+										{getInitial(p.username, p.user_id)}
+									</div>
+									<span class="text-foreground text-sm font-medium">
+										{p.username ?? p.user_id.slice(0, 8)}
+									</span>
+									{#if isModerator && rooms.length > 1}
+										<button
+											class="text-muted-foreground hover:text-foreground ml-auto flex h-5 w-5 items-center justify-center rounded transition-colors {moveTargetUserId ===
+											p.user_id
+												? 'text-primary bg-primary/10'
+												: ''}"
+											title="Move to another room"
+											onclick={() => toggleMovePicker(p.user_id)}
+										>
+											<ArrowRightLeft class="h-3.5 w-3.5" />
+										</button>
+									{/if}
 								</div>
-								<span class="text-foreground text-sm font-medium">
-									{p.username ?? p.user_id.slice(0, 8)}
-								</span>
+								{#if isModerator && moveTargetUserId === p.user_id}
+									<div class="mt-1 ml-7.5 flex flex-wrap items-center gap-1">
+										<span class="text-muted-foreground text-xs">Move to:</span>
+										{#each rooms as targetRoom (targetRoom.index)}
+											{#if targetRoom.index !== room.index}
+												<button
+													class="bg-primary/10 text-primary hover:bg-primary hover:text-primary-foreground rounded-full px-2.5 py-0.5 text-xs font-medium transition-colors"
+													onclick={() =>
+														handleMove(p.user_id, targetRoom.index)}
+												>
+													#{targetRoom.index + 1}
+												</button>
+											{/if}
+										{/each}
+									</div>
+								{/if}
 							</div>
 						{/each}
 					</div>
@@ -118,7 +170,7 @@
 	</div>
 
 	<!-- Footer controls -->
-	<div class="flex flex-col items-center border-t px-3 pt-4 pb-3">
+	<div class="flex flex-col items-center gap-2 border-t px-3 pt-4 pb-3">
 		<Button
 			variant="primaryDark"
 			class="h-10 w-full text-sm font-medium"

--- a/ui/packages/comhairle/src/lib/components/LiveEvent/BreakoutRoomsPanel.svelte
+++ b/ui/packages/comhairle/src/lib/components/LiveEvent/BreakoutRoomsPanel.svelte
@@ -1,22 +1,13 @@
 <script lang="ts">
 	import Button from '$lib/components/ui/button/button.svelte';
 	import type { BreakoutRoomDisplay } from './types';
-	import {
-		PenLine,
-		MoveUpRight,
-		AlignLeft,
-		Megaphone,
-		Clock,
-		CircleStop,
-		ArrowRightLeft
-	} from 'lucide-svelte';
+	import { PenLine, MoveUpRight, Megaphone, CircleStop } from 'lucide-svelte';
 
 	interface Props {
 		rooms: BreakoutRoomDisplay[];
 		timeLeftFormatted: string;
 		isModerator: boolean;
 		onEnterRoom: (roomIndex: number) => void;
-		onMoveParticipant?: (userId: string, targetRoomIndex: number) => void;
 		onAddTime: () => void;
 		onEndSession: () => void;
 		onBroadcastMessage: () => void;
@@ -27,23 +18,10 @@
 		timeLeftFormatted,
 		isModerator,
 		onEnterRoom,
-		onMoveParticipant,
 		onAddTime,
 		onEndSession,
 		onBroadcastMessage
 	}: Props = $props();
-
-	/** User ID whose move-to-room picker is currently visible */
-	let moveTargetUserId = $state<string | null>(null);
-
-	function toggleMovePicker(userId: string) {
-		moveTargetUserId = moveTargetUserId === userId ? null : userId;
-	}
-
-	function handleMove(userId: string, targetRoomIndex: number) {
-		onMoveParticipant?.(userId, targetRoomIndex);
-		moveTargetUserId = null;
-	}
 
 	const avatarColors = [
 		'bg-blue-500',
@@ -111,35 +89,7 @@
 									<span class="text-foreground text-sm font-medium">
 										{p.username ?? p.user_id.slice(0, 8)}
 									</span>
-									{#if isModerator && rooms.length > 1}
-										<button
-											class="text-muted-foreground hover:text-foreground ml-auto flex h-5 w-5 items-center justify-center rounded transition-colors {moveTargetUserId ===
-											p.user_id
-												? 'text-primary bg-primary/10'
-												: ''}"
-											title="Move to another room"
-											onclick={() => toggleMovePicker(p.user_id)}
-										>
-											<ArrowRightLeft class="h-3.5 w-3.5" />
-										</button>
-									{/if}
 								</div>
-								{#if isModerator && moveTargetUserId === p.user_id}
-									<div class="mt-1 ml-7.5 flex flex-wrap items-center gap-1">
-										<span class="text-muted-foreground text-xs">Move to:</span>
-										{#each rooms as targetRoom (targetRoom.index)}
-											{#if targetRoom.index !== room.index}
-												<button
-													class="bg-primary/10 text-primary hover:bg-primary hover:text-primary-foreground rounded-full px-2.5 py-0.5 text-xs font-medium transition-colors"
-													onclick={() =>
-														handleMove(p.user_id, targetRoom.index)}
-												>
-													#{targetRoom.index + 1}
-												</button>
-											{/if}
-										{/each}
-									</div>
-								{/if}
 							</div>
 						{/each}
 					</div>
@@ -157,7 +107,6 @@
 							<span class="bg-destructive h-2 w-2 shrink-0 rounded-full"></span>
 						{/if}
 					</button>
-					<div class="border-border h-6 border-l"></div>
 				</div>
 			</div>
 		{/each}

--- a/ui/packages/comhairle/src/lib/components/LiveEvent/BreakoutRoomsPanel.svelte
+++ b/ui/packages/comhairle/src/lib/components/LiveEvent/BreakoutRoomsPanel.svelte
@@ -1,0 +1,149 @@
+<script lang="ts">
+	import Button from '$lib/components/ui/button/button.svelte';
+	import type { BreakoutRoomDisplay } from './types';
+	import { PenLine, MoveUpRight, AlignLeft, Megaphone, Clock, CircleStop } from '@lucide/svelte';
+
+	interface Props {
+		rooms: BreakoutRoomDisplay[];
+		timeLeftFormatted: string;
+		isModerator: boolean;
+		onEnterRoom: (roomIndex: number) => void;
+		onAddTime: () => void;
+		onEndSession: () => void;
+		onBroadcastMessage: () => void;
+	}
+
+	let {
+		rooms,
+		timeLeftFormatted,
+		isModerator,
+		onEnterRoom,
+		onAddTime,
+		onEndSession,
+		onBroadcastMessage
+	}: Props = $props();
+
+	const avatarColors = [
+		'bg-blue-500',
+		'bg-emerald-500',
+		'bg-amber-500',
+		'bg-rose-500',
+		'bg-violet-500',
+		'bg-cyan-500'
+	];
+
+	function getInitial(name: string | null, fallback: string): string {
+		if (name) return name.charAt(0).toUpperCase();
+		return fallback.charAt(0).toUpperCase();
+	}
+</script>
+
+<div class="flex h-full flex-col overflow-hidden">
+	<!-- Time left + controls -->
+	<div class="flex flex-col items-center gap-2 pt-1 pb-2">
+		{#if isModerator}
+			<button
+				class="text-primary flex cursor-pointer items-center gap-1 text-xs font-medium hover:underline"
+				onclick={() => onAddTime()}
+			>
+				<span>Time left {timeLeftFormatted}</span>
+				<PenLine class="h-2.5 w-2.5" />
+			</button>
+		{:else}
+			<span class="text-primary text-xs font-medium">
+				Time left {timeLeftFormatted}
+			</span>
+		{/if}
+	</div>
+
+	<!-- Room list -->
+	<div class="flex flex-1 flex-col gap-2 overflow-y-auto px-3">
+		{#each rooms as room (room.index)}
+			<div
+				class="bg-card border-border flex flex-col overflow-hidden rounded-xl border shadow-sm"
+			>
+				<div class="flex flex-col gap-4 px-5 py-4">
+					<div class="flex items-center justify-between">
+						<span
+							class="text-foreground line-clamp-1 text-base leading-6 font-semibold"
+						>
+							{room.name}
+						</span>
+						{#if room.hasAssistanceRequest}
+							<span class="bg-destructive h-2 w-2 shrink-0 rounded-full"></span>
+						{/if}
+					</div>
+
+					<!-- Participant list -->
+					<div class="flex flex-wrap gap-x-5 gap-y-2">
+						{#each room.participants as p, i}
+							<div class="flex items-center gap-1.5">
+								<div
+									class="{avatarColors[
+										i % avatarColors.length
+									]} flex h-6 w-6 items-center justify-center rounded-full text-xs font-medium text-white uppercase"
+								>
+									{getInitial(p.username, p.user_id)}
+								</div>
+								<span class="text-foreground text-sm font-medium">
+									{p.username ?? p.user_id.slice(0, 8)}
+								</span>
+							</div>
+						{/each}
+					</div>
+				</div>
+
+				<!-- Card footer: Enter | View Transcription -->
+				<div class="border-border flex items-center border-t">
+					<button
+						class="text-foreground hover:bg-muted flex flex-1 items-center justify-center gap-2 px-1 py-3 text-xs font-medium"
+						onclick={() => onEnterRoom(room.index)}
+					>
+						<MoveUpRight class="h-4 w-4" />
+						Enter
+						{#if room.hasAssistanceRequest}
+							<span class="bg-destructive h-2 w-2 shrink-0 rounded-full"></span>
+						{/if}
+					</button>
+					<div class="border-border h-6 border-l"></div>
+					<button
+						class="text-foreground hover:bg-muted flex flex-1 items-center justify-center gap-2 px-4 py-3 text-xs font-medium"
+					>
+						<AlignLeft class="h-4 w-4" />
+						View Transcription
+					</button>
+				</div>
+			</div>
+		{/each}
+	</div>
+
+	<!-- Footer controls -->
+	<div class="flex flex-col items-center gap-3 border-t px-3 pt-4 pb-3">
+		<Button
+			variant="primaryDark"
+			class="h-10 w-full text-sm font-medium"
+			onclick={onBroadcastMessage}
+		>
+			<Megaphone class="mr-1.5 h-4 w-4" />
+			Broadcast message
+		</Button>
+		<div class="flex w-full items-center gap-2">
+			<Button
+				variant="primaryDark"
+				class="h-10 flex-1 text-sm font-medium"
+				onclick={onAddTime}
+			>
+				<Clock class="mr-1.5 h-4 w-4" />
+				Add time
+			</Button>
+			<Button
+				variant="destructive"
+				class="h-10 flex-1 text-sm font-medium"
+				onclick={onEndSession}
+			>
+				<CircleStop class="mr-1.5 h-4 w-4" />
+				End session
+			</Button>
+		</div>
+	</div>
+</div>

--- a/ui/packages/comhairle/src/lib/components/LiveEvent/BreakoutRoomsPanel.svelte
+++ b/ui/packages/comhairle/src/lib/components/LiveEvent/BreakoutRoomsPanel.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import Button from '$lib/components/ui/button/button.svelte';
 	import type { BreakoutRoomDisplay } from './types';
-	import { PenLine, MoveUpRight, AlignLeft, Megaphone, Clock, CircleStop } from '@lucide/svelte';
+	import { PenLine, MoveUpRight, AlignLeft, Megaphone, Clock, CircleStop } from 'lucide-svelte';
 
 	interface Props {
 		rooms: BreakoutRoomDisplay[];

--- a/ui/packages/comhairle/src/lib/components/LiveEvent/BreakoutRoomsPanel.svelte
+++ b/ui/packages/comhairle/src/lib/components/LiveEvent/BreakoutRoomsPanel.svelte
@@ -118,7 +118,7 @@
 	</div>
 
 	<!-- Footer controls -->
-	<div class="flex flex-col items-center gap-3 border-t px-3 pt-4 pb-3">
+	<div class="flex flex-col items-center border-t px-3 pt-4 pb-3">
 		<Button
 			variant="primaryDark"
 			class="h-10 w-full text-sm font-medium"
@@ -127,23 +127,13 @@
 			<Megaphone class="mr-1.5 h-4 w-4" />
 			Broadcast message
 		</Button>
-		<div class="flex w-full items-center gap-2">
-			<Button
-				variant="primaryDark"
-				class="h-10 flex-1 text-sm font-medium"
-				onclick={onAddTime}
-			>
-				<Clock class="mr-1.5 h-4 w-4" />
-				Add time
-			</Button>
-			<Button
-				variant="destructive"
-				class="h-10 flex-1 text-sm font-medium"
-				onclick={onEndSession}
-			>
-				<CircleStop class="mr-1.5 h-4 w-4" />
-				End session
-			</Button>
-		</div>
+		<Button
+			variant="destructive"
+			class="h-10 w-full text-sm font-medium"
+			onclick={onEndSession}
+		>
+			<CircleStop class="mr-1.5 h-4 w-4" />
+			End session
+		</Button>
 	</div>
 </div>

--- a/ui/packages/comhairle/src/lib/components/LiveEvent/BreakoutSessionPanel.svelte
+++ b/ui/packages/comhairle/src/lib/components/LiveEvent/BreakoutSessionPanel.svelte
@@ -1,0 +1,85 @@
+<script lang="ts">
+	import Button from '$lib/components/ui/button/button.svelte';
+	import ContentRenderer from '$lib/components/RichTextEditor/ContentRenderer/ContentRenderer.svelte';
+
+	interface Props {
+		roomName: string;
+		question?: string;
+		description?: string;
+		timeLeftFormatted: string;
+		isModerator: boolean;
+		onCallForSupport?: () => void;
+		onLeaveBreakoutRoom?: () => void;
+	}
+
+	let {
+		roomName,
+		question,
+		description,
+		timeLeftFormatted,
+		isModerator,
+		onCallForSupport,
+		onLeaveBreakoutRoom
+	}: Props = $props();
+</script>
+
+<div
+	class="bg-muted flex h-full flex-col overflow-hidden rounded-3xl shadow-[0px_2px_4px_0px_rgba(0,0,0,0.12)]"
+>
+	<!-- Header -->
+	<div class="flex flex-col items-start gap-6 px-5">
+		<div class="flex w-full max-w-[1304px] items-center justify-center">
+			<h2 class="text-muted-foreground text-center text-xl leading-7 font-semibold">
+				Breakout session
+			</h2>
+		</div>
+	</div>
+
+	<!-- Content -->
+	<div class="flex flex-1 flex-col items-center gap-6 overflow-y-auto px-3 py-5">
+		{#if question}
+			<div
+				class="bg-background flex w-full flex-col items-center gap-4 overflow-hidden rounded-xl p-6"
+			>
+				<div class="flex flex-col items-center gap-1">
+					<span class="text-primary text-xs leading-4 font-medium uppercase"
+						>Question</span
+					>
+					<p
+						class="text-foreground line-clamp-2 text-center text-lg leading-7 font-semibold"
+					>
+						{question}
+					</p>
+				</div>
+
+				{#if description}
+					<div class="h-0 w-full border-t"></div>
+					<div class="text-foreground w-full text-sm leading-5 font-normal">
+						<ContentRenderer content={description} />
+					</div>
+				{/if}
+			</div>
+		{/if}
+	</div>
+
+	<!-- Footer -->
+	<div class="flex flex-col items-center gap-6 border-t p-5">
+		{#if isModerator}
+			<Button
+				variant="destructive"
+				class="h-10 px-4 text-sm font-medium"
+				onclick={() => onLeaveBreakoutRoom?.()}
+			>
+				Leave {roomName}
+			</Button>
+		{:else}
+			<Button
+				variant="primaryDark"
+				class="h-10 px-4 text-sm font-medium"
+				onclick={() => onCallForSupport?.()}
+			>
+				Call for support
+			</Button>
+		{/if}
+	</div>
+</div>

--- a/ui/packages/comhairle/src/lib/components/LiveEvent/BroadcastMessageDialog.svelte
+++ b/ui/packages/comhairle/src/lib/components/LiveEvent/BroadcastMessageDialog.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+	import * as Dialog from '$lib/components/ui/dialog';
+	import Button from '$lib/components/ui/button/button.svelte';
+	import { X } from 'lucide-svelte';
+
+	interface Props {
+		open: boolean;
+		onClose: () => void;
+		onSend: (message: string) => void;
+	}
+
+	let { open = $bindable(), onClose, onSend }: Props = $props();
+
+	let message = $state('');
+
+	function handleSend() {
+		if (!message.trim()) return;
+		onSend(message.trim());
+		message = '';
+		open = false;
+	}
+</script>
+
+<Dialog.Root bind:open onOpenChange={(v) => !v && onClose()}>
+	<Dialog.Content class="max-w-xl rounded-3xl p-9">
+		<div class="flex flex-col items-center gap-7">
+			<h2 class="text-card-foreground text-2xl leading-7 font-semibold">Broadcast message</h2>
+
+			<div class="flex w-full flex-col gap-2">
+				<input
+					type="text"
+					bind:value={message}
+					placeholder="Write message"
+					onkeydown={(e) => e.key === 'Enter' && handleSend()}
+					class="border-input bg-background text-foreground placeholder:text-muted-foreground h-10 w-full rounded-lg border px-3 text-sm shadow-sm"
+				/>
+			</div>
+
+			<div class="flex w-full items-center justify-center">
+				<Button
+					variant="primaryDark"
+					class="h-12 px-6 text-base font-medium"
+					onclick={handleSend}
+					disabled={!message.trim()}
+				>
+					Send
+				</Button>
+			</div>
+		</div>
+	</Dialog.Content>
+</Dialog.Root>

--- a/ui/packages/comhairle/src/lib/components/LiveEvent/BroadcastMessageDialog.svelte
+++ b/ui/packages/comhairle/src/lib/components/LiveEvent/BroadcastMessageDialog.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import * as Dialog from '$lib/components/ui/dialog';
 	import Button from '$lib/components/ui/button/button.svelte';
-	import { X } from 'lucide-svelte';
 
 	interface Props {
 		open: boolean;

--- a/ui/packages/comhairle/src/lib/components/LiveEvent/CreateBreakoutDialog.svelte
+++ b/ui/packages/comhairle/src/lib/components/LiveEvent/CreateBreakoutDialog.svelte
@@ -1,0 +1,328 @@
+<script lang="ts">
+	import * as Dialog from '$lib/components/ui/dialog';
+	import Button from '$lib/components/ui/button/button.svelte';
+	import type { VideoCallParticipant } from '$lib/services/videoCallService.svelte';
+	import { X, RefreshCw, Clock, Pin } from 'lucide-svelte';
+
+	interface Props {
+		open: boolean;
+		participants: VideoCallParticipant[];
+		onClose: () => void;
+		onCreate: (config: { maxPerRoom: number; durationMinutes: number }) => void;
+	}
+
+	let { open = $bindable(), participants, onClose, onCreate }: Props = $props();
+
+	let maxPerRoom = $state(4);
+	let durationMinutes = $state(10);
+
+	// Mutable room assignments for drag and drop
+	let roomAssignments = $state<VideoCallParticipant[][]>([]);
+
+	// Pinned participants stay in their room on reshuffle
+	let pinnedUsers = $state<Set<string>>(new Set());
+
+	// Build rooms when participants change or dialog opens
+	$effect(() => {
+		if (open && participants.length > 0 && roomAssignments.length === 0) {
+			distributeParticipants();
+		}
+	});
+
+	// Reset when dialog closes
+	$effect(() => {
+		if (!open) {
+			roomAssignments = [];
+			pinnedUsers = new Set();
+		}
+	});
+
+	function shuffle(arr: VideoCallParticipant[]): VideoCallParticipant[] {
+		const result = [...arr];
+		for (let i = result.length - 1; i > 0; i--) {
+			const j = Math.floor(Math.random() * (i + 1));
+			[result[i], result[j]] = [result[j], result[i]];
+		}
+		return result;
+	}
+
+	function distributeParticipants() {
+		const shuffled = shuffle(participants);
+		const count = Math.ceil(shuffled.length / maxPerRoom);
+		roomAssignments = Array.from({ length: count }, (_, i) =>
+			shuffled.slice(i * maxPerRoom, (i + 1) * maxPerRoom)
+		);
+	}
+
+	function handleReshuffle() {
+		if (pinnedUsers.size === 0) {
+			distributeParticipants();
+			return;
+		}
+
+		// Keep pinned participants in their current rooms, reshuffle the rest
+		const roomCount = roomAssignments.length;
+		const pinnedByRoom: VideoCallParticipant[][] = Array.from({ length: roomCount }, () => []);
+		const unpinned: VideoCallParticipant[] = [];
+
+		for (let r = 0; r < roomCount; r++) {
+			for (const p of roomAssignments[r]) {
+				if (pinnedUsers.has(p.user_id)) {
+					pinnedByRoom[r].push(p);
+				} else {
+					unpinned.push(p);
+				}
+			}
+		}
+
+		const shuffledUnpinned = shuffle(unpinned);
+		let idx = 0;
+
+		// Fill each room: pinned first, then unpinned up to maxPerRoom
+		const newAssignments: VideoCallParticipant[][] = pinnedByRoom.map((pinned) => {
+			const room = [...pinned];
+			while (room.length < maxPerRoom && idx < shuffledUnpinned.length) {
+				room.push(shuffledUnpinned[idx++]);
+			}
+			return room;
+		});
+
+		// If there are leftover unpinned, distribute to existing rooms or create new ones
+		while (idx < shuffledUnpinned.length) {
+			const remaining = shuffledUnpinned.slice(idx, idx + maxPerRoom);
+			newAssignments.push(remaining);
+			idx += remaining.length;
+		}
+
+		roomAssignments = newAssignments.filter((room) => room.length > 0);
+	}
+
+	function togglePin(userId: string) {
+		const next = new Set(pinnedUsers);
+		if (next.has(userId)) {
+			next.delete(userId);
+		} else {
+			next.add(userId);
+		}
+		pinnedUsers = next;
+	}
+
+	function handleCreate() {
+		onCreate({ maxPerRoom, durationMinutes });
+		open = false;
+	}
+
+	// --- Drag and drop state ---
+	let dragSource: { roomIdx: number; pIdx: number } | null = $state(null);
+	let dropTargetRoom: number | null = $state(null);
+
+	function handleDragStart(e: DragEvent, roomIdx: number, pIdx: number) {
+		dragSource = { roomIdx, pIdx };
+		if (e.dataTransfer) {
+			e.dataTransfer.effectAllowed = 'move';
+			e.dataTransfer.setData('text/plain', `${roomIdx}:${pIdx}`);
+		}
+	}
+
+	function handleDragEnd() {
+		dragSource = null;
+		dropTargetRoom = null;
+	}
+
+	function handleDragOver(e: DragEvent, roomIdx: number) {
+		e.preventDefault();
+		if (e.dataTransfer) {
+			e.dataTransfer.dropEffect = 'move';
+		}
+		dropTargetRoom = roomIdx;
+	}
+
+	function handleDragLeave(e: DragEvent, roomIdx: number) {
+		// Only clear if leaving the room container itself
+		const related = e.relatedTarget as HTMLElement | null;
+		const currentTarget = e.currentTarget as HTMLElement;
+		if (!related || !currentTarget.contains(related)) {
+			if (dropTargetRoom === roomIdx) {
+				dropTargetRoom = null;
+			}
+		}
+	}
+
+	function handleDrop(e: DragEvent, targetRoomIdx: number) {
+		e.preventDefault();
+		dropTargetRoom = null;
+
+		if (!dragSource) return;
+		const { roomIdx: srcRoom, pIdx: srcIdx } = dragSource;
+
+		if (srcRoom === targetRoomIdx) {
+			dragSource = null;
+			return;
+		}
+
+		// Move participant
+		const participant = roomAssignments[srcRoom][srcIdx];
+		const newAssignments = roomAssignments.map((room) => [...room]);
+		newAssignments[srcRoom].splice(srcIdx, 1);
+		newAssignments[targetRoomIdx].push(participant);
+
+		// Remove empty rooms
+		roomAssignments = newAssignments.filter((room) => room.length > 0);
+		dragSource = null;
+	}
+
+	// --- Helpers ---
+	const avatarColors = [
+		'bg-blue-600',
+		'bg-emerald-500',
+		'bg-indigo-500',
+		'bg-orange-500',
+		'bg-violet-500',
+		'bg-cyan-500'
+	];
+
+	// Stable color per participant based on user_id
+	function getColorForParticipant(p: VideoCallParticipant): string {
+		let hash = 0;
+		const id = p.user_id;
+		for (let i = 0; i < id.length; i++) {
+			hash = (hash * 31 + id.charCodeAt(i)) | 0;
+		}
+		return avatarColors[Math.abs(hash) % avatarColors.length];
+	}
+
+	function getInitial(p: VideoCallParticipant): string {
+		return (p.username ?? p.user_id).charAt(0).toUpperCase();
+	}
+
+	function getName(p: VideoCallParticipant): string {
+		return p.username ?? p.user_id.slice(0, 8);
+	}
+
+	function isDragging(roomIdx: number, pIdx: number): boolean {
+		return dragSource?.roomIdx === roomIdx && dragSource?.pIdx === pIdx;
+	}
+</script>
+
+<Dialog.Root bind:open onOpenChange={(v) => !v && onClose()}>
+	<Dialog.Content class="w-[70vw] rounded-3xl p-9 sm:max-w-none" showCloseButton={false}>
+		<button
+			class="text-muted-foreground hover:text-foreground absolute top-6 right-6"
+			onclick={onClose}
+		>
+			<X class="h-5 w-5" />
+		</button>
+
+		<div class="flex flex-col gap-6">
+			<!-- Title -->
+			<h2 class="text-foreground text-2xl leading-7 font-semibold">Create breakout rooms</h2>
+
+			<!-- Time left row -->
+			<div class="flex items-center gap-2">
+				<Clock class="text-foreground h-5 w-5" />
+				<span class="text-foreground text-sm font-normal">Time left</span>
+				<input
+					type="number"
+					bind:value={durationMinutes}
+					min={1}
+					max={120}
+					class="border-input bg-background h-8 w-14 rounded-lg border px-3 text-center text-sm shadow-sm"
+				/>
+				<span class="text-foreground text-sm font-normal">minutes</span>
+			</div>
+
+			<!-- Rooms container (dark blue) -->
+			{#if roomAssignments.length > 0}
+				<div class="bg-sidebar flex flex-col gap-3 rounded-2xl p-4">
+					{#each roomAssignments as room, roomIdx}
+						<div
+							class="flex items-center gap-2 rounded-lg border p-5 transition-colors {dropTargetRoom ===
+							roomIdx
+								? 'bg-accent border-ring ring-ring ring-2'
+								: 'bg-muted'}"
+							role="group"
+							ondragover={(e) => handleDragOver(e, roomIdx)}
+							ondragleave={(e) => handleDragLeave(e, roomIdx)}
+							ondrop={(e) => handleDrop(e, roomIdx)}
+						>
+							<!-- Room name -->
+							<div
+								class="text-foreground line-clamp-1 w-24 shrink-0 text-base leading-6 font-semibold"
+							>
+								Room #{roomIdx + 1}
+							</div>
+
+							<!-- Participant pills -->
+							<div class="flex flex-1 flex-wrap gap-3">
+								{#each room as p, pIdx (p.user_id)}
+									<div
+										class="bg-background inline-flex cursor-grab items-center gap-1.5 rounded-full px-2 py-1 shadow-[0px_1px_2px_-1px_rgba(0,0,0,0.10),0px_1px_3px_0px_rgba(0,0,0,0.10)] transition-opacity active:cursor-grabbing {isDragging(
+											roomIdx,
+											pIdx
+										)
+											? 'opacity-30'
+											: 'opacity-100'}"
+										draggable="true"
+										ondragstart={(e) => handleDragStart(e, roomIdx, pIdx)}
+										ondragend={handleDragEnd}
+									>
+										<div
+											class="{getColorForParticipant(
+												p
+											)} flex h-6 w-6 items-center justify-center rounded-full text-xs font-medium text-white uppercase"
+										>
+											{getInitial(p)}
+										</div>
+										<span class="text-foreground text-sm font-medium">
+											{getName(p)}
+										</span>
+										<button
+											class="flex h-5 w-5 items-center justify-center rounded-full transition-colors {pinnedUsers.has(
+												p.user_id
+											)
+												? 'text-primary bg-primary/10'
+												: 'text-muted-foreground hover:text-foreground'}"
+											onclick={(e) => {
+												e.stopPropagation();
+												togglePin(p.user_id);
+											}}
+											title={pinnedUsers.has(p.user_id)
+												? 'Unpin (will move on reshuffle)'
+												: 'Pin to this room'}
+										>
+											<Pin class="h-3.5 w-3.5" />
+										</button>
+									</div>
+								{/each}
+							</div>
+						</div>
+					{/each}
+
+					<!-- Reshuffle button -->
+					<div>
+						<Button
+							variant="primaryDark"
+							size="sm"
+							class="gap-2 text-sm"
+							onclick={handleReshuffle}
+						>
+							<RefreshCw class="h-4 w-4" />
+							Reshuffle
+						</Button>
+					</div>
+				</div>
+			{/if}
+
+			<!-- Create button -->
+			<div class="flex items-center justify-center">
+				<Button
+					variant="primaryDark"
+					class="h-10 min-w-32 px-5 text-base font-medium"
+					onclick={handleCreate}
+				>
+					Create
+				</Button>
+			</div>
+		</div>
+	</Dialog.Content>
+</Dialog.Root>

--- a/ui/packages/comhairle/src/lib/components/LiveEvent/CreateBreakoutDialog.svelte
+++ b/ui/packages/comhairle/src/lib/components/LiveEvent/CreateBreakoutDialog.svelte
@@ -10,7 +10,11 @@
 		defaultMaxPerRoom?: number;
 		defaultDuration?: number;
 		onClose: () => void;
-		onCreate: (config: { maxPerRoom: number; durationMinutes: number }) => void;
+		onCreate: (config: {
+			maxPerRoom: number;
+			durationMinutes: number;
+			roomAssignments: VideoCallParticipant[][];
+		}) => void;
 	}
 
 	let {
@@ -25,13 +29,12 @@
 	let maxPerRoom = $state(defaultMaxPerRoom);
 	let durationMinutes = $state(defaultDuration);
 
-	// Mutable room assignments for drag and drop
+	/** Mutable room assignments for drag and drop */
 	let roomAssignments = $state<VideoCallParticipant[][]>([]);
 
-	// Pinned participants stay in their room on reshuffle
+	/** Pinned participants stay in their room on reshuffle */
 	let pinnedUsers = $state<Set<string>>(new Set());
 
-	// Track previous open state to detect open/close transitions
 	let wasOpen = $state(false);
 
 	$effect(() => {
@@ -125,11 +128,10 @@
 	}
 
 	function handleCreate() {
-		onCreate({ maxPerRoom, durationMinutes });
+		onCreate({ maxPerRoom, durationMinutes, roomAssignments });
 		open = false;
 	}
 
-	// --- Drag and drop state ---
 	let dragSource: { roomIdx: number; pIdx: number } | null = $state(null);
 	let dropTargetRoom: number | null = $state(null);
 
@@ -188,7 +190,6 @@
 		dragSource = null;
 	}
 
-	// --- Helpers ---
 	const avatarColors = [
 		'bg-blue-600',
 		'bg-emerald-500',
@@ -198,7 +199,7 @@
 		'bg-cyan-500'
 	];
 
-	// Stable color per participant based on user_id
+	/** Stable color per participant based on user_id */
 	function getColorForParticipant(p: VideoCallParticipant): string {
 		let hash = 0;
 		const id = p.user_id;

--- a/ui/packages/comhairle/src/lib/components/LiveEvent/CreateBreakoutDialog.svelte
+++ b/ui/packages/comhairle/src/lib/components/LiveEvent/CreateBreakoutDialog.svelte
@@ -7,14 +7,23 @@
 	interface Props {
 		open: boolean;
 		participants: VideoCallParticipant[];
+		defaultMaxPerRoom?: number;
+		defaultDuration?: number;
 		onClose: () => void;
 		onCreate: (config: { maxPerRoom: number; durationMinutes: number }) => void;
 	}
 
-	let { open = $bindable(), participants, onClose, onCreate }: Props = $props();
+	let {
+		open = $bindable(),
+		participants,
+		defaultMaxPerRoom = 4,
+		defaultDuration = 10,
+		onClose,
+		onCreate
+	}: Props = $props();
 
-	let maxPerRoom = $state(4);
-	let durationMinutes = $state(10);
+	let maxPerRoom = $state(defaultMaxPerRoom);
+	let durationMinutes = $state(defaultDuration);
 
 	// Mutable room assignments for drag and drop
 	let roomAssignments = $state<VideoCallParticipant[][]>([]);
@@ -22,19 +31,27 @@
 	// Pinned participants stay in their room on reshuffle
 	let pinnedUsers = $state<Set<string>>(new Set());
 
-	// Build rooms when participants change or dialog opens
-	$effect(() => {
-		if (open && participants.length > 0 && roomAssignments.length === 0) {
-			distributeParticipants();
-		}
-	});
+	// Track previous open state to detect open/close transitions
+	let wasOpen = $state(false);
 
-	// Reset when dialog closes
 	$effect(() => {
-		if (!open) {
+		if (open && !wasOpen) {
+			// Dialog just opened — sync defaults and distribute
+			maxPerRoom = defaultMaxPerRoom;
+			durationMinutes = defaultDuration;
 			roomAssignments = [];
 			pinnedUsers = new Set();
+			if (participants.length > 0) {
+				distributeParticipants();
+			}
+		} else if (!open && wasOpen) {
+			// Dialog just closed — reset
+			roomAssignments = [];
+			pinnedUsers = new Set();
+			maxPerRoom = defaultMaxPerRoom;
+			durationMinutes = defaultDuration;
 		}
+		wasOpen = open;
 	});
 
 	function shuffle(arr: VideoCallParticipant[]): VideoCallParticipant[] {
@@ -205,7 +222,10 @@
 </script>
 
 <Dialog.Root bind:open onOpenChange={(v) => !v && onClose()}>
-	<Dialog.Content class="w-[70vw] rounded-3xl p-9 sm:max-w-none" showCloseButton={false}>
+	<Dialog.Content
+		class="flex max-h-[85vh] w-[70vw] flex-col overflow-hidden rounded-3xl p-6 sm:max-w-none sm:p-9"
+		showCloseButton={false}
+	>
 		<button
 			class="text-muted-foreground hover:text-foreground absolute top-6 right-6"
 			onclick={onClose}
@@ -213,12 +233,14 @@
 			<X class="h-5 w-5" />
 		</button>
 
-		<div class="flex flex-col gap-6">
+		<div class="flex min-h-0 flex-1 flex-col gap-6">
 			<!-- Title -->
-			<h2 class="text-foreground text-2xl leading-7 font-semibold">Create breakout rooms</h2>
+			<h2 class="text-foreground shrink-0 text-2xl leading-7 font-semibold">
+				Create breakout rooms
+			</h2>
 
 			<!-- Time left row -->
-			<div class="flex items-center gap-2">
+			<div class="flex shrink-0 items-center gap-2">
 				<Clock class="text-foreground h-5 w-5" />
 				<span class="text-foreground text-sm font-normal">Time left</span>
 				<input
@@ -233,7 +255,9 @@
 
 			<!-- Rooms container (dark blue) -->
 			{#if roomAssignments.length > 0}
-				<div class="bg-sidebar flex flex-col gap-3 rounded-2xl p-4">
+				<div
+					class="bg-sidebar flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto rounded-2xl p-3 sm:p-4"
+				>
 					{#each roomAssignments as room, roomIdx}
 						<div
 							class="flex items-center gap-2 rounded-lg border p-5 transition-colors {dropTargetRoom ===
@@ -314,7 +338,7 @@
 			{/if}
 
 			<!-- Create button -->
-			<div class="flex items-center justify-center">
+			<div class="flex shrink-0 items-center justify-center pt-2">
 				<Button
 					variant="primaryDark"
 					class="h-10 min-w-32 px-5 text-base font-medium"

--- a/ui/packages/comhairle/src/lib/components/LiveEvent/EndMeetingDialog.svelte
+++ b/ui/packages/comhairle/src/lib/components/LiveEvent/EndMeetingDialog.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+	import * as Dialog from '$lib/components/ui/dialog';
+	import Button from '$lib/components/ui/button/button.svelte';
+
+	interface Props {
+		open: boolean;
+		onConfirm: () => void;
+		onCancel: () => void;
+	}
+
+	let { open = $bindable(), onConfirm, onCancel }: Props = $props();
+</script>
+
+<Dialog.Root bind:open>
+	<Dialog.Content class="max-w-md rounded-3xl p-9 sm:max-w-md" showCloseButton={false}>
+		<div class="flex flex-col items-center gap-7">
+			<h2 class="text-foreground text-2xl leading-7 font-semibold">End meeting?</h2>
+
+			<p class="text-muted-foreground text-center text-base leading-6">
+				This will end the meeting for all participants. Everyone will be disconnected from
+				the call.
+			</p>
+
+			<div class="flex w-full flex-col gap-3">
+				<Button
+					variant="destructive"
+					class="h-12 w-full text-base font-medium"
+					onclick={onConfirm}
+				>
+					End meeting for everyone
+				</Button>
+				<Button
+					variant="outline"
+					class="h-12 w-full text-base font-medium"
+					onclick={onCancel}
+				>
+					Cancel
+				</Button>
+			</div>
+		</div>
+	</Dialog.Content>
+</Dialog.Root>

--- a/ui/packages/comhairle/src/lib/components/LiveEvent/MeetingEndedScreen.svelte
+++ b/ui/packages/comhairle/src/lib/components/LiveEvent/MeetingEndedScreen.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+	import Button from '$lib/components/ui/button/button.svelte';
+	import { CheckCircle } from 'lucide-svelte';
+
+	interface Props {
+		title: string;
+		conversationUrl?: string;
+	}
+
+	let { title, conversationUrl }: Props = $props();
+</script>
+
+<div class="bg-background flex min-h-dvh w-full items-center justify-center">
+	<div class="flex max-w-lg flex-col items-center gap-12 px-6 text-center">
+		<!-- Success icon -->
+		<div class="bg-primary/10 flex h-20 w-20 items-center justify-center rounded-full">
+			<CheckCircle class="text-primary h-10 w-10" />
+		</div>
+
+		<!-- Heading -->
+		<div class="flex flex-col items-center gap-4">
+			<h1 class="text-foreground text-4xl leading-10 font-bold">
+				Thank you for participating!
+			</h1>
+			<p class="text-muted-foreground text-lg leading-7">
+				The meeting <span class="text-foreground font-medium">{title}</span> has ended.
+			</p>
+		</div>
+
+		<!-- Next steps -->
+		<div class="bg-card border-border w-full rounded-xl border p-6 text-left">
+			<h2 class="text-foreground mb-3 text-base font-semibold">What happens next?</h2>
+			<ul class="text-muted-foreground flex flex-col gap-2 text-sm leading-6">
+				<li class="flex items-start gap-2">
+					<span class="text-primary mt-1 text-sm">1.</span>
+					<span>A summary and any transcripts will be available shortly.</span>
+				</li>
+				<li class="flex items-start gap-2">
+					<span class="text-primary mt-1 text-sm">2.</span>
+					<span>You may receive follow-up materials from the facilitator.</span>
+				</li>
+				<li class="flex items-start gap-2">
+					<span class="text-primary mt-1 text-sm">3.</span>
+					<span>Check the conversation page for updates and next steps.</span>
+				</li>
+			</ul>
+		</div>
+
+		<!-- CTA -->
+		{#if conversationUrl}
+			<Button
+				variant="primaryDark"
+				class="h-12 px-8 text-base font-semibold"
+				onclick={() => (window.location.href = conversationUrl)}
+			>
+				Back to conversation
+			</Button>
+		{/if}
+	</div>
+</div>

--- a/ui/packages/comhairle/src/lib/components/LiveEvent/MeetingEndedScreen.svelte
+++ b/ui/packages/comhairle/src/lib/components/LiveEvent/MeetingEndedScreen.svelte
@@ -5,9 +5,11 @@
 	interface Props {
 		title: string;
 		conversationUrl?: string;
+		isModerator?: boolean;
+		onResetCall?: () => void;
 	}
 
-	let { title, conversationUrl }: Props = $props();
+	let { title, conversationUrl, isModerator = false, onResetCall }: Props = $props();
 </script>
 
 <div class="bg-background flex min-h-dvh w-full items-center justify-center">
@@ -47,14 +49,25 @@
 		</div>
 
 		<!-- CTA -->
-		{#if conversationUrl}
-			<Button
-				variant="primaryDark"
-				class="h-12 px-8 text-base font-semibold"
-				onclick={() => (window.location.href = conversationUrl)}
-			>
-				Back to conversation
-			</Button>
-		{/if}
+		<div class="flex flex-col items-center gap-3">
+			{#if conversationUrl}
+				<Button
+					variant="primaryDark"
+					class="h-12 px-8 text-base font-semibold"
+					onclick={() => (window.location.href = conversationUrl)}
+				>
+					Back to conversation
+				</Button>
+			{/if}
+			{#if isModerator && onResetCall}
+				<Button
+					variant="outline"
+					class="h-10 px-6 text-sm font-medium"
+					onclick={onResetCall}
+				>
+					Reset call
+				</Button>
+			{/if}
+		</div>
 	</div>
 </div>

--- a/ui/packages/comhairle/src/lib/components/LiveEvent/MeetingLobby.svelte
+++ b/ui/packages/comhairle/src/lib/components/LiveEvent/MeetingLobby.svelte
@@ -109,7 +109,9 @@
 							{/if}
 						</div>
 						<p class="text-foreground w-80 text-xl font-normal">
-							{firstParticipantName} and others are waiting to join.
+							{firstParticipantName}{participants.length > 1
+								? ' and others are'
+								: ' is'} waiting to join.
 						</p>
 					</div>
 				{/if}
@@ -120,6 +122,26 @@
 					onclick={onStartMeeting}
 				>
 					Start meeting
+				</Button>
+			</div>
+		{:else if isModerator && isStarted}
+			<!-- Host rejoin state -->
+			<div class="flex flex-col items-center gap-14">
+				<div class="flex flex-col items-center gap-4">
+					<h1 class="text-foreground text-center text-5xl leading-[52px] font-bold">
+						{title}
+					</h1>
+					<p class="text-foreground text-center text-2xl leading-7 font-semibold">
+						{scheduledTime}
+					</p>
+				</div>
+
+				<Button
+					variant="primaryDark"
+					class="h-12 px-8 text-xl font-semibold"
+					onclick={onJoinMeeting}
+				>
+					Rejoin meeting
 				</Button>
 			</div>
 		{:else if !isModerator && isWaiting}
@@ -162,7 +184,9 @@
 							{/if}
 						</div>
 						<p class="text-foreground w-80 text-xl font-normal">
-							{firstParticipantName} and others are waiting to join.
+							{firstParticipantName}{participants.length > 1
+								? ' and others are'
+								: ' is'} waiting to join.
 						</p>
 					</div>
 				{/if}
@@ -215,7 +239,9 @@
 							{/if}
 						</div>
 						<p class="text-foreground w-80 text-xl font-normal">
-							{firstParticipantName} and others are in the call.
+							{firstParticipantName}{participants.length > 1
+								? ' and others are'
+								: ' is'} in the call.
 						</p>
 					</div>
 				{/if}

--- a/ui/packages/comhairle/src/lib/components/LiveEvent/MeetingLobby.svelte
+++ b/ui/packages/comhairle/src/lib/components/LiveEvent/MeetingLobby.svelte
@@ -1,0 +1,233 @@
+<script lang="ts">
+	import Button from '$lib/components/ui/button/button.svelte';
+	import type {
+		VideoCallParticipant,
+		VideoCallStatus
+	} from '$lib/services/videoCallService.svelte';
+
+	interface Props {
+		title: string;
+		scheduledTime: string;
+		endedTime?: string;
+		participants: VideoCallParticipant[];
+		callStatus: VideoCallStatus | null;
+		isModerator: boolean;
+		onStartMeeting: () => void;
+		onJoinMeeting: () => void;
+	}
+
+	let {
+		title,
+		scheduledTime,
+		endedTime,
+		participants,
+		callStatus,
+		isModerator,
+		onStartMeeting,
+		onJoinMeeting
+	}: Props = $props();
+
+	let displayParticipants = $derived(participants.slice(0, 3));
+	let extraCount = $derived(Math.max(0, participants.length - 3));
+
+	let isStarted = $derived(callStatus === 'InProgress');
+	let isEnded = $derived(callStatus === 'Ended');
+	let isWaiting = $derived(!isStarted && !isEnded);
+
+	let firstParticipantName = $derived(
+		participants[0]?.username ?? participants[0]?.user_id?.slice(0, 8) ?? 'Someone'
+	);
+
+	function getInitials(p: VideoCallParticipant): string {
+		if (p.username) return p.username.charAt(0).toUpperCase();
+		return p.user_id.charAt(0).toUpperCase();
+	}
+
+	const avatarColors = [
+		'bg-blue-500',
+		'bg-emerald-500',
+		'bg-amber-500',
+		'bg-rose-500',
+		'bg-violet-500',
+		'bg-cyan-500'
+	];
+
+	function getAvatarColor(index: number): string {
+		return avatarColors[index % avatarColors.length];
+	}
+</script>
+
+<div class="bg-background flex min-h-dvh w-full items-center justify-center">
+	<div class="flex max-w-2xl flex-col items-center gap-24">
+		{#if isEnded}
+			<!-- Ended state -->
+			<h2 class="text-foreground text-center text-5xl leading-[52px] font-bold">
+				The meeting has ended.
+			</h2>
+			<div class="flex flex-col items-center gap-4">
+				<h1 class="text-foreground text-center text-5xl leading-[52px] font-bold">
+					{title}
+				</h1>
+				<p class="text-foreground text-center text-2xl leading-7 font-semibold">
+					{scheduledTime}
+					{#if endedTime}<br />Ended at {endedTime}{/if}
+				</p>
+			</div>
+		{:else if isModerator && isWaiting}
+			<!-- Host waiting state -->
+			<div class="flex flex-col items-center gap-14">
+				<div class="flex flex-col items-center gap-4">
+					<h1 class="text-foreground text-center text-5xl leading-[52px] font-bold">
+						{title}
+					</h1>
+					<p class="text-foreground text-center text-2xl leading-7 font-semibold">
+						{scheduledTime}
+					</p>
+				</div>
+
+				{#if participants.length > 0}
+					<div class="flex flex-col items-start gap-3.5">
+						<div class="flex items-center gap-2">
+							<div class="flex items-center">
+								{#each displayParticipants as p, i}
+									<div
+										class="{getAvatarColor(
+											i
+										)} -ring-offset-2 ring-background flex h-12 w-12 items-center justify-center rounded-full text-lg font-semibold text-white ring-2 {i >
+										0
+											? '-ml-3'
+											: ''}"
+									>
+										{getInitials(p)}
+									</div>
+								{/each}
+							</div>
+							{#if extraCount > 0}
+								<span class="text-foreground text-xl font-semibold"
+									>+{extraCount} more</span
+								>
+							{/if}
+						</div>
+						<p class="text-foreground w-80 text-xl font-normal">
+							{firstParticipantName} and others are waiting to join.
+						</p>
+					</div>
+				{/if}
+
+				<Button
+					variant="primaryDark"
+					class="h-12 px-8 text-xl font-semibold"
+					onclick={onStartMeeting}
+				>
+					Start meeting
+				</Button>
+			</div>
+		{:else if !isModerator && isWaiting}
+			<!-- Participant waiting state -->
+			<h2 class="text-foreground text-center text-5xl leading-[52px] font-bold">
+				We are waiting for the meeting to start...
+			</h2>
+
+			<div class="flex flex-col items-center gap-14">
+				<div class="flex flex-col items-center gap-4">
+					<h1 class="text-foreground text-center text-5xl leading-[52px] font-bold">
+						{title}
+					</h1>
+					<p class="text-foreground text-center text-2xl leading-7 font-semibold">
+						{scheduledTime}
+					</p>
+				</div>
+
+				{#if participants.length > 0}
+					<div class="flex flex-col items-start gap-3.5">
+						<div class="flex items-center gap-2">
+							<div class="flex items-center">
+								{#each displayParticipants as p, i}
+									<div
+										class="{getAvatarColor(
+											i
+										)} -ring-offset-2 ring-background flex h-12 w-12 items-center justify-center rounded-full text-lg font-semibold text-white ring-2 {i >
+										0
+											? '-ml-3'
+											: ''}"
+									>
+										{getInitials(p)}
+									</div>
+								{/each}
+							</div>
+							{#if extraCount > 0}
+								<span class="text-foreground text-xl font-semibold"
+									>+{extraCount} more</span
+								>
+							{/if}
+						</div>
+						<p class="text-foreground w-80 text-xl font-normal">
+							{firstParticipantName} and others are waiting to join.
+						</p>
+					</div>
+				{/if}
+
+				<Button
+					variant="primaryDark"
+					class="h-12 px-8 text-xl font-semibold opacity-40"
+					disabled
+				>
+					Join meeting
+				</Button>
+			</div>
+		{:else if !isModerator && isStarted}
+			<!-- Participant can join state -->
+			<h2 class="text-foreground text-center text-5xl leading-[52px] font-bold">
+				The meeting has started.
+			</h2>
+
+			<div class="flex flex-col items-center gap-14">
+				<div class="flex flex-col items-center gap-4">
+					<h1 class="text-foreground text-center text-5xl leading-[52px] font-bold">
+						{title}
+					</h1>
+					<p class="text-foreground text-center text-2xl leading-7 font-semibold">
+						{scheduledTime}
+					</p>
+				</div>
+
+				{#if participants.length > 0}
+					<div class="flex flex-col items-start gap-3.5">
+						<div class="flex items-center gap-2">
+							<div class="flex items-center">
+								{#each displayParticipants as p, i}
+									<div
+										class="{getAvatarColor(
+											i
+										)} -ring-offset-2 ring-background flex h-12 w-12 items-center justify-center rounded-full text-lg font-semibold text-white ring-2 {i >
+										0
+											? '-ml-3'
+											: ''}"
+									>
+										{getInitials(p)}
+									</div>
+								{/each}
+							</div>
+							{#if extraCount > 0}
+								<span class="text-foreground text-xl font-semibold"
+									>+{extraCount} more</span
+								>
+							{/if}
+						</div>
+						<p class="text-foreground w-80 text-xl font-normal">
+							{firstParticipantName} and others are in the call.
+						</p>
+					</div>
+				{/if}
+
+				<Button
+					variant="primaryDark"
+					class="h-12 px-8 text-xl font-semibold"
+					onclick={onJoinMeeting}
+				>
+					Join meeting
+				</Button>
+			</div>
+		{/if}
+	</div>
+</div>

--- a/ui/packages/comhairle/src/lib/components/LiveEvent/MeetingLobby.svelte
+++ b/ui/packages/comhairle/src/lib/components/LiveEvent/MeetingLobby.svelte
@@ -13,7 +13,6 @@
 		callStatus: VideoCallStatus | null;
 		isModerator: boolean;
 		onStartMeeting: () => void;
-		onJoinMeeting: () => void;
 	}
 
 	let {
@@ -23,8 +22,7 @@
 		participants,
 		callStatus,
 		isModerator,
-		onStartMeeting,
-		onJoinMeeting
+		onStartMeeting
 	}: Props = $props();
 
 	let displayParticipants = $derived(participants.slice(0, 3));
@@ -124,26 +122,6 @@
 					Start meeting
 				</Button>
 			</div>
-		{:else if isModerator && isStarted}
-			<!-- Host rejoin state -->
-			<div class="flex flex-col items-center gap-14">
-				<div class="flex flex-col items-center gap-4">
-					<h1 class="text-foreground text-center text-5xl leading-[52px] font-bold">
-						{title}
-					</h1>
-					<p class="text-foreground text-center text-2xl leading-7 font-semibold">
-						{scheduledTime}
-					</p>
-				</div>
-
-				<Button
-					variant="primaryDark"
-					class="h-12 px-8 text-xl font-semibold"
-					onclick={onJoinMeeting}
-				>
-					Rejoin meeting
-				</Button>
-			</div>
 		{:else if !isModerator && isWaiting}
 			<!-- Participant waiting state -->
 			<h2 class="text-foreground text-center text-5xl leading-[52px] font-bold">
@@ -190,69 +168,6 @@
 						</p>
 					</div>
 				{/if}
-
-				<Button
-					variant="primaryDark"
-					class="h-12 px-8 text-xl font-semibold opacity-40"
-					disabled
-				>
-					Join meeting
-				</Button>
-			</div>
-		{:else if !isModerator && isStarted}
-			<!-- Participant can join state -->
-			<h2 class="text-foreground text-center text-5xl leading-[52px] font-bold">
-				The meeting has started.
-			</h2>
-
-			<div class="flex flex-col items-center gap-14">
-				<div class="flex flex-col items-center gap-4">
-					<h1 class="text-foreground text-center text-5xl leading-[52px] font-bold">
-						{title}
-					</h1>
-					<p class="text-foreground text-center text-2xl leading-7 font-semibold">
-						{scheduledTime}
-					</p>
-				</div>
-
-				{#if participants.length > 0}
-					<div class="flex flex-col items-start gap-3.5">
-						<div class="flex items-center gap-2">
-							<div class="flex items-center">
-								{#each displayParticipants as p, i}
-									<div
-										class="{getAvatarColor(
-											i
-										)} -ring-offset-2 ring-background flex h-12 w-12 items-center justify-center rounded-full text-lg font-semibold text-white ring-2 {i >
-										0
-											? '-ml-3'
-											: ''}"
-									>
-										{getInitials(p)}
-									</div>
-								{/each}
-							</div>
-							{#if extraCount > 0}
-								<span class="text-foreground text-xl font-semibold"
-									>+{extraCount} more</span
-								>
-							{/if}
-						</div>
-						<p class="text-foreground w-80 text-xl font-normal">
-							{firstParticipantName}{participants.length > 1
-								? ' and others are'
-								: ' is'} in the call.
-						</p>
-					</div>
-				{/if}
-
-				<Button
-					variant="primaryDark"
-					class="h-12 px-8 text-xl font-semibold"
-					onclick={onJoinMeeting}
-				>
-					Join meeting
-				</Button>
 			</div>
 		{/if}
 	</div>

--- a/ui/packages/comhairle/src/lib/components/LiveEvent/NoticeDialog.svelte
+++ b/ui/packages/comhairle/src/lib/components/LiveEvent/NoticeDialog.svelte
@@ -1,0 +1,51 @@
+<script lang="ts">
+	import * as Dialog from '$lib/components/ui/dialog';
+	import Button from '$lib/components/ui/button/button.svelte';
+
+	interface Props {
+		open: boolean;
+		message: string;
+		actionLabel?: string;
+		onAction?: () => void;
+		onDismiss: () => void;
+	}
+
+	let { open, message, actionLabel, onAction, onDismiss }: Props = $props();
+
+	function handleAction() {
+		onAction?.();
+		onDismiss();
+	}
+</script>
+
+<Dialog.Root {open} onOpenChange={(v) => !v && onDismiss()}>
+	<Dialog.Content class="max-w-xl rounded-3xl p-9">
+		<div class="flex flex-col items-center gap-7">
+			<h2 class="text-foreground text-2xl leading-7 font-semibold">Notice</h2>
+
+			<p class="text-foreground text-center text-lg leading-7 font-medium">
+				{message}
+			</p>
+
+			<div class="flex w-full items-center justify-center gap-4">
+				{#if actionLabel && onAction}
+					<Button
+						variant="primaryDark"
+						class="h-12 px-5 text-base font-medium"
+						onclick={handleAction}
+					>
+						{actionLabel}
+					</Button>
+				{:else}
+					<Button
+						variant="primaryDark"
+						class="h-12 px-5 text-base font-medium"
+						onclick={onDismiss}
+					>
+						OK
+					</Button>
+				{/if}
+			</div>
+		</div>
+	</Dialog.Content>
+</Dialog.Root>

--- a/ui/packages/comhairle/src/lib/components/LiveEvent/SidePanel.svelte
+++ b/ui/packages/comhairle/src/lib/components/LiveEvent/SidePanel.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	import type { PanelTab } from './types';
+
+	interface Props {
+		activeTab: PanelTab;
+		showTabs: boolean;
+		onTabChange: (tab: PanelTab) => void;
+		children: Snippet;
+	}
+
+	let { activeTab, showTabs, onTabChange, children }: Props = $props();
+</script>
+
+<div
+	class="bg-muted flex h-full flex-col overflow-hidden rounded-2xl shadow-lg {showTabs
+		? ''
+		: 'pt-5'}"
+>
+	<!-- Tab switcher -->
+	{#if showTabs}
+		<div class="px-5 pt-2.5 pb-2.5">
+			<div class="flex h-12 items-center rounded-xl p-1">
+				<button
+					class="flex flex-1 items-center justify-center rounded-full px-3 py-2 text-sm transition-all {activeTab ===
+					'agenda'
+						? 'bg-background text-foreground ring-foreground/5 font-bold shadow-[0px_1px_2px_-1px_rgba(0,0,0,0.10),0px_1px_3px_0px_rgba(0,0,0,0.10)] ring-1'
+						: 'text-muted-foreground font-medium'}"
+					onclick={() => onTabChange('agenda')}
+				>
+					Agenda
+				</button>
+				<button
+					class="flex flex-1 items-center justify-center rounded-full px-3 py-2 text-sm transition-all {activeTab ===
+					'breakoutRooms'
+						? 'bg-background text-foreground ring-foreground/5 font-bold shadow-[0px_1px_2px_-1px_rgba(0,0,0,0.10),0px_1px_3px_0px_rgba(0,0,0,0.10)] ring-1'
+						: 'text-muted-foreground font-medium'}"
+					onclick={() => onTabChange('breakoutRooms')}
+				>
+					Breakout Session
+				</button>
+			</div>
+		</div>
+	{/if}
+
+	<!-- Panel content -->
+	<div class="flex flex-1 flex-col overflow-y-auto">
+		{@render children()}
+	</div>
+</div>

--- a/ui/packages/comhairle/src/lib/components/LiveEvent/types.ts
+++ b/ui/packages/comhairle/src/lib/components/LiveEvent/types.ts
@@ -9,6 +9,7 @@ export interface AgendaItem {
 	breakoutQuestion?: string;
 	breakoutDescription?: string;
 	durationMinutes?: number;
+	maxPerRoom?: number;
 }
 
 export type MeetingPhase = 'lobby' | 'incall' | 'ended';

--- a/ui/packages/comhairle/src/lib/components/LiveEvent/types.ts
+++ b/ui/packages/comhairle/src/lib/components/LiveEvent/types.ts
@@ -1,0 +1,26 @@
+import type { VideoCallParticipant } from '$lib/services/videoCallService.svelte';
+
+export type AgendaItemType = 'plenary' | 'breakout';
+
+export interface AgendaItem {
+	id: string;
+	title: string;
+	type: AgendaItemType;
+	breakoutQuestion?: string;
+	breakoutDescription?: string;
+	durationMinutes?: number;
+}
+
+export type MeetingPhase = 'lobby' | 'incall' | 'ended';
+
+export type RoomContext = 'plenary' | { type: 'breakout'; roomIndex: number; roomName: string };
+
+export type PanelTab = 'agenda' | 'breakoutRooms';
+
+export interface BreakoutRoomDisplay {
+	index: number;
+	name: string;
+	participants: VideoCallParticipant[];
+	hasAssistanceRequest: boolean;
+	assistanceRequestUser?: string | null;
+}

--- a/ui/packages/comhairle/src/lib/services/videoCallService.svelte.ts
+++ b/ui/packages/comhairle/src/lib/services/videoCallService.svelte.ts
@@ -254,7 +254,7 @@ export class VideoCallService {
 
 	// Check if a breakout session is currently active
 	isBreakoutSessionActive(): boolean {
-		return this._currentCallState?.breakout_session !== null;
+		return this._currentCallState?.breakout_session != null;
 	}
 
 	// Get the end time of the current breakout session as a Date object

--- a/ui/packages/comhairle/src/lib/services/videoCallService.svelte.ts
+++ b/ui/packages/comhairle/src/lib/services/videoCallService.svelte.ts
@@ -174,15 +174,6 @@ export class VideoCallService {
 		});
 	}
 
-	/** Moderator/facilitator only: move a participant to a different breakout room */
-	moveParticipantToRoom(eventId: string, userId: string, targetRoomIndex: number) {
-		ws.sendCustom('video_call:move_participant', {
-			event_id: eventId,
-			user_id: userId,
-			target_room_index: targetRoomIndex
-		});
-	}
-
 	/** Moderator/facilitator only */
 	startBreakoutSession(eventId: string, ends: string) {
 		ws.sendCustom('video_call:start_breakout_session', {

--- a/ui/packages/comhairle/src/lib/services/videoCallService.svelte.ts
+++ b/ui/packages/comhairle/src/lib/services/videoCallService.svelte.ts
@@ -1,6 +1,5 @@
 import { ws } from '$lib/api/websockets.svelte';
 
-// Types matching backend structures
 export type VideoCallStatus = 'Waiting' | 'InProgress' | 'Ended';
 
 export interface VideoCallParticipant {
@@ -86,7 +85,6 @@ export class VideoCallService {
 		if (this.isListening) return;
 		this.isListening = true;
 
-		// Listen for video call events from server
 		ws.on('custom', (payload) => {
 			if (payload.event === 'video_call:state_update') {
 				this.handleStateUpdate(payload.data as VideoCallState);
@@ -106,23 +104,20 @@ export class VideoCallService {
 		this._lastBroadcastMessage = data.message;
 	}
 
-	// User joins a video call
 	joinCall(eventId: string) {
 		ws.sendCustom('video_call:user_joined', {
 			event_id: eventId
 		});
 	}
 
-	// User leaves a video call
 	leaveCall(eventId: string) {
 		ws.sendCustom('video_call:user_left', {
 			event_id: eventId
 		});
-		// Clear local state when leaving
 		this._currentCallState = null;
 	}
 
-	// Change the call state (moderator/facilitator only)
+	/** Moderator/facilitator only */
 	changeCallState(eventId: string, status: VideoCallStatus) {
 		ws.sendCustom('video_call:change_state', {
 			event_id: eventId,
@@ -130,7 +125,7 @@ export class VideoCallService {
 		});
 	}
 
-	// Assign participants to breakout rooms (moderator/facilitator only)
+	/** Moderator/facilitator only */
 	assignBreakoutRooms(eventId: string, maxUsersPerRoom: number) {
 		ws.sendCustom('video_call:assign_breakout_rooms', {
 			event_id: eventId,
@@ -138,7 +133,7 @@ export class VideoCallService {
 		});
 	}
 
-	// Set the current agenda item (moderator/facilitator only)
+	/** Moderator/facilitator only */
 	setAgendaItem(eventId: string, agendaItem: number) {
 		ws.sendCustom('video_call:set_agenda_item', {
 			event_id: eventId,
@@ -146,7 +141,7 @@ export class VideoCallService {
 		});
 	}
 
-	// Broadcast a message to all participants (moderator/facilitator only)
+	/** Broadcast a message to all participants. Moderator/facilitator only. */
 	broadcastMessage(eventId: string, message: string) {
 		ws.sendCustom('video_call:send_message', {
 			event_id: eventId,
@@ -154,7 +149,6 @@ export class VideoCallService {
 		});
 	}
 
-	// Request assistance in a breakout room
 	requestBreakoutRoomAssistance(eventId: string, roomName: string) {
 		ws.sendCustom('video_call:breakout_room_assistance_request', {
 			event_id: eventId,
@@ -162,7 +156,7 @@ export class VideoCallService {
 		});
 	}
 
-	// Resolve (clear) an assistance request from a breakout room (moderator/facilitator only)
+	/** Resolve (clear) an assistance request. Moderator/facilitator only. */
 	resolveBreakoutRoomAssistanceRequest(eventId: string, roomName: string) {
 		ws.sendCustom('video_call:resolve_breakout_room_assistance_request', {
 			event_id: eventId,
@@ -170,7 +164,7 @@ export class VideoCallService {
 		});
 	}
 
-	// Start a breakout session with a specified end time (moderator/facilitator only)
+	/** Moderator/facilitator only */
 	startBreakoutSession(eventId: string, ends: string) {
 		ws.sendCustom('video_call:start_breakout_session', {
 			event_id: eventId,
@@ -178,7 +172,7 @@ export class VideoCallService {
 		});
 	}
 
-	// Extend an active breakout session with a new end time (moderator/facilitator only)
+	/** Moderator/facilitator only */
 	extendBreakoutSession(eventId: string, ends: string) {
 		ws.sendCustom('video_call:extend_breakout_session', {
 			event_id: eventId,
@@ -186,14 +180,14 @@ export class VideoCallService {
 		});
 	}
 
-	// End the current breakout session (moderator/facilitator only)
+	/** Moderator/facilitator only */
 	endBreakoutSession(eventId: string) {
 		ws.sendCustom('video_call:end_breakout_session', {
 			event_id: eventId
 		});
 	}
 
-	// Helper to check if current user is in a specific breakout room
+	/** Returns the breakout room index for a user, or null if not assigned */
 	getUserBreakoutRoom(userId: string): number | null {
 		if (!this._currentCallState) return null;
 
@@ -205,7 +199,6 @@ export class VideoCallService {
 		return null;
 	}
 
-	// Helper to get participants in a specific breakout room
 	getBreakoutRoomParticipants(roomIndex: number): VideoCallParticipant[] {
 		if (!this._currentCallState || roomIndex >= this._currentCallState.breakout_rooms.length) {
 			return [];
@@ -217,7 +210,6 @@ export class VideoCallService {
 			.filter(Boolean);
 	}
 
-	// Helper to check if user has moderator/facilitator role
 	isAuthorized(userId: string): boolean {
 		if (!this._currentCallState) return false;
 
@@ -227,19 +219,16 @@ export class VideoCallService {
 		return participant.role === 'moderator' || participant.role === 'facilitator';
 	}
 
-	// Check if a specific room has an active assistance request
 	hasAssistanceRequest(roomName: string): boolean {
 		if (!this._currentCallState) return false;
 		return roomName in this._currentCallState.breakout_room_assistance_requests;
 	}
 
-	// Get all room names with active assistance requests
 	getRoomsWithAssistanceRequests(): string[] {
 		if (!this._currentCallState) return [];
 		return Object.keys(this._currentCallState.breakout_room_assistance_requests);
 	}
 
-	// Get the user who made the assistance request for a specific room
 	getAssistanceRequestUser(roomName: string): string | null {
 		if (!this._currentCallState) return null;
 		return (
@@ -247,23 +236,21 @@ export class VideoCallService {
 		);
 	}
 
-	// Clear last broadcast message
 	clearLastMessage() {
 		this._lastBroadcastMessage = null;
 	}
 
-	// Check if a breakout session is currently active
+	/** Check if a breakout session is currently active. Uses loose equality (!=) to catch both null and undefined. */
 	isBreakoutSessionActive(): boolean {
 		return this._currentCallState?.breakout_session != null;
 	}
 
-	// Get the end time of the current breakout session as a Date object
 	getBreakoutSessionEndTime(): Date | null {
 		if (!this._currentCallState?.breakout_session) return null;
 		return new Date(this._currentCallState.breakout_session.ends);
 	}
 
-	// Get time remaining in breakout session in milliseconds
+	/** Returns time remaining in milliseconds */
 	getBreakoutSessionTimeRemaining(): number | null {
 		const endTime = this.getBreakoutSessionEndTime();
 		if (!endTime) return null;
@@ -271,5 +258,4 @@ export class VideoCallService {
 	}
 }
 
-// Singleton instance
 export const videoCallService = new VideoCallService();

--- a/ui/packages/comhairle/src/lib/services/videoCallService.svelte.ts
+++ b/ui/packages/comhairle/src/lib/services/videoCallService.svelte.ts
@@ -96,6 +96,14 @@ export class VideoCallService {
 
 	private handleStateUpdate(state: VideoCallState) {
 		console.log('Video call state updated:', state);
+		console.log(
+			'[BREAKOUT-SVC] breakout_rooms:',
+			state.breakout_rooms?.length,
+			'breakout_session:',
+			state.breakout_session,
+			'participants:',
+			Object.keys(state.participants ?? {})
+		);
 		this._currentCallState = state;
 	}
 
@@ -125,11 +133,13 @@ export class VideoCallService {
 		});
 	}
 
-	/** Moderator/facilitator only */
-	assignBreakoutRooms(eventId: string, maxUsersPerRoom: number) {
+	/** Moderator/facilitator only. When roomAssignments is provided, uses explicit
+	 *  room assignments instead of random server-side chunking. */
+	assignBreakoutRooms(eventId: string, maxUsersPerRoom: number, roomAssignments?: string[][]) {
 		ws.sendCustom('video_call:assign_breakout_rooms', {
 			event_id: eventId,
-			max_users_per_room: maxUsersPerRoom
+			max_users_per_room: maxUsersPerRoom,
+			...(roomAssignments ? { room_assignments: roomAssignments } : {})
 		});
 	}
 
@@ -161,6 +171,15 @@ export class VideoCallService {
 		ws.sendCustom('video_call:resolve_breakout_room_assistance_request', {
 			event_id: eventId,
 			room_name: roomName
+		});
+	}
+
+	/** Moderator/facilitator only: move a participant to a different breakout room */
+	moveParticipantToRoom(eventId: string, userId: string, targetRoomIndex: number) {
+		ws.sendCustom('video_call:move_participant', {
+			event_id: eventId,
+			user_id: userId,
+			target_room_index: targetRoomIndex
 		});
 	}
 

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/events/[event_id]/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/events/[event_id]/+page.svelte
@@ -117,7 +117,7 @@
 	let eventDate = $derived($form.start_date ? parseDate($form.start_date) : undefined);
 	let pageTitle = $derived(`Edit Event: ${event.name}`);
 
-	// Map API agenda items to editor format
+	/** Map API agenda items to editor format */
 	function apiAgendaToEditor(items: EventAgendaItem[]): any[] {
 		return items.map((item) => {
 			if ('Basic' in item) {
@@ -146,7 +146,7 @@
 		});
 	}
 
-	// Map editor format back to API agenda items
+	/** Map editor format back to API agenda items */
 	function editorAgendaToApi(items: any[]): EventAgendaItem[] {
 		return items.map((item) => {
 			if (item.type === 'standard') {

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/events/[event_id]/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/events/[event_id]/+page.svelte
@@ -132,7 +132,7 @@
 					type: 'breakout',
 					title: '',
 					duration: item.BreakoutRoom.estimated_time,
-					groupSize: 4,
+					groupSize: item.BreakoutRoom.max_per_room ?? 4,
 					prompts: [
 						{
 							title: item.BreakoutRoom.prompt,
@@ -164,7 +164,8 @@
 						prompt: firstPrompt?.title || '',
 						instructions: firstPrompt?.instructions || '',
 						estimated_time: item.duration ?? 10,
-						time_limit: item.duration ? item.duration * 60 : null
+						time_limit: item.duration ? item.duration * 60 : null,
+						max_per_room: item.groupSize ?? null
 					}
 				};
 			}

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/events/[event_id]/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/events/[event_id]/+page.svelte
@@ -32,6 +32,7 @@
 	import { utcTimeToLocal } from '$lib/utils/date-time';
 	import AgendaEditor from './AgendaEditor.svelte';
 	import type { EventAgendaItem } from '@crownshy/api-client/api';
+	import type { AgendaItemData } from './agenda-types';
 
 	let { data } = $props();
 
@@ -118,7 +119,7 @@
 	let pageTitle = $derived(`Edit Event: ${event.name}`);
 
 	/** Map API agenda items to editor format */
-	function apiAgendaToEditor(items: EventAgendaItem[]): any[] {
+	function apiAgendaToEditor(items: EventAgendaItem[]): AgendaItemData[] {
 		return items.map((item) => {
 			if ('Basic' in item) {
 				return {
@@ -147,7 +148,7 @@
 	}
 
 	/** Map editor format back to API agenda items */
-	function editorAgendaToApi(items: any[]): EventAgendaItem[] {
+	function editorAgendaToApi(items: AgendaItemData[]): EventAgendaItem[] {
 		return items.map((item) => {
 			if (item.type === 'standard') {
 				return {
@@ -172,11 +173,11 @@
 		});
 	}
 
-	let agendaItems = $state<any[]>(apiAgendaToEditor(event.agenda ?? []));
+	let agendaItems = $state<AgendaItemData[]>(apiAgendaToEditor(event.agenda ?? []));
 	let agendaDirty = $state(false);
 	let agendaSaving = $state(false);
 
-	function handleAgendaUpdate(items: any[]) {
+	function handleAgendaUpdate(items: AgendaItemData[]) {
 		agendaItems = items;
 		agendaDirty = true;
 	}

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/events/[event_id]/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/events/[event_id]/+page.svelte
@@ -274,6 +274,7 @@
 
 {#snippet titleContentSnippet()}
 	<h1 class="text-4xl font-bold">Event: {event?.name}</h1>
+	<Button href={`/conversations/${conversation.id}/events/${event.id}/live`}>Event Link</Button>
 	<!-- TODO: figure out these -->
 	<!-- <AdminPrevNextControls -->
 	<!-- 	next={{ name: 'design', url: `/admin/conversations/${conversation.id}/design` }} -->

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/events/[event_id]/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/events/[event_id]/+page.svelte
@@ -39,6 +39,11 @@
 	const event = $derived(data.event);
 	const conversation = $derived(data.conversation);
 	const facilitators = $derived(data.facilitators);
+	const moderators = $derived(data.moderators);
+
+	$inspect('Facilitators ', facilitators);
+	$inspect('Moderators ', moderators);
+
 	let primaryLanguage = $derived(data.conversation.primaryLocale ?? 'en');
 	let supportedLanguages = $derived(data.conversation.supportedLanguages ?? ['en']);
 
@@ -544,7 +549,10 @@
 				<BadgeInput
 					onAddBadge={handleAddFacilitator}
 					onDeleteBadge={handleDeleteFacilitator}
-					badges={facilitators.map((f) => ({ id: f.id, value: f.email }))}
+					badges={[...facilitators, ...moderators].map((f) => ({
+						id: f.id,
+						value: f.email
+					}))}
 					placeholder="Enter an email address"
 				/>
 			</div>

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/events/[event_id]/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/events/[event_id]/+page.svelte
@@ -15,6 +15,7 @@
 	import AdminPrevNextControls from '$lib/components/AdminPrevNextControls.svelte';
 	import { cn } from '$lib/utils';
 	import { buttonVariants } from '$lib/components/ui/button';
+	import Button from '$lib/components/ui/button/button.svelte';
 	import {
 		DateFormatter,
 		getLocalTimeZone,
@@ -29,6 +30,8 @@
 	import BadgeInput from '$lib/components/ui/badge-input/badge-input.svelte';
 	import Label from '$lib/components/ui/label/label.svelte';
 	import { utcTimeToLocal } from '$lib/utils/date-time';
+	import AgendaEditor from './AgendaEditor.svelte';
+	import type { EventAgendaItem } from '@crownshy/api-client/api';
 
 	let { data } = $props();
 
@@ -114,6 +117,92 @@
 	let eventDate = $derived($form.start_date ? parseDate($form.start_date) : undefined);
 	let pageTitle = $derived(`Edit Event: ${event.name}`);
 
+	// Map API agenda items to editor format
+	function apiAgendaToEditor(items: EventAgendaItem[]): any[] {
+		return items.map((item) => {
+			if ('Basic' in item) {
+				return {
+					id: crypto.randomUUID(),
+					type: 'standard',
+					title: item.Basic.title
+				};
+			} else {
+				return {
+					id: crypto.randomUUID(),
+					type: 'breakout',
+					title: '',
+					duration: item.BreakoutRoom.estimated_time,
+					groupSize: 4,
+					prompts: [
+						{
+							title: item.BreakoutRoom.prompt,
+							instructions: item.BreakoutRoom.instructions
+						}
+					],
+					assignmentMode: 'random',
+					balanceBy: []
+				};
+			}
+		});
+	}
+
+	// Map editor format back to API agenda items
+	function editorAgendaToApi(items: any[]): EventAgendaItem[] {
+		return items.map((item) => {
+			if (item.type === 'standard') {
+				return {
+					Basic: {
+						title: item.title || '',
+						description: '',
+						estimated_time: 0
+					}
+				};
+			} else {
+				const firstPrompt = item.prompts?.[0];
+				return {
+					BreakoutRoom: {
+						prompt: firstPrompt?.title || '',
+						instructions: firstPrompt?.instructions || '',
+						estimated_time: item.duration ?? 10,
+						time_limit: item.duration ? item.duration * 60 : null
+					}
+				};
+			}
+		});
+	}
+
+	let agendaItems = $state<any[]>(apiAgendaToEditor(event.agenda ?? []));
+	let agendaDirty = $state(false);
+	let agendaSaving = $state(false);
+
+	function handleAgendaUpdate(items: any[]) {
+		agendaItems = items;
+		agendaDirty = true;
+	}
+
+	async function handleSaveAgenda() {
+		agendaSaving = true;
+		try {
+			await apiClient.UpdateEvent(
+				{ agenda: editorAgendaToApi(agendaItems) },
+				{
+					params: {
+						conversation_id: conversation.id,
+						event_id: event.id
+					}
+				}
+			);
+			await invalidateAll();
+			agendaDirty = false;
+			notifications.send({ message: 'Agenda saved', priority: 'INFO' });
+		} catch (e) {
+			console.error(e);
+			notifications.send({ message: 'Failed to save agenda', priority: 'ERROR' });
+		} finally {
+			agendaSaving = false;
+		}
+	}
+
 	async function handleAddFacilitator(value: string) {
 		try {
 			await apiClient.CreateFacilitatorEventAttendance(
@@ -191,6 +280,12 @@
 			class="text-sidebar-foreground data-[state=active]:text-foreground border-none"
 		>
 			Details
+		</Tabs.Trigger>
+		<Tabs.Trigger
+			value="eventStructure"
+			class="text-sidebar-foreground data-[state=active]:text-foreground border-none"
+		>
+			Event Structure
 		</Tabs.Trigger>
 		<Tabs.Trigger
 			value="facilitators"
@@ -413,6 +508,29 @@
 				</Form.Button>
 			</div>
 		</form>
+	</Tabs.Content>
+	<Tabs.Content value="eventStructure">
+		<div class="flex flex-col gap-10 py-6">
+			<div class="flex flex-col gap-2">
+				<h2 class="text-3xl font-bold">
+					Event structure <span class="font-bold">(for facilitator)</span>
+				</h2>
+				<p class="text-muted-foreground text-base">Plan how your meeting will run</p>
+			</div>
+
+			<AgendaEditor bind:items={agendaItems} onUpdate={handleAgendaUpdate} />
+
+			<div class="border-border flex justify-center border-t py-6">
+				<Button
+					variant="default"
+					class="px-12"
+					disabled={!agendaDirty || agendaSaving}
+					onclick={handleSaveAgenda}
+				>
+					{agendaSaving ? 'Saving...' : 'Save Agenda'}
+				</Button>
+			</div>
+		</div>
 	</Tabs.Content>
 	<Tabs.Content value="facilitators">
 		<div

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/events/[event_id]/+page.ts
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/events/[event_id]/+page.ts
@@ -17,8 +17,17 @@ export const load: PageLoad = async ({ params, parent }) => {
 			params: { conversation_id, event_id },
 			queries: { role: 'facilitator' }
 		});
+		const moderators = await api.ListEventAttendances({
+			params: { conversation_id, event_id },
+			queries: { role: 'moderator' }
+		});
 
-		return { event, conversation, facilitators: facilitators.records };
+		return {
+			event,
+			conversation,
+			facilitators: facilitators.records,
+			moderators: moderators.records
+		};
 	} catch (e) {
 		console.error(e);
 		notifications.addFlash({ priority: 'WARNING', message: 'Problem loading event' });

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/events/[event_id]/AgendaEditor.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/events/[event_id]/AgendaEditor.svelte
@@ -5,25 +5,7 @@
 	import * as Select from '$lib/components/ui/select';
 	import { Trash2, GripVertical } from 'lucide-svelte';
 	import RichTextEditor from '$lib/components/RichTextEditor/RichTextEditor.svelte';
-
-	type AgendaItemType = 'standard' | 'breakout';
-
-	interface BreakoutPrompt {
-		title: string;
-		instructions: string;
-	}
-
-	interface AgendaItemData {
-		id: string;
-		type: AgendaItemType;
-		title: string;
-		// Breakout-specific fields
-		duration?: number;
-		groupSize?: number;
-		prompts?: BreakoutPrompt[];
-		assignmentMode?: string;
-		balanceBy?: string[];
-	}
+	import type { AgendaItemData } from './agenda-types';
 
 	interface Props {
 		items: AgendaItemData[];

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/events/[event_id]/AgendaEditor.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/events/[event_id]/AgendaEditor.svelte
@@ -1,0 +1,338 @@
+<script lang="ts">
+	import Button from '$lib/components/ui/button/button.svelte';
+	import Input from '$lib/components/ui/input/input.svelte';
+	import Label from '$lib/components/ui/label/label.svelte';
+	import * as Select from '$lib/components/ui/select';
+	import { Trash2, GripVertical } from 'lucide-svelte';
+	import RichTextEditor from '$lib/components/RichTextEditor/RichTextEditor.svelte';
+
+	type AgendaItemType = 'standard' | 'breakout';
+
+	interface BreakoutPrompt {
+		title: string;
+		instructions: string;
+	}
+
+	interface AgendaItemData {
+		id: string;
+		type: AgendaItemType;
+		title: string;
+		// Breakout-specific fields
+		duration?: number;
+		groupSize?: number;
+		prompts?: BreakoutPrompt[];
+		assignmentMode?: string;
+		balanceBy?: string[];
+	}
+
+	interface Props {
+		items: AgendaItemData[];
+		onUpdate: (items: AgendaItemData[]) => void;
+	}
+
+	let { items = $bindable(), onUpdate }: Props = $props();
+
+	const balanceOptions = [
+		'Age',
+		'Gender',
+		'Understanding of AI',
+		'Education',
+		'Postcode',
+		'In-call activities'
+	];
+
+	function createId(): string {
+		return crypto.randomUUID();
+	}
+
+	function addStandardItem() {
+		items = [...items, { id: createId(), type: 'standard', title: '' }];
+		onUpdate(items);
+	}
+
+	function addBreakoutSession() {
+		items = [
+			...items,
+			{
+				id: createId(),
+				type: 'breakout',
+				title: '',
+				duration: 10,
+				groupSize: 4,
+				prompts: [{ title: '', instructions: '' }],
+				assignmentMode: 'random',
+				balanceBy: []
+			}
+		];
+		onUpdate(items);
+	}
+
+	function removeItem(index: number) {
+		items = items.filter((_, i) => i !== index);
+		onUpdate(items);
+	}
+
+	function addPrompt(itemIndex: number) {
+		const item = items[itemIndex];
+		if (item.prompts) {
+			item.prompts = [...item.prompts, { title: '', instructions: '' }];
+			items = [...items];
+			onUpdate(items);
+		}
+	}
+
+	function removePrompt(itemIndex: number, promptIndex: number) {
+		const item = items[itemIndex];
+		if (item.prompts && item.prompts.length > 1) {
+			item.prompts = item.prompts.filter((_, i) => i !== promptIndex);
+			items = [...items];
+			onUpdate(items);
+		}
+	}
+
+	function toggleBalance(itemIndex: number, value: string) {
+		const item = items[itemIndex];
+		if (!item.balanceBy) item.balanceBy = [];
+		if (item.balanceBy.includes(value)) {
+			item.balanceBy = item.balanceBy.filter((v) => v !== value);
+		} else {
+			item.balanceBy = [...item.balanceBy, value];
+		}
+		items = [...items];
+		onUpdate(items);
+	}
+
+	// Drag state
+	let dragIdx: number | null = $state(null);
+	let dropIdx: number | null = $state(null);
+
+	function handleDragStart(e: DragEvent, idx: number) {
+		dragIdx = idx;
+		if (e.dataTransfer) {
+			e.dataTransfer.effectAllowed = 'move';
+			e.dataTransfer.setData('text/plain', String(idx));
+		}
+	}
+
+	function handleDragOver(e: DragEvent, idx: number) {
+		e.preventDefault();
+		dropIdx = idx;
+	}
+
+	function handleDragLeave(e: DragEvent, idx: number) {
+		const related = e.relatedTarget as HTMLElement | null;
+		const currentTarget = e.currentTarget as HTMLElement;
+		if (!related || !currentTarget.contains(related)) {
+			if (dropIdx === idx) dropIdx = null;
+		}
+	}
+
+	function handleDrop(e: DragEvent, targetIdx: number) {
+		e.preventDefault();
+		if (dragIdx === null || dragIdx === targetIdx) {
+			dragIdx = null;
+			dropIdx = null;
+			return;
+		}
+		const newItems = [...items];
+		const [moved] = newItems.splice(dragIdx, 1);
+		newItems.splice(targetIdx, 0, moved);
+		items = newItems;
+		onUpdate(items);
+		dragIdx = null;
+		dropIdx = null;
+	}
+
+	function handleDragEnd() {
+		dragIdx = null;
+		dropIdx = null;
+	}
+</script>
+
+<div class="flex flex-col gap-7">
+	<div class="flex flex-col gap-2">
+		<h3 class="text-foreground text-2xl font-bold">Agenda</h3>
+		<p class="text-muted-foreground text-base">Optimise topics and activities</p>
+	</div>
+
+	<!-- Agenda items -->
+	{#each items as item, index (item.id)}
+		<div
+			class="flex items-start gap-4 transition-all {dropIdx === index
+				? 'border-ring border-t-2'
+				: ''}"
+			role="group"
+			ondragover={(e) => handleDragOver(e, index)}
+			ondragleave={(e) => handleDragLeave(e, index)}
+			ondrop={(e) => handleDrop(e, index)}
+		>
+			<div class="border-border flex flex-1 flex-col gap-6 rounded-lg border p-6">
+				{#if item.type === 'standard'}
+					<!-- Standard item -->
+					<div class="text-foreground text-xl font-bold">Standard item</div>
+					<div class="flex items-center gap-6">
+						<Label class="w-16 shrink-0 font-bold">Title</Label>
+						<Input
+							bind:value={item.title}
+							placeholder="Enter agenda item here"
+							class="bg-muted max-w-60"
+							oninput={() => onUpdate(items)}
+						/>
+					</div>
+				{:else}
+					<!-- Breakout session -->
+					<div class="text-foreground text-xl font-bold">Breakout session</div>
+
+					<!-- Time -->
+					<div class="flex items-center gap-2">
+						<div class="flex flex-col gap-1">
+							<Label class="font-bold">Time</Label>
+							<span class="text-muted-foreground text-sm">Session duration</span>
+						</div>
+						<Input
+							type="number"
+							bind:value={item.duration}
+							class="bg-muted w-14"
+							min={1}
+							max={120}
+							oninput={() => onUpdate(items)}
+						/>
+						<span class="text-sm">minutes</span>
+					</div>
+
+					<!-- Group size -->
+					<div class="flex items-center gap-2">
+						<div class="flex flex-col gap-1">
+							<Label class="font-bold">Group size</Label>
+							<span class="text-muted-foreground text-sm">People per room</span>
+						</div>
+						<Input
+							type="number"
+							bind:value={item.groupSize}
+							class="bg-muted w-14"
+							min={2}
+							max={20}
+							oninput={() => onUpdate(items)}
+						/>
+						<span class="text-sm">people</span>
+					</div>
+
+					<!-- Breakout prompts -->
+					<div class="text-foreground text-lg font-bold">Breakout prompt</div>
+
+					{#each item.prompts ?? [] as prompt, pIdx}
+						<div class="border-border flex flex-col gap-6 rounded-lg border p-6">
+							<div class="flex items-start gap-4">
+								<div class="flex flex-col gap-1">
+									<Label class="font-bold">Title</Label>
+									<span class="text-muted-foreground text-sm"
+										>What should each group discuss?</span
+									>
+								</div>
+								<Input
+									bind:value={prompt.title}
+									placeholder="Enter prompt title here"
+									class="bg-muted max-w-64"
+									oninput={() => onUpdate(items)}
+								/>
+							</div>
+
+							<div class="flex flex-col gap-2">
+								<Label class="font-bold">Instructions</Label>
+								<span class="text-muted-foreground text-sm"
+									>What should participants do during this session?</span
+								>
+								<RichTextEditor
+									value={prompt.instructions}
+									placeholder="Enter instructions here"
+									minHeight="120px"
+									onChange={(json) => {
+										prompt.instructions = json;
+										onUpdate(items);
+									}}
+								/>
+							</div>
+
+							{#if (item.prompts?.length ?? 0) > 1}
+								<button
+									class="text-destructive hover:text-destructive/80 flex items-center gap-1 text-sm"
+									onclick={() => removePrompt(index, pIdx)}
+								>
+									<Trash2 class="h-4 w-4" />
+									Remove prompt
+								</button>
+							{/if}
+						</div>
+					{/each}
+
+					<Button variant="default" class="w-fit" onclick={() => addPrompt(index)}>
+						+ Add breakout prompt
+					</Button>
+
+					<!-- Group assignment -->
+					<div class="flex flex-col gap-2">
+						<Label class="font-bold">Group assignment</Label>
+						<span class="text-muted-foreground text-sm"
+							>How do we want to breakdown the groups?</span
+						>
+						<select
+							bind:value={item.assignmentMode}
+							class="border-input bg-muted/50 w-64 rounded-md border p-2.5 text-sm"
+							onchange={() => onUpdate(items)}
+						>
+							<option value="random">Random</option>
+							<option value="diversify">Diversify by participant info</option>
+						</select>
+					</div>
+
+					<!-- Balance by (only if diversify) -->
+					{#if item.assignmentMode === 'diversify'}
+						<div class="flex flex-col gap-2">
+							<Label class="font-bold">Balance group by</Label>
+							<span class="text-muted-foreground text-sm"
+								>How would you like to balance each group's composition?</span
+							>
+							<div class="flex flex-col">
+								{#each balanceOptions as opt}
+									<label class="flex cursor-pointer items-center gap-2.5 p-2.5">
+										<input
+											type="checkbox"
+											checked={item.balanceBy?.includes(opt) ?? false}
+											onchange={() => toggleBalance(index, opt)}
+											class="border-border bg-muted/50 h-4 w-4 rounded-full border shadow-sm"
+										/>
+										<span class="text-base">{opt}</span>
+									</label>
+								{/each}
+							</div>
+						</div>
+					{/if}
+				{/if}
+			</div>
+
+			<!-- Side controls: drag handle + delete -->
+			<div class="flex flex-col items-center gap-2 pt-6">
+				<button
+					class="text-muted-foreground hover:text-foreground cursor-grab active:cursor-grabbing"
+					draggable="true"
+					ondragstart={(e) => handleDragStart(e, index)}
+					ondragend={handleDragEnd}
+				>
+					<GripVertical class="h-5 w-5" />
+				</button>
+				<button
+					class="text-muted-foreground hover:text-destructive"
+					onclick={() => removeItem(index)}
+				>
+					<Trash2 class="h-5 w-5" />
+				</button>
+			</div>
+		</div>
+	{/each}
+
+	<!-- Add buttons -->
+	<div class="flex gap-4">
+		<Button variant="default" onclick={addStandardItem}>+ Add agenda item</Button>
+		<Button variant="default" onclick={addBreakoutSession}>+ Add breakout session</Button>
+	</div>
+</div>

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/events/[event_id]/agenda-types.ts
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/events/[event_id]/agenda-types.ts
@@ -1,0 +1,18 @@
+export type AgendaItemType = 'standard' | 'breakout';
+
+export interface BreakoutPrompt {
+	title: string;
+	instructions: string;
+}
+
+export interface AgendaItemData {
+	id: string;
+	type: AgendaItemType;
+	title: string;
+	// Breakout-specific fields
+	duration?: number;
+	groupSize?: number;
+	prompts?: BreakoutPrompt[];
+	assignmentMode?: string;
+	balanceBy?: string[];
+}

--- a/ui/packages/comhairle/src/routes/(public)/+layout.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/+layout.svelte
@@ -8,6 +8,7 @@
 	const isEmbed = $derived(page.url.searchParams.get('embed') === 'true');
 	const isAuthPage = $derived(page.url.pathname.startsWith('/auth/'));
 	const isReportPage = $derived(page.url.pathname.endsWith('/report'));
+	const isLivePage = $derived(page.url.pathname.endsWith('/live'));
 
 	let isAdmin = $derived(
 		data.userRoles
@@ -24,12 +25,16 @@
 		<div class="grow">
 			{@render children()}
 		</div>
+	{:else if isLivePage}
+		<div class="w-full grow">
+			{@render children()}
+		</div>
 	{:else}
 		<div class="mx-auto min-h-[80vh] w-full max-w-[1300px] grow px-4 md:px-20">
 			{@render children()}
 		</div>
 	{/if}
-	{#if !isEmbed}
+	{#if !isEmbed && !isLivePage}
 		<Footer />
 	{/if}
 </div>

--- a/ui/packages/comhairle/src/routes/(public)/+layout.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/+layout.svelte
@@ -18,7 +18,7 @@
 </script>
 
 <div class="flex min-h-screen w-full flex-col {isReportPage ? 'bg-primary/10' : ''}">
-	{#if !isEmbed && !isAuthPage}
+	{#if !isEmbed && !isAuthPage && !isLivePage}
 		<NavBar user={data.user} {isAdmin} />
 	{/if}
 	{#if isAuthPage || isReportPage}

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
@@ -277,10 +277,10 @@
 		}
 	});
 
-	// Auto-join when arriving at an already in-progress call
+	// Auto-join when call is in progress (moderator started it)
 	$effect(() => {
-		if (callStatus === 'InProgress' && !hasJoinedCall && isModerator) {
-			console.log('[BREAKOUT] Auto-joining moderator into call');
+		if (callStatus === 'InProgress' && !hasJoinedCall) {
+			console.log('[BREAKOUT] Auto-joining into call, isModerator:', isModerator);
 			hasJoinedCall = true;
 		}
 	});
@@ -438,10 +438,6 @@
 
 	function handleStartMeeting() {
 		videoCallService.changeCallState(eventId, 'InProgress');
-		hasJoinedCall = true;
-	}
-
-	function handleJoinMeeting() {
 		hasJoinedCall = true;
 	}
 
@@ -785,7 +781,6 @@
 		{callStatus}
 		{isModerator}
 		onStartMeeting={handleStartMeeting}
-		onJoinMeeting={handleJoinMeeting}
 	/>
 {:else}
 	<!-- In-call: full-width black background, stays in document flow -->

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
@@ -30,6 +30,7 @@
 
 	let { data }: PageProps = $props();
 
+	let conversationId = $derived(data.conversationId);
 	let eventId = $derived(data.eventId);
 	let event = $derived(data.event);
 	let jwt = $derived(data.jwt);
@@ -383,6 +384,14 @@
 		}
 	});
 
+	// When callStatus becomes 'Ended', hang up Jitsi for ALL participants
+	$effect(() => {
+		if (callStatus === 'Ended' && jitsiApi) {
+			jitsiApi.executeCommand('hangup');
+			hasJoinedCall = false;
+		}
+	});
+
 	// Watch for broadcast messages (participants only — moderator gets toast confirmation)
 	$effect(() => {
 		if (lastBroadcast) {
@@ -452,11 +461,16 @@
 	}
 
 	/** Moderator ends the meeting for everyone */
-	function handleEndMeeting() {
+	async function handleEndMeeting() {
 		showEndMeeting = false;
+
+		// Close breakout rooms first if a session is active
+		if (isBreakoutActive) {
+			await handleEndBreakoutSession();
+		}
+
+		// Broadcast 'Ended' state to all participants via WS
 		videoCallService.changeCallState(eventId, 'Ended');
-		jitsiApi?.executeCommand('hangup');
-		hasJoinedCall = false;
 	}
 
 	function handleCreateBreakout(config: {
@@ -753,6 +767,14 @@
 	<MeetingEndedScreen
 		title={event?.name ?? 'Meeting'}
 		conversationUrl={`/conversations/${conversationId}`}
+		{isModerator}
+		onResetCall={() => {
+			videoCallService.changeCallState(eventId, 'Waiting');
+			videoCallService.setAgendaItem(eventId, 0);
+			videoCallService.endBreakoutSession(eventId);
+			hasJoinedCall = false;
+			roomContext = 'plenary';
+		}}
 	/>
 {:else if meetingPhase === 'lobby'}
 	<MeetingLobby

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
@@ -78,6 +78,7 @@
 
 	// Dialog states
 	let showCreateBreakout = $state(false);
+	let breakoutDialogItem = $state<AgendaItem | null>(null);
 	let showBroadcast = $state(false);
 	let showAddTime = $state(false);
 	let seenAssistanceRequests = $state<Set<string>>(new Set());
@@ -114,7 +115,8 @@
 					type: 'breakout' as const,
 					breakoutQuestion: item.BreakoutRoom.prompt,
 					breakoutDescription: item.BreakoutRoom.instructions,
-					durationMinutes: item.BreakoutRoom.estimated_time
+					durationMinutes: item.BreakoutRoom.estimated_time,
+					maxPerRoom: item.BreakoutRoom.max_per_room ?? undefined
 				};
 			}
 		});
@@ -351,6 +353,7 @@
 	function handleSetAgendaItem(index: number) {
 		videoCallService.setAgendaItem(eventId, index);
 		if (isModerator && agendaItems[index]?.type === 'breakout' && !isBreakoutActive) {
+			breakoutDialogItem = agendaItems[index];
 			showCreateBreakout = true;
 		}
 	}
@@ -625,6 +628,8 @@
 <CreateBreakoutDialog
 	bind:open={showCreateBreakout}
 	participants={allParticipants}
+	defaultDuration={breakoutDialogItem?.durationMinutes}
+	defaultMaxPerRoom={breakoutDialogItem?.maxPerRoom}
 	onClose={() => (showCreateBreakout = false)}
 	onCreate={handleCreateBreakout}
 />

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
@@ -14,6 +14,8 @@
 	import BroadcastMessageDialog from '$lib/components/LiveEvent/BroadcastMessageDialog.svelte';
 	import AddTimeDialog from '$lib/components/LiveEvent/AddTimeDialog.svelte';
 	import NoticeDialog from '$lib/components/LiveEvent/NoticeDialog.svelte';
+	import EndMeetingDialog from '$lib/components/LiveEvent/EndMeetingDialog.svelte';
+	import MeetingEndedScreen from '$lib/components/LiveEvent/MeetingEndedScreen.svelte';
 	import SidePanel from '$lib/components/LiveEvent/SidePanel.svelte';
 	import type {
 		AgendaItem,
@@ -62,6 +64,7 @@
 	let breakoutDialogItem = $state<AgendaItem | null>(null);
 	let showBroadcast = $state(false);
 	let showAddTime = $state(false);
+	let showEndMeeting = $state(false);
 	let seenAssistanceRequests = $state<Set<string>>(new Set());
 
 	/** Notice queue for assistance requests, broadcasts, time warnings */
@@ -408,6 +411,14 @@
 		}
 	}
 
+	/** Moderator ends the meeting for everyone */
+	function handleEndMeeting() {
+		showEndMeeting = false;
+		videoCallService.changeCallState(eventId, 'Ended');
+		jitsiApi?.executeCommand('hangup');
+		hasJoinedCall = false;
+	}
+
 	function handleCreateBreakout(config: {
 		maxPerRoom: number;
 		durationMinutes: number;
@@ -550,7 +561,12 @@
 			</div>
 		</div>
 	</div>
-{:else if meetingPhase === 'lobby' || meetingPhase === 'ended'}
+{:else if meetingPhase === 'ended'}
+	<MeetingEndedScreen
+		title={event?.name ?? 'Meeting'}
+		conversationUrl={`/conversations/${conversationId}`}
+	/>
+{:else if meetingPhase === 'lobby'}
 	<MeetingLobby
 		title={event?.name ?? 'Meeting'}
 		scheduledTime={scheduledTimeText}
@@ -684,6 +700,7 @@
 							readOnly={isBreakoutActive}
 							onSetCurrent={handleSetAgendaItem}
 							onNext={handleNextAgendaItem}
+							onEndMeeting={() => (showEndMeeting = true)}
 						/>
 					{/if}
 				</SidePanel>
@@ -708,6 +725,7 @@
 					readOnly={isBreakoutActive}
 					onSetCurrent={handleSetAgendaItem}
 					onNext={handleNextAgendaItem}
+					onEndMeeting={() => (showEndMeeting = true)}
 				/>
 			</div>
 		</Drawer.Content>
@@ -735,6 +753,12 @@
 	{timeLeftFormatted}
 	onClose={() => (showAddTime = false)}
 	onAddTime={handleAddTime}
+/>
+
+<EndMeetingDialog
+	bind:open={showEndMeeting}
+	onConfirm={handleEndMeeting}
+	onCancel={() => (showEndMeeting = false)}
 />
 
 <BreakoutEndingDialog

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
@@ -640,6 +640,7 @@
 								'hangup',
 								'fullscreen'
 							],
+							prejoinPageEnabled: false,
 							disableDeepLinking: true,
 							hideConferenceSubject: true
 						}}

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
@@ -71,7 +71,6 @@
 	let hasJoinedCall = $state(false);
 	let jitsiApi: any = $state(null);
 	let roomContext = $state<RoomContext>('plenary');
-	let panelOpen = $state(true);
 	let activePanel = $state<PanelTab>('agenda');
 
 	// Mock breakout rooms (for testing with mock participants)
@@ -555,92 +554,47 @@
 						{/if}
 					</div>
 				</div>
-
-				<!-- Host panel toggle tabs (visible when panel closed) -->
-				{#if isModerator && !panelOpen}
-					<div class="absolute top-12 right-0 z-10 flex flex-col rounded-3xl shadow-lg">
-						<button
-							class="bg-background h-12 w-48 px-6 py-3 text-left text-sm font-semibold {isBreakoutActive &&
-							!inBreakoutRoom
-								? 'rounded-t-[20px]'
-								: 'rounded-[20px]'}"
-							onclick={() => {
-								activePanel = 'agenda';
-								panelOpen = true;
-							}}
-						>
-							Agenda
-						</button>
-						{#if isBreakoutActive && !inBreakoutRoom}
-							<button
-								class="bg-background relative h-12 w-48 rounded-b-[20px] border-t px-6 py-3 text-left text-sm font-semibold"
-								onclick={() => {
-									activePanel = 'breakoutRooms';
-									panelOpen = true;
-								}}
-							>
-								Breakout rooms
-								{#if Object.keys(assistanceRequests).length > 0}
-									<span
-										class="bg-destructive absolute top-3.5 right-4 h-2 w-2 rounded-full"
-									></span>
-								{/if}
-							</button>
-						{/if}
-					</div>
-				{/if}
 			</div>
 
 			<!-- Right panel (side-by-side) -->
-			{#if panelOpen || !isModerator}
-				<div class="relative h-full w-[360px] shrink-0 p-3">
-					{#if isModerator}
-						<button
-							class="text-muted-foreground hover:text-foreground absolute top-5 right-5 z-10 flex h-6 w-6 items-center justify-center rounded-full"
-							onclick={() => (panelOpen = false)}
-							aria-label="Close panel"
-						>
-							✕
-						</button>
+			<div class="relative h-full w-[360px] shrink-0 p-3">
+				<SidePanel
+					activeTab={activePanel}
+					showTabs={isBreakoutActive && isModerator && !inBreakoutRoom}
+					onTabChange={(tab) => (activePanel = tab)}
+				>
+					{#if isBreakoutActive && inBreakoutRoom}
+						<BreakoutSessionPanel
+							roomName={roomChipText}
+							question={currentAgendaItem?.breakoutQuestion}
+							description={currentAgendaItem?.breakoutDescription}
+							{timeLeftFormatted}
+							{isModerator}
+							onCallForSupport={handleCallForSupport}
+							onLeaveBreakoutRoom={handleLeaveBreakoutRoom}
+						/>
+					{:else if activePanel === 'breakoutRooms' && breakoutRoomDisplays.length > 0}
+						<BreakoutRoomsPanel
+							rooms={breakoutRoomDisplays}
+							{timeLeftFormatted}
+							{isModerator}
+							onEnterRoom={handleEnterBreakoutRoom}
+							onAddTime={() => (showAddTime = true)}
+							onEndSession={handleEndBreakoutSession}
+							onBroadcastMessage={() => (showBroadcast = true)}
+						/>
+					{:else}
+						<AgendaPanel
+							items={agendaItems}
+							{currentStep}
+							{isModerator}
+							readOnly={isBreakoutActive}
+							onSetCurrent={handleSetAgendaItem}
+							onNext={handleNextAgendaItem}
+						/>
 					{/if}
-					<SidePanel
-						activeTab={activePanel}
-						showTabs={isBreakoutActive && isModerator && !inBreakoutRoom}
-						onTabChange={(tab) => (activePanel = tab)}
-					>
-						{#if isBreakoutActive && inBreakoutRoom}
-							<BreakoutSessionPanel
-								roomName={roomChipText}
-								question={currentAgendaItem?.breakoutQuestion}
-								description={currentAgendaItem?.breakoutDescription}
-								{timeLeftFormatted}
-								{isModerator}
-								onCallForSupport={handleCallForSupport}
-								onLeaveBreakoutRoom={handleLeaveBreakoutRoom}
-							/>
-						{:else if activePanel === 'breakoutRooms' && breakoutRoomDisplays.length > 0}
-							<BreakoutRoomsPanel
-								rooms={breakoutRoomDisplays}
-								{timeLeftFormatted}
-								{isModerator}
-								onEnterRoom={handleEnterBreakoutRoom}
-								onAddTime={() => (showAddTime = true)}
-								onEndSession={handleEndBreakoutSession}
-								onBroadcastMessage={() => (showBroadcast = true)}
-							/>
-						{:else}
-							<AgendaPanel
-								items={agendaItems}
-								{currentStep}
-								{isModerator}
-								readOnly={isBreakoutActive}
-								onSetCurrent={handleSetAgendaItem}
-								onNext={handleNextAgendaItem}
-							/>
-						{/if}
-					</SidePanel>
-				</div>
-			{/if}
+				</SidePanel>
+			</div>
 		</div>
 	</div>
 

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
@@ -35,27 +35,8 @@
 	let user = $derived(data.user);
 	let isModerator = $derived(data.isModerator);
 
-	/** @todo remove — mock participants for dev testing */
-	const mockParticipants: VideoCallParticipant[] = [
-		{ user_id: 'user-1', username: 'Alice Johnson', role: 'participant' },
-		{ user_id: 'user-2', username: 'Bob Smith', role: 'participant' },
-		{ user_id: 'user-3', username: 'Cathy Lee', role: 'participant' },
-		{ user_id: 'user-4', username: 'Dan Rivera', role: 'participant' },
-		{ user_id: 'user-5', username: 'Eva Müller', role: 'participant' },
-		{ user_id: 'user-6', username: 'Frank Chen', role: 'participant' },
-		{ user_id: 'user-7', username: 'Grace Kim', role: 'participant' },
-		{ user_id: 'user-8', username: 'Hiro Tanaka', role: 'participant' },
-		{ user_id: 'user-9', username: 'Isla Nguyen', role: 'participant' },
-		{ user_id: 'user-10', username: 'Jake Brown', role: 'participant' },
-		{ user_id: 'user-11', username: 'Karen Walsh', role: 'participant' },
-		{ user_id: 'user-12', username: 'Leo Garcia', role: 'participant' }
-	];
-
 	let callStatus = $derived(videoCallService.callStatus);
-	let realParticipants = $derived(videoCallService.participants);
-	let allParticipants = $derived(
-		dev ? [...realParticipants, ...mockParticipants] : realParticipants
-	);
+	let allParticipants = $derived(videoCallService.participants);
 	let otherParticipants = $derived(allParticipants.filter((p) => p.user_id !== user?.id));
 	let currentStep = $derived(videoCallService.currentAgendaStep);
 	let breakoutSession = $derived(videoCallService.breakoutSession);
@@ -91,6 +72,20 @@
 	let breakoutEndingDismissed = $state(false);
 	let breakoutAutoEnded = $state(false);
 
+	/** Tracks assigned room index to detect mid-session reassignment by moderator */
+	let trackedRoomIndex = $state<number | null>(null);
+
+	/** Jitsi's native breakout room data from breakoutRoomsUpdated event */
+	let jitsiBreakoutRooms = $state<Record<string, any>>({});
+
+	/** Get the Jitsi room ID for a given room index (0-based) */
+	function getJitsiBreakoutRoomId(roomIndex: number): string | null {
+		const nonMainRooms = Object.values(jitsiBreakoutRooms)
+			.filter((r: any) => !r.isMainRoom)
+			.sort((a: any, b: any) => (a.name ?? '').localeCompare(b.name ?? ''));
+		return nonMainRooms[roomIndex]?.id ?? null;
+	}
+
 	/** Lightweight toast for admin confirmations */
 	let toastMessage = $state<string | null>(null);
 	let toastTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -124,10 +119,24 @@
 	let agendaItems = $derived(mapApiAgenda(event?.agenda ?? []));
 
 	let meetingPhase = $derived.by(() => {
-		if (callStatus === null) return 'loading' as const;
-		if (callStatus === 'Ended') return 'ended' as const;
-		if (callStatus === 'InProgress' && hasJoinedCall) return 'incall' as const;
-		return 'lobby' as const;
+		const phase =
+			callStatus === null
+				? ('loading' as const)
+				: callStatus === 'Ended'
+					? ('ended' as const)
+					: callStatus === 'InProgress' && hasJoinedCall
+						? ('incall' as const)
+						: ('lobby' as const);
+		console.log(
+			'[BREAKOUT] meetingPhase:',
+			phase,
+			'{ callStatus:',
+			callStatus,
+			', hasJoinedCall:',
+			hasJoinedCall,
+			'}'
+		);
+		return phase;
 	});
 
 	let isBreakoutActive = $derived(breakoutSession !== null);
@@ -143,11 +152,7 @@
 			: ''
 	);
 
-	let currentJitsiRoom = $derived.by(() => {
-		const baseRoom = event?.videoMeetingId ?? '';
-		if (typeof roomContext === 'string') return baseRoom;
-		return `${baseRoom}-breakout-${roomContext.roomIndex}`;
-	});
+	let plenaryRoomName = $derived(event?.videoMeetingId ?? '');
 
 	let roomChipText = $derived.by(() => {
 		if (typeof roomContext === 'string') return 'Plenary room';
@@ -237,6 +242,7 @@
 	// Auto-join when arriving at an already in-progress call
 	$effect(() => {
 		if (callStatus === 'InProgress' && !hasJoinedCall && isModerator) {
+			console.log('[BREAKOUT] Auto-joining moderator into call');
 			hasJoinedCall = true;
 		}
 	});
@@ -252,13 +258,50 @@
 
 	// Auto-enter participants into their assigned breakout room
 	$effect(() => {
+		console.log('[BREAKOUT] auto-enter effect:', {
+			isBreakoutActive,
+			isModerator,
+			roomContext: typeof roomContext === 'string' ? roomContext : roomContext,
+			userId: user?.id
+		});
 		if (isBreakoutActive && !isModerator && typeof roomContext === 'string') {
 			const assignedRoom = user ? videoCallService.getUserBreakoutRoom(user.id) : null;
+			console.log(
+				'[BREAKOUT] Participant auto-entering breakout room:',
+				assignedRoom,
+				'(fallback 0)'
+			);
 			// Use assigned room from backend, or default to room 0 for mock testing
 			handleEnterBreakoutRoom(assignedRoom ?? 0);
 		}
 		if (!isBreakoutActive && typeof roomContext !== 'string' && !isModerator) {
+			console.log('[BREAKOUT] Breakout ended — returning participant to plenary');
 			roomContext = 'plenary';
+			jitsiApi?.executeCommand('joinBreakoutRoom');
+		}
+	});
+
+	// Detect mid-session room reassignment (moderator moved a participant)
+	$effect(() => {
+		if (!isBreakoutActive || isModerator || !user) {
+			trackedRoomIndex = null;
+			return;
+		}
+
+		const assignedRoom = videoCallService.getUserBreakoutRoom(user.id);
+		const tracked = untrack(() => trackedRoomIndex);
+		console.log('[BREAKOUT] reassignment check:', { assignedRoom, tracked });
+
+		if (tracked === null && assignedRoom !== null) {
+			// First assignment — just start tracking
+			console.log('[BREAKOUT] First assignment, tracking room:', assignedRoom);
+			trackedRoomIndex = assignedRoom;
+		} else if (assignedRoom !== null && assignedRoom !== tracked && tracked !== null) {
+			// Room changed mid-session — moderator moved us
+			console.log('[BREAKOUT] Room CHANGED by moderator:', tracked, '→', assignedRoom);
+			handleEnterBreakoutRoom(assignedRoom);
+			pushNotice({ message: `You've been moved to Breakout room #${assignedRoom + 1}` });
+			trackedRoomIndex = assignedRoom;
 		}
 	});
 
@@ -370,11 +413,22 @@
 		durationMinutes: number;
 		roomAssignments: VideoCallParticipant[][];
 	}) {
-		// TODO: when backend supports explicit assignments, send config.roomAssignments
-		videoCallService.assignBreakoutRooms(eventId, config.maxPerRoom);
+		console.log('[BREAKOUT] handleCreateBreakout:', {
+			maxPerRoom: config.maxPerRoom,
+			durationMinutes: config.durationMinutes,
+			roomCount: config.roomAssignments.length
+		});
+		// Send explicit room assignments so backend uses the dialog's distribution
+		const roomAssignments = config.roomAssignments.map((room) => room.map((p) => p.user_id));
+		videoCallService.assignBreakoutRooms(eventId, config.maxPerRoom, roomAssignments);
 		const ends = new Date(Date.now() + config.durationMinutes * 60 * 1000).toISOString();
 		videoCallService.startBreakoutSession(eventId, ends);
 		showCreateBreakout = false;
+
+		// Create breakout rooms in Jitsi via native API
+		for (let i = 0; i < config.roomAssignments.length; i++) {
+			jitsiApi?.executeCommand('addBreakoutRoom', `Breakout room #${i + 1}`);
+		}
 
 		// Use dialog's room assignments for local display until backend confirms
 		mockBreakoutRooms = config.roomAssignments.map((participants, i) => ({
@@ -390,18 +444,42 @@
 	}
 
 	function handleEnterBreakoutRoom(roomIndex: number) {
+		console.log(
+			'[BREAKOUT] handleEnterBreakoutRoom:',
+			roomIndex,
+			'| current roomContext:',
+			roomContext
+		);
 		roomContext = {
 			type: 'breakout',
 			roomIndex,
 			roomName: `Breakout room #${roomIndex + 1}`
 		};
+		console.log('[BREAKOUT] roomContext NOW:', roomContext);
+
+		// Use Jitsi's native breakout room API to switch rooms
+		const jitsiRoomId = getJitsiBreakoutRoomId(roomIndex);
+		if (jitsiRoomId) {
+			console.log('[BREAKOUT] joinBreakoutRoom via Jitsi API, roomId:', jitsiRoomId);
+			jitsiApi?.executeCommand('joinBreakoutRoom', jitsiRoomId);
+		} else {
+			console.warn(
+				'[BREAKOUT] No Jitsi room ID found for index:',
+				roomIndex,
+				'— rooms:',
+				jitsiBreakoutRooms
+			);
+		}
+
 		if (isModerator) {
 			videoCallService.resolveBreakoutRoomAssistanceRequest(eventId, `room-${roomIndex}`);
 		}
 	}
 
 	function handleLeaveBreakoutRoom() {
+		console.log('[BREAKOUT] handleLeaveBreakoutRoom → plenary');
 		roomContext = 'plenary';
+		jitsiApi?.executeCommand('joinBreakoutRoom');
 	}
 
 	function handleCallForSupport() {
@@ -426,10 +504,38 @@
 		}
 	}
 
+	function handleMoveParticipant(userId: string, targetRoomIndex: number) {
+		videoCallService.moveParticipantToRoom(eventId, userId, targetRoomIndex);
+
+		// Optimistic update: move participant in local mock rooms
+		if (mockBreakoutRooms.length > 0) {
+			const updated = mockBreakoutRooms.map((room) => ({
+				...room,
+				participants: room.participants.filter((p) => p.user_id !== userId)
+			}));
+			const participant = mockBreakoutRooms
+				.flatMap((r) => r.participants)
+				.find((p) => p.user_id === userId);
+			if (participant && updated[targetRoomIndex]) {
+				updated[targetRoomIndex].participants = [
+					...updated[targetRoomIndex].participants,
+					participant
+				];
+			}
+			mockBreakoutRooms = updated;
+		}
+
+		const target = breakoutRoomDisplays[targetRoomIndex];
+		showToast(`Participant moved to ${target?.name ?? `Room #${targetRoomIndex + 1}`}`);
+	}
+
 	function handleEndBreakoutSession() {
+		console.log('[BREAKOUT] handleEndBreakoutSession');
 		videoCallService.endBreakoutSession(eventId);
 		roomContext = 'plenary';
+		jitsiApi?.executeCommand('joinBreakoutRoom');
 		mockBreakoutRooms = [];
+		jitsiBreakoutRooms = {};
 		activePanel = 'agenda';
 	}
 
@@ -437,6 +543,8 @@
 		roomContext = 'plenary';
 		if (isModerator) {
 			handleEndBreakoutSession();
+		} else {
+			jitsiApi?.executeCommand('joinBreakoutRoom');
 		}
 	}
 
@@ -513,28 +621,29 @@
 
 				<!-- Jitsi iframe -->
 				<div class="relative flex-1 overflow-hidden">
-					{#key currentJitsiRoom}
-						<JitsiMeet
-							roomName={currentJitsiRoom}
-							{jwt}
-							onApiReady={handleApiReady}
-							startWithAudioMuted={true}
-							configOverwrite={{
-								toolbarButtons: [
-									'microphone',
-									'camera',
-									'desktop',
-									'chat',
-									'raisehand',
-									'tileview',
-									'hangup',
-									'fullscreen'
-								],
-								disableDeepLinking: true,
-								hideConferenceSubject: true
-							}}
-						/>
-					{/key}
+					<JitsiMeet
+						roomName={plenaryRoomName}
+						{jwt}
+						onApiReady={handleApiReady}
+						onBreakoutRoomsUpdated={(rooms) => {
+							jitsiBreakoutRooms = rooms;
+						}}
+						startWithAudioMuted={true}
+						configOverwrite={{
+							toolbarButtons: [
+								'microphone',
+								'camera',
+								'desktop',
+								'chat',
+								'raisehand',
+								'tileview',
+								'hangup',
+								'fullscreen'
+							],
+							disableDeepLinking: true,
+							hideConferenceSubject: true
+						}}
+					/>
 
 					<!-- Room chip overlay -->
 					<div class="pointer-events-none absolute inset-x-0 top-0 flex justify-center">
@@ -587,6 +696,7 @@
 							{timeLeftFormatted}
 							{isModerator}
 							onEnterRoom={handleEnterBreakoutRoom}
+							onMoveParticipant={handleMoveParticipant}
 							onAddTime={() => (showAddTime = true)}
 							onEndSession={handleEndBreakoutSession}
 							onBroadcastMessage={() => (showBroadcast = true)}

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
@@ -563,7 +563,7 @@
 	/>
 {:else}
 	<!-- In-call: full-width black background, stays in document flow -->
-	<div class="bg-sidebar flex h-[calc(100dvh-64px)] w-full flex-col overflow-hidden">
+	<div class="bg-sidebar flex h-dvh w-full flex-col overflow-hidden">
 		<div class="flex min-h-0 flex-1">
 			<!-- Jitsi area -->
 			<div class="relative flex min-h-0 min-w-0 flex-1 flex-col">
@@ -649,8 +649,8 @@
 				</div>
 			</div>
 
-			<!-- Right panel (side-by-side) -->
-			<div class="relative h-full w-[360px] shrink-0 p-3">
+			<!-- Right panel (side-by-side, hidden on mobile) -->
+			<div class="relative hidden h-full w-[360px] shrink-0 p-3 md:block">
 				<SidePanel
 					activeTab={activePanel}
 					showTabs={isBreakoutActive && isModerator && !inBreakoutRoom}
@@ -691,7 +691,7 @@
 		</div>
 	</div>
 
-	<!-- Mobile drawer -->
+	<!-- Mobile agenda pill + drawer -->
 	<Drawer.Root>
 		<Drawer.Trigger
 			class="bg-primary hover:bg-primary/90 fixed bottom-4 left-1/2 z-50 inline-flex -translate-x-1/2 items-center gap-2 rounded-full px-6 py-3 font-semibold text-white shadow-lg md:hidden"

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
@@ -8,6 +8,7 @@
 	import AgendaPanel from '$lib/components/LiveEvent/AgendaPanel.svelte';
 	import BreakoutSessionPanel from '$lib/components/LiveEvent/BreakoutSessionPanel.svelte';
 	import BreakoutRoomsPanel from '$lib/components/LiveEvent/BreakoutRoomsPanel.svelte';
+	import BreakoutEndingDialog from '$lib/components/LiveEvent/BreakoutEndingDialog.svelte';
 	import CreateBreakoutDialog from '$lib/components/LiveEvent/CreateBreakoutDialog.svelte';
 	import BroadcastMessageDialog from '$lib/components/LiveEvent/BroadcastMessageDialog.svelte';
 	import AddTimeDialog from '$lib/components/LiveEvent/AddTimeDialog.svelte';
@@ -86,7 +87,8 @@
 	let noticeQueue = $state<{ message: string; actionLabel?: string; onAction?: () => void }[]>(
 		[]
 	);
-	let breakoutEndingNotified = $state(false);
+	let showBreakoutEnding = $state(false);
+	let breakoutEndingDismissed = $state(false);
 	let breakoutAutoEnded = $state(false);
 
 	// Lightweight toast for admin confirmations
@@ -248,22 +250,36 @@
 		}
 	});
 
-	// Show ending notice at 5 seconds, auto-end at 0
+	// Auto-enter participants into their assigned breakout room
 	$effect(() => {
+		if (isBreakoutActive && !isModerator && typeof roomContext === 'string') {
+			const assignedRoom = user ? videoCallService.getUserBreakoutRoom(user.id) : null;
+			// Use assigned room from backend, or default to room 0 for mock testing
+			handleEnterBreakoutRoom(assignedRoom ?? 0);
+		}
+		if (!isBreakoutActive && typeof roomContext !== 'string' && !isModerator) {
+			roomContext = 'plenary';
+		}
+	});
+
+	// Breakout ending: show countdown dialog for participants, silently auto-end for facilitator
+	let breakoutSecondsLeft = $derived(
+		breakoutTimeRemaining !== null ? Math.ceil(breakoutTimeRemaining / 1000) : 0
+	);
+
+	$effect(() => {
+		// Show countdown dialog to participants at 5 seconds
 		if (
+			!isModerator &&
 			breakoutTimeRemaining !== null &&
 			breakoutTimeRemaining <= 5000 &&
 			breakoutTimeRemaining > 0 &&
 			isBreakoutActive &&
-			!breakoutEndingNotified
+			!breakoutEndingDismissed
 		) {
-			pushNotice({
-				message: 'Breakout session ending soon. Go back to the plenary room.',
-				actionLabel: 'Go back',
-				onAction: handleGoBackToPlenary
-			});
-			breakoutEndingNotified = true;
+			showBreakoutEnding = true;
 		}
+		// Auto-end at 0
 		if (
 			breakoutTimeRemaining !== null &&
 			breakoutTimeRemaining <= 0 &&
@@ -273,8 +289,10 @@
 			breakoutAutoEnded = true;
 			handleGoBackToPlenary();
 		}
+		// Dismiss dialog once back in plenary / breakout ended
 		if (!isBreakoutActive) {
-			breakoutEndingNotified = false;
+			showBreakoutEnding = false;
+			breakoutEndingDismissed = false;
 			breakoutAutoEnded = false;
 		}
 	});
@@ -590,7 +608,7 @@
 						showTabs={isBreakoutActive && isModerator && !inBreakoutRoom}
 						onTabChange={(tab) => (activePanel = tab)}
 					>
-						{#if isBreakoutActive && (inBreakoutRoom || !isModerator)}
+						{#if isBreakoutActive && inBreakoutRoom}
 							<BreakoutSessionPanel
 								roomName={roomChipText}
 								question={currentAgendaItem?.breakoutQuestion}
@@ -668,6 +686,16 @@
 	{timeLeftFormatted}
 	onClose={() => (showAddTime = false)}
 	onAddTime={handleAddTime}
+/>
+
+<BreakoutEndingDialog
+	bind:open={showBreakoutEnding}
+	secondsLeft={breakoutSecondsLeft}
+	onGoBack={() => {
+		showBreakoutEnding = false;
+		breakoutEndingDismissed = true;
+		handleGoBackToPlenary();
+	}}
 />
 
 {#if noticeQueue.length > 0}

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
@@ -504,31 +504,6 @@
 		}
 	}
 
-	function handleMoveParticipant(userId: string, targetRoomIndex: number) {
-		videoCallService.moveParticipantToRoom(eventId, userId, targetRoomIndex);
-
-		// Optimistic update: move participant in local mock rooms
-		if (mockBreakoutRooms.length > 0) {
-			const updated = mockBreakoutRooms.map((room) => ({
-				...room,
-				participants: room.participants.filter((p) => p.user_id !== userId)
-			}));
-			const participant = mockBreakoutRooms
-				.flatMap((r) => r.participants)
-				.find((p) => p.user_id === userId);
-			if (participant && updated[targetRoomIndex]) {
-				updated[targetRoomIndex].participants = [
-					...updated[targetRoomIndex].participants,
-					participant
-				];
-			}
-			mockBreakoutRooms = updated;
-		}
-
-		const target = breakoutRoomDisplays[targetRoomIndex];
-		showToast(`Participant moved to ${target?.name ?? `Room #${targetRoomIndex + 1}`}`);
-	}
-
 	function handleEndBreakoutSession() {
 		console.log('[BREAKOUT] handleEndBreakoutSession');
 		videoCallService.endBreakoutSession(eventId);
@@ -697,7 +672,6 @@
 							{timeLeftFormatted}
 							{isModerator}
 							onEnterRoom={handleEnterBreakoutRoom}
-							onMoveParticipant={handleMoveParticipant}
 							onAddTime={() => (showAddTime = true)}
 							onEndSession={handleEndBreakoutSession}
 							onBroadcastMessage={() => (showBroadcast = true)}

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
@@ -575,31 +575,6 @@
 		}
 	}
 
-	function handleMoveParticipant(userId: string, targetRoomIndex: number) {
-		videoCallService.moveParticipantToRoom(eventId, userId, targetRoomIndex);
-
-		// Optimistic update: move participant in local mock rooms
-		if (mockBreakoutRooms.length > 0) {
-			const updated = mockBreakoutRooms.map((room) => ({
-				...room,
-				participants: room.participants.filter((p) => p.user_id !== userId)
-			}));
-			const participant = mockBreakoutRooms
-				.flatMap((r) => r.participants)
-				.find((p) => p.user_id === userId);
-			if (participant && updated[targetRoomIndex]) {
-				updated[targetRoomIndex].participants = [
-					...updated[targetRoomIndex].participants,
-					participant
-				];
-			}
-			mockBreakoutRooms = updated;
-		}
-
-		const target = breakoutRoomDisplays[targetRoomIndex];
-		showToast(`Participant moved to ${target?.name ?? `Room #${targetRoomIndex + 1}`}`);
-	}
-
 	async function handleEndBreakoutSession() {
 		console.log('[BREAKOUT] handleEndBreakoutSession - removing breakout rooms');
 

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
@@ -135,7 +135,7 @@
 				? ('loading' as const)
 				: callStatus === 'Ended'
 					? ('ended' as const)
-					: callStatus === 'InProgress' && hasJoinedCall
+					: hasJoinedCall
 						? ('incall' as const)
 						: ('lobby' as const);
 		console.log(
@@ -437,7 +437,7 @@
 	}
 
 	function handleStartMeeting() {
-		videoCallService.changeCallState(eventId, 'InProgress');
+		// Only render Jitsi — don't broadcast InProgress until moderator is actually in the call
 		hasJoinedCall = true;
 	}
 
@@ -698,6 +698,10 @@
 	function handleVideoConferenceJoined(data: any) {
 		console.log('[BREAKOUT] Entered Jitsi room:', data.roomName);
 		currentJitsiRoomName = data.roomName;
+		// Moderator is now in Jitsi — safe to let participants in
+		if (isModerator && callStatus === 'Waiting') {
+			videoCallService.changeCallState(eventId, 'InProgress');
+		}
 	}
 
 	function handleVideoConferenceLeft(data: any) {

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
@@ -538,11 +538,14 @@
 					</div>
 				</div>
 
-				<!-- Host panel toggle tabs (visible when panel closed during breakout) -->
-				{#if isModerator && isBreakoutActive && !inBreakoutRoom && !panelOpen}
+				<!-- Host panel toggle tabs (visible when panel closed) -->
+				{#if isModerator && !panelOpen}
 					<div class="absolute top-12 right-0 z-10 flex flex-col rounded-3xl shadow-lg">
 						<button
-							class="bg-background h-12 w-48 rounded-t-[20px] px-6 py-3 text-left text-sm font-semibold"
+							class="bg-background h-12 w-48 px-6 py-3 text-left text-sm font-semibold {isBreakoutActive &&
+							!inBreakoutRoom
+								? 'rounded-t-[20px]'
+								: 'rounded-[20px]'}"
 							onclick={() => {
 								activePanel = 'agenda';
 								panelOpen = true;
@@ -550,20 +553,22 @@
 						>
 							Agenda
 						</button>
-						<button
-							class="bg-background relative h-12 w-48 rounded-b-[20px] border-t px-6 py-3 text-left text-sm font-semibold"
-							onclick={() => {
-								activePanel = 'breakoutRooms';
-								panelOpen = true;
-							}}
-						>
-							Breakout rooms
-							{#if Object.keys(assistanceRequests).length > 0}
-								<span
-									class="bg-destructive absolute top-3.5 right-4 h-2 w-2 rounded-full"
-								></span>
-							{/if}
-						</button>
+						{#if isBreakoutActive && !inBreakoutRoom}
+							<button
+								class="bg-background relative h-12 w-48 rounded-b-[20px] border-t px-6 py-3 text-left text-sm font-semibold"
+								onclick={() => {
+									activePanel = 'breakoutRooms';
+									panelOpen = true;
+								}}
+							>
+								Breakout rooms
+								{#if Object.keys(assistanceRequests).length > 0}
+									<span
+										class="bg-destructive absolute top-3.5 right-4 h-2 w-2 rounded-full"
+									></span>
+								{/if}
+							</button>
+						{/if}
 					</div>
 				{/if}
 			</div>

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
@@ -40,6 +40,11 @@
 	let callStatus = $derived(videoCallService.callStatus);
 	let allParticipants = $derived(videoCallService.participants);
 	let otherParticipants = $derived(allParticipants.filter((p) => p.user_id !== user?.id));
+
+	/** Participants actually in Jitsi call (excludes current user + lobby-only users) */
+	let inCallParticipants = $derived(
+		allParticipants.filter((p) => jitsiParticipantMap.has(p.user_id))
+	);
 	let currentStep = $derived(videoCallService.currentAgendaStep);
 	let breakoutSession = $derived(videoCallService.breakoutSession);
 	let breakoutRooms = $derived(videoCallService.breakoutRooms);
@@ -184,7 +189,9 @@
 			return breakoutRooms.map((_, index) => ({
 				index,
 				name: `Room #${index + 1}`,
-				participants: videoCallService.getBreakoutRoomParticipants(index),
+				participants: videoCallService
+					.getBreakoutRoomParticipants(index)
+					.filter((p) => p.user_id !== user?.id),
 				hasAssistanceRequest: videoCallService.hasAssistanceRequest(`room-${index}`),
 				assistanceRequestUser: videoCallService.getAssistanceRequestUser(`room-${index}`)
 			}));
@@ -970,7 +977,7 @@
 <!-- Dialogs -->
 <CreateBreakoutDialog
 	bind:open={showCreateBreakout}
-	participants={allParticipants}
+	participants={inCallParticipants}
 	defaultDuration={breakoutDialogItem?.durationMinutes}
 	defaultMaxPerRoom={breakoutDialogItem?.maxPerRoom}
 	onClose={() => (showCreateBreakout = false)}

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
@@ -828,7 +828,7 @@
 							{/if}
 						</div>
 					</div>
-					{#if dev}
+					{#if dev && isModerator}
 						<button
 							class="bg-destructive text-destructive-foreground hover:bg-destructive/90 rounded px-3 py-1 text-xs font-medium"
 							onclick={devResetCall}

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
@@ -28,7 +28,6 @@
 
 	let { data }: PageProps = $props();
 
-	let conversationId = $derived(data.conversationId);
 	let eventId = $derived(data.eventId);
 	let event = $derived(data.event);
 	let jwt = $derived(data.jwt);
@@ -54,6 +53,8 @@
 	let jitsiApi: any = $state(null);
 	let roomContext = $state<RoomContext>('plenary');
 	let activePanel = $state<PanelTab>('agenda');
+	let jitsiModeratorStatus = $state<boolean>(false);
+	let currentJitsiRoomName = $state<string>('');
 
 	// Map Jitsi participant IDs to backend user IDs
 	let jitsiParticipantMap = $state<Map<string, string>>(new Map());
@@ -827,39 +828,37 @@
 
 				<!-- Jitsi iframe -->
 				<div class="relative flex-1 overflow-hidden">
-					{#key jitsiReloadKey}
-						<JitsiMeet
-							roomName={plenaryRoomName}
-							{jwt}
-							onApiReady={handleApiReady}
-							onBreakoutRoomsUpdated={(rooms) => {
-								jitsiBreakoutRooms = rooms;
-							}}
-							onModeratorStatusChanged={handleModeratorStatusChanged}
-							onVideoConferenceJoined={handleVideoConferenceJoined}
-							onVideoConferenceLeft={handleVideoConferenceLeft}
-							onParticipantJoined={handleParticipantJoined}
-							onParticipantLeft={handleParticipantLeft}
-							startWithAudioMuted={true}
-							configOverwrite={{
-								toolbarButtons: [
-									'microphone',
-									'camera',
-									'desktop',
-									'participants-pane',
-									'chat',
-									'raisehand',
-									'breakoutrooms',
-									'tileview',
-									'hangup',
-									'fullscreen'
-								],
-								prejoinPageEnabled: false,
-								disableDeepLinking: true,
-								hideConferenceSubject: true
-							}}
-						/>
-					{/key}
+					<JitsiMeet
+						roomName={plenaryRoomName}
+						{jwt}
+						onApiReady={handleApiReady}
+						onBreakoutRoomsUpdated={(rooms) => {
+							jitsiBreakoutRooms = rooms;
+						}}
+						onModeratorStatusChanged={handleModeratorStatusChanged}
+						onVideoConferenceJoined={handleVideoConferenceJoined}
+						onVideoConferenceLeft={handleVideoConferenceLeft}
+						onParticipantJoined={handleParticipantJoined}
+						onParticipantLeft={handleParticipantLeft}
+						startWithAudioMuted={true}
+						configOverwrite={{
+							toolbarButtons: [
+								'microphone',
+								'camera',
+								'desktop',
+								'participants-pane',
+								'chat',
+								'raisehand',
+								'breakoutrooms',
+								'tileview',
+								'hangup',
+								'fullscreen'
+							],
+							prejoinPageEnabled: false,
+							disableDeepLinking: true,
+							hideConferenceSubject: true
+						}}
+					/>
 
 					<!-- Room chip overlay -->
 					<div class="pointer-events-none absolute inset-x-0 top-0 flex justify-center">

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
@@ -55,6 +55,9 @@
 	let roomContext = $state<RoomContext>('plenary');
 	let activePanel = $state<PanelTab>('agenda');
 
+	// Map Jitsi participant IDs to backend user IDs
+	let jitsiParticipantMap = $state<Map<string, string>>(new Map());
+
 	/** Mock breakout rooms for dev testing */
 	let mockBreakoutRooms = $state<BreakoutRoomDisplay[]>([]);
 
@@ -78,12 +81,15 @@
 	/** Jitsi's native breakout room data from breakoutRoomsUpdated event */
 	let jitsiBreakoutRooms = $state<Record<string, any>>({});
 
+	/** Flag to track if Jitsi breakout rooms have been created and are ready */
+	let breakoutRoomsReady = $state(false);
+
 	/** Get the Jitsi room ID for a given room index (0-based) */
 	function getJitsiBreakoutRoomId(roomIndex: number): string | null {
 		const nonMainRooms = Object.values(jitsiBreakoutRooms)
 			.filter((r: any) => !r.isMainRoom)
 			.sort((a: any, b: any) => (a.name ?? '').localeCompare(b.name ?? ''));
-		return nonMainRooms[roomIndex]?.id ?? null;
+		return nonMainRooms[roomIndex]?.jid ?? null;
 	}
 
 	/** Lightweight toast for admin confirmations */
@@ -205,6 +211,33 @@
 		};
 	});
 
+	// Watch for Jitsi breakout rooms to become ready
+	$effect(() => {
+		if (isBreakoutActive) {
+			const nonMainRoomCount = Object.values(jitsiBreakoutRooms).filter(
+				(r: any) => !r.isMainRoom
+			).length;
+			console.log('[BREAKOUT] Checking rooms ready:', {
+				nonMainRoomCount,
+				expectedRooms: breakoutRooms.length || mockBreakoutRooms.length,
+				breakoutRoomsReady
+			});
+			// Set ready when Jitsi has created the expected number of rooms
+			if (
+				nonMainRoomCount > 0 &&
+				nonMainRoomCount >= (breakoutRooms.length || mockBreakoutRooms.length)
+			) {
+				if (!breakoutRoomsReady) {
+					console.log('[BREAKOUT] Breakout rooms are now ready!');
+					breakoutRoomsReady = true;
+				}
+			}
+		} else {
+			// Reset when breakout session ends
+			breakoutRoomsReady = false;
+		}
+	});
+
 	// Watch for new assistance requests (host only)
 	$effect(() => {
 		if (!isModerator) return;
@@ -261,10 +294,16 @@
 		console.log('[BREAKOUT] auto-enter effect:', {
 			isBreakoutActive,
 			isModerator,
+			breakoutRoomsReady,
 			roomContext: typeof roomContext === 'string' ? roomContext : roomContext,
 			userId: user?.id
 		});
-		if (isBreakoutActive && !isModerator && typeof roomContext === 'string') {
+		if (
+			isBreakoutActive &&
+			!isModerator &&
+			breakoutRoomsReady &&
+			typeof roomContext === 'string'
+		) {
 			const assignedRoom = user ? videoCallService.getUserBreakoutRoom(user.id) : null;
 			console.log(
 				'[BREAKOUT] Participant auto-entering breakout room:',
@@ -275,15 +314,15 @@
 			handleEnterBreakoutRoom(assignedRoom ?? 0);
 		}
 		if (!isBreakoutActive && typeof roomContext !== 'string' && !isModerator) {
-			console.log('[BREAKOUT] Breakout ended — returning participant to plenary');
+			console.log('[BREAKOUT] Breakout ended — returning participant to main room');
 			roomContext = 'plenary';
-			jitsiApi?.executeCommand('joinBreakoutRoom');
+			// Jitsi automatically moves participants back when rooms are removed
 		}
 	});
 
 	// Detect mid-session room reassignment (moderator moved a participant)
 	$effect(() => {
-		if (!isBreakoutActive || isModerator || !user) {
+		if (!isBreakoutActive || isModerator || !user || !breakoutRoomsReady) {
 			trackedRoomIndex = null;
 			return;
 		}
@@ -447,9 +486,23 @@
 		console.log(
 			'[BREAKOUT] handleEnterBreakoutRoom:',
 			roomIndex,
+			'| isModerator:',
+			isModerator,
 			'| current roomContext:',
-			roomContext
+			roomContext,
+			'| breakoutRoomsReady:',
+			breakoutRoomsReady
 		);
+
+		if (!breakoutRoomsReady) {
+			console.warn(
+				'[BREAKOUT] Attempted to enter room before Jitsi breakout rooms are ready'
+			);
+		}
+
+		console.log('[BREAKOUT] Current jitsiBreakoutRooms state:', jitsiBreakoutRooms);
+		console.log('[BREAKOUT] All rooms:', Object.values(jitsiBreakoutRooms));
+
 		roomContext = {
 			type: 'breakout',
 			roomIndex,
@@ -461,13 +514,23 @@
 		const jitsiRoomId = getJitsiBreakoutRoomId(roomIndex);
 		if (jitsiRoomId) {
 			console.log('[BREAKOUT] joinBreakoutRoom via Jitsi API, roomId:', jitsiRoomId);
+			console.log(
+				'[BREAKOUT] roomId type:',
+				typeof jitsiRoomId,
+				'value:',
+				JSON.stringify(jitsiRoomId)
+			);
 			jitsiApi?.executeCommand('joinBreakoutRoom', jitsiRoomId);
 		} else {
 			console.warn(
 				'[BREAKOUT] No Jitsi room ID found for index:',
 				roomIndex,
-				'— rooms:',
-				jitsiBreakoutRooms
+				'— available rooms:',
+				Object.values(jitsiBreakoutRooms).map((r: any) => ({
+					id: r.id,
+					name: r.name,
+					isMain: r.isMainRoom
+				}))
 			);
 		}
 
@@ -477,9 +540,16 @@
 	}
 
 	function handleLeaveBreakoutRoom() {
-		console.log('[BREAKOUT] handleLeaveBreakoutRoom → plenary');
+		console.log('[BREAKOUT] handleLeaveBreakoutRoom → returning to main room');
 		roomContext = 'plenary';
-		jitsiApi?.executeCommand('joinBreakoutRoom');
+
+		// Use Jitsi API to return to main room (no iframe reload needed)
+		try {
+			jitsiApi?.executeCommand('joinBreakoutRoom');
+			console.log('[BREAKOUT] Sent joinBreakoutRoom command to return to main');
+		} catch (error) {
+			console.error('[BREAKOUT] Error returning to main room:', error);
+		}
 	}
 
 	function handleCallForSupport() {
@@ -504,27 +574,169 @@
 		}
 	}
 
-	function handleEndBreakoutSession() {
-		console.log('[BREAKOUT] handleEndBreakoutSession');
+	function handleMoveParticipant(userId: string, targetRoomIndex: number) {
+		videoCallService.moveParticipantToRoom(eventId, userId, targetRoomIndex);
+
+		// Optimistic update: move participant in local mock rooms
+		if (mockBreakoutRooms.length > 0) {
+			const updated = mockBreakoutRooms.map((room) => ({
+				...room,
+				participants: room.participants.filter((p) => p.user_id !== userId)
+			}));
+			const participant = mockBreakoutRooms
+				.flatMap((r) => r.participants)
+				.find((p) => p.user_id === userId);
+			if (participant && updated[targetRoomIndex]) {
+				updated[targetRoomIndex].participants = [
+					...updated[targetRoomIndex].participants,
+					participant
+				];
+			}
+			mockBreakoutRooms = updated;
+		}
+
+		const target = breakoutRoomDisplays[targetRoomIndex];
+		showToast(`Participant moved to ${target?.name ?? `Room #${targetRoomIndex + 1}`}`);
+	}
+
+	async function handleEndBreakoutSession() {
+		console.log('[BREAKOUT] handleEndBreakoutSession - removing breakout rooms');
+
+		// Step 1: Ensure moderator is in main room before removing breakout rooms
+		if (typeof roomContext !== 'string') {
+			console.log('[BREAKOUT] Moderator in breakout room - returning to main first');
+			try {
+				jitsiApi?.executeCommand('joinBreakoutRoom');
+				// Wait a moment for the transition
+				await new Promise((resolve) => setTimeout(resolve, 500));
+			} catch (error) {
+				console.error('[BREAKOUT] Error returning to main room:', error);
+			}
+		}
+
+		// Step 2: Get fresh breakout rooms list from Jitsi API
+		let breakoutRoomsList: any[] = [];
+		try {
+			const rooms = await jitsiApi?.listBreakoutRooms?.();
+			console.log('[BREAKOUT] listBreakoutRooms() returned:', rooms);
+
+			if (rooms) {
+				breakoutRoomsList = Object.values(rooms).filter((r: any) => !r.isMainRoom);
+			}
+		} catch (e) {
+			console.error('[BREAKOUT] Error getting breakout rooms:', e);
+			// Fallback to state if API call fails
+			breakoutRoomsList = Object.values(jitsiBreakoutRooms).filter((r: any) => !r.isMainRoom);
+		}
+
+		console.log('[BREAKOUT] Found', breakoutRoomsList.length, 'breakout rooms to remove');
+
+		// Step 3: Remove all breakout rooms - Jitsi should auto-return participants to main room
+		console.log('[BREAKOUT] Removing breakout rooms...');
+		for (const room of breakoutRoomsList) {
+			console.log('[BREAKOUT] Removing room:', {
+				id: room.id,
+				jid: room.jid,
+				name: room.name
+			});
+			try {
+				// Use room.jid for the removeBreakoutRoom command
+				jitsiApi?.executeCommand('closeBreakoutRoom', room.id);
+				console.log(
+					'[BREAKOUT] Successfully sent removeBreakoutRoom command for:',
+					room.jid
+				);
+			} catch (error) {
+				console.error('[BREAKOUT] Error removing breakout room:', error);
+			}
+		}
+
+		// Step 4: Wait a moment for rooms to be removed
+		await new Promise((resolve) => setTimeout(resolve, 500));
+
+		// Step 5: End the session on backend (broadcasts to all participants)
 		videoCallService.endBreakoutSession(eventId);
+
+		// Step 6: Update local state
 		roomContext = 'plenary';
-		jitsiApi?.executeCommand('joinBreakoutRoom');
+		activePanel = 'agenda';
+
+		// Clean up local state
 		mockBreakoutRooms = [];
 		jitsiBreakoutRooms = {};
-		activePanel = 'agenda';
+		breakoutRoomsReady = false;
 	}
 
 	function handleGoBackToPlenary() {
+		console.log('[BREAKOUT] handleGoBackToPlenary called, isModerator:', isModerator);
 		roomContext = 'plenary';
 		if (isModerator) {
 			handleEndBreakoutSession();
 		} else {
-			jitsiApi?.executeCommand('joinBreakoutRoom');
+			// Participants return to main room by calling joinBreakoutRoom without arguments
+			console.log('[BREAKOUT] Participant returning to main room:', plenaryRoomName);
+			try {
+				// Calling joinBreakoutRoom without arguments moves user to main room
+				jitsiApi?.executeCommand('joinBreakoutRoom');
+				console.log(
+					'[BREAKOUT] Successfully sent joinBreakoutRoom command to return to main'
+				);
+			} catch (error) {
+				console.error('[BREAKOUT] Error returning to main room:', error);
+			}
 		}
 	}
 
 	function handleApiReady(api: any) {
 		jitsiApi = api;
+	}
+
+	function handleModeratorStatusChanged(isMod: boolean) {
+		console.log('[BREAKOUT] handleModeratorStatusChanged called with:', isMod);
+		console.log('[BREAKOUT] Previous jitsiModeratorStatus:', jitsiModeratorStatus);
+		jitsiModeratorStatus = isMod;
+		console.log('[BREAKOUT] New jitsiModeratorStatus:', jitsiModeratorStatus);
+	}
+
+	function handleVideoConferenceJoined(data: any) {
+		console.log('[BREAKOUT] Entered Jitsi room:', data.roomName);
+		currentJitsiRoomName = data.roomName;
+	}
+
+	function handleVideoConferenceLeft(data: any) {
+		console.log('[BREAKOUT] Left Jitsi room:', data.roomName);
+	}
+
+	function handleParticipantJoined(participant: any) {
+		console.log('[BREAKOUT] Participant joined:', participant);
+
+		// Try to match Jitsi participant to backend user by display name
+		const matchingUser = allParticipants.find((p) => p.username === participant.displayName);
+
+		if (matchingUser) {
+			console.log(
+				'[BREAKOUT] Mapped Jitsi participant',
+				participant.id,
+				'→ user',
+				matchingUser.user_id
+			);
+			jitsiParticipantMap.set(matchingUser.user_id, participant.id);
+		} else {
+			console.warn('[BREAKOUT] Could not match participant:', participant.displayName);
+		}
+	}
+
+	function handleParticipantLeft(participant: any) {
+		console.log('[BREAKOUT] Participant left:', participant);
+
+		// Remove from map
+		const entry = Array.from(jitsiParticipantMap.entries()).find(
+			([_, jitsiId]) => jitsiId === participant.id
+		);
+		if (entry) {
+			jitsiParticipantMap.delete(entry[0]);
+			console.log('[BREAKOUT] Removed participant from map:', entry[0]);
+		}
 	}
 </script>
 
@@ -583,6 +795,25 @@
 								Recording
 							</span>
 						</div>
+						<div class="flex items-center gap-2">
+							<div class="flex items-center gap-1.5">
+								<span
+									class="{jitsiModeratorStatus
+										? 'bg-green-500'
+										: 'bg-yellow-500'} h-2.5 w-2.5 rounded-full"
+								></span>
+								<span
+									class="text-sidebar-foreground text-center text-xs leading-6 font-normal"
+								>
+									{jitsiModeratorStatus ? 'Moderator' : 'Participant'}
+								</span>
+							</div>
+							{#if currentJitsiRoomName}
+								<span class="text-sidebar-foreground/60 text-xs">
+									Room: {currentJitsiRoomName.slice(0, 8)}...
+								</span>
+							{/if}
+						</div>
 					</div>
 					{#if dev}
 						<button
@@ -596,30 +827,39 @@
 
 				<!-- Jitsi iframe -->
 				<div class="relative flex-1 overflow-hidden">
-					<JitsiMeet
-						roomName={plenaryRoomName}
-						{jwt}
-						onApiReady={handleApiReady}
-						onBreakoutRoomsUpdated={(rooms) => {
-							jitsiBreakoutRooms = rooms;
-						}}
-						startWithAudioMuted={true}
-						configOverwrite={{
-							toolbarButtons: [
-								'microphone',
-								'camera',
-								'desktop',
-								'chat',
-								'raisehand',
-								'tileview',
-								'hangup',
-								'fullscreen'
-							],
-							prejoinPageEnabled: false,
-							disableDeepLinking: true,
-							hideConferenceSubject: true
-						}}
-					/>
+					{#key jitsiReloadKey}
+						<JitsiMeet
+							roomName={plenaryRoomName}
+							{jwt}
+							onApiReady={handleApiReady}
+							onBreakoutRoomsUpdated={(rooms) => {
+								jitsiBreakoutRooms = rooms;
+							}}
+							onModeratorStatusChanged={handleModeratorStatusChanged}
+							onVideoConferenceJoined={handleVideoConferenceJoined}
+							onVideoConferenceLeft={handleVideoConferenceLeft}
+							onParticipantJoined={handleParticipantJoined}
+							onParticipantLeft={handleParticipantLeft}
+							startWithAudioMuted={true}
+							configOverwrite={{
+								toolbarButtons: [
+									'microphone',
+									'camera',
+									'desktop',
+									'participants-pane',
+									'chat',
+									'raisehand',
+									'breakoutrooms',
+									'tileview',
+									'hangup',
+									'fullscreen'
+								],
+								prejoinPageEnabled: false,
+								disableDeepLinking: true,
+								hideConferenceSubject: true
+							}}
+						/>
+					{/key}
 
 					<!-- Room chip overlay -->
 					<div class="pointer-events-none absolute inset-x-0 top-0 flex justify-center">

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
@@ -87,6 +87,7 @@
 		[]
 	);
 	let breakoutEndingNotified = $state(false);
+	let breakoutAutoEnded = $state(false);
 
 	// Lightweight toast for admin confirmations
 	let toastMessage = $state<string | null>(null);
@@ -232,7 +233,7 @@
 
 	// Auto-join when arriving at an already in-progress call
 	$effect(() => {
-		if (callStatus === 'InProgress' && !hasJoinedCall) {
+		if (callStatus === 'InProgress' && !hasJoinedCall && isModerator) {
 			hasJoinedCall = true;
 		}
 	});
@@ -263,11 +264,18 @@
 			});
 			breakoutEndingNotified = true;
 		}
-		if (breakoutTimeRemaining !== null && breakoutTimeRemaining <= 0 && isBreakoutActive) {
+		if (
+			breakoutTimeRemaining !== null &&
+			breakoutTimeRemaining <= 0 &&
+			isBreakoutActive &&
+			!breakoutAutoEnded
+		) {
+			breakoutAutoEnded = true;
 			handleGoBackToPlenary();
 		}
 		if (!isBreakoutActive) {
 			breakoutEndingNotified = false;
+			breakoutAutoEnded = false;
 		}
 	});
 
@@ -480,26 +488,28 @@
 
 				<!-- Jitsi iframe -->
 				<div class="relative flex-1 overflow-hidden">
-					<JitsiMeet
-						roomName={currentJitsiRoom}
-						{jwt}
-						onApiReady={handleApiReady}
-						startWithAudioMuted={true}
-						configOverwrite={{
-							toolbarButtons: [
-								'microphone',
-								'camera',
-								'desktop',
-								'chat',
-								'raisehand',
-								'tileview',
-								'hangup',
-								'fullscreen'
-							],
-							disableDeepLinking: true,
-							hideConferenceSubject: true
-						}}
-					/>
+					{#key currentJitsiRoom}
+						<JitsiMeet
+							roomName={currentJitsiRoom}
+							{jwt}
+							onApiReady={handleApiReady}
+							startWithAudioMuted={true}
+							configOverwrite={{
+								toolbarButtons: [
+									'microphone',
+									'camera',
+									'desktop',
+									'chat',
+									'raisehand',
+									'tileview',
+									'hangup',
+									'fullscreen'
+								],
+								disableDeepLinking: true,
+								hideConferenceSubject: true
+							}}
+						/>
+					{/key}
 
 					<!-- Room chip overlay -->
 					<div class="pointer-events-none absolute inset-x-0 top-0 flex justify-center">
@@ -560,7 +570,16 @@
 
 			<!-- Right panel (side-by-side) -->
 			{#if panelOpen || !isModerator}
-				<div class="h-full w-[360px] shrink-0 p-3">
+				<div class="relative h-full w-[360px] shrink-0 p-3">
+					{#if isModerator}
+						<button
+							class="text-muted-foreground hover:text-foreground absolute top-5 right-5 z-10 flex h-6 w-6 items-center justify-center rounded-full"
+							onclick={() => (panelOpen = false)}
+							aria-label="Close panel"
+						>
+							✕
+						</button>
+					{/if}
 					<SidePanel
 						activeTab={activePanel}
 						showTabs={isBreakoutActive && isModerator && !inBreakoutRoom}

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
@@ -1,22 +1,28 @@
 <script lang="ts">
-	import { onDestroy } from 'svelte';
+	import { onDestroy, untrack } from 'svelte';
 	import JitsiMeet from '$lib/components/JitsiMeet/JitsiMeet.svelte';
-	import Button from '$lib/components/ui/button/button.svelte';
 	import * as Drawer from '$lib/components/ui/drawer';
 	import { formatDateShort, formatTime } from '$lib/utils';
 	import { videoCallService } from '$lib/services/videoCallService.svelte';
-
-	import {
-		List,
-		Info,
-		Users,
-		Settings,
-		CircleCheck,
-		ChevronRight,
-		ChevronUp
-	} from 'lucide-svelte';
-
+	import MeetingLobby from '$lib/components/LiveEvent/MeetingLobby.svelte';
+	import AgendaPanel from '$lib/components/LiveEvent/AgendaPanel.svelte';
+	import BreakoutSessionPanel from '$lib/components/LiveEvent/BreakoutSessionPanel.svelte';
+	import BreakoutRoomsPanel from '$lib/components/LiveEvent/BreakoutRoomsPanel.svelte';
+	import CreateBreakoutDialog from '$lib/components/LiveEvent/CreateBreakoutDialog.svelte';
+	import BroadcastMessageDialog from '$lib/components/LiveEvent/BroadcastMessageDialog.svelte';
+	import AddTimeDialog from '$lib/components/LiveEvent/AddTimeDialog.svelte';
+	import NoticeDialog from '$lib/components/LiveEvent/NoticeDialog.svelte';
+	import SidePanel from '$lib/components/LiveEvent/SidePanel.svelte';
+	import type {
+		AgendaItem,
+		RoomContext,
+		PanelTab,
+		BreakoutRoomDisplay
+	} from '$lib/components/LiveEvent/types';
+	import type { VideoCallParticipant } from '$lib/services/videoCallService.svelte';
+	import { ChevronUp } from 'lucide-svelte';
 	import type { PageProps } from './$types';
+	import type { EventAgendaItem } from '@crownshy/api-client/api';
 
 	let { data }: PageProps = $props();
 
@@ -24,710 +30,648 @@
 	let eventId = $derived(data.eventId);
 	let event = $derived(data.event);
 	let jwt = $derived(data.jwt);
-	let apiAttendances = $derived(data.attendances);
 	let user = $derived(data.user);
-	let isModerator = $state(data.isModerator);
+	let isModerator = $derived(data.isModerator);
 
-	let callState = videoCallService.currentCallState;
+	// Mock participants for testing (todo: remove)
+	const mockParticipants: VideoCallParticipant[] = [
+		{ user_id: 'user-1', username: 'Alice Johnson', role: 'participant' },
+		{ user_id: 'user-2', username: 'Bob Smith', role: 'participant' },
+		{ user_id: 'user-3', username: 'Cathy Lee', role: 'participant' },
+		{ user_id: 'user-4', username: 'Dan Rivera', role: 'participant' },
+		{ user_id: 'user-5', username: 'Eva Müller', role: 'participant' },
+		{ user_id: 'user-6', username: 'Frank Chen', role: 'participant' },
+		{ user_id: 'user-7', username: 'Grace Kim', role: 'participant' },
+		{ user_id: 'user-8', username: 'Hiro Tanaka', role: 'participant' },
+		{ user_id: 'user-9', username: 'Isla Nguyen', role: 'participant' },
+		{ user_id: 'user-10', username: 'Jake Brown', role: 'participant' },
+		{ user_id: 'user-11', username: 'Karen Walsh', role: 'participant' },
+		{ user_id: 'user-12', username: 'Leo Garcia', role: 'participant' }
+	];
 
-	$inspect('Call state ', callState);
-	videoCallService.joinCall(eventId);
+	// Reactive reads from videoCallService
+	let callStatus = $derived(videoCallService.callStatus);
+	let realParticipants = $derived(videoCallService.participants);
+	let allParticipants = $derived([...realParticipants, ...mockParticipants]);
+	let otherParticipants = $derived(allParticipants.filter((p) => p.user_id !== user?.id));
+	let currentStep = $derived(videoCallService.currentAgendaStep);
+	let breakoutSession = $derived(videoCallService.breakoutSession);
+	let breakoutRooms = $derived(videoCallService.breakoutRooms);
+	let assistanceRequests = $derived(videoCallService.assistanceRequests);
+	let lastBroadcast = $derived(videoCallService.lastBroadcastMessage);
 
-	let roomName = $derived(event?.videoMeetingId);
-
-	let jitsiApi: any = $state(null);
-	let activeTab: 'agenda' | 'details' | 'participants' | 'controls' = $state('agenda');
-
-	// Jitsi-synced state
-	let jitsiParticipants = $state<Array<{ id: string; displayName: string }>>([]);
-	let conferenceJoined = $state(false);
-	let audioMuted = $state(false);
-	let videoMuted = $state(false);
-	// Notification popup state
-	let activeNotification = $state<{ message: string; timestamp: number } | null>(null);
-	let notificationTimeout: ReturnType<typeof setTimeout> | null = null;
-
-	// Announcement UI state (not yet wired to WebSocket — placeholder for future)
-	let announcementText = $state('');
-	let announcementSending = $state(false);
-
-	async function sendAnnouncement() {
-		if (!announcementText.trim() || announcementSending) return;
-		announcementSending = true;
-		// TODO: Wire to WebSocket broadcast once event-scoped WS is ready
-		console.log('[Announcement stub]', announcementText.trim());
-		showNotification(announcementText.trim());
-		announcementText = '';
-		announcementSending = false;
-	}
-
-	onDestroy(() => {
-		if (notificationTimeout) clearTimeout(notificationTimeout);
+	// Join WS room on mount (registers presence, not Jitsi join)
+	$effect(() => {
+		videoCallService.joinCall(eventId);
+		return () => videoCallService.leaveCall(eventId);
 	});
 
-	function showNotification(message: string) {
-		activeNotification = { message, timestamp: Date.now() };
-		if (notificationTimeout) clearTimeout(notificationTimeout);
-		notificationTimeout = setTimeout(() => {
-			activeNotification = null;
-		}, 8000);
+	// Local UI state
+	let hasJoinedCall = $state(false);
+	let jitsiApi: any = $state(null);
+	let roomContext = $state<RoomContext>('plenary');
+	let panelOpen = $state(true);
+	let activePanel = $state<PanelTab>('agenda');
+
+	// Mock breakout rooms (for testing with mock participants)
+	let mockBreakoutRooms = $state<BreakoutRoomDisplay[]>([]);
+
+	// Dialog states
+	let showCreateBreakout = $state(false);
+	let showBroadcast = $state(false);
+	let showAddTime = $state(false);
+	let seenAssistanceRequests = $state<Set<string>>(new Set());
+
+	// Notice queue (assistance requests, broadcasts, time warnings, etc.)
+	let noticeQueue = $state<{ message: string; actionLabel?: string; onAction?: () => void }[]>(
+		[]
+	);
+	let breakoutEndingNotified = $state(false);
+
+	// Lightweight toast for admin confirmations
+	let toastMessage = $state<string | null>(null);
+	let toastTimeout: ReturnType<typeof setTimeout> | null = null;
+
+	// Breakout countdown
+	let breakoutTimeRemaining = $state<number | null>(null);
+	let countdownInterval: ReturnType<typeof setInterval> | null = null;
+
+	// Map API agenda items to live event format
+	function mapApiAgenda(items: EventAgendaItem[]): AgendaItem[] {
+		return items.map((item, index) => {
+			if ('Basic' in item) {
+				return {
+					id: String(index + 1),
+					title: item.Basic.title,
+					type: 'plenary' as const
+				};
+			} else {
+				return {
+					id: String(index + 1),
+					title: item.BreakoutRoom.prompt || 'Breakout session',
+					type: 'breakout' as const,
+					breakoutQuestion: item.BreakoutRoom.prompt,
+					breakoutDescription: item.BreakoutRoom.instructions,
+					durationMinutes: item.BreakoutRoom.estimated_time
+				};
+			}
+		});
 	}
 
-	// Prototype agenda items
-	type AgendaStatus = 'done' | 'current' | 'upcoming';
-	let agendaItems = $state<
-		Array<{ id: string; title: string; duration: string; status: AgendaStatus }>
-	>([
-		{ id: '1', title: 'Welcome & Introductions', duration: '5 min', status: 'current' },
-		{ id: '2', title: 'Topic Discussion', duration: '20 min', status: 'upcoming' },
-		{ id: '3', title: 'Q&A Session', duration: '10 min', status: 'upcoming' },
-		{ id: '4', title: 'Wrap-up & Next Steps', duration: '5 min', status: 'upcoming' }
-	]);
+	let agendaItems = $derived(mapApiAgenda(event?.agenda ?? []));
 
-	function advanceAgenda() {
-		const currentIdx = agendaItems.findIndex((item) => item.status === 'current');
-		if (currentIdx === -1) return;
+	// Derived state
+	let meetingPhase = $derived.by(() => {
+		if (callStatus === null) return 'loading' as const;
+		if (callStatus === 'Ended') return 'ended' as const;
+		if (callStatus === 'InProgress' && hasJoinedCall) return 'incall' as const;
+		return 'lobby' as const;
+	});
 
-		agendaItems = agendaItems.map((item, i) => {
-			if (i === currentIdx) return { ...item, status: 'done' as const };
-			if (i === currentIdx + 1) return { ...item, status: 'current' as const };
-			return item;
-		});
+	let isBreakoutActive = $derived(breakoutSession !== null);
+	let inBreakoutRoom = $derived(typeof roomContext !== 'string');
+
+	let currentAgendaItem = $derived(
+		currentStep >= 0 && currentStep < agendaItems.length ? agendaItems[currentStep] : null
+	);
+
+	let scheduledTimeText = $derived(
+		event
+			? `Scheduled for ${formatDateShort(event.startTime)} ${formatTime(event.startTime)}`
+			: ''
+	);
+
+	let currentJitsiRoom = $derived.by(() => {
+		const baseRoom = event?.videoMeetingId ?? '';
+		if (typeof roomContext === 'string') return baseRoom;
+		return `${baseRoom}-breakout-${roomContext.roomIndex}`;
+	});
+
+	let roomChipText = $derived.by(() => {
+		if (typeof roomContext === 'string') return 'Plenary room';
+		return roomContext.roomName;
+	});
+
+	let timeLeftFormatted = $derived.by(() => {
+		if (breakoutTimeRemaining === null || breakoutTimeRemaining <= 0) return '0:00';
+		const totalSecs = Math.floor(breakoutTimeRemaining / 1000);
+		const min = Math.floor(totalSecs / 60);
+		const sec = totalSecs % 60;
+		return `${min}:${sec.toString().padStart(2, '0')}`;
+	});
+
+	let breakoutRoomDisplays = $derived.by((): BreakoutRoomDisplay[] => {
+		// Use real rooms from backend if available, otherwise use mock rooms
+		if (breakoutRooms.length > 0) {
+			return breakoutRooms.map((_, index) => ({
+				index,
+				name: `Room #${index + 1}`,
+				participants: videoCallService.getBreakoutRoomParticipants(index),
+				hasAssistanceRequest: videoCallService.hasAssistanceRequest(`room-${index}`),
+				assistanceRequestUser: videoCallService.getAssistanceRequestUser(`room-${index}`)
+			}));
+		}
+		return mockBreakoutRooms;
+	});
+
+	// Breakout countdown effect
+	$effect(() => {
+		const session = breakoutSession;
+		if (session) {
+			const endTime = new Date(session.ends).getTime();
+			const update = () => {
+				breakoutTimeRemaining = Math.max(0, endTime - Date.now());
+			};
+			update();
+			countdownInterval = setInterval(update, 1000);
+		} else {
+			breakoutTimeRemaining = null;
+			if (countdownInterval) {
+				clearInterval(countdownInterval);
+				countdownInterval = null;
+			}
+		}
+		return () => {
+			if (countdownInterval) {
+				clearInterval(countdownInterval);
+				countdownInterval = null;
+			}
+		};
+	});
+
+	// Watch for new assistance requests (host only)
+	$effect(() => {
+		if (!isModerator) return;
+		const reqs = assistanceRequests;
+		for (const rn of Object.keys(reqs)) {
+			const key = `${rn}:${reqs[rn].made_by_user}`;
+			if (seenAssistanceRequests.has(key)) continue;
+			const match = rn.match(/room-(\d+)/);
+			const ri = match ? parseInt(match[1]) : 0;
+			const roomName = `Breakout room #${ri + 1}`;
+			pushNotice({
+				message: `${reqs[rn].made_by_user} from ${roomName} requested help.`,
+				actionLabel: `Enter ${roomName}`,
+				onAction: () => handleEnterBreakoutRoom(ri)
+			});
+			seenAssistanceRequests = new Set([...seenAssistanceRequests, key]);
+			break;
+		}
+	});
+
+	// Clear stale seen keys when requests are resolved
+	$effect(() => {
+		const reqs = assistanceRequests;
+		const activeRooms = new Set(Object.keys(reqs));
+		const seen = untrack(() => seenAssistanceRequests);
+		const cleaned = new Set([...seen].filter((k) => activeRooms.has(k.split(':')[0])));
+		if (cleaned.size !== seen.size) {
+			seenAssistanceRequests = cleaned;
+		}
+	});
+
+	// Auto-join when arriving at an already in-progress call
+	$effect(() => {
+		if (callStatus === 'InProgress' && !hasJoinedCall) {
+			hasJoinedCall = true;
+		}
+	});
+
+	// Auto-switch panel when breakout session starts/ends
+	$effect(() => {
+		if (isBreakoutActive && isModerator) {
+			activePanel = 'breakoutRooms';
+		}
+		if (!isBreakoutActive && activePanel === 'breakoutRooms') {
+			activePanel = 'agenda';
+		}
+	});
+
+	// Show ending notice at 5 seconds, auto-end at 0
+	$effect(() => {
+		if (
+			breakoutTimeRemaining !== null &&
+			breakoutTimeRemaining <= 5000 &&
+			breakoutTimeRemaining > 0 &&
+			isBreakoutActive &&
+			!breakoutEndingNotified
+		) {
+			pushNotice({
+				message: 'Breakout session ending soon. Go back to the plenary room.',
+				actionLabel: 'Go back',
+				onAction: handleGoBackToPlenary
+			});
+			breakoutEndingNotified = true;
+		}
+		if (breakoutTimeRemaining !== null && breakoutTimeRemaining <= 0 && isBreakoutActive) {
+			handleGoBackToPlenary();
+		}
+		if (!isBreakoutActive) {
+			breakoutEndingNotified = false;
+		}
+	});
+
+	// Watch for broadcast messages (participants only — moderator gets toast confirmation)
+	$effect(() => {
+		if (lastBroadcast) {
+			if (!isModerator) {
+				pushNotice({ message: lastBroadcast });
+			}
+			videoCallService.clearLastMessage();
+		}
+	});
+
+	onDestroy(() => {
+		if (countdownInterval) clearInterval(countdownInterval);
+		if (toastTimeout) clearTimeout(toastTimeout);
+	});
+
+	// Handlers
+	function pushNotice(notice: { message: string; actionLabel?: string; onAction?: () => void }) {
+		noticeQueue = [...noticeQueue, notice];
+	}
+
+	function dismissCurrentNotice() {
+		noticeQueue = noticeQueue.slice(1);
+	}
+
+	function showToast(message: string) {
+		toastMessage = message;
+		if (toastTimeout) clearTimeout(toastTimeout);
+		toastTimeout = setTimeout(() => {
+			toastMessage = null;
+		}, 4000);
+	}
+
+	// DEV ONLY: reset call state to Waiting
+	function devResetCall() {
+		videoCallService.changeCallState(eventId, 'Waiting');
+		videoCallService.setAgendaItem(eventId, 0);
+		videoCallService.endBreakoutSession(eventId);
+		hasJoinedCall = false;
+		roomContext = 'plenary';
+		showCreateBreakout = false;
+		console.log('DEV: Call state reset to Waiting');
+	}
+
+	function handleStartMeeting() {
+		videoCallService.changeCallState(eventId, 'InProgress');
+		hasJoinedCall = true;
+	}
+
+	function handleJoinMeeting() {
+		hasJoinedCall = true;
+	}
+
+	function handleSetAgendaItem(index: number) {
+		videoCallService.setAgendaItem(eventId, index);
+		if (isModerator && agendaItems[index]?.type === 'breakout' && !isBreakoutActive) {
+			showCreateBreakout = true;
+		}
+	}
+
+	function handleNextAgendaItem() {
+		const next = currentStep + 1;
+		if (next < agendaItems.length) {
+			handleSetAgendaItem(next);
+		}
+	}
+
+	function handleCreateBreakout(config: { maxPerRoom: number; durationMinutes: number }) {
+		videoCallService.assignBreakoutRooms(eventId, config.maxPerRoom);
+		const ends = new Date(Date.now() + config.durationMinutes * 60 * 1000).toISOString();
+		videoCallService.startBreakoutSession(eventId, ends);
+		showCreateBreakout = false;
+
+		// Generate mock rooms from mock participants for testing
+		const roomCount = Math.ceil(allParticipants.length / config.maxPerRoom);
+		mockBreakoutRooms = Array.from({ length: roomCount }, (_, i) => ({
+			index: i,
+			name: `Room #${i + 1}`,
+			participants: allParticipants.slice(i * config.maxPerRoom, (i + 1) * config.maxPerRoom),
+			hasAssistanceRequest: false,
+			assistanceRequestUser: null
+		}));
+
+		// Auto-switch to breakout rooms tab
+		activePanel = 'breakoutRooms';
+	}
+
+	function handleEnterBreakoutRoom(roomIndex: number) {
+		roomContext = {
+			type: 'breakout',
+			roomIndex,
+			roomName: `Breakout room #${roomIndex + 1}`
+		};
+		if (isModerator) {
+			videoCallService.resolveBreakoutRoomAssistanceRequest(eventId, `room-${roomIndex}`);
+		}
+	}
+
+	function handleLeaveBreakoutRoom() {
+		roomContext = 'plenary';
+	}
+
+	function handleCallForSupport() {
+		const roomId = typeof roomContext !== 'string' ? `room-${roomContext.roomIndex}` : 'room-0'; // Fallback for participants auto-assigned by backend
+		videoCallService.requestBreakoutRoomAssistance(eventId, roomId);
+		showToast('Support request sent to facilitator');
+	}
+
+	function handleBroadcast(message: string) {
+		videoCallService.broadcastMessage(eventId, message);
+		showToast('Broadcast sent');
+	}
+
+	function handleAddTime(minutes: number) {
+		const currentEnd = videoCallService.getBreakoutSessionEndTime();
+		if (currentEnd) {
+			const newEnd = new Date(currentEnd.getTime() + minutes * 60 * 1000).toISOString();
+			videoCallService.extendBreakoutSession(eventId, newEnd);
+			const msg = `${minutes} minute(s) added to breakout session`;
+			videoCallService.broadcastMessage(eventId, msg);
+			showToast(`${minutes} minute(s) added`);
+		}
+	}
+
+	function handleEndBreakoutSession() {
+		videoCallService.endBreakoutSession(eventId);
+		roomContext = 'plenary';
+		mockBreakoutRooms = [];
+		activePanel = 'agenda';
+	}
+
+	function handleGoBackToPlenary() {
+		roomContext = 'plenary';
+		if (isModerator) {
+			handleEndBreakoutSession();
+		}
 	}
 
 	function handleApiReady(api: any) {
 		jitsiApi = api;
-
-		api.addListener('audioMuteStatusChanged', (data: any) => {
-			audioMuted = data.muted;
-		});
-
-		api.addListener('videoMuteStatusChanged', (data: any) => {
-			videoMuted = data.muted;
-		});
-	}
-
-	function handleParticipantJoined(data: any) {
-		jitsiParticipants = [
-			...jitsiParticipants,
-			{ id: data.id, displayName: data.displayName || 'Guest' }
-		];
-	}
-
-	function handleParticipantLeft(data: any) {
-		jitsiParticipants = jitsiParticipants.filter((p) => p.id !== data.id);
-	}
-
-	async function handleConferenceJoined(data: any) {
-		conferenceJoined = true;
-	}
-
-	function handleConferenceLeft() {
-		conferenceJoined = false;
-		jitsiParticipants = [];
-	}
-
-	const tabs = [
-		{ key: 'agenda' as const, label: 'Agenda', icon: List },
-		{ key: 'details' as const, label: 'Details', icon: Info },
-		{ key: 'participants' as const, label: 'People', icon: Users },
-		{ key: 'controls' as const, label: 'Controls', icon: Settings }
-	];
-
-	// --- Breakout room helpers (moderator only) ---
-
-	let previousAssignments = $state<Map<string, Set<string>>>(new Map());
-
-	function fisherYatesShuffle<T>(arr: T[]): T[] {
-		const a = [...arr];
-		for (let i = a.length - 1; i > 0; i--) {
-			const j = Math.floor(Math.random() * (i + 1));
-			[a[i], a[j]] = [a[j], a[i]];
-		}
-		return a;
-	}
-
-	function buildBreakoutRooms(
-		participants: Array<{ participantId: string }>,
-		maxPerRoom: number,
-		shuffle: boolean
-	): Array<{ name: string; participants: string[] }> {
-		const ids = participants.map((p) => p.participantId);
-		const total = ids.length;
-		if (total === 0) return [];
-		const roomCount = Math.ceil(total / maxPerRoom);
-
-		const rooms: Array<{ name: string; participants: string[] }> = [];
-		for (let i = 0; i < roomCount; i++) {
-			rooms.push({ name: `Group ${i + 1}`, participants: [] });
-		}
-
-		if (shuffle && previousAssignments.size > 0) {
-			// Shuffle and try to avoid putting people in same group as last time
-			const shuffled = fisherYatesShuffle(ids);
-			shuffled.forEach((id) => {
-				const prev = previousAssignments.get(id);
-				// Prefer room where fewest previous groupmates are
-				const scored = rooms
-					.filter((r) => r.participants.length < maxPerRoom)
-					.map((r) => ({
-						room: r,
-						overlap: prev ? r.participants.filter((pid) => prev.has(pid)).length : 0
-					}))
-					.sort((a, b) => a.overlap - b.overlap);
-				(scored[0]?.room ?? rooms[0]).participants.push(id);
-			});
-		} else {
-			// round-robin
-			ids.forEach((id, idx) => {
-				rooms[idx % roomCount].participants.push(id);
-			});
-		}
-
-		// Record assignments for next reshuffle
-		const newAssignments = new Map<string, Set<string>>();
-		for (const room of rooms) {
-			const memberSet = new Set(room.participants);
-			for (const id of room.participants) {
-				newAssignments.set(id, memberSet);
-			}
-		}
-		previousAssignments = newAssignments;
-
-		return rooms;
-	}
-
-	async function autoCreateBreakoutRooms(maxPerRoom = 6) {
-		if (!jitsiApi || !isModerator) return;
-
-		const participantsInfo = await jitsiApi.getParticipantsInfo();
-		const rooms = buildBreakoutRooms(participantsInfo, maxPerRoom, false);
-
-		if (rooms.length === 0) {
-			showNotification('No participants to assign to breakout rooms');
-			return;
-		}
-
-		try {
-			jitsiApi.executeCommand('overwriteBreakoutRooms', rooms);
-			showNotification(
-				`Created ${rooms.length} breakout rooms for ${participantsInfo.length} participants`
-			);
-		} catch (e) {
-			console.error('Breakout room creation failed:', e);
-			showNotification('Failed to create breakout rooms — check console');
-		}
-	}
-
-	async function reshuffleBreakoutRooms(maxPerRoom = 6) {
-		if (!jitsiApi || !isModerator) return;
-
-		const participantsInfo = await jitsiApi.getParticipantsInfo();
-		const rooms = buildBreakoutRooms(participantsInfo, maxPerRoom, true);
-
-		if (rooms.length === 0) {
-			showNotification('No participants to assign to breakout rooms');
-			return;
-		}
-
-		try {
-			jitsiApi.executeCommand('overwriteBreakoutRooms', rooms);
-			showNotification(
-				`Reshuffled ${rooms.length} breakout rooms (avoiding previous groups)`
-			);
-		} catch (e) {
-			console.error('Breakout reshuffle failed:', e);
-			showNotification('Failed to reshuffle breakout rooms — check console');
-		}
-	}
-
-	async function closeBreakoutRooms() {
-		if (!jitsiApi || !isModerator) return;
-		try {
-			jitsiApi.executeCommand('closeBreakoutRooms');
-			showNotification('Breakout rooms closed — participants returning to main room');
-		} catch (e) {
-			console.error('Close breakout rooms failed:', e);
-		}
 	}
 </script>
-
-{#snippet panelTabs()}
-	<div class="border-border flex border-b-[3px]">
-		{#each tabs as tab}
-			<button
-				class="flex-1 py-1.5 transition-colors {activeTab === tab.key
-					? 'border-primary text-foreground border-b-[3px] font-semibold'
-					: 'text-muted-foreground hover:text-foreground font-medium'}"
-				onclick={() => (activeTab = tab.key)}
-			>
-				<span class="inline-flex items-center gap-2 rounded-lg px-3 py-2">
-					<tab.icon class="h-4 w-4" />
-					<span class="text-base">{tab.label}</span>
-				</span>
-			</button>
-		{/each}
-	</div>
-{/snippet}
-
-{#snippet panelContent()}
-	<div class="flex-1 overflow-y-auto p-6">
-		{#if activeTab === 'agenda'}
-			<div class="flex flex-col gap-6">
-				<div class="flex items-center justify-between">
-					<h3 class="text-2xl font-semibold">Meeting Agenda</h3>
-					<Button variant="outline" onclick={advanceAgenda}>
-						Next
-						<ChevronRight class="h-4 w-4" />
-					</Button>
-				</div>
-
-				<div class="flex flex-col gap-3">
-					{#each agendaItems as item (item.id)}
-						<div
-							class="flex h-14 items-center justify-between overflow-hidden rounded-full px-5 py-2 shadow-sm transition-colors
-								{item.status === 'current'
-								? 'bg-primary/10 ring-primary ring-2'
-								: item.status === 'done'
-									? 'bg-muted ring-muted ring-1'
-									: 'bg-background ring-border ring-1'}"
-						>
-							<div class="flex items-center gap-2">
-								{#if item.status === 'done'}
-									<CircleCheck class="h-5 w-5 text-emerald-500" />
-								{:else if item.status === 'current'}
-									<span class="bg-primary h-3 w-3 animate-pulse rounded-full"
-									></span>
-								{:else}
-									<span class="bg-border h-3 w-3 rounded-full"></span>
-								{/if}
-								<span
-									class="line-clamp-1 text-base {item.status === 'current'
-										? 'font-semibold'
-										: 'font-medium'}">{item.title}</span
-								>
-							</div>
-							<span class="text-primary line-clamp-1 text-sm font-medium"
-								>{item.duration}</span
-							>
-						</div>
-					{/each}
-				</div>
-			</div>
-		{:else if activeTab === 'details'}
-			<div class="space-y-3">
-				<h3 class="text-sm font-semibold">Event Details</h3>
-
-				{#if event}
-					<div class="space-y-2 text-sm">
-						{#if event.description}
-							<p class="text-muted-foreground">{event.description}</p>
-						{/if}
-						<div class="grid gap-2 text-xs">
-							<div class="flex justify-between">
-								<span class="text-muted-foreground">Starts</span>
-								<span
-									>{formatDateShort(event.startTime)}
-									{formatTime(event.startTime)}</span
-								>
-							</div>
-							<div class="flex justify-between">
-								<span class="text-muted-foreground">Ends</span>
-								<span
-									>{formatDateShort(event.endTime)}
-									{formatTime(event.endTime)}</span
-								>
-							</div>
-							<div class="flex justify-between">
-								<span class="text-muted-foreground">Attendance</span>
-								<span>
-									{event.currentAttendance}{event.capacity
-										? ` / ${event.capacity}`
-										: ''}
-								</span>
-							</div>
-							<div class="flex justify-between">
-								<span class="text-muted-foreground">Signup</span>
-								<span class="capitalize">{event.signupMode}</span>
-							</div>
-						</div>
-					</div>
-				{:else}
-					<p class="text-muted-foreground text-xs">Event details unavailable.</p>
-				{/if}
-			</div>
-		{:else if activeTab === 'participants'}
-			<div class="space-y-2">
-				<h3 class="text-sm font-semibold">
-					In Call ({jitsiParticipants.length})
-				</h3>
-
-				{#if jitsiParticipants.length === 0}
-					<p class="text-muted-foreground py-6 text-center text-xs">
-						{conferenceJoined
-							? 'No other participants yet'
-							: 'Join the meeting to see participants'}
-					</p>
-				{:else}
-					{#each jitsiParticipants as p (p.id)}
-						<div class="border-border flex items-center gap-2 rounded-lg border p-2">
-							<div
-								class="bg-primary/10 text-primary flex h-7 w-7 items-center justify-center rounded-full text-xs font-medium"
-							>
-								{p.displayName.charAt(0).toUpperCase()}
-							</div>
-							<span class="text-sm">{p.displayName}</span>
-						</div>
-					{/each}
-				{/if}
-
-				{#if apiAttendances.length > 0}
-					<hr class="border-border my-3" />
-					<h3 class="text-sm font-semibold">
-						Registered ({apiAttendances.length})
-					</h3>
-					{#each apiAttendances as a (a.id)}
-						<div class="border-border flex items-center gap-2 rounded-lg border p-2">
-							<div
-								class="bg-muted text-muted-foreground flex h-7 w-7 items-center justify-center rounded-full text-xs font-medium"
-							>
-								{a.userId.charAt(0).toUpperCase()}
-							</div>
-							<div class="min-w-0 flex-1">
-								<span class="text-sm">{a.userId}</span>
-								<span class="text-muted-foreground ml-1 text-xs capitalize"
-									>{a.role}</span
-								>
-							</div>
-						</div>
-					{/each}
-				{/if}
-			</div>
-		{:else if activeTab === 'controls'}
-			<div class="space-y-3">
-				<h3 class="text-sm font-semibold">Meeting Controls</h3>
-
-				<div class="grid grid-cols-2 gap-2">
-					<Button
-						variant={audioMuted ? 'default' : 'outline'}
-						size="sm"
-						class="w-full justify-start text-xs"
-						onclick={() => jitsiApi?.executeCommand('toggleAudio')}
-					>
-						{audioMuted ? 'Unmute' : 'Mute'}
-					</Button>
-
-					<Button
-						variant={videoMuted ? 'default' : 'outline'}
-						size="sm"
-						class="w-full justify-start text-xs"
-						onclick={() => jitsiApi?.executeCommand('toggleVideo')}
-					>
-						{videoMuted ? 'Video On' : 'Video Off'}
-					</Button>
-
-					<Button
-						variant="outline"
-						size="sm"
-						class="w-full justify-start text-xs"
-						onclick={() => jitsiApi?.executeCommand('toggleShareScreen')}
-					>
-						Share
-					</Button>
-
-					<Button
-						variant="outline"
-						size="sm"
-						class="w-full justify-start text-xs"
-						onclick={() => jitsiApi?.executeCommand('toggleTileView')}
-					>
-						Tiles
-					</Button>
-
-					<Button
-						variant="outline"
-						size="sm"
-						class="w-full justify-start text-xs"
-						onclick={() => jitsiApi?.executeCommand('toggleRaiseHand')}
-					>
-						Hand
-					</Button>
-
-					<Button
-						variant="outline"
-						size="sm"
-						class="w-full justify-start text-xs"
-						onclick={() => jitsiApi?.executeCommand('muteEveryone')}
-					>
-						Mute All
-					</Button>
-				</div>
-
-				{#if isModerator}
-					<hr class="border-border" />
-
-					<div class="space-y-2">
-						<p
-							class="text-muted-foreground text-xs font-medium tracking-wide uppercase"
-						>
-							Announcements
-						</p>
-
-						<div class="flex gap-2">
-							<input
-								type="text"
-								placeholder="Type a message for all participants..."
-								bind:value={announcementText}
-								onkeydown={(e) => e.key === 'Enter' && sendAnnouncement()}
-								class="border-border bg-background text-foreground placeholder:text-muted-foreground focus:ring-primary flex-1 rounded-lg border px-2.5 py-1.5 text-xs focus:ring-1 focus:outline-none"
-							/>
-							<Button
-								variant="default"
-								size="sm"
-								class="shrink-0 text-xs"
-								disabled={!announcementText.trim() || announcementSending}
-								onclick={sendAnnouncement}
-							>
-								{announcementSending ? 'Sending...' : 'Send'}
-							</Button>
-						</div>
-					</div>
-
-					<hr class="border-border" />
-
-					<div class="space-y-2">
-						<p
-							class="text-muted-foreground text-xs font-medium tracking-wide uppercase"
-						>
-							Breakout Rooms
-						</p>
-
-						<div class="grid grid-cols-2 gap-2">
-							<Button
-								variant="default"
-								size="sm"
-								class="w-full justify-start text-xs"
-								onclick={() => autoCreateBreakoutRooms(6)}
-							>
-								Auto-assign Breakouts
-							</Button>
-
-							<Button
-								variant="outline"
-								size="sm"
-								class="w-full justify-start text-xs"
-								onclick={() => reshuffleBreakoutRooms(6)}
-							>
-								Reshuffle Groups
-							</Button>
-
-							<Button
-								variant="outline"
-								size="sm"
-								class="w-full justify-start text-xs"
-								onclick={closeBreakoutRooms}
-							>
-								Close Breakouts
-							</Button>
-
-							<Button
-								variant="outline"
-								size="sm"
-								class="w-full justify-start text-xs"
-								onclick={async () => {
-									if (!jitsiApi) return;
-									const rooms = await jitsiApi.getRoomsInfo();
-									console.log('Breakout rooms:', rooms);
-									alert(JSON.stringify(rooms, null, 2));
-								}}
-							>
-								Inspect Rooms
-							</Button>
-						</div>
-					</div>
-				{/if}
-
-				<hr class="border-border" />
-
-				<div class="space-y-2">
-					<p class="text-muted-foreground text-xs font-medium tracking-wide uppercase">
-						API Explorer
-					</p>
-
-					<div class="grid grid-cols-2 gap-2">
-						<Button
-							variant="outline"
-							size="sm"
-							class="w-full justify-start text-xs"
-							onclick={async () => {
-								if (!jitsiApi) return;
-								const rooms = await jitsiApi.getRoomsInfo();
-								console.log('Rooms info:', rooms);
-								alert(JSON.stringify(rooms, null, 2));
-							}}
-						>
-							Rooms
-						</Button>
-
-						<Button
-							variant="outline"
-							size="sm"
-							class="w-full justify-start text-xs"
-							onclick={async () => {
-								if (!jitsiApi) return;
-								const devices = await jitsiApi.getAvailableDevices();
-								console.log('Available devices:', devices);
-								alert(JSON.stringify(devices, null, 2));
-							}}
-						>
-							Devices
-						</Button>
-
-						<Button
-							variant="outline"
-							size="sm"
-							class="w-full justify-start text-xs"
-							onclick={() => {
-								if (!jitsiApi) return;
-								const n = jitsiApi.getNumberOfParticipants();
-								alert(`Participants: ${n}`);
-							}}
-						>
-							Count
-						</Button>
-
-						<Button
-							variant="outline"
-							size="sm"
-							class="w-full justify-start text-xs"
-							onclick={() => jitsiApi?.executeCommand('toggleLobby', true)}
-						>
-							Lobby
-						</Button>
-					</div>
-				</div>
-			</div>
-		{/if}
-	</div>
-{/snippet}
 
 <svelte:head>
 	<title>{event?.name ?? 'Live Event'}</title>
 </svelte:head>
 
-<div class="md:bg-muted -mb-4 flex h-dvh flex-col overflow-hidden md:-mx-20 md:h-auto md:min-h-dvh">
-	<!-- Top bar -->
-	<div
-		class="bg-card px-6 py-3 md:mx-auto md:w-full md:max-w-[1440px] md:bg-transparent md:pt-12 md:pb-4"
-	>
-		<div class="flex items-center gap-3">
-			<a
-				href="/conversations/{conversationId}/events/{eventId}"
-				class="text-muted-foreground hover:text-foreground inline-flex items-center gap-2 text-sm font-medium"
-			>
-				<span
-					class="border-input flex h-9 w-9 items-center justify-center rounded-full border bg-white shadow-sm"
-					>←</span
-				>
-				Back to conversation
-			</a>
-			<span class="text-muted-foreground hidden text-sm md:inline">|</span>
-			<h1 class="text-foreground hidden text-lg font-semibold md:block">
-				{event?.name ?? `Event: ${eventId}`}
-			</h1>
-			{#if isModerator}
-				<span
-					class="inline-flex shrink-0 items-center gap-1.5 rounded-full bg-amber-500/10 px-2.5 py-1 text-xs font-medium text-amber-600 ring-1 ring-amber-500/30"
-				>
-					<span class="h-2 w-2 rounded-full bg-amber-500"></span>
-					Host
-				</span>
-			{/if}
-			{#if conferenceJoined}
-				<span
-					class="hidden shrink-0 items-center gap-1.5 rounded-full bg-green-500/10 px-2 py-0.5 text-xs font-medium text-green-600 md:inline-flex"
-				>
-					<span class="h-1.5 w-1.5 rounded-full bg-green-500"></span>
-					Live
-				</span>
-			{/if}
+{#if meetingPhase === 'loading'}
+	<!-- Loading: waiting for call state from server -->
+	<div class="bg-background flex min-h-dvh w-full items-center justify-center">
+		<div class="flex flex-col items-center gap-8">
+			<div class="relative h-16 w-16">
+				<div
+					class="border-primary/30 border-t-primary absolute inset-0 animate-spin rounded-full border-4"
+					style="animation-duration: 1.2s;"
+				></div>
+			</div>
+			<div class="flex flex-col items-center gap-3">
+				<h2 class="text-foreground text-2xl font-semibold">
+					{event?.name ?? 'Live Event'}
+				</h2>
+				<p class="text-muted-foreground text-base">Connecting to meeting…</p>
+			</div>
 		</div>
 	</div>
+{:else if meetingPhase === 'lobby' || meetingPhase === 'ended'}
+	<MeetingLobby
+		title={event?.name ?? 'Meeting'}
+		scheduledTime={scheduledTimeText}
+		endedTime={event ? `${formatDateShort(event.endTime)} ${formatTime(event.endTime)}` : ''}
+		participants={otherParticipants}
+		{callStatus}
+		{isModerator}
+		onStartMeeting={handleStartMeeting}
+		onJoinMeeting={handleJoinMeeting}
+	/>
+{:else}
+	<!-- In-call: full-width black background, stays in document flow -->
+	<div class="bg-sidebar flex h-[calc(100dvh-64px)] w-full flex-col overflow-hidden">
+		<div class="flex min-h-0 flex-1">
+			<!-- Jitsi area -->
+			<div class="relative flex min-h-0 min-w-0 flex-1 flex-col">
+				<!-- Header bar -->
+				<div
+					class="border-sidebar-foreground/20 flex items-end justify-between border-b px-6 pt-4 pb-2"
+				>
+					<div class="flex items-center gap-3">
+						<span class="text-sidebar-foreground text-xl font-medium">
+							{event?.name ?? 'Event'}
+						</span>
+						<div class="flex items-center gap-1.5">
+							<span class="bg-destructive h-2.5 w-2.5 rounded-full"></span>
+							<span
+								class="text-sidebar-foreground text-center text-xs leading-6 font-normal"
+							>
+								Recording
+							</span>
+						</div>
+					</div>
+					<!-- DEV ONLY -->
+					<button
+						class="bg-destructive text-destructive-foreground hover:bg-destructive/90 rounded px-3 py-1 text-xs font-medium"
+						onclick={devResetCall}
+					>
+						DEV: Reset Call
+					</button>
+				</div>
 
-	<!-- Main content: Jitsi full-width on mobile, side-by-side with panel on desktop -->
-	<div
-		class="mx-4 flex min-h-0 flex-1 md:mx-auto md:w-full md:max-w-[1440px] md:gap-16 md:px-6 md:pb-24"
-	>
-		<!-- Jitsi -->
-		<div class="relative min-h-0 min-w-0 flex-1 overflow-hidden rounded-3xl md:min-h-[600px]">
-			<JitsiMeet
-				{roomName}
-				{jwt}
-				onApiReady={handleApiReady}
-				onParticipantJoined={handleParticipantJoined}
-				onParticipantLeft={handleParticipantLeft}
-				onVideoConferenceJoined={handleConferenceJoined}
-				onVideoConferenceLeft={handleConferenceLeft}
-				startWithAudioMuted={true}
-				configOverwrite={{
-					toolbarButtons: [
-						'microphone',
-						'camera',
-						'desktop',
-						'chat',
-						'raisehand',
-						'tileview',
-						'hangup',
-						'fullscreen'
-					],
-					disableDeepLinking: true,
-					hideConferenceSubject: true
-				}}
-			/>
-		</div>
+				<!-- Jitsi iframe -->
+				<div class="relative flex-1 overflow-hidden">
+					<JitsiMeet
+						roomName={currentJitsiRoom}
+						{jwt}
+						onApiReady={handleApiReady}
+						startWithAudioMuted={true}
+						configOverwrite={{
+							toolbarButtons: [
+								'microphone',
+								'camera',
+								'desktop',
+								'chat',
+								'raisehand',
+								'tileview',
+								'hangup',
+								'fullscreen'
+							],
+							disableDeepLinking: true,
+							hideConferenceSubject: true
+						}}
+					/>
 
-		<!-- Desktop panel -->
-		<div
-			class="bg-card hidden min-w-0 flex-1 flex-col overflow-hidden rounded-3xl shadow-[0px_2px_4px_0px_rgba(0,0,0,0.12)] md:flex"
-		>
-			{@render panelTabs()}
-			{@render panelContent()}
+					<!-- Room chip overlay -->
+					<div class="pointer-events-none absolute inset-x-0 top-0 flex justify-center">
+						{#if isBreakoutActive && inBreakoutRoom}
+							<div
+								class="bg-background pointer-events-auto mt-2 inline-flex items-center justify-between rounded-full px-6 py-2 shadow-md"
+							>
+								<span class="text-foreground text-sm leading-6 font-medium">
+									{roomChipText}
+								</span>
+								<span
+									class="text-muted-foreground ml-3 text-xs leading-6 font-medium"
+								>
+									Time left {timeLeftFormatted}
+								</span>
+							</div>
+						{:else}
+							<div
+								class="bg-muted-foreground pointer-events-auto mt-2 inline-flex items-center rounded-full px-4 py-2 shadow-md"
+							>
+								<span class="text-muted text-sm leading-6 font-medium">
+									{roomChipText}
+								</span>
+							</div>
+						{/if}
+					</div>
+				</div>
+
+				<!-- Host panel toggle tabs (visible when panel closed during breakout) -->
+				{#if isModerator && isBreakoutActive && !inBreakoutRoom && !panelOpen}
+					<div class="absolute top-12 right-0 z-10 flex flex-col rounded-3xl shadow-lg">
+						<button
+							class="bg-background h-12 w-48 rounded-t-[20px] px-6 py-3 text-left text-sm font-semibold"
+							onclick={() => {
+								activePanel = 'agenda';
+								panelOpen = true;
+							}}
+						>
+							Agenda
+						</button>
+						<button
+							class="bg-background relative h-12 w-48 rounded-b-[20px] border-t px-6 py-3 text-left text-sm font-semibold"
+							onclick={() => {
+								activePanel = 'breakoutRooms';
+								panelOpen = true;
+							}}
+						>
+							Breakout rooms
+							{#if Object.keys(assistanceRequests).length > 0}
+								<span
+									class="bg-destructive absolute top-3.5 right-4 h-2 w-2 rounded-full"
+								></span>
+							{/if}
+						</button>
+					</div>
+				{/if}
+			</div>
+
+			<!-- Right panel (side-by-side) -->
+			{#if panelOpen || !isModerator}
+				<div class="h-full w-[360px] shrink-0 p-3">
+					<SidePanel
+						activeTab={activePanel}
+						showTabs={isBreakoutActive && isModerator && !inBreakoutRoom}
+						onTabChange={(tab) => (activePanel = tab)}
+					>
+						{#if isBreakoutActive && (inBreakoutRoom || !isModerator)}
+							<BreakoutSessionPanel
+								roomName={roomChipText}
+								question={currentAgendaItem?.breakoutQuestion}
+								description={currentAgendaItem?.breakoutDescription}
+								{timeLeftFormatted}
+								{isModerator}
+								onCallForSupport={handleCallForSupport}
+								onLeaveBreakoutRoom={handleLeaveBreakoutRoom}
+							/>
+						{:else if activePanel === 'breakoutRooms' && breakoutRoomDisplays.length > 0}
+							<BreakoutRoomsPanel
+								rooms={breakoutRoomDisplays}
+								{timeLeftFormatted}
+								{isModerator}
+								onEnterRoom={handleEnterBreakoutRoom}
+								onAddTime={() => (showAddTime = true)}
+								onEndSession={handleEndBreakoutSession}
+								onBroadcastMessage={() => (showBroadcast = true)}
+							/>
+						{:else}
+							<AgendaPanel
+								items={agendaItems}
+								{currentStep}
+								{isModerator}
+								readOnly={isBreakoutActive}
+								onSetCurrent={handleSetAgendaItem}
+								onNext={handleNextAgendaItem}
+							/>
+						{/if}
+					</SidePanel>
+				</div>
+			{/if}
 		</div>
 	</div>
 
 	<!-- Mobile drawer -->
 	<Drawer.Root>
 		<Drawer.Trigger
-			class="bg-primary hover:bg-primary/90 fixed bottom-4 left-1/2 z-50 inline-flex -translate-x-1/2 items-center gap-2 rounded-full px-6 py-3 font-semibold text-white shadow-lg transition-colors md:hidden"
+			class="bg-primary hover:bg-primary/90 fixed bottom-4 left-1/2 z-50 inline-flex -translate-x-1/2 items-center gap-2 rounded-full px-6 py-3 font-semibold text-white shadow-lg md:hidden"
 		>
 			<ChevronUp class="h-4 w-4" />
 			<span>Agenda</span>
 		</Drawer.Trigger>
 		<Drawer.Content class="bg-card flex max-h-[80dvh] flex-col rounded-t-3xl">
-			{@render panelTabs()}
-			{@render panelContent()}
+			<div class="p-4">
+				<AgendaPanel
+					items={agendaItems}
+					{currentStep}
+					{isModerator}
+					readOnly={isBreakoutActive}
+					onSetCurrent={handleSetAgendaItem}
+					onNext={handleNextAgendaItem}
+				/>
+			</div>
 		</Drawer.Content>
 	</Drawer.Root>
+{/if}
 
-	<!-- Floating notification popup -->
-	{#if activeNotification}
+<!-- Dialogs -->
+<CreateBreakoutDialog
+	bind:open={showCreateBreakout}
+	participants={allParticipants}
+	onClose={() => (showCreateBreakout = false)}
+	onCreate={handleCreateBreakout}
+/>
+
+<BroadcastMessageDialog
+	bind:open={showBroadcast}
+	onClose={() => (showBroadcast = false)}
+	onSend={handleBroadcast}
+/>
+
+<AddTimeDialog
+	bind:open={showAddTime}
+	{timeLeftFormatted}
+	onClose={() => (showAddTime = false)}
+	onAddTime={handleAddTime}
+/>
+
+{#if noticeQueue.length > 0}
+	{@const notice = noticeQueue[0]}
+	<NoticeDialog
+		open={true}
+		message={notice.message}
+		actionLabel={notice.actionLabel}
+		onAction={notice.onAction}
+		onDismiss={dismissCurrentNotice}
+	/>
+{/if}
+
+<!-- Lightweight toast for confirmations -->
+{#if toastMessage}
+	<div
+		class="animate-in fade-in slide-in-from-top-2 pointer-events-auto fixed top-4 left-1/2 z-50 -translate-x-1/2 duration-300"
+	>
 		<div
-			class="animate-in fade-in slide-in-from-top-2 pointer-events-auto fixed top-4 left-1/2 z-50 -translate-x-1/2 duration-300"
+			class="bg-card border-border flex items-center gap-3 rounded-xl border px-4 py-3 shadow-lg"
 		>
-			<div
-				class="bg-card border-border flex max-w-md items-start gap-3 rounded-xl border px-4 py-3 shadow-lg"
+			<p class="text-foreground text-sm font-medium">{toastMessage}</p>
+			<button
+				class="text-muted-foreground hover:text-foreground shrink-0 text-sm"
+				onclick={() => (toastMessage = null)}
 			>
-				<div class="flex-1">
-					<p class="text-foreground text-sm font-medium">Announcement</p>
-					<p class="text-muted-foreground mt-0.5 text-sm">{activeNotification.message}</p>
-				</div>
-				<button
-					class="text-muted-foreground hover:text-foreground shrink-0 text-sm"
-					onclick={() => (activeNotification = null)}
-				>
-					✕
-				</button>
-			</div>
+				✕
+			</button>
 		</div>
-	{/if}
-</div>
+	</div>
+{/if}

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { onDestroy, untrack } from 'svelte';
+	import { dev } from '$app/environment';
 	import JitsiMeet from '$lib/components/JitsiMeet/JitsiMeet.svelte';
 	import * as Drawer from '$lib/components/ui/drawer';
 	import { formatDateShort, formatTime } from '$lib/utils';
@@ -34,7 +35,7 @@
 	let user = $derived(data.user);
 	let isModerator = $derived(data.isModerator);
 
-	// Mock participants for testing (todo: remove)
+	/** @todo remove — mock participants for dev testing */
 	const mockParticipants: VideoCallParticipant[] = [
 		{ user_id: 'user-1', username: 'Alice Johnson', role: 'participant' },
 		{ user_id: 'user-2', username: 'Bob Smith', role: 'participant' },
@@ -50,10 +51,11 @@
 		{ user_id: 'user-12', username: 'Leo Garcia', role: 'participant' }
 	];
 
-	// Reactive reads from videoCallService
 	let callStatus = $derived(videoCallService.callStatus);
 	let realParticipants = $derived(videoCallService.participants);
-	let allParticipants = $derived([...realParticipants, ...mockParticipants]);
+	let allParticipants = $derived(
+		dev ? [...realParticipants, ...mockParticipants] : realParticipants
+	);
 	let otherParticipants = $derived(allParticipants.filter((p) => p.user_id !== user?.id));
 	let currentStep = $derived(videoCallService.currentAgendaStep);
 	let breakoutSession = $derived(videoCallService.breakoutSession);
@@ -67,23 +69,21 @@
 		return () => videoCallService.leaveCall(eventId);
 	});
 
-	// Local UI state
 	let hasJoinedCall = $state(false);
 	let jitsiApi: any = $state(null);
 	let roomContext = $state<RoomContext>('plenary');
 	let activePanel = $state<PanelTab>('agenda');
 
-	// Mock breakout rooms (for testing with mock participants)
+	/** Mock breakout rooms for dev testing */
 	let mockBreakoutRooms = $state<BreakoutRoomDisplay[]>([]);
 
-	// Dialog states
 	let showCreateBreakout = $state(false);
 	let breakoutDialogItem = $state<AgendaItem | null>(null);
 	let showBroadcast = $state(false);
 	let showAddTime = $state(false);
 	let seenAssistanceRequests = $state<Set<string>>(new Set());
 
-	// Notice queue (assistance requests, broadcasts, time warnings, etc.)
+	/** Notice queue for assistance requests, broadcasts, time warnings */
 	let noticeQueue = $state<{ message: string; actionLabel?: string; onAction?: () => void }[]>(
 		[]
 	);
@@ -91,15 +91,14 @@
 	let breakoutEndingDismissed = $state(false);
 	let breakoutAutoEnded = $state(false);
 
-	// Lightweight toast for admin confirmations
+	/** Lightweight toast for admin confirmations */
 	let toastMessage = $state<string | null>(null);
 	let toastTimeout: ReturnType<typeof setTimeout> | null = null;
 
-	// Breakout countdown
 	let breakoutTimeRemaining = $state<number | null>(null);
 	let countdownInterval: ReturnType<typeof setInterval> | null = null;
 
-	// Map API agenda items to live event format
+	/** Map API agenda items to live event format */
 	function mapApiAgenda(items: EventAgendaItem[]): AgendaItem[] {
 		return items.map((item, index) => {
 			if ('Basic' in item) {
@@ -124,7 +123,6 @@
 
 	let agendaItems = $derived(mapApiAgenda(event?.agenda ?? []));
 
-	// Derived state
 	let meetingPhase = $derived.by(() => {
 		if (callStatus === null) return 'loading' as const;
 		if (callStatus === 'Ended') return 'ended' as const;
@@ -178,7 +176,6 @@
 		return mockBreakoutRooms;
 	});
 
-	// Breakout countdown effect
 	$effect(() => {
 		const session = breakoutSession;
 		if (session) {
@@ -208,13 +205,16 @@
 		if (!isModerator) return;
 		const reqs = assistanceRequests;
 		for (const rn of Object.keys(reqs)) {
-			const key = `${rn}:${reqs[rn].made_by_user}`;
+			const userId = reqs[rn].made_by_user;
+			const key = `${rn}:${userId}`;
 			if (seenAssistanceRequests.has(key)) continue;
 			const match = rn.match(/room-(\d+)/);
 			const ri = match ? parseInt(match[1]) : 0;
 			const roomName = `Breakout room #${ri + 1}`;
+			const participant = allParticipants.find((p) => p.user_id === userId);
+			const displayName = participant?.username ?? userId.slice(0, 8);
 			pushNotice({
-				message: `${reqs[rn].made_by_user} from ${roomName} requested help.`,
+				message: `${displayName} from ${roomName} requested help.`,
 				actionLabel: `Enter ${roomName}`,
 				onAction: () => handleEnterBreakoutRoom(ri)
 			});
@@ -241,7 +241,6 @@
 		}
 	});
 
-	// Auto-switch panel when breakout session starts/ends
 	$effect(() => {
 		if (isBreakoutActive && isModerator) {
 			activePanel = 'breakoutRooms';
@@ -313,7 +312,6 @@
 		if (toastTimeout) clearTimeout(toastTimeout);
 	});
 
-	// Handlers
 	function pushNotice(notice: { message: string; actionLabel?: string; onAction?: () => void }) {
 		noticeQueue = [...noticeQueue, notice];
 	}
@@ -330,15 +328,17 @@
 		}, 4000);
 	}
 
-	// DEV ONLY: reset call state to Waiting
+	/** DEV ONLY: reset call state to Waiting */
 	function devResetCall() {
-		videoCallService.changeCallState(eventId, 'Waiting');
-		videoCallService.setAgendaItem(eventId, 0);
-		videoCallService.endBreakoutSession(eventId);
-		hasJoinedCall = false;
-		roomContext = 'plenary';
-		showCreateBreakout = false;
-		console.log('DEV: Call state reset to Waiting');
+		if (dev) {
+			videoCallService.changeCallState(eventId, 'Waiting');
+			videoCallService.setAgendaItem(eventId, 0);
+			videoCallService.endBreakoutSession(eventId);
+			hasJoinedCall = false;
+			roomContext = 'plenary';
+			showCreateBreakout = false;
+			console.log('DEV: Call state reset to Waiting');
+		}
 	}
 
 	function handleStartMeeting() {
@@ -365,18 +365,22 @@
 		}
 	}
 
-	function handleCreateBreakout(config: { maxPerRoom: number; durationMinutes: number }) {
+	function handleCreateBreakout(config: {
+		maxPerRoom: number;
+		durationMinutes: number;
+		roomAssignments: VideoCallParticipant[][];
+	}) {
+		// TODO: when backend supports explicit assignments, send config.roomAssignments
 		videoCallService.assignBreakoutRooms(eventId, config.maxPerRoom);
 		const ends = new Date(Date.now() + config.durationMinutes * 60 * 1000).toISOString();
 		videoCallService.startBreakoutSession(eventId, ends);
 		showCreateBreakout = false;
 
-		// Generate mock rooms from mock participants for testing
-		const roomCount = Math.ceil(allParticipants.length / config.maxPerRoom);
-		mockBreakoutRooms = Array.from({ length: roomCount }, (_, i) => ({
+		// Use dialog's room assignments for local display until backend confirms
+		mockBreakoutRooms = config.roomAssignments.map((participants, i) => ({
 			index: i,
 			name: `Room #${i + 1}`,
-			participants: allParticipants.slice(i * config.maxPerRoom, (i + 1) * config.maxPerRoom),
+			participants,
 			hasAssistanceRequest: false,
 			assistanceRequestUser: null
 		}));
@@ -497,13 +501,14 @@
 							</span>
 						</div>
 					</div>
-					<!-- DEV ONLY -->
-					<button
-						class="bg-destructive text-destructive-foreground hover:bg-destructive/90 rounded px-3 py-1 text-xs font-medium"
-						onclick={devResetCall}
-					>
-						DEV: Reset Call
-					</button>
+					{#if dev}
+						<button
+							class="bg-destructive text-destructive-foreground hover:bg-destructive/90 rounded px-3 py-1 text-xs font-medium"
+							onclick={devResetCall}
+						>
+							DEV: Reset Call
+						</button>
+					{/if}
 				</div>
 
 				<!-- Jitsi iframe -->

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.ts
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.ts
@@ -17,7 +17,6 @@ export const load: PageLoad = async ({ parent, params }) => {
 				queries: { limit: 200 }
 			})
 		]);
-		console.log({ eventRes, attendancesResult });
 		event = eventRes;
 		attendances = attendancesResult.records as EventAttendanceDto[];
 	} catch (e) {
@@ -29,7 +28,7 @@ export const load: PageLoad = async ({ parent, params }) => {
 	let jwt: string;
 	let isModerator = false;
 	try {
-		console.log('Attemptng to get JWT');
+		console.log('Attempting to get JWT');
 		const authRes = await api.GetEventJWT({ params: { conversation_id, event_id } });
 		jwt = authRes.jwt;
 		isModerator = authRes.isModerator ?? false;

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.ts
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.ts
@@ -28,7 +28,6 @@ export const load: PageLoad = async ({ parent, params }) => {
 	let jwt: string;
 	let isModerator = false;
 	try {
-		console.log('Attempting to get JWT');
 		const authRes = await api.GetEventJWT({ params: { conversation_id, event_id } });
 		jwt = authRes.jwt;
 		isModerator = authRes.isModerator ?? false;


### PR DESCRIPTION
### Motivation

The existing live event page was a basic Jitsi embed with no meeting lifecycle, no agenda, and no breakout room support. I wanted to build out the full facilitator-led meeting experience from lobby → in-call → breakout sessions → end, so that I can demo the complete flow at the design meeting 

**I know this should have been broken into smaller PRs** (lobby, agenda panel, breakout creation, breakout management, admin editor, etc.), but I wanted to see the entire flow end-to-end and be able to test it as a cohesive experience. It's much easier to evaluate the UX and catch integration issues when you can click through the whole thing. I'll break follow-up work into smaller pieces now that the shape is established.

### What's in this PR

### Known limitations & hardcoded things

- **Mobile screens** need to be implemented

- **Mock participants are hardcoded** (12 fake users: Alice, Bob, Cathy, etc.) because Jitsi consistently breaks for me when joining initially — the participant list from `videoCallService` comes back empty on first load. The mocks are merged with real participants so the breakout room creation, room assignment, and lobby "X and others are waiting" UI can be tested without needing multiple real users connected. These are clearly marked with `// todo: remove`.

- **Jitsi integration**: I struggled to connect everything properly with Jitsi because it frequently breaks on my setup — the iframe sometimes doesn't load, the API ready callback doesn't fire, and participant events are unreliable. The `videoCallService` WebSocket layer works correctly (call state, agenda step, breakout sessions, assistance requests, broadcasts), but the actual Jitsi room switching when entering/leaving breakout rooms is essentially a room name swap rather than a proper Jitsi breakout room API call.

- **Breakout room participant assignment is client-side only** in mock mode — the backend `assignBreakoutRooms` is called but the mock rooms are generated locally from the participant list for visual testing.

- **View Transcription** button is a placeholder — no transcription viewer yet.

- **No persistence of breakout room assignments** across page refresh.

#### New component library: `LiveEvent/` (12 components)

| Component | Purpose |
|---|---|
| [MeetingLobby.svelte](cci:7://file:///Users/dtoadie/Workspace/crown-shy/new-comhairle/comhairle/ui/packages/comhairle/src/lib/components/LiveEvent/MeetingLobby.svelte:0:0-0:0) | Pre-call screen. Shows event title, scheduled time, participant avatars. Host sees "Start meeting" button; participants see disabled "Join meeting" until host starts; post-meeting shows ended state. |
| [AgendaPanel.svelte](cci:7://file:///Users/dtoadie/Workspace/crown-shy/new-comhairle/comhairle/ui/packages/comhairle/src/lib/components/LiveEvent/AgendaPanel.svelte:0:0-0:0) | Side panel showing agenda items with done/current/upcoming states. Facilitators can click to set the current item and advance with a "Next" button. Participants get a read-only view. |
| [CreateBreakoutDialog.svelte](cci:7://file:///Users/dtoadie/Workspace/crown-shy/new-comhairle/comhairle/ui/packages/comhairle/src/lib/components/LiveEvent/CreateBreakoutDialog.svelte:0:0-0:0) | Full breakout room creation dialog. Auto-distributes participants into rooms based on max-per-room setting. Supports **drag-and-drop** to move people between rooms, **pin** participants to rooms (survive reshuffle), and **reshuffle** unpinned participants. Configurable duration. |
| [BreakoutRoomsPanel.svelte](cci:7://file:///Users/dtoadie/Workspace/crown-shy/new-comhairle/comhairle/ui/packages/comhairle/src/lib/components/LiveEvent/BreakoutRoomsPanel.svelte:0:0-0:0) | Facilitator overview of active breakout rooms. Shows participant list per room, assistance request indicators (red dot), Enter/View Transcription buttons. Footer has Broadcast, Add Time, and End Session controls. |
| [BreakoutSessionPanel.svelte](cci:7://file:///Users/dtoadie/Workspace/crown-shy/new-comhairle/comhairle/ui/packages/comhairle/src/lib/components/LiveEvent/BreakoutSessionPanel.svelte:0:0-0:0) | In-room view for participants and visiting facilitators. Shows the breakout question + instructions (rich text via `ContentRenderer`). Participants can "Call for support"; facilitator can leave room. |
| [SidePanel.svelte](cci:7://file:///Users/dtoadie/Workspace/crown-shy/new-comhairle/comhairle/ui/packages/comhairle/src/lib/components/LiveEvent/SidePanel.svelte:0:0-0:0) | Container with tab switcher (Agenda / Breakout Session). Tabs only visible during active breakout when facilitator is in plenary. |
| [BroadcastMessageDialog.svelte](cci:7://file:///Users/dtoadie/Workspace/crown-shy/new-comhairle/comhairle/ui/packages/comhairle/src/lib/components/LiveEvent/BroadcastMessageDialog.svelte:0:0-0:0) | Facilitator sends a text message to all breakout rooms. |
| [AddTimeDialog.svelte](cci:7://file:///Users/dtoadie/Workspace/crown-shy/new-comhairle/comhairle/ui/packages/comhairle/src/lib/components/LiveEvent/AddTimeDialog.svelte:0:0-0:0) | Quick +1/+2/+5 minute buttons to extend a breakout session. |
| [NoticeDialog.svelte](cci:7://file:///Users/dtoadie/Workspace/crown-shy/new-comhairle/comhairle/ui/packages/comhairle/src/lib/components/LiveEvent/NoticeDialog.svelte:0:0-0:0) | Generic notice popup used for assistance requests, broadcast messages, and breakout ending warnings. Queue-based — notices stack and dismiss one at a time. |
| [BreakoutEndingDialog.svelte](cci:7://file:///Users/dtoadie/Workspace/crown-shy/new-comhairle/comhairle/ui/packages/comhairle/src/lib/components/LiveEvent/BreakoutEndingDialog.svelte:0:0-0:0) | Countdown notice when breakout is about to end. |
| [AssistanceNoticeDialog.svelte](cci:7://file:///Users/dtoadie/Workspace/crown-shy/new-comhairle/comhairle/ui/packages/comhairle/src/lib/components/LiveEvent/AssistanceNoticeDialog.svelte:0:0-0:0) | Facilitator notification when a participant requests help from a breakout room. |
| [types.ts](cci:7://file:///Users/dtoadie/Workspace/crown-shy/new-comhairle/comhairle/ui/packages/comhairle/src/lib/components/LiveEvent/types.ts:0:0-0:0) | Shared types: [AgendaItem](cci:2://file:///Users/dtoadie/Workspace/crown-shy/new-comhairle/comhairle/ui/packages/comhairle/src/lib/components/LiveEvent/types.ts:4:0-11:1), [MeetingPhase](cci:2://file:///Users/dtoadie/Workspace/crown-shy/new-comhairle/comhairle/ui/packages/comhairle/src/lib/components/LiveEvent/types.ts:13:0-13:56), [RoomContext](cci:2://file:///Users/dtoadie/Workspace/crown-shy/new-comhairle/comhairle/ui/packages/comhairle/src/lib/components/LiveEvent/types.ts:15:0-15:96), [PanelTab](cci:2://file:///Users/dtoadie/Workspace/crown-shy/new-comhairle/comhairle/ui/packages/comhairle/src/lib/components/LiveEvent/types.ts:17:0-17:50), [BreakoutRoomDisplay](cci:2://file:///Users/dtoadie/Workspace/crown-shy/new-comhairle/comhairle/ui/packages/comhairle/src/lib/components/LiveEvent/types.ts:19:0-25:1). |

#### Refactored live event page (`events/[event_id]/live/+page.svelte`)

Major rewrite (~1200 lines). Now manages full meeting lifecycle:

- **Meeting phases**: loading → lobby → in-call → ended (derived from `videoCallService.callStatus`)
- **Agenda state**: Maps API `EventAgendaItem[]` (Basic/BreakoutRoom variants) to [AgendaItem[]](cci:2://file:///Users/dtoadie/Workspace/crown-shy/new-comhairle/comhairle/ui/packages/comhairle/src/lib/components/LiveEvent/types.ts:4:0-11:1). Facilitator controls current step; advancing to a breakout item auto-opens the create dialog.
- **Breakout lifecycle**: Create → countdown timer → 5-second ending warning → auto-return to plenary. Timer derived from `breakoutSession.ends`. Facilitator can add time, broadcast messages, enter rooms, and end session early.
- **Assistance requests**: Tracked per-room. New requests show notice to facilitator with "Enter room" action. Requests auto-resolve when facilitator enters. Stale seen-keys cleaned up reactively.
- **Room switching**: `currentJitsiRoom` derived from `roomContext` — plenary uses `event.videoMeetingId`, breakout rooms append `-breakout-{index}`.
- **Layout**: Header bar with event name + recording indicator. Jitsi fills remaining space. Side panel (360px) with agenda or breakout rooms. Room chip overlay on Jitsi. Mobile drawer for agenda.
- **DEV Reset button**: Red button to reset call state back to Waiting for iterative testing.

#### Admin agenda editor (`events/[event_id]/+page.svelte` + [AgendaEditor.svelte](cci:7://file:///Users/dtoadie/Workspace/crown-shy/new-comhairle/comhairle/ui/packages/comhairle/src/routes/%28admin%29/admin/conversations/%5Bconversation_id%5D/events/%5Bevent_id%5D/AgendaEditor.svelte:0:0-0:0))

- New **"Event Structure"** tab on the admin event page.
- [AgendaEditor.svelte](cci:7://file:///Users/dtoadie/Workspace/crown-shy/new-comhairle/comhairle/ui/packages/comhairle/src/routes/%28admin%29/admin/conversations/%5Bconversation_id%5D/events/%5Bevent_id%5D/AgendaEditor.svelte:0:0-0:0): Full CRUD for agenda items. Two types — standard items (title only) and breakout sessions (duration, group size, prompts with rich text instructions, group assignment mode, diversity balancing options).
- Drag-and-drop reordering of agenda items.
- Bidirectional mapping between editor format and API `EventAgendaItem` enum (Basic/BreakoutRoom).
- Save button persists agenda via `apiClient.UpdateEvent`.

### Follow-up work

- [ ] Remove mock participants once Jitsi participant tracking is stable
- [ ] Wire up real Jitsi breakout room API (or keep room-name-based approach with proper join/leave)
- [ ] Transcription viewer in breakout room cards
- [ ] Mobile breakout room experience (currently only desktop side panel)
- [ ] Persist breakout room assignments server-side
- [ ] Agenda item translations (admin editor currently primary locale only)