### PR TITLE
Pimp the lobby screens

### DIFF
--- a/ui/packages/comhairle/src/lib/components/LiveEvent/AnimatedLoader.svelte
+++ b/ui/packages/comhairle/src/lib/components/LiveEvent/AnimatedLoader.svelte
@@ -1,0 +1,122 @@
+<script lang="ts">
+	interface Props {
+		size?: number;
+	}
+	let { size = 48 }: Props = $props();
+	let cell = $derived(size / 3);
+	let pad = $derived(size / 6);
+	let x1 = $derived(pad);
+	let y1 = $derived(pad);
+	let x2 = $derived(pad + cell);
+	let y2 = $derived(pad + cell);
+	let path = $derived(`M${x1},${y1} L${x2},${y1} L${x2},${y2} L${x1},${y2} Z`);
+</script>
+
+<div
+	class="loader-animation relative"
+	style="width: {size}px; height: {size}px;"
+	aria-hidden="true"
+>
+	<span
+		class="trail tl bg-primary/40"
+		style="width:{cell}px;height:{cell}px;left:{x1}px;top:{y1}px;"
+	></span>
+	<span
+		class="trail tr bg-primary/40"
+		style="width:{cell}px;height:{cell}px;left:{x2}px;top:{y1}px;"
+	></span>
+	<span
+		class="trail br bg-primary/40"
+		style="width:{cell}px;height:{cell}px;left:{x2}px;top:{y2}px;"
+	></span>
+	<span
+		class="trail bl bg-primary/40"
+		style="width:{cell}px;height:{cell}px;left:{x1}px;top:{y2}px;"
+	></span>
+
+	<span
+		class="head bg-primary"
+		style="width:{cell}px;height:{cell}px;offset-path: path('{path}');"
+	></span>
+</div>
+
+<style>
+	/*
+	 * Two-lap cycle: head walks the square twice per full cycle.
+	 * Lap 1 (0%–50%): head paints a light trail at each corner it leaves.
+	 * Lap 2 (50%–100%): head eats the trail at each corner it passes.
+	 * Each trail uses the same keyframes with a delay matching when the
+	 * head first reaches that corner.
+	 */
+	.trail {
+		position: absolute;
+		opacity: 0;
+		animation: paint-eat 5.6s linear infinite;
+	}
+
+	.tl {
+		animation-delay: 0s;
+	}
+	.tr {
+		animation-delay: 0.7s;
+	}
+	.br {
+		animation-delay: 1.4s;
+	}
+	.bl {
+		animation-delay: 2.1s;
+	}
+
+	@keyframes paint-eat {
+		0% {
+			opacity: 0;
+		}
+		3% {
+			opacity: 1;
+		}
+		6% {
+			opacity: 1;
+		}
+		50% {
+			opacity: 1;
+		}
+		53% {
+			opacity: 0.2;
+		}
+		56% {
+			opacity: 0;
+		}
+		100% {
+			opacity: 0;
+		}
+	}
+
+	.head {
+		position: absolute;
+		top: 0;
+		left: 0;
+		offset-anchor: 0 0;
+		offset-rotate: 0deg;
+		animation: travel 2.8s linear infinite;
+	}
+	@keyframes travel {
+		from {
+			offset-distance: 0%;
+		}
+		to {
+			offset-distance: 100%;
+		}
+	}
+	@media (prefers-reduced-motion: reduce) {
+		.trail,
+		.head {
+			animation: none;
+		}
+		.head {
+			offset-distance: 0%;
+		}
+		.trail {
+			opacity: 1;
+		}
+	}
+</style>

--- a/ui/packages/comhairle/src/lib/components/LiveEvent/MeetingLobby.svelte
+++ b/ui/packages/comhairle/src/lib/components/LiveEvent/MeetingLobby.svelte
@@ -49,7 +49,7 @@
 
 	let phase = $derived.by(() => {
 		if (callStatus === 'Ended') return 'ended' as const;
-		if (endMs && now > endMs && callStatus !== 'InProgress') return 'ended' as const;
+		if (!isModerator && endMs && now > endMs && callStatus !== 'InProgress') return 'ended' as const;
 		return 'waiting' as const;
 	});
 

