### PR TITLE
230 preview for launched conversations

### DIFF
--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/+page.svelte
@@ -12,7 +12,7 @@
 	import PrivacyPolicyDialog from '$lib/components/PrivacyPolicyDialog.svelte';
 
 	let { data }: PageProps = $props();
-	let { conversation, workflows, participation } = data;
+	let { conversation, workflows, participation, preview } = data;
 	let user = $derived(data.user);
 	let pageTitle = $derived(conversation?.title ?? 'Conversation');
 
@@ -43,7 +43,7 @@
 	let url = $derived(page.url);
 
 	let firstWorkflowPath = $derived(
-		`/conversations/${conversation.slug}/workflow/${firstWorkflow.id}/next`
+		`/conversations/${conversation.slug}${preview ? '/preview' : ''}/workflow/${firstWorkflow.id}/next`
 	);
 
 	async function redirectToLogin() {

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/workflow/[workflow_id]/next/+page.ts
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/workflow/[workflow_id]/next/+page.ts
@@ -17,7 +17,7 @@ export const load: PageLoad = async ({ parent, params, url }) => {
 	try {
 		if (conversation.isComplete) {
 			redirect_url = `/conversations/${conversation.id}`;
-		} else if (conversation.isLive) {
+		} else if (!preview && conversation.isLive) {
 			const next_step = await api.NextConversationWorkflowStepForUser({
 				params: { conversation_id: conversation.id, workflow_id: workflow_id }
 			});

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/workflow/[workflow_id]/s/[workflow_step_id]/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/workflow/[workflow_id]/s/[workflow_step_id]/+page.svelte
@@ -19,7 +19,7 @@
 	const queryString = $derived(url.search);
 
 	let { data }: PageProps = $props();
-	let { user } = data;
+	let { user, preview: isPreview } = data;
 	let workflow_id = $derived(data.workflow_id);
 	let workflowStep = $derived(data.workflowStep);
 	let conversation = $derived(data.conversation);
@@ -62,7 +62,6 @@
 				status = 'upcoming';
 			}
 
-			const isPreview = !conversation.isLive;
 			const href =
 				status === 'completed'
 					? workflow_step_url(conversation.id, workflow_id, ws.id, isPreview) +

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/workflow/[workflow_id]/s/[workflow_step_id]/+page.ts
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/workflow/[workflow_id]/s/[workflow_step_id]/+page.ts
@@ -43,7 +43,7 @@ export const load: PageLoad = async (event) => {
 
 		// If we are in preview mode then let the user see this step regardless of if it
 		// is next. Also dont capture progress
-		if (conversation.isLive) {
+		if (!preview && conversation.isLive) {
 			if (isStepAlreadyDone && !isRevisitable) {
 				return redirect(
 					302,
@@ -72,7 +72,7 @@ export const load: PageLoad = async (event) => {
 
 		const workflowStep = thisStep!;
 
-		return { conversation, workflowStep, api, workflowSteps, workflow_id };
+		return { conversation, workflowStep, api, workflowSteps, workflow_id, preview };
 	} catch (e: any) {
 		// TODO: figure out how to type this from the generated api
 		/// Throw if error is a redirect


### PR DESCRIPTION
Actions:

+ expose preview url param in workflow routes
+ replace instances where preview is determined only by conversation.isLive status

Motivation:

+ preview mode not working for launched conversations