### PR TITLE
Replace direct end breakout session with 1 minute countdown warning

### DIFF
--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
@@ -673,6 +673,11 @@
 	}
 
 	function handleEndBreakoutSessionCountdown() {
+		const currentEnd = videoCallService.getBreakoutSessionEndTime();
+		if (!currentEnd || !isBreakoutActive) {
+			showToast('No active breakout session to end');
+			return;
+		}
 		const newEnd = new Date(Date.now() + 60 * 1000).toISOString();
 		const message = 'Breakout rooms will finish in 1 min';
 		videoCallService.extendBreakoutSession(eventId, newEnd);

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
@@ -674,9 +674,10 @@
 
 	function handleEndBreakoutSessionCountdown() {
 		const newEnd = new Date(Date.now() + 60 * 1000).toISOString();
+		const message = 'Breakout rooms will finish in 1 min';
 		videoCallService.extendBreakoutSession(eventId, newEnd);
-		videoCallService.broadcastMessage(eventId, 'Breakout rooms will finish in 1 min');
-		showToast('Breakout rooms will finish in 1 min');
+		videoCallService.broadcastMessage(eventId, message);
+		showToast(message);
 	}
 
 	async function handleEndBreakoutSession() {

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
@@ -435,7 +435,7 @@
 	$effect(() => {
 		if (lastBroadcast) {
 			if (!isModerator) {
-				pushNotice({ message: lastBroadcast });
+				showToast(lastBroadcast);
 			}
 			videoCallService.clearLastMessage();
 		}
@@ -640,6 +640,13 @@
 			videoCallService.broadcastMessage(eventId, msg);
 			showToast(`${abs} minute(s) ${verb}`);
 		}
+	}
+
+	function handleEndBreakoutSessionCountdown() {
+		const newEnd = new Date(Date.now() + 60 * 1000).toISOString();
+		videoCallService.extendBreakoutSession(eventId, newEnd);
+		videoCallService.broadcastMessage(eventId, 'Breakout rooms will finish in 1 min');
+		showToast('Breakout rooms will finish in 1 min');
 	}
 
 	async function handleEndBreakoutSession() {
@@ -970,7 +977,7 @@
 							{isModerator}
 							onEnterRoom={handleEnterBreakoutRoom}
 							onUpdateTime={handleUpdateTime}
-							onEndSession={handleEndBreakoutSession}
+							onEndSession={handleEndBreakoutSessionCountdown}
 							onBroadcastMessage={() => (showBroadcast = true)}
 						/>
 					{:else}
@@ -1434,7 +1441,7 @@
 			<Button
 				variant="outline"
 				class="border-input text-destructive hover:bg-destructive/5 hover:text-destructive h-11 w-full text-sm font-medium"
-				onclick={handleEndBreakoutSession}
+				onclick={handleEndBreakoutSessionCountdown}
 			>
 				<CircleStop class="mr-1.5 h-4 w-4" />
 				End breakout session


### PR DESCRIPTION
I just realised there was a ticket that described this behaviour, so I tweaked it to do the following:

- Moderator clicks on "end breakout session" button
- Time left is overwritten (becomes 1 minute)
- All participants see a notification (the one that pops on top, not the one that has to be dismissed?) cuz the other one is maybe too intrusive? "Breakout rooms will finish in 1 min"
- The existing "end breakout sesh" behaviour is triggered with the 5 sec timer and "Go back" button 