### PR TITLE
Adjust conversation title (and breadcrumb) truncation for responsive display

### DIFF
--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/+layout.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/+layout.svelte
@@ -52,7 +52,7 @@
 				<Breadcrumb.Item class="min-w-0">
 					<Breadcrumb.Link
 						href={`/admin/conversations/${conversation.id}/configure`}
-						class="block max-w-[12ch] truncate sm:max-w-[20ch]"
+						class="block max-w-[12ch] truncate sm:max-w-[20ch] lg:max-w-[24ch]"
 						title={conversation.title}
 					>
 						{conversation.title}
@@ -65,11 +65,11 @@
 			</Breadcrumb.List>
 		</Breadcrumb.Root>
 		<div class="flex w-full min-w-0 items-center gap-3 xl:ml-auto xl:w-auto">
-			<!-- Identity -->
+			<!-- Conversation Title -->
 			<div class="flex min-w-0 shrink items-center gap-2">
 				<MessageSquareText class="text-primary size-5 shrink-0" />
 				<span
-					class="text-primary truncate text-base font-semibold sm:text-lg"
+					class="text-primary max-w-[30ch] truncate text-base font-semibold sm:max-w-[40ch] sm:text-lg lg:max-w-[60ch] xl:max-w-[24ch]"
 					title={conversation.title}
 				>
 					{conversation.title}


### PR DESCRIPTION
Truncate long breadcrumbs and conversation titles 
<img width="1460" height="222" alt="image" src="https://github.com/user-attachments/assets/87c3e9c9-c702-4fe1-8ead-16a77dbaf2e7" />
