### PR TITLE
388 ux improvements

### DIFF
--- a/api/src/models/conversation.rs
+++ b/api/src/models/conversation.rs
@@ -547,8 +547,9 @@ pub async fn update(
 pub async fn list_for_user_participation(
     db: &PgPool,
     user_id: &Uuid,
-) -> Result<Vec<Conversation>, ComhairleError> {
-    let (sql, values) = Query::select()
+    locale: &str,
+) -> Result<Vec<LocalizedConversation>, ComhairleError> {
+    let query = Query::select()
         .from(ConversationIden::Table)
         .columns(DEFAULT_COLUMNS.map(|col| (ConversationIden::Table, col)))
         .join(
@@ -578,9 +579,12 @@ pub async fn list_for_user_participation(
         //     sea_query::Order::Desc,
         // )
         .distinct()
+        .to_owned();
+
+    let (sql, values) = LocalizedConversation::query_to_localisation(query, locale)
         .build_sqlx(PostgresQueryBuilder);
 
-    let conversations = sqlx::query_as_with::<_, Conversation, _>(&sql, values)
+    let conversations = sqlx::query_as_with::<_, LocalizedConversation, _>(&sql, values)
         .fetch_all(db)
         .await?;
     Ok(conversations)

--- a/api/src/routes/user.rs
+++ b/api/src/routes/user.rs
@@ -22,7 +22,7 @@ use crate::{
         users::{UpdateUserRequest, UpgradeAccountRequest},
     },
     routes::{
-        conversations::dto::{ConversationDto, LocalizedConversationDto},
+        conversations::dto::LocalizedConversationDto,
         user::dto::UserDto,
     },
     ComhairleState,
@@ -31,6 +31,7 @@ use crate::{
 pub mod dto;
 
 use super::auth::{is_user_admin, RequiredAdminUser, RequiredUser};
+use super::translations::LocaleExtractor;
 
 pub async fn get_user_owned_conversations(
     State(state): State<Arc<ComhairleState>>,
@@ -73,12 +74,14 @@ pub struct UserRoles {
 pub async fn get_conversations_user_participating_in(
     State(state): State<Arc<ComhairleState>>,
     RequiredUser(user): RequiredUser,
-) -> Result<(StatusCode, Json<Vec<ConversationDto>>), ComhairleError> {
-    let conversations = models::conversation::list_for_user_participation(&state.db, &user.id)
-        .await?
-        .into_iter()
-        .map(Into::into)
-        .collect();
+    LocaleExtractor(locale): LocaleExtractor,
+) -> Result<(StatusCode, Json<Vec<LocalizedConversationDto>>), ComhairleError> {
+    let conversations =
+        models::conversation::list_for_user_participation(&state.db, &user.id, &locale)
+            .await?
+            .into_iter()
+            .map(Into::into)
+            .collect();
     Ok((StatusCode::OK, Json(conversations)))
 }
 
@@ -140,7 +143,7 @@ pub fn router(state: Arc<ComhairleState>) -> ApiRouter {
                         "Returns a list of all the conversations the user has taken part in",
                     )
                     .security_requirement("JWT")
-                    .response::<201, Json<Vec<ConversationDto>>>()
+                    .response::<201, Json<Vec<LocalizedConversationDto>>>()
             }),
         )
         .api_route(

--- a/ui/packages/api-client/src/api.ts
+++ b/ui/packages/api-client/src/api.ts
@@ -97,42 +97,6 @@ export const UserRoles = z
   .object({ resource: ResourceType, roles: z.array(ResourceRole) })
   .passthrough();
 export type UserRoles = z.infer<typeof UserRoles>;
-export const ConversationDto = z
-  .object({
-    callToAction: z.union([z.string(), z.null()]).optional(),
-    chatBotId: z.union([z.string(), z.null()]).optional(),
-    description: z.string().uuid(),
-    enableQaChatBot: z.boolean(),
-    enableSignupPrompts: z.boolean(),
-    faqs: z.union([z.string(), z.null()]).optional(),
-    id: z.string().uuid(),
-    imageUrl: z.string(),
-    isComplete: z.boolean(),
-    isInviteOnly: z.boolean(),
-    isLive: z.boolean(),
-    isPublic: z.boolean(),
-    knowledgeBaseId: z.union([z.string(), z.null()]).optional(),
-    organizationId: z.union([z.string(), z.null()]).optional(),
-    primaryLocale: z.string(),
-    privacyPolicy: z.union([z.string(), z.null()]).optional(),
-    shortDescription: z.string().uuid(),
-    shortPrivacyPolicy: z.union([z.string(), z.null()]).optional(),
-    showThankYouPageAnnonInstructions: z.boolean(),
-    slug: z.union([z.string(), z.null()]).optional(),
-    supportedLanguages: z.array(z.string()),
-    tags: z.array(z.string()),
-    thankYouMessage: z.union([z.string(), z.null()]).optional(),
-    title: z.string().uuid(),
-    videoUrl: z.union([z.string(), z.null()]).optional(),
-  })
-  .passthrough();
-export type ConversationDto = z.infer<typeof ConversationDto>;
-export const created_after = z.union([z.string(), z.null()]).optional();
-export type created_after = z.infer<typeof created_after>;
-export const is_complete = z.union([z.boolean(), z.null()]).optional();
-export type is_complete = z.infer<typeof is_complete>;
-export const limit = z.union([z.number(), z.null()]).optional();
-export type limit = z.infer<typeof limit>;
 export const LocalizedConversationDto = z
   .object({
     callToAction: z.union([z.string(), z.null()]).optional(),
@@ -163,6 +127,12 @@ export const LocalizedConversationDto = z
   })
   .passthrough();
 export type LocalizedConversationDto = z.infer<typeof LocalizedConversationDto>;
+export const created_after = z.union([z.string(), z.null()]).optional();
+export type created_after = z.infer<typeof created_after>;
+export const is_complete = z.union([z.boolean(), z.null()]).optional();
+export type is_complete = z.infer<typeof is_complete>;
+export const limit = z.union([z.number(), z.null()]).optional();
+export type limit = z.infer<typeof limit>;
 export const PaginatedResults_for_LocalizedConversationDto = z
   .object({
     records: z.array(LocalizedConversationDto),
@@ -505,6 +475,36 @@ export const CreateConversation = z
   })
   .passthrough();
 export type CreateConversation = z.infer<typeof CreateConversation>;
+export const ConversationDto = z
+  .object({
+    callToAction: z.union([z.string(), z.null()]).optional(),
+    chatBotId: z.union([z.string(), z.null()]).optional(),
+    description: z.string().uuid(),
+    enableQaChatBot: z.boolean(),
+    enableSignupPrompts: z.boolean(),
+    faqs: z.union([z.string(), z.null()]).optional(),
+    id: z.string().uuid(),
+    imageUrl: z.string(),
+    isComplete: z.boolean(),
+    isInviteOnly: z.boolean(),
+    isLive: z.boolean(),
+    isPublic: z.boolean(),
+    knowledgeBaseId: z.union([z.string(), z.null()]).optional(),
+    organizationId: z.union([z.string(), z.null()]).optional(),
+    primaryLocale: z.string(),
+    privacyPolicy: z.union([z.string(), z.null()]).optional(),
+    shortDescription: z.string().uuid(),
+    shortPrivacyPolicy: z.union([z.string(), z.null()]).optional(),
+    showThankYouPageAnnonInstructions: z.boolean(),
+    slug: z.union([z.string(), z.null()]).optional(),
+    supportedLanguages: z.array(z.string()),
+    tags: z.array(z.string()),
+    thankYouMessage: z.union([z.string(), z.null()]).optional(),
+    title: z.string().uuid(),
+    videoUrl: z.union([z.string(), z.null()]).optional(),
+  })
+  .passthrough();
+export type ConversationDto = z.infer<typeof ConversationDto>;
 export const Translation = z
   .object({
     textContent: TextContentDto,
@@ -1641,11 +1641,10 @@ export const schemas: Record<string, z.ZodType<any>> = {
   ResourceType,
   ResourceRole,
   UserRoles,
-  ConversationDto,
+  LocalizedConversationDto,
   created_after,
   is_complete,
   limit,
-  LocalizedConversationDto,
   PaginatedResults_for_LocalizedConversationDto,
   UpdateUserRequest,
   UpgradeAccountRequest,
@@ -1686,6 +1685,7 @@ export const schemas: Record<string, z.ZodType<any>> = {
   CreateAnswerRequest,
   UpdateAnswer,
   CreateConversation,
+  ConversationDto,
   Translation,
   ConversationTranslations,
   ConversationWithTranslations,
@@ -3728,7 +3728,7 @@ This struct contains optional fields that can be updated on a TextTranslation re
     alias: "GetConversationsUserIsParticipatingIn",
     description: `Returns a list of all the conversations the user has taken part in`,
     requestFormat: "json",
-    response: z.array(ConversationDto),
+    response: z.array(LocalizedConversationDto),
   },
   {
     method: "put",

--- a/ui/packages/comhairle/src/lib/components/Footer.svelte
+++ b/ui/packages/comhairle/src/lib/components/Footer.svelte
@@ -53,7 +53,7 @@
 			<!-- Bottom row: Copyright + Legal links -->
 			<div class="flex flex-col items-center gap-4 md:flex-row md:justify-between">
 				<p class="text-sidebar-foreground/50 order-2 text-base font-normal md:order-1">
-					Copyright {new Date().getFullYear()} &copy; Crown Shy
+					Copyright {new Date().getFullYear()} &copy; CrownShy
 				</p>
 				<div class="order-1 flex flex-wrap items-center justify-center gap-8 md:order-2">
 					{#each legalLinks as link (link.href)}

--- a/ui/packages/comhairle/src/lib/components/PrivacyPolicyDialog.svelte
+++ b/ui/packages/comhairle/src/lib/components/PrivacyPolicyDialog.svelte
@@ -22,8 +22,6 @@
 <Dialog.Root bind:open>
 	<Dialog.Content
 		showCloseButton={false}
-		escapeKeydownBehavior="ignore"
-		interactOutsideBehavior="ignore"
 		class="flex max-h-[85vh] flex-col gap-0 p-0 sm:max-w-lg"
 	>
 		<Dialog.Header class="border-b px-6 pt-6 pb-4">

--- a/ui/packages/comhairle/src/lib/tools/learn/LearnUI.svelte
+++ b/ui/packages/comhairle/src/lib/tools/learn/LearnUI.svelte
@@ -123,8 +123,10 @@
 	{/if}
 
 	{#if currentPageNo == pages.length - 1}
-		<Button class="mt-10" onclick={onDone} disabled={showSkeleton}>{m.continue_()}</Button>
+		<Button class="mx-auto mt-10" onclick={onDone} disabled={showSkeleton}
+			>{m.continue_()}</Button
+		>
 	{:else}
-		<Button class="mt-10" onclick={nextPage} disabled={showSkeleton}>{m.next()}</Button>
+		<Button class="mx-auto mt-10" onclick={nextPage} disabled={showSkeleton}>{m.next()}</Button>
 	{/if}
 </div>

--- a/ui/packages/comhairle/src/routes/(public)/settings/+page.ts
+++ b/ui/packages/comhairle/src/routes/(public)/settings/+page.ts
@@ -11,7 +11,24 @@ export const load: PageLoad = async ({ parent }) => {
 		const participation = await api.GetConversationsUserIsParticipatingIn();
 		const conversation_settings = await api.GetAllUserConversationPreferences();
 
-		return { participation, conversation_settings, user };
+		const localizedParticipation = await Promise.all(
+			participation.map(async (c) => {
+				try {
+					const localized = await api.GetConversation({
+						params: { conversation_id: c.id }
+					});
+					return { id: c.id, title: localized.title };
+				} catch {
+					return { id: c.id, title: c.id };
+				}
+			})
+		);
+
+		return {
+			participation: localizedParticipation,
+			conversation_settings,
+			user
+		};
 	} catch (e) {
 		return { error: e };
 	}

--- a/ui/packages/comhairle/src/routes/(public)/settings/+page.ts
+++ b/ui/packages/comhairle/src/routes/(public)/settings/+page.ts
@@ -11,24 +11,7 @@ export const load: PageLoad = async ({ parent }) => {
 		const participation = await api.GetConversationsUserIsParticipatingIn();
 		const conversation_settings = await api.GetAllUserConversationPreferences();
 
-		const localizedParticipation = await Promise.all(
-			participation.map(async (c) => {
-				try {
-					const localized = await api.GetConversation({
-						params: { conversation_id: c.id }
-					});
-					return { id: c.id, title: localized.title };
-				} catch {
-					return { id: c.id, title: c.id };
-				}
-			})
-		);
-
-		return {
-			participation: localizedParticipation,
-			conversation_settings,
-			user
-		};
+		return { participation, conversation_settings, user };
 	} catch (e) {
 		return { error: e };
 	}


### PR DESCRIPTION
Small UX fixes from feedback round

Here were the requests: https://github.com/crownshy/comhairle/issues/388

- **Privacy policy modal**: was trapping users. only the Accept button closed it. Removed the `escapeKeydownBehavior="ignore"` / `interactOutsideBehavior="ignore"` overrides so ESC and outside-click now dismiss. No consent fires on dismiss; user just returns to the conversation landing page.
- **Learn tool Continue / Next buttons**: move back to middle
- **Footer copyright**: "Crown Shy" → "CrownShy" 
- **Settings → Notifications**: was showing the conversation UUID instead of the name. Settings loader now resolves each title via `GetConversation` in parallel and the page renders the real name.

> ⚠️ Note on the settings fix: this is dedinitely not the best approach. Wanted to have something now, but I think we need to do this properly? 