### PR TITLE
navigate to next revisitable step when completing revisited workflows steps

### DIFF
--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/workflow/[workflow_id]/s/[workflow_step_id]/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/workflow/[workflow_id]/s/[workflow_step_id]/+page.svelte
@@ -147,15 +147,14 @@
 
 	async function stepComplete() {
 		if (isRevisiting) {
-			if (actualCurrentStep) {
-				const isPreview = !conversation.isLive;
+			const isPreview = !conversation.isLive;
+			const currentIdx = sortedSteps.findIndex((ws) => ws.id === workflowStep.id);
+			const nextRevisitable = sortedSteps.slice(currentIdx + 1).find((ws) => ws.canRevisit);
+			const target = nextRevisitable ?? actualCurrentStep;
+			if (target) {
 				goto(
-					workflow_step_url(
-						conversation.id,
-						workflow_id,
-						actualCurrentStep.id,
-						isPreview
-					) + queryString
+					workflow_step_url(conversation.id, workflow_id, target.id, isPreview) +
+						queryString
 				);
 			} else {
 				goToThankYouPage();


### PR DESCRIPTION
Actions:

- find next revisitable step after current step in sorted steps array
- use next revisitable step as navigation target, fallback to actual current step
- simplify conditional logic by moving isPreview outside nested block

Motivation:

- allow users to continue through revisitable steps in sequence
- prevent skipping over intermediate revisitable steps when navigating forward

Before fix:

https://github.com/user-attachments/assets/3054d885-edc8-4053-880c-979c3c9e29a8


After fix:

https://github.com/user-attachments/assets/906bb97d-8518-4031-a8bc-b90fcfdc1409
