### PR TITLE
Add document attachments to learn tool

### DIFF
--- a/api/src/routes/documents.rs
+++ b/api/src/routes/documents.rs
@@ -22,19 +22,60 @@ use crate::{
     models::{
         conversation,
         job::{self, CreateJob},
+        user_participation,
     },
-    routes::auth::RequiredAdminUser,
+    routes::auth::{is_user_admin, OptionalUser, RequiredAdminUser},
     workers::process_documents::DocumentJob,
     ComhairleState,
 };
+
+/// Not sure if this is the desired behaviour. I made a few assumptions: 
+/// - The user owns the conversation
+/// - The user is a participant in any workflow of the conversation
+/// - No user is logged in but the conversation is public and live
+#[instrument(err(Debug), skip(state))]
+async fn require_conversation_document_access(
+    state: &Arc<ComhairleState>,
+    user: &OptionalUser,
+    conversation_id: &Uuid,
+) -> Result<(), ComhairleError> {
+    let conversation = conversation::get_by_id(&state.db, conversation_id).await?;
+
+    if conversation.is_public && conversation.is_live {
+        return Ok(());
+    }
+
+    let Some(ref user) = user.0 else {
+        return Err(ComhairleError::UserNotAuthorized);
+    };
+
+    if is_user_admin(user, &state.config) {
+        return Ok(());
+    }
+
+    if conversation.owner_id == user.id {
+        return Ok(());
+    }
+
+    let participant_ids =
+        user_participation::get_participant_user_ids_for_conversation(&state.db, conversation_id)
+            .await?;
+
+    if participant_ids.contains(&user.id) {
+        return Ok(());
+    }
+
+    Err(ComhairleError::UserNotAuthorized)
+}
 
 #[instrument(err(Debug), skip(state))]
 async fn list(
     State(state): State<Arc<ComhairleState>>,
     Path(conversation_id): Path<Uuid>,
     Query(params): Query<GetQueryParams>,
-    RequiredAdminUser(_user): RequiredAdminUser,
+    user: OptionalUser,
 ) -> Result<(StatusCode, Json<Vec<ComhairleDocument>>), ComhairleError> {
+    require_conversation_document_access(&state, &user, &conversation_id).await?;
     let bot_service = state.required_bot_service()?;
 
     let knowledge_base_id = get_knowledge_base_id(&state, &conversation_id).await?;
@@ -118,8 +159,9 @@ async fn stop_parsing_document(
 async fn download_document(
     State(state): State<Arc<ComhairleState>>,
     Path((conversation_id, document_id)): Path<(Uuid, String)>,
-    RequiredAdminUser(_user): RequiredAdminUser,
+    user: OptionalUser,
 ) -> Result<Response<Body>, ComhairleError> {
+    require_conversation_document_access(&state, &user, &conversation_id).await?;
     let bot_service = state.required_bot_service()?;
 
     let knowledge_base_id = get_knowledge_base_id(&state, &conversation_id).await?;

--- a/api/src/tools/learn.rs
+++ b/api/src/tools/learn.rs
@@ -46,6 +46,8 @@ pub enum LearnPageEntry {
 #[derive(Clone, Deserialize, Serialize, Debug, JsonSchema, PartialEq)]
 pub struct LearnToolConfig {
     pub pages: Vec<LearnPageEntry>,
+    #[serde(default)]
+    pub documents: Vec<String>,
 }
 
 impl ToolConfigSanitize for LearnToolConfig {
@@ -60,11 +62,14 @@ pub struct LearnReport;
 #[derive(Clone, Deserialize, Serialize, Debug, JsonSchema)]
 pub struct LearnToolSetup {
     pub pages: Vec<LearnPageEntry>,
+    #[serde(default)]
+    pub documents: Vec<String>,
 }
 
 async fn learn_setup(setup_config: &LearnToolSetup) -> Result<LearnToolConfig, ComhairleError> {
     Ok(LearnToolConfig {
         pages: setup_config.pages.clone(),
+        documents: setup_config.documents.clone(),
     })
 }
 

--- a/ui/packages/api-client/src/api.ts
+++ b/ui/packages/api-client/src/api.ts
@@ -611,7 +611,11 @@ export const ToolConfig = z.union([
     })
     .passthrough(),
   z
-    .object({ pages: z.array(LearnPageEntry), type: z.literal("learn") })
+    .object({
+      documents: z.array(z.string()).optional().default([]),
+      pages: z.array(LearnPageEntry),
+      type: z.literal("learn"),
+    })
     .passthrough(),
   z
     .object({
@@ -794,7 +798,11 @@ export const ToolSetup = z.union([
     })
     .passthrough(),
   z
-    .object({ pages: z.array(LearnPageEntry), type: z.literal("learn") })
+    .object({
+      documents: z.array(z.string()).optional().default([]),
+      pages: z.array(LearnPageEntry),
+      type: z.literal("learn"),
+    })
     .passthrough(),
   z
     .object({

--- a/ui/packages/comhairle/src/lib/tools/learn/LearnManage.svelte
+++ b/ui/packages/comhairle/src/lib/tools/learn/LearnManage.svelte
@@ -2,7 +2,8 @@
 	import type {
 		LocalizedPage,
 		WorkflowStepWithTranslations,
-		ConversationWithTranslations
+		ConversationWithTranslations,
+		ComhairleDocument
 	} from '@crownshy/api-client/api';
 
 	interface ExtendedLocalizedPage extends LocalizedPage {
@@ -19,7 +20,9 @@
 
 	import { apiClient } from '@crownshy/api-client/client';
 	import { invalidateAll } from '$app/navigation';
+	import { Checkbox } from '$lib/components/ui/checkbox';
 	import { notifications } from '$lib/notifications.svelte';
+	import { FileText } from 'lucide-svelte';
 	import * as Select from '$lib/components/ui/select';
 	import { Button } from '$lib/components/ui/button';
 	import TranslatableField from '$lib/components/Translation/TranslatableField.svelte';
@@ -36,20 +39,25 @@
 	let primaryLocale = $derived(conversation.primaryLocale ?? 'en');
 	let supportedLanguages = $derived(conversation.supportedLanguages ?? ['en']);
 
-	type LearnToolConfig = { type: 'learn'; pages: ExtendedLocalizedPage[][] };
+	type LearnToolConfig = { type: 'learn'; pages: ExtendedLocalizedPage[][]; documents: string[] };
 
 	let sourceConfig = $derived(
 		(isLive ? workflowStep.toolConfig : workflowStep.previewToolConfig) as LearnToolConfig
 	);
 
 	let pages = $state<ExtendedLocalizedPage[][]>([]);
+	let documentIds = $state<string[]>([]);
 	let hasLocalChanges = $state(false);
 
 	let lastPropsConfig = $state<string>('');
 	$effect(() => {
-		const propsConfig = JSON.stringify(sourceConfig?.pages);
+		const propsConfig = JSON.stringify({
+			pages: sourceConfig?.pages,
+			documents: sourceConfig?.documents
+		});
 		if (propsConfig !== lastPropsConfig && !hasLocalChanges) {
 			pages = structuredClone(sourceConfig?.pages ?? []);
+			documentIds = structuredClone(sourceConfig?.documents ?? []);
 			lastPropsConfig = propsConfig;
 			if (isInitialLoad && pages.length > 0) {
 				isInitialLoad = false;
@@ -58,7 +66,7 @@
 	});
 
 	function getToolConfigForSave(): LearnToolConfig {
-		return { type: 'learn', pages };
+		return { type: 'learn', pages, documents: documentIds };
 	}
 
 	function markLocalChanges() {
@@ -67,7 +75,10 @@
 
 	function clearLocalChanges() {
 		hasLocalChanges = false;
-		lastPropsConfig = JSON.stringify(sourceConfig?.pages);
+		lastPropsConfig = JSON.stringify({
+			pages: sourceConfig?.pages,
+			documents: sourceConfig?.documents
+		});
 	}
 
 	let currentPageIndex = $state(0);
@@ -226,6 +237,35 @@
 		pages = [...pages];
 		await saveToServer({ invalidate: false });
 	}
+
+	// --- Document picker ---
+	let availableDocuments = $state<ComhairleDocument[]>([]);
+	let docsLoading = $state(true);
+
+	$effect(() => {
+		if (!conversationId) return;
+		apiClient
+			.ListDocuments({ params: { conversation_id: conversationId } })
+			.then((docs) => {
+				availableDocuments = docs.filter((d) => d.parse_status === 'DONE');
+			})
+			.catch(() => {
+				availableDocuments = [];
+			})
+			.finally(() => {
+				docsLoading = false;
+			});
+	});
+
+	function toggleDocument(docId: string) {
+		markLocalChanges();
+		if (documentIds.includes(docId)) {
+			documentIds = documentIds.filter((id) => id !== docId);
+		} else {
+			documentIds = [...documentIds, docId];
+		}
+		saveToServer({ invalidate: false });
+	}
 </script>
 
 <!-- Controls -->
@@ -303,5 +343,32 @@
 			onApprove={handleApprove}
 			onMarkAsDraft={handleMarkAsDraft}
 		/>
+	{/if}
+
+	{#if !isInitialLoad}
+		<div class="rounded-xl border p-4">
+			<h3 class="mb-3 text-sm font-semibold">Source materials</h3>
+			{#if docsLoading}
+				<Skeleton class="mb-2 h-5 w-full" />
+				<Skeleton class="h-5 w-2/3" />
+			{:else if availableDocuments.length === 0}
+				<p class="text-muted-foreground text-sm">
+					No parsed documents in the knowledge base.
+				</p>
+			{:else}
+				<ul class="flex flex-col gap-2">
+					{#each availableDocuments as doc (doc.id)}
+						<li class="flex items-center gap-2">
+							<Checkbox
+								checked={documentIds.includes(doc.id)}
+								onCheckedChange={() => toggleDocument(doc.id)}
+							/>
+							<FileText class="text-muted-foreground h-4 w-4" />
+							<span class="text-sm">{doc.name}</span>
+						</li>
+					{/each}
+				</ul>
+			{/if}
+		</div>
 	{/if}
 </div>

--- a/ui/packages/comhairle/src/lib/tools/learn/LearnUI.svelte
+++ b/ui/packages/comhairle/src/lib/tools/learn/LearnUI.svelte
@@ -3,27 +3,52 @@
 	import ContentRenderer from '$lib/components/RichTextEditor/ContentRenderer/ContentRenderer.svelte';
 	import * as m from '$lib/paraglide/messages';
 	import { getLocale } from '$lib/paraglide/runtime.js';
-	import type { Page, LocalizedConversationDto } from '@crownshy/api-client/api';
+	import type {
+		Page,
+		LocalizedConversationDto,
+		ComhairleDocument
+	} from '@crownshy/api-client/api';
 	import { tick } from 'svelte';
 	import { navigating } from '$app/state';
 	import LearnTutor from './LearnTutor.svelte';
 	import LearnArticleSkeleton from './LearnArticleSkeleton.svelte';
+	import { FileText } from 'lucide-svelte';
+	import { apiClient } from '@crownshy/api-client/client';
 
 	let {
 		pages,
 		onDone,
 		onNextAction,
-		conversation
+		conversation,
+		documentIds = []
 	}: {
 		pages: Array<Page>;
 		onDone: () => void;
 		onNextAction?: (fn: () => void) => void;
 		conversation?: LocalizedConversationDto;
+		documentIds?: string[];
 	} = $props();
 
 	let tutorAvailable = $derived(
 		!!conversation?.id && !!conversation?.chatBotId && !!conversation?.enableQaChatBot
 	);
+
+	let attachedDocuments = $state<ComhairleDocument[]>([]);
+
+	$effect(() => {
+		if (!conversation?.id || documentIds.length === 0) {
+			attachedDocuments = [];
+			return;
+		}
+		apiClient
+			.ListDocuments({ params: { conversation_id: conversation.id } })
+			.then((docs) => {
+				attachedDocuments = docs.filter((d) => documentIds.includes(d.id));
+			})
+			.catch(() => {
+				attachedDocuments = [];
+			});
+	});
 
 	let currentPageNo = $state(0);
 	let currentPage = $derived(pages[currentPageNo]);
@@ -65,6 +90,28 @@
 		</article>
 	{:else}
 		<h1>Sorry this page is currently not avaliable in this language</h1>
+	{/if}
+
+	{#if attachedDocuments.length > 0}
+		<div class="mx-auto w-full max-w-[65ch]">
+			<div class="rounded-xl border p-4">
+				<h3 class="mb-2 text-sm font-semibold">Source materials</h3>
+				<ul class="flex flex-col gap-2">
+					{#each attachedDocuments as doc (doc.id)}
+						<li>
+							<a
+								href={`/api/conversation/${conversation?.id}/documents/${doc.id}/download`}
+								download
+								class="flex items-center gap-2 text-sm hover:underline"
+							>
+								<FileText class="text-muted-foreground h-4 w-4" />
+								<span>{doc.name}</span>
+							</a>
+						</li>
+					{/each}
+				</ul>
+			</div>
+		</div>
 	{/if}
 
 	{#if tutorAvailable && conversation}

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/workflow/[workflow_id]/s/[workflow_step_id]/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/workflow/[workflow_id]/s/[workflow_step_id]/+page.svelte
@@ -218,6 +218,7 @@
 							user_id={user.id}
 							onNextAction={handleNextAction}
 							{conversation}
+							documentIds={toolConfig.documents ?? []}
 						/>
 					{/if}
 					{#if toolConfig?.type === Polis.TOOL_NAME}


### PR DESCRIPTION
## Changes 
- download_document route with conversation-level access control. **Assumptions:**
  - User owns conversation → allow
  - User is participant in any workflow of conversation → allow  
  - Public + live conversation + no login → allow
  - Admin → allow
- Add documents[] to LearnToolConfig/LearnToolSetup
- Add document picker in LearnManage UI



**Also in this branch:**
- [LearnToolConfig](cci:2://file:///Users/dtoadie/Workspace/crown-shy/new-comhairle/comhairle/api/src/tools/learn.rs:46:0-50:1) + [LearnToolSetup](cci:2://file:///Users/dtoadie/Workspace/crown-shy/new-comhairle/comhairle/api/src/tools/learn.rs:62:0-66:1) gain `documents: Vec<String>` (`api/src/tools/learn.rs:50`)
- [LearnManage.svelte](cci:7://file:///Users/dtoadie/Workspace/crown-shy/new-comhairle/comhairle/ui/packages/comhairle/src/lib/tools/learn/LearnManage.svelte:0:0-0:0) gets document picker UI. Lists parsed docs from knowledge base. Checkbox to attach/detach. Saves to `preview_tool_config` / `tool_config`.
- API client schema updated for `documents` field in Learn tool config.



<img width="1345" height="873" alt="2026-05-13_15-52-51" src="https://github.com/user-attachments/assets/ed9ef2e6-af8b-461b-9479-4e2d9343b74e" />
<img width="1256" height="735" alt="2026-05-13_15-53-08" src="https://github.com/user-attachments/assets/eae0bf40-5f2a-4a2e-9ab1-ce7ed4179bc3" />
