### PR TITLE
Change image sizing to responsive for better aspect ratio

### DIFF
--- a/ui/packages/comhairle/src/lib/components/ConversationSummary.svelte
+++ b/ui/packages/comhairle/src/lib/components/ConversationSummary.svelte
@@ -22,7 +22,7 @@
 
 	<div class="flex flex-col gap-5">
 		<img
-			class="h-[468px] self-stretch object-cover"
+			class="max-h-[468px] w-full object-contain"
 			src={conversation.imageUrl}
 			alt={conversation.title}
 		/>


### PR DESCRIPTION
Actions:
- replace fixed h-[468px] with max-h-[468px]
- replace self-stretch with w-full
- change object-cover to object-contain

Motivation:
- prevent image distortion on smaller screens
- maintain aspect ratio while constraining maximum height

https://github.com/user-attachments/assets/cd648e0b-3917-47ba-a57d-4a705338f594

https://github.com/user-attachments/assets/e54f8e50-41a7-48b8-8545-8db1dc220b22

https://github.com/user-attachments/assets/9797d0fb-a89d-47e7-992c-1497336edd84

https://github.com/user-attachments/assets/f3b5ee6d-3abe-4f84-bbe4-aecf23591890

https://github.com/user-attachments/assets/f27624ab-a7c0-45f7-856a-3814fdfa9915

https://github.com/user-attachments/assets/af9bb05f-513f-4bca-8418-2c5044b8de8d


https://github.com/user-attachments/assets/b3a0c145-3e08-4d9c-8639-235efa656319

