### PR TITLE
fix event detail actions and lobby visibility

### DIFF
--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/+page.svelte
@@ -50,6 +50,8 @@
 
 	/** Grace window before the scheduled start during which an admin may open the meeting. */
 	const EARLY_START_WINDOW_MS = 60 * 60 * 1000;
+	/** Window before the scheduled start during which a participant may enter the lobby. */
+	const PARTICIPANT_JOIN_WINDOW_MS = 15 * 60 * 1000;
 
 	/** Reactive clock so the countdown updates without a refresh. Ticks once per minute. */
 	let now = $state(Date.now());
@@ -61,6 +63,9 @@
 	let msUntilStart = $derived(event ? new Date(event.startTime).getTime() - now : 0);
 	let canStartEarly = $derived(
 		status === 'upcoming' && msUntilStart > 0 && msUntilStart <= EARLY_START_WINDOW_MS
+	);
+	let canJoinLobbySoon = $derived(
+		status === 'upcoming' && msUntilStart > 0 && msUntilStart <= PARTICIPANT_JOIN_WINDOW_MS
 	);
 
 	let countdownText = $derived.by(() => {
@@ -262,9 +267,9 @@
 				<p class="text-muted-foreground text-xs">
 					You'll be able to start the meeting up to an hour before it begins.
 				</p>
-			{:else if status !== 'past' && isToday && userAttendance}
+			{:else if userAttendance && canJoinLobbySoon}
 				<Button variant="primaryDark" size="lg" class="h-12 px-8 text-base" href={liveHref}>
-					Go to lobby{countdownText ? ` (in ${countdownText})` : ''}
+					Go to lobby (in {countdownText})
 				</Button>
 				<p class="text-muted-foreground text-xs">
 					The lobby will open when the facilitator starts the meeting.
@@ -274,7 +279,7 @@
 					Starts in {countdownText}
 				</Button>
 				<p class="text-muted-foreground text-xs">
-					Come back on the day to join the meeting lobby.
+					You'll be able to join the lobby 15 minutes before the meeting starts.
 				</p>
 			{:else if !userAttendance && user && status !== 'past'}
 				<Button

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/+page.svelte
@@ -30,7 +30,19 @@
 		return 'live' as const;
 	});
 
+	let isToday = $derived.by(() => {
+		if (!event) return false;
+		const start = new Date(event.startTime);
+		const now = new Date();
+		return (
+			start.getFullYear() === now.getFullYear() &&
+			start.getMonth() === now.getMonth() &&
+			start.getDate() === now.getDate()
+		);
+	});
+
 	let userAttendance = $derived(user ? attendances.find((a) => a.userId === user.id) : undefined);
