### PR TITLE
Remove hardcoded text-black classes from breadcrumb components

### DIFF
--- a/ui/packages/comhairle/src/lib/components/Breadcrumbs.svelte
+++ b/ui/packages/comhairle/src/lib/components/Breadcrumbs.svelte
@@ -13,24 +13,24 @@
 
 <Breadcrumb.Root class="mb-16">
 	<Breadcrumb.List>
-		<Breadcrumb.Item class="text-black">
+		<Breadcrumb.Item>
 			<Breadcrumb.Link href="/">Home</Breadcrumb.Link>
 		</Breadcrumb.Item>
 		{#if conversation}
-			<Breadcrumb.Separator class="text-black" />
-			<Breadcrumb.Item class="text-black">
+			<Breadcrumb.Separator />
+			<Breadcrumb.Item>
 				<Breadcrumb.Link href="/conversations">Conversations</Breadcrumb.Link>
 			</Breadcrumb.Item>
-			<Breadcrumb.Separator class="text-black" />
-			<Breadcrumb.Item class="text-black">
+			<Breadcrumb.Separator />
+			<Breadcrumb.Item>
 				<Breadcrumb.Link href={`/conversations/${conversation.id}`}>
 					{conversation.title}
 				</Breadcrumb.Link>
 			</Breadcrumb.Item>
 		{/if}
 		{#if workflowStep}
-			<Breadcrumb.Separator class="text-black" />
-			<Breadcrumb.Item class="text-black">
+			<Breadcrumb.Separator />
+			<Breadcrumb.Item>
 				<Breadcrumb.Page>{workflowStep.name}</Breadcrumb.Page>
 			</Breadcrumb.Item>
 		{/if}


### PR DESCRIPTION
After fix:
<img width="594" height="125" alt="image" src="https://github.com/user-attachments/assets/745a16af-a851-4af9-bf14-bd63e04226eb" />
<img width="504" height="142" alt="image" src="https://github.com/user-attachments/assets/aa7dd6bb-5b65-4962-9406-a6ed017c3329" />
