### PR TITLE
try to remove watermark (unsuccessfully lol)

### DIFF
--- a/ui/packages/comhairle/src/lib/components/JitsiMeet/JitsiMeet.svelte
+++ b/ui/packages/comhairle/src/lib/components/JitsiMeet/JitsiMeet.svelte
@@ -121,6 +121,11 @@
 			interfaceConfigOverwrite: {
 				SHOW_JITSI_WATERMARK: false,
 				SHOW_WATERMARK_FOR_GUESTS: false,
+				SHOW_BRAND_WATERMARK: false,
+				HIDE_DEEP_LINKING_LOGO: true,
+				JITSI_WATERMARK_LINK: '',
+				DEFAULT_LOGO_URL: '',
+				DEFAULT_WELCOME_PAGE_LOGO_URL: '',
 				...interfaceConfigOverwrite
 			}
 		};


### PR DESCRIPTION
SHOW_JITSI_WATERMARK + SHOW_WATERMARK_FOR_GUESTS already there, watermark still visible :/ 
<img width="610" height="207" alt="image" src="https://github.com/user-attachments/assets/19265793-39e8-46c2-a34b-e6ce2c7c9bd5" />


server-side interface_config.js probably overrides client?

Two paths to try?
1. SSH into Jitsi host, edit /etc/jitsi/meet/<domain>-config.js or /usr/share/jitsi-meet/interface_config.js, set same flags false, reload nginx.
2. Check Jitsi server got interfaceConfigOverwrite whitelist enabled. Apparently new Jitsi versions ignore some client overrides unless server allow.