### PR TITLE
Update workspace header UI to match figma designs

### DIFF
--- a/ui/packages/comhairle/src/lib/components/CommonStepConfig/CommonStepConfig.svelte
+++ b/ui/packages/comhairle/src/lib/components/CommonStepConfig/CommonStepConfig.svelte
@@ -21,10 +21,23 @@
 		conversation_id: string;
 		conversation: ConversationWithTranslations;
 		step: WorkflowStepWithTranslations;
+		/**
+		 * When true, renders only the edit-metadata dialog (no
+		 * inline header / trigger). Useful when the consumer renders the step
+		 * name + description + edit button in the page header itself and just
+		 * wants to bind `open` to control the dialog.
+		 */
+		headerless?: boolean;
+		open?: boolean;
 	};
 
-	let open = $state(false);
-	let { step, conversation_id, conversation }: Props = $props();
+	let {
+		step,
+		conversation_id,
+		conversation,
+		headerless = false,
+		open = $bindable(false)
+	}: Props = $props();
 
 	let primaryLocale = $derived(conversation?.primaryLocale ?? 'en');
 	let supportedLanguages = $derived(conversation?.supportedLanguages ?? ['en']);
@@ -81,103 +94,101 @@
 	}
 </script>
 
-<div class="mb-10 flex flex-row items-start justify-between">
-	<div class="flex flex-col gap-2">
-		<div class="flex flex-row items-end gap-2">
-			<h2 class="text-2xl">{name || sourceName || 'Unnamed Step'}</h2>
-			{#if step?.required}
-				<p class="text-red-900">(Required)</p>
-			{:else}
-				<p class="text-green-900">(Skippable)</p>
-			{/if}
+{#if !headerless}
+	<div class="mb-10 flex flex-row items-start justify-between">
+		<div class="flex flex-col gap-2">
+			<div class="flex flex-row items-end gap-2">
+				<h2 class="text-2xl">{name || sourceName || 'Unnamed Step'}</h2>
+				{#if step?.required}
+					<p class="text-red-900">(Required)</p>
+				{:else}
+					<p class="text-green-900">(Skippable)</p>
+				{/if}
+			</div>
+			<ContentRenderer
+				content={description || sourceDescription}
+				class="text-muted-foreground text-sm"
+			/>
 		</div>
-		<ContentRenderer
-			content={description || sourceDescription}
-			class="text-muted-foreground text-sm"
-		/>
+		<Button variant="default" onclick={() => (open = true)}>Edit Metadata</Button>
 	</div>
-	<Dialog.Root
-		bind:open
-		onOpenChange={(isOpen) => {
-			if (!isOpen) invalidateAll();
-		}}
-	>
-		<Dialog.Trigger>
-			<Button variant="default">Edit Metadata</Button>
-		</Dialog.Trigger>
+{/if}
 
-		<Dialog.Content class="flex max-h-[90vh] min-w-[70vw] flex-col rounded-xl p-0">
-			<Dialog.Header class="shrink-0 border-b p-6 pb-4">
-				<Dialog.Title class="text-2xl">Edit Step Metadata</Dialog.Title>
-				<Dialog.Description>
-					Configure the name and description shown to participants.
-				</Dialog.Description>
-			</Dialog.Header>
+<Dialog.Root
+	bind:open
+	onOpenChange={(isOpen) => {
+		if (!isOpen) invalidateAll();
+	}}
+>
+	<Dialog.Content class="flex max-h-[90vh] min-w-[70vw] flex-col rounded-xl p-0">
+		<Dialog.Header class="shrink-0 border-b p-6 pb-4">
+			<Dialog.Title class="text-2xl">Edit Step Metadata</Dialog.Title>
+			<Dialog.Description>
+				Configure the name and description shown to participants.
+			</Dialog.Description>
+		</Dialog.Header>
 
-			<ScrollArea.Root class="min-h-0 flex-1">
-				<div class="px-6 pb-6">
-					<!-- Name field -->
+		<ScrollArea.Root class="min-h-0 flex-1">
+			<div class="px-6 pb-6">
+				<!-- Name field -->
+				<div class="flex flex-col gap-1">
+					<span class="text-lg font-semibold">Name</span>
+					<p class="text-muted-foreground mb-2 text-sm">
+						The name of the step that will be shown to participants.
+					</p>
+					<TranslatableField
+						value={name}
+						onValueChange={(v) => (name = v)}
+						translation={step.translations?.name}
+						{primaryLocale}
+						{supportedLanguages}
+					/>
+				</div>
+
+				<!-- Description field -->
+				<div class="pt-4">
 					<div class="flex flex-col gap-1">
-						<span class="text-lg font-semibold">Name</span>
-						<p class="text-muted-foreground mb-2 text-sm">
-							The name of the step that will be shown to participants.
+						<span class="text-lg font-semibold">Description</span>
+						<p class="text-muted-foreground text-sm">
+							A description of this step that will inform users of its intent.
 						</p>
+					</div>
+					<div class="pt-4">
 						<TranslatableField
-							value={name}
-							onValueChange={(v) => (name = v)}
-							translation={step.translations?.name}
+							value={description}
+							onValueChange={(v) => (description = v)}
+							translation={step.translations?.description}
 							{primaryLocale}
 							{supportedLanguages}
+							editorType="rich"
+							minHeight="100px"
+							maxHeight="150px"
 						/>
 					</div>
-
-					<!-- Description field -->
-					<div class="pt-4">
-						<div class="flex flex-col gap-1">
-							<span class="text-lg font-semibold">Description</span>
-							<p class="text-muted-foreground text-sm">
-								A description of this step that will inform users of its intent.
-							</p>
-						</div>
-						<div class="pt-4">
-							<TranslatableField
-								value={description}
-								onValueChange={(v) => (description = v)}
-								translation={step.translations?.description}
-								{primaryLocale}
-								{supportedLanguages}
-								editorType="rich"
-								minHeight="100px"
-								maxHeight="150px"
-							/>
-						</div>
-					</div>
-				</div>
-			</ScrollArea.Root>
-
-			<!-- Fixed footer with required toggle -->
-			<div class="bg-muted/30 flex shrink-0 flex-col gap-4 border-t p-6">
-				<div class="flex items-center gap-2">
-					<Switch
-						checked={revisitable}
-						onCheckedChange={(value) => handleSwitchChange(value, 'canRevisit')}
-					/>
-					<Label class="text-base">Revisitable step</Label>
-					<span class="text-muted-foreground ml-2 text-sm"
-						>(Can users revisit this step?)</span
-					>
-				</div>
-				<div class="flex items-center gap-2">
-					<Switch
-						checked={required}
-						onCheckedChange={(value) => handleSwitchChange(value, 'required')}
-					/>
-					<Label class="text-base">Required step</Label>
-					<span class="text-muted-foreground ml-2 text-sm"
-						>(Can users skip this step?)</span
-					>
 				</div>
 			</div>
-		</Dialog.Content>
-	</Dialog.Root>
-</div>
+		</ScrollArea.Root>
+
+		<!-- Fixed footer with required toggle -->
+		<div class="bg-muted/30 flex shrink-0 flex-col gap-4 border-t p-6">
+			<div class="flex items-center gap-2">
+				<Switch
+					checked={revisitable}
+					onCheckedChange={(value) => handleSwitchChange(value, 'canRevisit')}
+				/>
+				<Label class="text-base">Revisitable step</Label>
+				<span class="text-muted-foreground ml-2 text-sm"
+					>(Can users revisit this step?)</span
+				>
+			</div>
+			<div class="flex items-center gap-2">
+				<Switch
+					checked={required}
+					onCheckedChange={(value) => handleSwitchChange(value, 'required')}
+				/>
+				<Label class="text-base">Required step</Label>
+				<span class="text-muted-foreground ml-2 text-sm">(Can users skip this step?)</span>
+			</div>
+		</div>
+	</Dialog.Content>
+</Dialog.Root>

--- a/ui/packages/comhairle/src/lib/components/CommonStepConfig/CommonStepConfig.svelte
+++ b/ui/packages/comhairle/src/lib/components/CommonStepConfig/CommonStepConfig.svelte
@@ -21,12 +21,6 @@
 		conversation_id: string;
 		conversation: ConversationWithTranslations;
 		step: WorkflowStepWithTranslations;
-		/**
-		 * When true, renders only the edit-metadata dialog (no
-		 * inline header / trigger). Useful when the consumer renders the step
-		 * name + description + edit button in the page header itself and just
-		 * wants to bind `open` to control the dialog.
-		 */
 		headerless?: boolean;
 		open?: boolean;
 	};

--- a/ui/packages/comhairle/src/lib/components/EndConversationModal.svelte
+++ b/ui/packages/comhairle/src/lib/components/EndConversationModal.svelte
@@ -19,10 +19,11 @@
 
 	type Props = {
 		conversation: ConversationDto;
+		open?: boolean;
+		hideTrigger?: boolean;
 	};
 
-	let { conversation }: Props = $props();
-	let open = $state(false);
+	let { conversation, open = $bindable(false), hideTrigger = false }: Props = $props();
 	const loader = useLoading();
 
 	async function toggleComplete() {
@@ -59,12 +60,16 @@
 {#if conversation.isComplete}
 	<Button variant="outline" onclick={toggleComplete}>Re-open Conversation</Button>
 {:else}
-	<Dialog {open}>
-		<DialogTrigger>
-			<Button variant="outline" class="text-red-400"
-				><LucideCircleX /> End Conversation</Button
-			>
-		</DialogTrigger>
+	<Dialog bind:open>
+		{#if !hideTrigger}
+			<DialogTrigger>
+				<Button
+					variant="outline"
+					class="text-destructive border-destructive hover:bg-destructive/10 hover:text-destructive!"
+					><LucideCircleX /> End Conversation</Button
+				>
+			</DialogTrigger>
+		{/if}
 
 		<DialogContent>
 			<DialogHeader>

--- a/ui/packages/comhairle/src/lib/components/EndConversationModal.svelte
+++ b/ui/packages/comhairle/src/lib/components/EndConversationModal.svelte
@@ -58,7 +58,31 @@
 </script>
 
 {#if conversation.isComplete}
-	<Button variant="outline" onclick={toggleComplete}>Re-open Conversation</Button>
+	{#if !hideTrigger}
+		<Button variant="outline" onclick={toggleComplete}>Re-open Conversation</Button>
+	{/if}
+
+	<Dialog bind:open>
+		<DialogContent>
+			<DialogHeader>
+				<DialogTitle>Re-open this conversation?</DialogTitle>
+			</DialogHeader>
+
+			<Alert>
+				<AlertTitle>Re-open</AlertTitle>
+				<AlertDescription>
+					This will re-open the conversation so participants can take part again.
+				</AlertDescription>
+			</Alert>
+
+			<DialogFooter>
+				<LoadingButton variant="default" onclick={toggleComplete} loading={loader.loading}>
+					Re-open
+				</LoadingButton>
+				<Button onclick={cancel} variant="outline">cancel</Button>
+			</DialogFooter>
+		</DialogContent>
+	</Dialog>
 {:else}
 	<Dialog bind:open>
 		{#if !hideTrigger}

--- a/ui/packages/comhairle/src/lib/components/LaunchConversationModal.svelte
+++ b/ui/packages/comhairle/src/lib/components/LaunchConversationModal.svelte
@@ -42,7 +42,7 @@
 
 <Dialog {open}>
 	<DialogTrigger>
-		<Button variant="default">Launch Conversation</Button>
+		<Button variant="default" class="h-[40px]">Launch Conversation</Button>
 	</DialogTrigger>
 
 	<DialogContent>

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/+layout.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/+layout.svelte
@@ -123,14 +123,19 @@
 									Live Conversation Link
 								</a>
 							</DropdownMenu.Item>
+							<DropdownMenu.Separator />
 							{#if !conversation.isComplete}
-								<DropdownMenu.Separator />
 								<DropdownMenu.Item
 									class="text-destructive focus:text-destructive focus:bg-destructive/10 hover:text-destructive! hover:bg-destructive/20!"
 									onclick={() => (endModalOpen = true)}
 								>
 									<CircleX class="text-destructive size-4" />
 									End Conversation
+								</DropdownMenu.Item>
+							{:else}
+								<DropdownMenu.Item onclick={() => (endModalOpen = true)}>
+									<Check class="size-4" />
+									Re-open Conversation
 								</DropdownMenu.Item>
 							{/if}
 						</DropdownMenu.Content>

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/+layout.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/+layout.svelte
@@ -1,11 +1,19 @@
 <script lang="ts">
 	import * as Breadcrumb from '$lib/components/ui/breadcrumb';
 	import { Button } from '$lib/components/ui/button';
-	import { MessageSquareText, ArrowUpRight, Check } from 'lucide-svelte';
+	import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
+	import {
+		MessageSquareText,
+		ArrowUpRight,
+		MoreHorizontal,
+		Eye,
+		ExternalLink,
+		Check,
+		CircleX
+	} from 'lucide-svelte';
 	import { setContext, type Snippet } from 'svelte';
 	import type { AdminPageSlots } from './slotTypes';
 	import LaunchConversationModal from '$lib/components/LaunchConversationModal.svelte';
-	import { Badge } from '$lib/components/ui/badge';
 	import EndConversationModal from '$lib/components/EndConversationModal.svelte';
 
 	let breadcrumbContent = $state<Snippet | null>(null);
@@ -21,81 +29,153 @@
 	let { data, children } = $props();
 
 	let conversation = $derived(data.conversation);
+	let endModalOpen = $state(false);
 </script>
 
-<div class="flex w-full flex-col justify-between gap-11 border-b-black px-16 py-8">
-	<Breadcrumb.Root>
-		<Breadcrumb.List>
-			<Breadcrumb.Item>
-				<Breadcrumb.Link href="/admin">Workspace</Breadcrumb.Link>
-			</Breadcrumb.Item>
-			<Breadcrumb.Separator />
-			<Breadcrumb.Item>Conversations</Breadcrumb.Item>
-			<Breadcrumb.Separator />
-			<Breadcrumb.Item>
-				<Breadcrumb.Link href={`/admin/conversations/${conversation.id}/configure`}
-					>{conversation.title}</Breadcrumb.Link
+<!-- Top bar: breadcrumb + conversation name + launch controls -->
+<div
+	class="border-base-border bg-background flex w-full flex-col items-center border-b px-4 pt-10 pb-6 sm:px-8 lg:px-16"
+>
+	<!--
+		- xl+: breadcrumb, conversation name, and actions all share one row.
+		- below xl: breadcrumb on its own row
+	-->
+	<div class="flex w-full max-w-[1200px] flex-wrap items-center gap-x-4 gap-y-3">
+		<Breadcrumb.Root class="min-w-0 xl:max-w-[50%]">
+			<Breadcrumb.List class="flex-nowrap">
+				<Breadcrumb.Item class="shrink-0">
+					<Breadcrumb.Link href="/admin">Workspace</Breadcrumb.Link>
+				</Breadcrumb.Item>
+				<Breadcrumb.Separator class="shrink-0" />
+				<Breadcrumb.Item class="shrink-0">Conversations</Breadcrumb.Item>
+				<Breadcrumb.Separator class="shrink-0" />
+				<Breadcrumb.Item class="min-w-0">
+					<Breadcrumb.Link
+						href={`/admin/conversations/${conversation.id}/configure`}
+						class="block max-w-[12ch] truncate sm:max-w-[20ch]"
+						title={conversation.title}
+					>
+						{conversation.title}
+					</Breadcrumb.Link>
+				</Breadcrumb.Item>
+				{#if breadcrumbContent}
+					<Breadcrumb.Separator class="shrink-0" />
+					{@render breadcrumbContent()}
+				{/if}
+			</Breadcrumb.List>
+		</Breadcrumb.Root>
+		<div class="flex w-full min-w-0 items-center gap-3 xl:ml-auto xl:w-auto">
+			<!-- Identity -->
+			<div class="flex min-w-0 shrink items-center gap-2">
+				<MessageSquareText class="text-primary size-5 shrink-0" />
+				<span
+					class="text-primary truncate text-base font-semibold sm:text-lg"
+					title={conversation.title}
 				>
-			</Breadcrumb.Item>
-			{#if breadcrumbContent}
-				<Breadcrumb.Separator />
-				{@render breadcrumbContent()}
-			{/if}
-		</Breadcrumb.List>
-	</Breadcrumb.Root>
-	<div class="flex w-full flex-row items-start justify-between">
-		<div class="flex flex-row gap-4">
-			<div class="flex flex-col gap-4">
-				<h2 class="text-primary flex flex-row items-center gap-2 text-2xl font-bold">
-					<MessageSquareText />
 					{conversation.title}
-				</h2>
-				{#if conversation.isComplete}
-					<p class="text-sm text-red-400">This conversation has closed</p>
+				</span>
+			</div>
+
+			<!-- Actions -->
+			<div class="ml-auto flex shrink-0 items-center gap-2">
+				{#if conversation.isLive}
+					<!--
+						Live state: compact "Launched" pill + 3-dot menu containing
+						Preview, Live Link, and End Conversation (obscured/destructive).
+					-->
+					{#if !conversation.isComplete}
+						<span
+							class="bg-primary text-primary-foreground inline-flex h-10 items-center gap-2 rounded-full py-1 pr-1 pl-5 text-sm font-medium"
+						>
+							Launched
+							<span
+								class="bg-primary-foreground text-primary inline-flex size-8 items-center justify-center rounded-full"
+							>
+								<Check class="size-4" strokeWidth={3} />
+							</span>
+						</span>
+					{/if}
+
+					<DropdownMenu.Root>
+						<DropdownMenu.Trigger
+							class="bg-primary/20 hover:bg-primary/30 inline-flex size-10 items-center justify-center rounded-full"
+							aria-label="More actions"
+						>
+							<MoreHorizontal class="size-4" />
+						</DropdownMenu.Trigger>
+						<DropdownMenu.Content align="end" class="w-56">
+							<DropdownMenu.Item>
+								<a
+									href={`/conversations/${conversation.id}/preview`}
+									target="_blank"
+									class="flex w-full items-center gap-2"
+								>
+									<Eye class="size-4" />
+									Preview
+								</a>
+							</DropdownMenu.Item>
+							<DropdownMenu.Item>
+								<a
+									href={`/conversations/${conversation.id}`}
+									class="flex w-full items-center gap-2"
+								>
+									<ExternalLink class="size-4" />
+									Live Conversation Link
+								</a>
+							</DropdownMenu.Item>
+							<DropdownMenu.Separator />
+							<DropdownMenu.Item
+								class="text-destructive focus:text-destructive focus:bg-destructive/10 hover:text-destructive! hover:bg-destructive/20!"
+								onclick={() => (endModalOpen = true)}
+							>
+								<CircleX class="text-destructive size-4" />
+								End Conversation
+							</DropdownMenu.Item>
+						</DropdownMenu.Content>
+					</DropdownMenu.Root>
+
+					<EndConversationModal {conversation} bind:open={endModalOpen} hideTrigger />
+				{:else}
+					<!--
+						Pre-launch state
+					-->
+					<Button
+						href={`/conversations/${conversation.id}/preview`}
+						target="_blank"
+						variant="secondary"
+						class="bg-primary/20 text-foreground hover:bg-primary/30 inline-flex h-10 rounded-full px-4 text-sm"
+					>
+						Preview
+						<ArrowUpRight class="size-4" />
+					</Button>
+
+					<LaunchConversationModal conversation_id={conversation.id} />
 				{/if}
 			</div>
-			<Button
-				href={`/conversations/${conversation.id}/preview`}
-				target="_blank"
-				class="bg-blue-200 px-8 py-3 text-sm text-black"
-			>
-				Preview
-				<ArrowUpRight />
-			</Button>
-			{#if conversation.isLive}
-				<Button
-					href={`/conversations/${conversation.id}`}
-					class="bg-blue-200 px-8 py-3 text-sm text-black"
-				>
-					Live Conversation Link
-					<ArrowUpRight />
-				</Button>
-			{/if}
 		</div>
-
-		<div class="flex flex-col gap-4 md:flex-row">
-			{#if conversation.isLive}
-				{#if !conversation.isComplete}
-					<Badge
-						variant="default"
-						class="flex flex-row items-center justify-between gap-2 px-8 py-2 text-sm"
-						>Launched! <Check
-							class="text-primary size-4 rounded-full bg-white"
-						/></Badge
-					>
-				{/if}
-				<EndConversationModal {conversation} />
-			{:else}
-				<LaunchConversationModal conversation_id={conversation.id} />
-			{/if}
-		</div>
-	</div>
-	<div class="flex w-full flex-row items-center justify-between">
-		{#if titleContent}
-			{@render titleContent()}
-		{/if}
 	</div>
 </div>
-<div class="bg-muted flex-grow px-16 py-18">
-	{@render children()}
+
+<!-- Secondary bar: page title + prev/next navigation -->
+{#if titleContent}
+	<div
+		class="border-base-border bg-background flex w-full flex-col items-center border-b px-4 py-6 sm:px-8 lg:px-16"
+	>
+		<div
+			class="flex w-full max-w-[1200px] flex-col items-start justify-between gap-4 lg:flex-row lg:items-center"
+		>
+			{@render titleContent()}
+		</div>
+		{#if conversation.isComplete}
+			<div class="mt-2 w-full max-w-[1200px]">
+				<p class="text-sm text-red-500">This conversation has closed</p>
+			</div>
+		{/if}
+	</div>
+{/if}
+
+<div class="bg-muted grow px-4 py-8 sm:px-8 sm:pt-10 sm:pb-12 lg:px-16 lg:pb-18">
+	<div class="mx-auto w-full max-w-[1200px]">
+		{@render children()}
+	</div>
 </div>

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/+layout.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/+layout.svelte
@@ -123,14 +123,16 @@
 									Live Conversation Link
 								</a>
 							</DropdownMenu.Item>
-							<DropdownMenu.Separator />
-							<DropdownMenu.Item
-								class="text-destructive focus:text-destructive focus:bg-destructive/10 hover:text-destructive! hover:bg-destructive/20!"
-								onclick={() => (endModalOpen = true)}
-							>
-								<CircleX class="text-destructive size-4" />
-								End Conversation
-							</DropdownMenu.Item>
+							{#if !conversation.isComplete}
+								<DropdownMenu.Separator />
+								<DropdownMenu.Item
+									class="text-destructive focus:text-destructive focus:bg-destructive/10 hover:text-destructive! hover:bg-destructive/20!"
+									onclick={() => (endModalOpen = true)}
+								>
+									<CircleX class="text-destructive size-4" />
+									End Conversation
+								</DropdownMenu.Item>
+							{/if}
 						</DropdownMenu.Content>
 					</DropdownMenu.Root>
 

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/design/step/[step_id]/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/design/step/[step_id]/+page.svelte
@@ -8,7 +8,13 @@
 	import { useAdminLayoutSlots } from '../../../useAdminLayoutSlots.svelte.js';
 	import AdminPrevNextControls from '$lib/components/AdminPrevNextControls.svelte';
 	import * as Breadcrumb from '$lib/components/ui/breadcrumb';
+	import { Button } from '$lib/components/ui/button';
+	import { Pencil } from 'lucide-svelte';
+	import ContentRenderer from '$lib/components/RichTextEditor/ContentRenderer/ContentRenderer.svelte';
+	import { getTextInLocale } from '$lib/components/Translation/translationUtils';
 	let { data } = $props();
+
+	let editMetadataOpen = $state(false);
 
 	let conversation = $derived(data.conversation);
 	let step_id = $derived(data.step_id);
@@ -38,7 +44,34 @@
 </svelte:head>
 
 {#snippet titleSnippet()}
-	<h1 class="text-4xl font-bold">Design: {step?.name}</h1>
+	<div class="flex min-w-0 flex-1 flex-col gap-2">
+		<div class="flex flex-wrap items-center gap-3">
+			<h1 class="text-3xl font-semibold sm:text-4xl">
+				{getTextInLocale(
+					step?.translations?.name,
+					conversation.primaryLocale ?? 'en',
+					step?.name ?? ''
+				) || 'Unnamed step'}
+			</h1>
+			<Button
+				onclick={() => (editMetadataOpen = true)}
+				class="bg-sidebar text-sidebar-foreground hover:bg-sidebar/90 h-8 rounded-full px-3 text-xs"
+			>
+				<Pencil class="size-3.5" />
+				Edit
+			</Button>
+		</div>
+		{#if step?.description || step?.translations?.description}
+			<ContentRenderer
+				content={getTextInLocale(
+					step?.translations?.description,
+					conversation.primaryLocale ?? 'en',
+					step?.description ?? ''
+				)}
+				class="text-muted-foreground text-base"
+			/>
+		{/if}
+	</div>
 	<AdminPrevNextControls
 		next={nextStep
 			? {
@@ -69,7 +102,13 @@
 {/snippet}
 
 {#if step}
-	<CommonStepConfig conversation_id={conversation.id} {conversation} {step} />
+	<CommonStepConfig
+		conversation_id={conversation.id}
+		{conversation}
+		{step}
+		headerless
+		bind:open={editMetadataOpen}
+	/>
 {/if}
 
 {#if step && toolConfig?.type === 'learn'}


### PR DESCRIPTION
Actions:
- Use less space at the top
- Obscure some buttons to respect visual hierarchy and still have some space
- Truncate breadcrumb
- Move `Edit Metadata` button next to the step title and description for a more intuitive UX

States: 
# Launched
<img width="1314" height="382" alt="image" src="https://github.com/user-attachments/assets/fe0d5052-c7a5-476f-93f1-6017e0f0ffb4" />
<img width="1313" height="468" alt="image" src="https://github.com/user-attachments/assets/5db4060a-2379-4fb1-8414-7a8be63ffb33" />
<img width="500" height="667" alt="image" src="https://github.com/user-attachments/assets/167f521e-3155-45f4-805b-5ef2b10edc18" />
<img width="1257" height="380" alt="image" src="https://github.com/user-attachments/assets/535daa7f-8854-4207-b3ec-36669595c4dc" />
<img width="500" height="462" alt="image" src="https://github.com/user-attachments/assets/cbd09d98-eb3f-4d61-833b-a5bcf09bb66f" />



# Not yet launched 
<img width="1432" height="487" alt="image" src="https://github.com/user-attachments/assets/ea2d3918-07b6-447d-a6e4-a70fe0cef5ad" />
<img width="1422" height="306" alt="image" src="https://github.com/user-attachments/assets/76931ac4-2480-4828-8fe6-d302d2d499e1" />
<img width="523" height="418" alt="image" src="https://github.com/user-attachments/assets/b3256686-6481-47d1-9e4d-bd364ef328f8" />
