### PR TITLE
Add "end meeting" functionality and a thank-you page (and hide navbar)

### DIFF
--- a/ui/packages/comhairle/src/lib/components/LiveEvent/AgendaPanel.svelte
+++ b/ui/packages/comhairle/src/lib/components/LiveEvent/AgendaPanel.svelte
@@ -10,6 +10,7 @@
 		readOnly?: boolean;
 		onSetCurrent?: (index: number) => void;
 		onNext?: () => void;
+		onEndMeeting?: () => void;
 	}
 
 	let {
@@ -18,7 +19,8 @@
 		isModerator,
 		readOnly = false,
 		onSetCurrent,
-		onNext
+		onNext,
+		onEndMeeting
 	}: Props = $props();
 
 	let interactive = $derived(isModerator && !readOnly);
@@ -35,6 +37,7 @@
 	}
 
 	let hasNext = $derived(currentStep < items.length - 1);
+	let isLastItem = $derived(currentStep === items.length - 1 && items.length > 0);
 </script>
 
 <div class="flex h-full flex-col overflow-hidden">
@@ -55,14 +58,24 @@
 	<!-- Footer (fixed at bottom) -->
 	{#if interactive}
 		<div class="shrink-0 border-t p-4">
-			<Button
-				variant="primaryDark"
-				class="h-10 w-full text-sm font-medium"
-				onclick={() => onNext?.()}
-				disabled={!hasNext}
-			>
-				Next
-			</Button>
+			{#if isLastItem}
+				<Button
+					variant="destructive"
+					class="h-10 w-full text-sm font-medium"
+					onclick={() => onEndMeeting?.()}
+				>
+					End meeting
+				</Button>
+			{:else}
+				<Button
+					variant="primaryDark"
+					class="h-10 w-full text-sm font-medium"
+					onclick={() => onNext?.()}
+					disabled={!hasNext}
+				>
+					Next
+				</Button>
+			{/if}
 		</div>
 	{/if}
 </div>

--- a/ui/packages/comhairle/src/lib/components/LiveEvent/EndMeetingDialog.svelte
+++ b/ui/packages/comhairle/src/lib/components/LiveEvent/EndMeetingDialog.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+	import * as Dialog from '$lib/components/ui/dialog';
+	import Button from '$lib/components/ui/button/button.svelte';
+
+	interface Props {
+		open: boolean;
+		onConfirm: () => void;
+		onCancel: () => void;
+	}
+
+	let { open = $bindable(), onConfirm, onCancel }: Props = $props();
+</script>
+
+<Dialog.Root bind:open>
+	<Dialog.Content class="max-w-md rounded-3xl p-9 sm:max-w-md" showCloseButton={false}>
+		<div class="flex flex-col items-center gap-7">
+			<h2 class="text-foreground text-2xl leading-7 font-semibold">End meeting?</h2>
+
+			<p class="text-muted-foreground text-center text-base leading-6">
+				This will end the meeting for all participants. Everyone will be disconnected from
+				the call.
+			</p>
+
+			<div class="flex w-full flex-col gap-3">
+				<Button
+					variant="destructive"
+					class="h-12 w-full text-base font-medium"
+					onclick={onConfirm}
+				>
+					End meeting for everyone
+				</Button>
+				<Button
+					variant="outline"
+					class="h-12 w-full text-base font-medium"
+					onclick={onCancel}
+				>
+					Cancel
+				</Button>
+			</div>
+		</div>
+	</Dialog.Content>
+</Dialog.Root>

--- a/ui/packages/comhairle/src/lib/components/LiveEvent/MeetingEndedScreen.svelte
+++ b/ui/packages/comhairle/src/lib/components/LiveEvent/MeetingEndedScreen.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+	import Button from '$lib/components/ui/button/button.svelte';
+	import { CheckCircle } from 'lucide-svelte';
+
+	interface Props {
+		title: string;
+		conversationUrl?: string;
+	}
+
+	let { title, conversationUrl }: Props = $props();
+</script>
+
+<div class="bg-background flex min-h-dvh w-full items-center justify-center">
+	<div class="flex max-w-lg flex-col items-center gap-12 px-6 text-center">
+		<!-- Success icon -->
+		<div class="bg-primary/10 flex h-20 w-20 items-center justify-center rounded-full">
+			<CheckCircle class="text-primary h-10 w-10" />
+		</div>
+
+		<!-- Heading -->
+		<div class="flex flex-col items-center gap-4">
+			<h1 class="text-foreground text-4xl leading-10 font-bold">
+				Thank you for participating!
+			</h1>
+			<p class="text-muted-foreground text-lg leading-7">
+				The meeting <span class="text-foreground font-medium">{title}</span> has ended.
+			</p>
+		</div>
+
+		<!-- Next steps -->
+		<div class="bg-card border-border w-full rounded-xl border p-6 text-left">
+			<h2 class="text-foreground mb-3 text-base font-semibold">What happens next?</h2>
+			<ul class="text-muted-foreground flex flex-col gap-2 text-sm leading-6">
+				<li class="flex items-start gap-2">
+					<span class="text-primary mt-1 text-sm">1.</span>
+					<span>A summary and any transcripts will be available shortly.</span>
+				</li>
+				<li class="flex items-start gap-2">
+					<span class="text-primary mt-1 text-sm">2.</span>
+					<span>You may receive follow-up materials from the facilitator.</span>
+				</li>
+				<li class="flex items-start gap-2">
+					<span class="text-primary mt-1 text-sm">3.</span>
+					<span>Check the conversation page for updates and next steps.</span>
+				</li>
+			</ul>
+		</div>
+
+		<!-- CTA -->
+		{#if conversationUrl}
+			<Button
+				variant="primaryDark"
+				class="h-12 px-8 text-base font-semibold"
+				onclick={() => (window.location.href = conversationUrl)}
+			>
+				Back to conversation
+			</Button>
+		{/if}
+	</div>
+</div>

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
@@ -14,6 +14,8 @@
 	import BroadcastMessageDialog from '$lib/components/LiveEvent/BroadcastMessageDialog.svelte';
 	import AddTimeDialog from '$lib/components/LiveEvent/AddTimeDialog.svelte';
 	import NoticeDialog from '$lib/components/LiveEvent/NoticeDialog.svelte';
+	import EndMeetingDialog from '$lib/components/LiveEvent/EndMeetingDialog.svelte';
+	import MeetingEndedScreen from '$lib/components/LiveEvent/MeetingEndedScreen.svelte';
 	import SidePanel from '$lib/components/LiveEvent/SidePanel.svelte';
 	import type {
 		AgendaItem,
@@ -62,6 +64,7 @@
 	let breakoutDialogItem = $state<AgendaItem | null>(null);
 	let showBroadcast = $state(false);
 	let showAddTime = $state(false);
+	let showEndMeeting = $state(false);
 	let seenAssistanceRequests = $state<Set<string>>(new Set());
 
 	/** Notice queue for assistance requests, broadcasts, time warnings */
@@ -408,6 +411,14 @@
 		}
 	}
 
+	/** Moderator ends the meeting for everyone */
+	function handleEndMeeting() {
+		showEndMeeting = false;
+		videoCallService.changeCallState(eventId, 'Ended');
+		jitsiApi?.executeCommand('hangup');
+		hasJoinedCall = false;
+	}
+
 	function handleCreateBreakout(config: {
 		maxPerRoom: number;
 		durationMinutes: number;
@@ -550,7 +561,12 @@
 			</div>
 		</div>
 	</div>
-{:else if meetingPhase === 'lobby' || meetingPhase === 'ended'}
+{:else if meetingPhase === 'ended'}
+	<MeetingEndedScreen
+		title={event?.name ?? 'Meeting'}
+		conversationUrl={`/conversations/${conversationId}`}
+	/>
+{:else if meetingPhase === 'lobby'}
 	<MeetingLobby
 		title={event?.name ?? 'Meeting'}
 		scheduledTime={scheduledTimeText}
@@ -684,6 +700,7 @@
 							readOnly={isBreakoutActive}
 							onSetCurrent={handleSetAgendaItem}
 							onNext={handleNextAgendaItem}
+							onEndMeeting={() => (showEndMeeting = true)}
 						/>
 					{/if}
 				</SidePanel>
@@ -708,6 +725,7 @@
 					readOnly={isBreakoutActive}
 					onSetCurrent={handleSetAgendaItem}
 					onNext={handleNextAgendaItem}
+					onEndMeeting={() => (showEndMeeting = true)}
 				/>
 			</div>
 		</Drawer.Content>
@@ -735,6 +753,12 @@
 	{timeLeftFormatted}
 	onClose={() => (showAddTime = false)}
 	onAddTime={handleAddTime}
+/>
+
+<EndMeetingDialog
+	bind:open={showEndMeeting}
+	onConfirm={handleEndMeeting}
+	onCancel={() => (showEndMeeting = false)}
 />
 
 <BreakoutEndingDialog


### PR DESCRIPTION
- Add "End meeting" button on last agenda item that triggers confirmation dialog. 
- Implement meeting end handler that updates call state to 'Ended' and disconnects all participants. Create MeetingEndedScreen component with thank you message, next steps, and link back to conversation. 
- Replace generic lobby/ended state with dedicated ended screen.