### PR TITLE
Add previous page navigation to learn tool

### DIFF
--- a/ui/packages/comhairle/src/lib/components/StepHeader.svelte
+++ b/ui/packages/comhairle/src/lib/components/StepHeader.svelte
@@ -10,6 +10,7 @@
 		description?: string;
 		estimatedMinutes?: number;
 		prevHref?: string;
+		onPrev?: () => void;
 		onNext?: () => void;
 		nextDisabled?: boolean;
 		boldDescription?: boolean;
@@ -24,6 +25,7 @@
 		description,
 		estimatedMinutes,
 		prevHref,
+		onPrev,
 		onNext,
 		nextDisabled = false,
 		boldDescription = true,
@@ -35,7 +37,15 @@
 <div class="bg-background w-full md:mx-auto md:max-w-4xl md:rounded-2xl md:px-6 md:pt-4">
 	<div class="flex flex-col items-center">
 		<div class="flex w-full items-center justify-between md:gap-12">
-			{#if prevHref}
+			{#if onPrev}
+				<button
+					onclick={onPrev}
+					class="text-muted-foreground shrink-0 p-2"
+					aria-label="Previous page"
+				>
+					<ChevronLeft class="h-6 w-6 md:h-8 md:w-8" />
+				</button>
+			{:else if prevHref}
 				<a
 					href={prevHref}
 					class="text-muted-foreground shrink-0 p-2"

--- a/ui/packages/comhairle/src/lib/tools/learn/LearnUI.svelte
+++ b/ui/packages/comhairle/src/lib/tools/learn/LearnUI.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { Button } from '$lib/components/ui/button';
+	import { Progress } from '$lib/components/ui/progress';
 	import ContentRenderer from '$lib/components/RichTextEditor/ContentRenderer/ContentRenderer.svelte';
 	import * as m from '$lib/paraglide/messages';
 	import { getLocale } from '$lib/paraglide/runtime.js';
@@ -18,11 +19,13 @@
 		pages,
 		onDone,
 		onNextAction,
+		onPrevAction,
 		conversation
 	}: {
 		pages: Array<Page>;
 		onDone: () => void;
 		onNextAction?: (fn: () => void) => void;
+		onPrevAction?: (fn: (() => void) | undefined) => void;
 		conversation?: LocalizedConversationDto;
 	} = $props();
 
@@ -65,6 +68,13 @@
 		});
 	}
 
+	function prevPage() {
+		currentPageNo -= 1;
+		tick().then(() => {
+			window.scrollTo(0, 0);
+		});
+	}
+
 	/** True while SvelteKit is routing to another step / page. */
 	let showSkeleton = $derived(!!navigating.to);
 
@@ -73,9 +83,22 @@
 			onNextAction(isLastPage ? onDone : nextPage);
 		}
 	});
+
+	$effect(() => {
+		onPrevAction?.(currentPageNo > 0 ? prevPage : undefined);
+	});
 </script>
 
 <div class="mx-auto flex grow flex-col">
+	{#if pages.length > 1}
+		<div class="mx-auto mb-6 w-full max-w-[65ch]">
+			<p class="text-muted-foreground mb-1.5 text-sm font-medium">
+				Page {currentPageNo + 1} of {pages.length}
+			</p>
+			<Progress value={currentPageNo + 1} max={pages.length} aria-label="Learning progress" />
+		</div>
+	{/if}
+
 	<!-- Article content: own loading state (route navigation / content not ready) -->
 	{#if showSkeleton}
 		<LearnArticleSkeleton />

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/workflow/[workflow_id]/s/[workflow_step_id]/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/workflow/[workflow_id]/s/[workflow_step_id]/+page.svelte
@@ -113,6 +113,7 @@
 	});
 
 	let currentNextAction = $state<(() => void) | undefined>(undefined);
+	let currentPrevAction = $state<(() => void) | undefined>(undefined);
 	let canProceed = $state(false);
 
 	$effect(() => {
@@ -122,10 +123,18 @@
 		} else {
 			canProceed = false;
 		}
+		if (type !== Learn.TOOL_NAME) {
+			currentNextAction = undefined;
+			currentPrevAction = undefined;
+		}
 	});
 
 	function handleNextAction(fn: () => void) {
 		currentNextAction = fn;
+	}
+
+	function handlePrevAction(fn: (() => void) | undefined) {
+		currentPrevAction = fn;
 	}
 
 	function handleCanContinueChange(value: boolean) {
@@ -216,6 +225,7 @@
 					title={workflowStep.name}
 					description={workflowStep.description}
 					prevHref={prevStepHref}
+					onPrev={currentPrevAction}
 					onNext={currentNextAction ?? stepComplete}
 					nextDisabled={!canProceed}
 					boldDescription={toolConfig.type === Polis.TOOL_NAME}
@@ -241,13 +251,16 @@
 							</div>
 						{/if}
 					{:else if toolConfig.type === Learn.TOOL_NAME}
-						<Learn.UserUI
-							onDone={stepComplete}
-							pages={toolConfig.pages}
-							user_id={user.id}
-							onNextAction={handleNextAction}
-							{conversation}
-						/>
+						{#key workflowStep.id}
+							<Learn.UserUI
+								onDone={stepComplete}
+								pages={toolConfig.pages}
+								user_id={user.id}
+								onNextAction={handleNextAction}
+								onPrevAction={handlePrevAction}
+								{conversation}
+							/>
+						{/key}
 					{/if}
 					{#if toolConfig?.type === Polis.TOOL_NAME}
 						<Polis.UserUI


### PR DESCRIPTION
## Description

Previously the back chevron on a Learn step always jumped to the *previous workflow step* (or was disabled), so there was no way to go back a page within a multi-page Learn step.

### Motivation:
+ allow users to navigate backwards through learn tool pages
+ provide visual feedback on progress through multi-page content

### Actions:
+ add onPrev prop to StepHeader component
+ implement prevPage function in LearnUI
+ add progress indicator showing current page and total pages
+ pass onPrevAction callback from page component to LearnUI
+ clear prev/next actions when switching away from learn tool
+ key LearnUI component by workflow step id


Behaviour

https://github.com/user-attachments/assets/f34a23d7-d805-495b-b2aa-c9b77e74254e