--- a/ui/packages/comhairle/src/lib/components/LiveEvent/MeetingLobby.svelte
+++ b/ui/packages/comhairle/src/lib/components/LiveEvent/MeetingLobby.svelte
@@ -49,7 +49,8 @@
 
 	let phase = $derived.by(() => {
 		if (callStatus === 'Ended') return 'ended' as const;
-		if (!isModerator && endMs && now > endMs && callStatus !== 'InProgress') return 'ended' as const;
+		if (!isModerator && endMs && now > endMs && callStatus !== 'InProgress')
+			return 'ended' as const;
 		return 'waiting' as const;
 	});
 
@@ -142,7 +143,11 @@
 
 				{#if phase === 'waiting' && !isModerator && hostPresent}
 					<p class="text-foreground text-center text-base leading-6 font-medium">
-						The admin is about to start the meeting.
+						The host is about to start the meeting.
+					</p>
+				{:else if phase === 'waiting' && !isModerator && !hostPresent}
+					<p class="text-foreground text-center text-base leading-6 font-medium">
+						Waiting for the host to join...
 					</p>
 				{:else if phase === 'waiting' && participants.length > 0}
 					<p class="text-foreground text-center text-base leading-6 font-medium">

--- a/ui/packages/comhairle/src/lib/components/LiveEvent/MeetingLobby.svelte
+++ b/ui/packages/comhairle/src/lib/components/LiveEvent/MeetingLobby.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import Button from '$lib/components/ui/button/button.svelte';
+	import AnimatedLoader from './AnimatedLoader.svelte';
 	import type {
 		VideoCallParticipant,
 		VideoCallStatus
@@ -9,32 +10,50 @@
 		title: string;
 		scheduledTime: string;
 		endedTime?: string;
+		startTimeIso?: string;
+		endTimeIso?: string;
 		participants: VideoCallParticipant[];
 		callStatus: VideoCallStatus | null;
 		isModerator: boolean;
+		hostPresent?: boolean;
 		onStartMeeting: () => void;
+		onResetCall?: () => void;
 	}
 
 	let {
 		title,
 		scheduledTime,
 		endedTime,
+		startTimeIso,
+		endTimeIso,
 		participants,
 		callStatus,
 		isModerator,
-		onStartMeeting
+		hostPresent = false,
+		onStartMeeting,
+		onResetCall
 	}: Props = $props();
 
 	let displayParticipants = $derived(participants.slice(0, 3));
 	let extraCount = $derived(Math.max(0, participants.length - 3));
 
-	let isStarted = $derived(callStatus === 'InProgress');
-	let isEnded = $derived(callStatus === 'Ended');
-	let isWaiting = $derived(!isStarted && !isEnded);
-
 	let firstParticipantName = $derived(
 		participants[0]?.username ?? participants[0]?.user_id?.slice(0, 8) ?? 'Someone'
 	);
+
+	let now = $state(Date.now());
+	$effect(() => {
+		const id = setInterval(() => (now = Date.now()), 60_000);
+		return () => clearInterval(id);
+	});
+
+	let endMs = $derived(endTimeIso ? new Date(endTimeIso).getTime() : 0);
+
+	let phase = $derived.by(() => {
+		if (callStatus === 'Ended') return 'ended' as const;
+		if (endMs && now > endMs && callStatus !== 'InProgress') return 'ended' as const;
+		return 'waiting' as const;
+	});
 
 	function getInitials(p: VideoCallParticipant): string {
 		if (p.username) return p.username.charAt(0).toUpperCase();
@@ -55,120 +74,104 @@
 	}
 </script>
 
-<div class="bg-background flex min-h-dvh w-full items-center justify-center">
-	<div class="flex max-w-2xl flex-col items-center gap-24">
-		{#if isEnded}
-			<!-- Ended state -->
-			<h2 class="text-foreground text-center text-5xl leading-[52px] font-bold">
-				The meeting has ended.
-			</h2>
-			<div class="flex flex-col items-center gap-4">
-				<h1 class="text-foreground text-center text-5xl leading-[52px] font-bold">
-					{title}
-				</h1>
-				<p class="text-foreground text-center text-2xl leading-7 font-semibold">
-					{scheduledTime}
-					{#if endedTime}<br />Ended at {endedTime}{/if}
-				</p>
+{#snippet avatarStack()}
+	{#if participants.length > 0}
+		<div class="inline-flex items-center gap-2">
+			<div class="flex items-center">
+				{#each displayParticipants as p, i (p.user_id)}
+					<div
+						class="{getAvatarColor(
+							i
+						)} ring-background flex h-12 w-12 items-center justify-center rounded-full text-lg font-semibold text-white ring-2 {i >
+						0
+							? '-ml-3'
+							: ''}"
+					>
+						{getInitials(p)}
+					</div>
+				{/each}
 			</div>
-		{:else if isModerator && isWaiting}
-			<!-- Host waiting state -->
-			<div class="flex flex-col items-center gap-14">
-				<div class="flex flex-col items-center gap-4">
-					<h1 class="text-foreground text-center text-5xl leading-[52px] font-bold">
-						{title}
-					</h1>
-					<p class="text-foreground text-center text-2xl leading-7 font-semibold">
-						{scheduledTime}
-					</p>
-				</div>
+			{#if extraCount > 0}
+				<span class="text-foreground text-base font-semibold">+{extraCount} more</span>
+			{/if}
+		</div>
+	{/if}
+{/snippet}
+
+{#snippet titleBlock()}
+	<div class="flex flex-col items-center gap-3">
+		<h1 class="text-foreground text-center text-2xl leading-7 font-semibold">{title}</h1>
+		<p class="text-muted-foreground text-center text-xl leading-6 font-semibold">
+			{scheduledTime}{#if phase === 'ended' && endedTime}<br />Ended at {endedTime}{/if}
+		</p>
+	</div>
+{/snippet}
+
+<div class="bg-background flex min-h-dvh w-full items-center justify-center px-6">
+	<div class="flex w-full max-w-[700px] flex-col items-center gap-8">
+		<!-- Logo + heading -->
+		<div class="flex flex-col items-center gap-3">
+			{#if phase !== 'ended'}
+				<AnimatedLoader />
+			{/if}
+
+			{#if phase === 'ended'}
+				<h2 class="text-foreground text-center text-3xl leading-9 font-semibold">
+					The meeting has ended.
+				</h2>
+			{:else if !isModerator}
+				<h2 class="text-foreground text-center text-3xl leading-9 font-semibold">
+					We are waiting for the meeting to start...
+				</h2>
+			{/if}
+		</div>
+
+		<!-- Card -->
+		<div
+			class="flex w-full min-w-[320px] flex-col items-center overflow-hidden rounded-3xl
+				{phase === 'ended'
+				? 'bg-muted border-border border shadow-sm'
+				: !isModerator && phase === 'waiting'
+					? 'bg-card border-primary/60 shadow-primary/20 border-[1.5px] shadow-[0_12px_12px_-5px_rgba(115,173,255,0.25)]'
+					: 'bg-card border-border border shadow-sm'}"
+		>
+			<div class="flex w-full flex-col items-center gap-6 px-6 py-8">
+				{@render titleBlock()}
 
 				{#if participants.length > 0}
-					<div class="flex flex-col items-start gap-3.5">
-						<div class="flex items-center gap-2">
-							<div class="flex items-center">
-								{#each displayParticipants as p, i}
-									<div
-										class="{getAvatarColor(
-											i
-										)} -ring-offset-2 ring-background flex h-12 w-12 items-center justify-center rounded-full text-lg font-semibold text-white ring-2 {i >
-										0
-											? '-ml-3'
-											: ''}"
-									>
-										{getInitials(p)}
-									</div>
-								{/each}
-							</div>
-							{#if extraCount > 0}
-								<span class="text-foreground text-xl font-semibold"
-									>+{extraCount} more</span
-								>
-							{/if}
-						</div>
-						<p class="text-foreground w-80 text-xl font-normal">
-							{firstParticipantName}{participants.length > 1
-								? ' and others are'
-								: ' is'} waiting to join.
-						</p>
-					</div>
+					{@render avatarStack()}
 				{/if}
 
-				<Button
-					variant="primaryDark"
-					class="h-12 px-8 text-xl font-semibold"
-					onclick={onStartMeeting}
-				>
-					Start meeting
-				</Button>
-			</div>
-		{:else if !isModerator && isWaiting}
-			<!-- Participant waiting state -->
-			<h2 class="text-foreground text-center text-5xl leading-[52px] font-bold">
-				We are waiting for the meeting to start...
-			</h2>
-
-			<div class="flex flex-col items-center gap-14">
-				<div class="flex flex-col items-center gap-4">
-					<h1 class="text-foreground text-center text-5xl leading-[52px] font-bold">
-						{title}
-					</h1>
-					<p class="text-foreground text-center text-2xl leading-7 font-semibold">
-						{scheduledTime}
+				{#if phase === 'waiting' && !isModerator && hostPresent}
+					<p class="text-foreground text-center text-base leading-6 font-medium">
+						The admin is about to start the meeting.
 					</p>
-				</div>
-
-				{#if participants.length > 0}
-					<div class="flex flex-col items-start gap-3.5">
-						<div class="flex items-center gap-2">
-							<div class="flex items-center">
-								{#each displayParticipants as p, i}
-									<div
-										class="{getAvatarColor(
-											i
-										)} -ring-offset-2 ring-background flex h-12 w-12 items-center justify-center rounded-full text-lg font-semibold text-white ring-2 {i >
-										0
-											? '-ml-3'
-											: ''}"
-									>
-										{getInitials(p)}
-									</div>
-								{/each}
-							</div>
-							{#if extraCount > 0}
-								<span class="text-foreground text-xl font-semibold"
-									>+{extraCount} more</span
-								>
-							{/if}
-						</div>
-						<p class="text-foreground w-80 text-xl font-normal">
-							{firstParticipantName}{participants.length > 1
-								? ' and others are'
-								: ' is'} waiting to join.
-						</p>
-					</div>
+				{:else if phase === 'waiting' && participants.length > 0}
+					<p class="text-foreground text-center text-base leading-6 font-medium">
+						{firstParticipantName}{participants.length > 1 ? ' and others are' : ' is'} waiting
+						to join.
+					</p>
 				{/if}
 			</div>
+		</div>
+
+		<!-- CTA -->
+		{#if phase === 'waiting' && isModerator}
+			<Button
+				variant="primaryDark"
+				class="h-12 rounded-full px-8 text-xl font-semibold"
+				onclick={onStartMeeting}
+			>
+				Start meeting
+			</Button>
+		{:else if phase === 'ended' && isModerator && onResetCall}
+			<Button
+				variant="outline"
+				class="h-10 rounded-full px-6 text-sm font-medium"
+				onclick={onResetCall}
+			>
+				Reset call
+			</Button>
 		{/if}
 	</div>
 </div>

--- a/ui/packages/comhairle/src/lib/components/LiveEvent/MeetingLobby.svelte
+++ b/ui/packages/comhairle/src/lib/components/LiveEvent/MeetingLobby.svelte
@@ -10,7 +10,6 @@
 		title: string;
 		scheduledTime: string;
 		endedTime?: string;
-		startTimeIso?: string;
 		endTimeIso?: string;
 		participants: VideoCallParticipant[];
 		callStatus: VideoCallStatus | null;
@@ -24,7 +23,6 @@
 		title,
 		scheduledTime,
 		endedTime,
-		startTimeIso,
 		endTimeIso,
 		participants,
 		callStatus,

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/events/[event_id]/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/events/[event_id]/+page.svelte
@@ -274,7 +274,7 @@
 
 {#snippet titleContentSnippet()}
 	<h1 class="text-4xl font-bold">Event: {event?.name}</h1>
-	<Button href={`/conversations/${conversation.id}/events/${event.id}/live`}>Event Link</Button>
+	<Button href={`/conversations/${conversation.id}/events/${event.id}`}>Event Link</Button>
 	<!-- TODO: figure out these -->
 	<!-- <AdminPrevNextControls -->
 	<!-- 	next={{ name: 'design', url: `/admin/conversations/${conversation.id}/design` }} -->

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/+page.svelte
@@ -48,11 +48,6 @@
 		userAttendance?.role === 'moderator' || userAttendance?.role === 'facilitator'
 	);
 
-	/** Grace window before the scheduled start during which an admin may open the meeting. */
-	const EARLY_START_WINDOW_MS = 60 * 60 * 1000;
-	/** Window before the scheduled start during which a participant may enter the lobby. */
-	const PARTICIPANT_JOIN_WINDOW_MS = 15 * 60 * 1000;
-
 	/** Reactive clock so the countdown updates without a refresh. Ticks once per minute. */
 	let now = $state(Date.now());
 	$effect(() => {
@@ -61,12 +56,6 @@
 	});
 
 	let msUntilStart = $derived(event ? new Date(event.startTime).getTime() - now : 0);
-	let canStartEarly = $derived(
-		status === 'upcoming' && msUntilStart > 0 && msUntilStart <= EARLY_START_WINDOW_MS
-	);
-	let canJoinLobbySoon = $derived(
-		status === 'upcoming' && msUntilStart > 0 && msUntilStart <= PARTICIPANT_JOIN_WINDOW_MS
-	);
 
 	let countdownText = $derived.by(() => {
 		if (msUntilStart <= 0) return '';
@@ -256,30 +245,20 @@
 				<Button variant="primaryDark" size="lg" class="h-12 px-8 text-base" href={liveHref}>
 					Join meeting
 				</Button>
-			{:else if isAdmin && canStartEarly}
-				<Button variant="primaryDark" size="lg" class="h-12 px-8 text-base" href={liveHref}>
-					Start meeting (in {countdownText})
-				</Button>
 			{:else if isAdmin && status === 'upcoming'}
-				<Button variant="primaryDark" size="lg" class="h-12 px-8 text-base" disabled>
-					Starts in {countdownText}
-				</Button>
-				<p class="text-muted-foreground text-xs">
-					You'll be able to start the meeting up to an hour before it begins.
-				</p>
-			{:else if userAttendance && canJoinLobbySoon}
 				<Button variant="primaryDark" size="lg" class="h-12 px-8 text-base" href={liveHref}>
-					Go to lobby (in {countdownText})
+					Start meeting{msUntilStart > 0 ? ` (in ${countdownText})` : ''}
 				</Button>
 				<p class="text-muted-foreground text-xs">
-					The lobby will open when the facilitator starts the meeting.
+					As a facilitator, you can start the meeting at any time.
 				</p>
 			{:else if userAttendance && status === 'upcoming'}
-				<Button variant="primaryDark" size="lg" class="h-12 px-8 text-base" disabled>
-					Starts in {countdownText}
+				<Button variant="primaryDark" size="lg" class="h-12 px-8 text-base" href={liveHref}>
+					Go to lobby{msUntilStart > 0 ? ` (starts in ${countdownText})` : ''}
 				</Button>
 				<p class="text-muted-foreground text-xs">
-					You'll be able to join the lobby 15 minutes before the meeting starts.
+					You can wait in the lobby. The meeting will begin when the facilitator starts
+					it.
 				</p>
 			{:else if !userAttendance && user && status !== 'past'}
 				<Button

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/+page.svelte
@@ -44,7 +44,7 @@
 	let userAttendance = $derived(user ? attendances.find((a) => a.userId === user.id) : undefined);
 	let liveHref = $derived(`/conversations/${conversationId}/events/${event?.id}/live`);
 
-	let isAdmin = $derived(
+	let canStartMeeting = $derived(
 		userAttendance?.role === 'moderator' || userAttendance?.role === 'facilitator'
 	);
 
@@ -245,7 +245,7 @@
 				<Button variant="primaryDark" size="lg" class="h-12 px-8 text-base" href={liveHref}>
 					Join meeting
 				</Button>
-			{:else if isAdmin && status === 'upcoming'}
+			{:else if canStartMeeting && status === 'upcoming'}
 				<Button variant="primaryDark" size="lg" class="h-12 px-8 text-base" href={liveHref}>
 					Start meeting{msUntilStart > 0 ? ` (in ${countdownText})` : ''}
 				</Button>

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
@@ -834,7 +834,6 @@
 		title={event?.name ?? 'Meeting'}
 		scheduledTime={scheduledTimeText}
 		endedTime={event ? `${formatDateShort(event.endTime)} ${formatTime(event.endTime)}` : ''}
-		startTimeIso={event?.startTime}
 		endTimeIso={event?.endTime}
 		participants={otherParticipants}
 		{callStatus}

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
@@ -155,14 +155,16 @@
 	let agendaItems = $derived(mapApiAgenda(event?.agenda ?? []));
 
 	let meetingPhase = $derived.by(() => {
-		const phase =
-			callStatus === null
-				? ('loading' as const)
-				: hasJoinedCall && callStatus === 'Ended'
-					? ('ended' as const)
-					: hasJoinedCall
-						? ('incall' as const)
-						: ('lobby' as const);
+		let phase: 'loading' | 'ended' | 'incall' | 'lobby';
+		if (callStatus === null) {
+			phase = 'loading';
+		} else if (hasJoinedCall && callStatus === 'Ended') {
+			phase = 'ended';
+		} else if (hasJoinedCall) {
+			phase = 'incall';
+		} else {
+			phase = 'lobby';
+		}
 		console.log(
 			'[BREAKOUT] meetingPhase:',
 			phase,

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
@@ -469,15 +469,36 @@
 		}, 4000);
 	}
 
+	/** clears all call and UI state */
+	function resetCall() {
+		videoCallService.changeCallState(eventId, 'Waiting');
+		videoCallService.setAgendaItem(eventId, 0);
+		videoCallService.endBreakoutSession(eventId);
+		hasJoinedCall = false;
+		roomContext = 'plenary';
+		showCreateBreakout = false;
+		breakoutDialogItem = null;
+		showBroadcast = false;
+		showEndMeeting = false;
+		activePanel = 'agenda';
+		noticeQueue = [];
+		showBreakoutEnding = false;
+		breakoutEndingDismissed = false;
+		breakoutAutoEnded = false;
+		trackedRoomIndex = null;
+		jitsiBreakoutRooms = {};
+		breakoutRoomsReady = false;
+		mockBreakoutRooms = [];
+		mobileRoomIndex = 0;
+		mobileAgendaViewIndex = 0;
+		mobileSheetCollapsed = false;
+		seenAssistanceRequests = new Set();
+	}
+
 	/** DEV ONLY: reset call state to Waiting */
 	function devResetCall() {
 		if (dev) {
-			videoCallService.changeCallState(eventId, 'Waiting');
-			videoCallService.setAgendaItem(eventId, 0);
-			videoCallService.endBreakoutSession(eventId);
-			hasJoinedCall = false;
-			roomContext = 'plenary';
-			showCreateBreakout = false;
+			resetCall();
 			console.log('DEV: Call state reset to Waiting');
 		}
 	}
@@ -821,13 +842,7 @@
 		title={event?.name ?? 'Meeting'}
 		conversationUrl={`/conversations/${conversationId}`}
 		{isModerator}
-		onResetCall={() => {
-			videoCallService.changeCallState(eventId, 'Waiting');
-			videoCallService.setAgendaItem(eventId, 0);
-			videoCallService.endBreakoutSession(eventId);
-			hasJoinedCall = false;
-			roomContext = 'plenary';
-		}}
+		onResetCall={resetCall}
 	/>
 {:else if meetingPhase === 'lobby'}
 	<MeetingLobby
@@ -840,13 +855,7 @@
 		{isModerator}
 		{hostPresent}
 		onStartMeeting={handleStartMeeting}
-		onResetCall={() => {
-			videoCallService.changeCallState(eventId, 'Waiting');
-			videoCallService.setAgendaItem(eventId, 0);
-			videoCallService.endBreakoutSession(eventId);
-			hasJoinedCall = false;
-			roomContext = 'plenary';
-		}}
+		onResetCall={resetCall}
 	/>
 {:else}
 	<!-- In-call: full-width black background, stays in document flow -->

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
@@ -158,7 +158,7 @@
 		const phase =
 			callStatus === null
 				? ('loading' as const)
-				: callStatus === 'Ended'
+				: hasJoinedCall && callStatus === 'Ended'
 					? ('ended' as const)
 					: hasJoinedCall
 						? ('incall' as const)
@@ -174,6 +174,13 @@
 		);
 		return phase;
 	});
+
+	/** True if any moderator/facilitator (other than current user) is in the lobby. */
+	let hostPresent = $derived(
+		allParticipants.some(
+			(p) => p.user_id !== user?.id && (p.role === 'moderator' || p.role === 'facilitator')
+		)
+	);
 
 	let isBreakoutActive = $derived(breakoutSession !== null);
 	let inBreakoutRoom = $derived(typeof roomContext !== 'string');
@@ -827,10 +834,20 @@
 		title={event?.name ?? 'Meeting'}
 		scheduledTime={scheduledTimeText}
 		endedTime={event ? `${formatDateShort(event.endTime)} ${formatTime(event.endTime)}` : ''}
+		startTimeIso={event?.startTime}
+		endTimeIso={event?.endTime}
 		participants={otherParticipants}
 		{callStatus}
 		{isModerator}
+		{hostPresent}
 		onStartMeeting={handleStartMeeting}
+		onResetCall={() => {
+			videoCallService.changeCallState(eventId, 'Waiting');
+			videoCallService.setAgendaItem(eventId, 0);
+			videoCallService.endBreakoutSession(eventId);
+			hasJoinedCall = false;
+			roomContext = 'plenary';
+		}}
 	/>
 {:else}
 	<!-- In-call: full-width black background, stays in document flow -->


### PR DESCRIPTION
- Create AnimatedLoader component with square path animation
- Redesign MeetingLobby to match updated designs
- Update lobby phase logic to check end time and show ended state appropriately
- Add hostPresent prop to show admin status message for participants
- Add onResetCall callback for moderators to reset ended calls
- (Shu raised a point that people might want to test/rehearse calls) Remove early start and join window restrictions from event detail

# Moderator 
<img width="915" height="619" alt="image" src="https://github.com/user-attachments/assets/73cd0652-b992-4b48-9ded-528e80e053e4" />
<img width="1008" height="640" alt="image" src="https://github.com/user-attachments/assets/f0fc36d7-0891-4bd5-8d4e-155aa2edb1ca" />


# Participant
<img width="898" height="608" alt="image" src="https://github.com/user-attachments/assets/c281cc65-5173-406a-8494-b8f20b505811" />