+	let liveHref = $derived(`/conversations/${conversationId}/events/${event?.id}/live`);
 
 	function formatDuration(start: string, end: string) {
 		const ms = new Date(end).getTime() - new Date(start).getTime();
@@ -205,7 +217,15 @@
 				</div>
 			{/if}
 
-			{#if !userAttendance && user && status !== 'past'}
+			{#if status === 'live' && userAttendance}
+				<Button variant="primaryDark" size="lg" class="h-12 px-8 text-base" href={liveHref}>
+					Join meeting
+				</Button>
+			{:else if status !== 'past' && isToday && userAttendance}
+				<Button variant="primaryDark" size="lg" class="h-12 px-8 text-base" href={liveHref}>
+					Go to lobby
+				</Button>
+			{:else if !userAttendance && user && status !== 'past'}
 				<Button
 					variant="primaryDark"
 					size="lg"

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/+page.svelte
@@ -44,6 +44,36 @@
 	let userAttendance = $derived(user ? attendances.find((a) => a.userId === user.id) : undefined);
 	let liveHref = $derived(`/conversations/${conversationId}/events/${event?.id}/live`);
 
+	let isAdmin = $derived(
+		userAttendance?.role === 'moderator' || userAttendance?.role === 'facilitator'
+	);
+
+	/** Grace window before the scheduled start during which an admin may open the meeting. */
+	const EARLY_START_WINDOW_MS = 60 * 60 * 1000;
+
+	/** Reactive clock so the countdown updates without a refresh. Ticks once per minute. */
+	let now = $state(Date.now());
+	$effect(() => {
+		const id = setInterval(() => (now = Date.now()), 60_000);
+		return () => clearInterval(id);
+	});
+
+	let msUntilStart = $derived(event ? new Date(event.startTime).getTime() - now : 0);
+	let canStartEarly = $derived(
+		status === 'upcoming' && msUntilStart > 0 && msUntilStart <= EARLY_START_WINDOW_MS
+	);
+
+	let countdownText = $derived.by(() => {
+		if (msUntilStart <= 0) return '';
+		const totalMins = Math.ceil(msUntilStart / 60_000);
+		const days = Math.floor(totalMins / (60 * 24));
+		const hours = Math.floor((totalMins % (60 * 24)) / 60);
+		const mins = totalMins % 60;
+		if (days > 0) return `${days}d ${hours}h`;
+		if (hours > 0) return `${hours}h ${mins}m`;
+		return `${mins}m`;
+	});
+
 	function formatDuration(start: string, end: string) {
 		const ms = new Date(end).getTime() - new Date(start).getTime();
 		const mins = Math.round(ms / 60000);
@@ -221,10 +251,31 @@
 				<Button variant="primaryDark" size="lg" class="h-12 px-8 text-base" href={liveHref}>
 					Join meeting
 				</Button>
+			{:else if isAdmin && canStartEarly}
+				<Button variant="primaryDark" size="lg" class="h-12 px-8 text-base" href={liveHref}>
+					Start meeting (in {countdownText})
+				</Button>
+			{:else if isAdmin && status === 'upcoming'}
+				<Button variant="primaryDark" size="lg" class="h-12 px-8 text-base" disabled>
+					Starts in {countdownText}
+				</Button>
+				<p class="text-muted-foreground text-xs">
+					You'll be able to start the meeting up to an hour before it begins.
+				</p>
 			{:else if status !== 'past' && isToday && userAttendance}
 				<Button variant="primaryDark" size="lg" class="h-12 px-8 text-base" href={liveHref}>
-					Go to lobby
+					Go to lobby{countdownText ? ` (in ${countdownText})` : ''}
 				</Button>
+				<p class="text-muted-foreground text-xs">
+					The lobby will open when the facilitator starts the meeting.
+				</p>
+			{:else if userAttendance && status === 'upcoming'}
+				<Button variant="primaryDark" size="lg" class="h-12 px-8 text-base" disabled>
+					Starts in {countdownText}
+				</Button>
+				<p class="text-muted-foreground text-xs">
+					Come back on the day to join the meeting lobby.
+				</p>
 			{:else if !userAttendance && user && status !== 'past'}
 				<Button
 					variant="primaryDark"

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/+page.ts
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/+page.ts
@@ -10,7 +10,7 @@ export const load: PageLoad = async ({ parent, params }) => {
 			api.GetEvent({ params: { conversation_id, event_id } }),
 			api.ListEventAttendances({
 				params: { conversation_id, event_id },
-				queries: { limit: 100, role: 'participant' }
+				queries: { limit: 100 }
 			})
 		]);
 

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
@@ -50,7 +50,13 @@
 
 	let callStatus = $derived(videoCallService.callStatus);
 	let allParticipants = $derived(videoCallService.participants);
-	let otherParticipants = $derived(allParticipants.filter((p) => p.user_id !== user?.id));
+	let otherParticipants = $derived(
+		allParticipants.filter((p) => {
+			if (p.user_id === user?.id) return false;
+			if (!isModerator && (p.role === 'moderator' || p.role === 'facilitator')) return false;
+			return true;
+		})
+	);
 
 	/** Participants actually in Jitsi call (excludes current user + lobby-only users) */
 	let inCallParticipants = $derived(


### PR DESCRIPTION
## Summary
Tightens the public event detail page so the primary action reflects the event's actual state, fixes a bug where admins/facilitators always saw "Register to Attend", and hides facilitator presence from participants in the live lobby.

## CTA State Matrix

Constants:
`EARLY_START_WINDOW_MS = 60min` (admin), `PARTICIPANT_JOIN_WINDOW_MS = 15min` (participant).


| # | Time vs event | Auth | Attendance role | CTA | State | Helper text |
|---|---|---|---|---|---|---|
| 1 | Live (start ≤ now ≤ end) | logged in | participant / facilitator / moderator | **Join meeting** → /live | enabled | — |
| 2 | Upcoming, ≤ 60min to start | logged in | facilitator / moderator | **Start meeting (in `{countdown}`)** → /live | enabled | — |
| 3 | Upcoming, > 60min to start | logged in | facilitator / moderator | **Starts in `{countdown}`** | disabled | "You'll be able to start the meeting up to an hour before it begins." |
| 4 | Upcoming, ≤ 15min to start | logged in | participant | **Go to lobby (in `{countdown}`)** → /live | enabled | "The lobby will open when the facilitator starts the meeting." |
| 5 | Upcoming, > 15min to start | logged in | participant | **Starts in `{countdown}`** | disabled | "You'll be able to join the lobby 15 minutes before the meeting starts." |
| 6 | Live or upcoming | logged in | none (not registered) | **Register to Attend** | enabled | — |



### Manual test cases
| Scenario | Expected |
|---|---|
| Facilitator opens event 2h before start | Row 3 — disabled "Starts in 2h 0m" |
| Facilitator opens event 45min before start | Row 2 — enabled "Start meeting (in 45m)" |
| Participant (registered) opens event 1h before start | Row 5 — disabled "Starts in 1h 0m" |
| Participant (registered) opens event 10min before start | Row 4 — enabled "Go to lobby (in 10m)" |
| Participant (registered) opens event during meeting | Row 1 — enabled "Join meeting" |
| Logged-in user with no attendance, upcoming event | Row 6 — enabled "Register to Attend" |
| Anonymous user, upcoming event | Row 7 — login prompt |
| Anyone opens past event | Row 8 — no CTA |

<img width="931" height="651" alt="image" src="https://github.com/user-attachments/assets/50903001-ff67-431b-a8ac-3f389ef8384c" />
<img width="940" height="708" alt="image" src="https://github.com/user-attachments/assets/049e874d-1129-41b3-b9cd-4451af9b02f9" />
<img width="1040" height="701" alt="image" src="https://github.com/user-attachments/assets/6e19637a-569d-4e8a-8935-822575c79df2" />
<img width="961" height="680" alt="image" src="https://github.com/user-attachments/assets/6aa98bc6-f04e-4040-9f87-2500284548dd" />
