### PR TITLE
191/bloom event registration

### DIFF
--- a/api/src/models/invites.rs
+++ b/api/src/models/invites.rs
@@ -19,7 +19,8 @@ pub struct Invite {
     #[partially(omit)]
     pub id: Uuid,
     pub invite_type: InviteType,
-    pub created_by: Uuid,
+    #[partially(omit)]
+    pub created_by: Option<Uuid>,
     pub status: InviteStatus,
     pub expires_at: Option<DateTime<Utc>>,
     pub conversation_id: Uuid,
@@ -314,35 +315,41 @@ pub async fn create(
     db: &PgPool,
     create_invite: CreateInviteDTO,
     conversation_id: &Uuid,
-    user_id: &Uuid,
+    user_id: Option<Uuid>,
 ) -> Result<Invite, ComhairleError> {
     let starting_status = match create_invite.invite_type {
         InviteType::Email(_) | InviteType::User(_) | InviteType::SingleUse => InviteStatus::Pending,
         InviteType::Open => InviteStatus::Open,
     };
 
+    let mut columns = vec![
+        InviteIden::ConversationId,
+        InviteIden::InviteType,
+        InviteIden::LoginBehaviour,
+        InviteIden::Status,
+        InviteIden::ExpiresAt,
+        InviteIden::Label,
+        InviteIden::EventId,
+    ];
+    let mut values = vec![
+        conversation_id.to_owned().into(),
+        create_invite.invite_type.into(),
+        create_invite.login_behaviour.into(),
+        starting_status.into(),
+        create_invite.expires_at.into(),
+        create_invite.label.into(),
+        create_invite.event_id.into(),
+    ];
+
+    if let Some(user_id) = user_id {
+        columns.push(InviteIden::CreatedBy);
+        values.push(user_id.into());
+    }
+
     let (sql, values) = Query::insert()
         .into_table(InviteIden::Table)
-        .columns(vec![
-            InviteIden::CreatedBy,
-            InviteIden::ConversationId,
-            InviteIden::InviteType,
-            InviteIden::LoginBehaviour,
-            InviteIden::Status,
-            InviteIden::ExpiresAt,
-            InviteIden::Label,
-            InviteIden::EventId,
-        ])
-        .values(vec![
-            user_id.to_owned().into(),
-            conversation_id.to_owned().into(),
-            create_invite.invite_type.into(),
-            create_invite.login_behaviour.into(),
-            starting_status.into(),
-            create_invite.expires_at.into(),
-            create_invite.label.into(),
-            create_invite.event_id.into(),
-        ])
+        .columns(columns)
+        .values(values)
         .unwrap()
         .returning(Query::returning().columns(DEFAULT_COLUMNS))
         .build_sqlx(PostgresQueryBuilder);
@@ -418,7 +425,7 @@ mod tests {
         let invite = Invite {
             id: Uuid::new_v4(),
             invite_type: InviteType::Email("testemail@gmail.com".into()),
-            created_by: Uuid::new_v4(),
+            created_by: Some(Uuid::new_v4()),
             status: InviteStatus::Pending,
             expires_at: None,
             conversation_id: Uuid::new_v4(),
@@ -496,7 +503,7 @@ mod tests {
                 event_id: None,
             },
             &conversation.id,
-            &user1.id,
+            Some(user1.id),
         )
         .await?;
 
@@ -580,7 +587,7 @@ mod tests {
                 event_id: None,
             },
             &conversation.id,
-            &user1.id,
+            Some(user1.id),
         )
         .await?;
 
@@ -658,7 +665,7 @@ mod tests {
                 event_id: None,
             },
             &conversation.id,
-            &user1.id,
+            Some(user1.id),
         )
         .await?;
 
@@ -703,7 +710,7 @@ mod tests {
                 event_id: Some(event.id),
             },
             &conversation_id,
-            &user1.id,
+            Some(user1.id),
         )
         .await?;
         create(
@@ -716,7 +723,7 @@ mod tests {
                 event_id: Some(event.id),
             },
             &conversation_id,
-            &user1.id,
+            Some(user1.id),
         )
         .await?;
         create(
@@ -729,7 +736,7 @@ mod tests {
                 event_id: Some(event.id),
             },
             &conversation_id,
-            &user1.id,
+            Some(user1.id),
         )
         .await?;
 

--- a/api/src/routes/invites.rs
+++ b/api/src/routes/invites.rs
@@ -101,7 +101,7 @@ async fn reject_invite(
 }
 
 #[instrument(err(Debug), skip(state))]
-async fn create_invite(
+async fn create_conversation_invite(
     State(state): State<Arc<ComhairleState>>,
     Path(conversation_id): Path<Uuid>,
     RequiredAdminUser(user): RequiredAdminUser,
@@ -122,38 +122,20 @@ async fn create_invite(
 
     // Send out an email notification if we can
     match &invite.invite_type {
-        models::invites::InviteType::Email(email) => {
-            if let Some(event_id) = invite.event_id {
-                let event =
-                    event::get_localized_by_id(&state.db, &event_id, &conversation.primary_locale)
-                        .await?;
-
-                let invite_link = format!(
-                    "{}/conversations/{}/events/{}/invite/{}",
-                    state.config.domain, conversation.id, event.id, invite.id
-                );
-
-                state.mailer.send_event_registration_email(
-                    email.to_string(),
-                    &event,
-                    &None,
-                    invite_link,
-                )?;
-            } else {
-                state.mailer.send_email(
-                    email,
-                    "Invitation to take part in a public consultation",
-                    "conversation_invite.html",
-                    context! {
-                        conversation_hero => conversation.image_url,
-                        conversation_title=> conversation.title,
-                        invite_link => format!("{}/conversations/{}/invite/{}",state.config.domain, conversation.slug.unwrap_or_else(|| conversation.id.to_string()), invite.id )
-                    },
-                    None,
-                )?;
-            }
+        InviteType::Email(email) => {
+            state.mailer.send_email(
+            email,
+            "Invitation to take part in a public consultation",
+            "conversation_invite.html",
+            context! {
+                conversation_hero => conversation.image_url,
+                conversation_title=> conversation.title,
+                invite_link => format!("{}/conversations/{}/invite/{}",state.config.domain, conversation.slug.unwrap_or_else(|| conversation.id.to_string()), invite.id )
+            },
+                None
+        )?;
         }
-        models::invites::InviteType::User(user_id) => {
+        InviteType::User(user_id) => {
             let user = models::users::get_user_by_id(user_id, &state.db).await?;
             if let Some(email) = &user.email {
                 state.mailer.send_email(
@@ -161,7 +143,7 @@ async fn create_invite(
                 "You have been invited to the conversation",
                 "conversation_invite.html",
                 context! {user=>user, conversation_hero => conversation.image_url , conversation_title=>conversation.title},
-                    None,
+                None
             )?;
             }
         }
@@ -170,6 +152,44 @@ async fn create_invite(
 
     let invite = invite.into();
     Ok((StatusCode::CREATED, Json(invite)))
+}
+
+#[instrument(err(Debug), skip(state))]
+async fn create_event_invite(
+    State(state): State<Arc<ComhairleState>>,
+    Path(conversation_id): Path<Uuid>,
+    RequiredUser(user): RequiredUser,
+    Json(create_invite): Json<CreateInviteDTO>,
+) -> Result<(StatusCode, Json<InviteDto>), ComhairleError> {
+    if create_invite.event_id.is_none() {
+        return Err(ComhairleError::BadRequest("Missing event_id".to_string()));
+    }
+
+    let conversation = models::conversation::get_by_id(&state.db, &conversation_id).await?;
+
+    // Create the invite
+    let invite =
+        models::invites::create(&state.db, create_invite, &conversation_id, &user.id).await?;
+
+    let InviteType::Email(email) = &invite.invite_type else {
+        return Err(ComhairleError::InvalidInviteType);
+    };
+
+    let event_id = &invite.event_id.ok_or(ComhairleError::InvalidInviteType)?;
+
+    let event =
+        event::get_localized_by_id(&state.db, event_id, &conversation.primary_locale).await?;
+
+    let invite_link = format!(
+        "{}/conversations/{}/events/{}/invite/{}",
+        state.config.domain, conversation.id, event.id, invite.id
+    );
+
+    state
+        .mailer
+        .send_event_registration_email(email.to_string(), &event, &None, invite_link)?;
+
+    Ok((StatusCode::CREATED, Json(invite.into())))
 }
 
 #[instrument(err(Debug), skip(state))]
@@ -333,7 +353,7 @@ pub fn router(state: Arc<ComhairleState>) -> ApiRouter {
     ApiRouter::new()
         .api_route(
             "/",
-            post_with(create_invite, |op| {
+            post_with(create_conversation_invite, |op| {
                 op.id("CreateInvite")
                     .summary("Create an invite")
                     .tag("Invites")
@@ -404,6 +424,17 @@ pub fn router(state: Arc<ComhairleState>) -> ApiRouter {
                     .tag("Invites")
                     .security_requirement("JWT")
                     .response::<200, Json<Vec<InviteDto>>>()
+            }),
+        )
+        .api_route(
+            "/events",
+            post_with(create_event_invite, |op| {
+                op.id("CreateEventInvite")
+                    .summary("Create an event invite")
+                    .description("Create an invite for a given event")
+                    .tag("Invites")
+                    .security_requirement("JWT")
+                    .response::<201, Json<InviteDto>>()
             }),
         )
         .api_route(

--- a/api/src/routes/invites.rs
+++ b/api/src/routes/invites.rs
@@ -118,7 +118,7 @@ async fn create_conversation_invite(
 
     // Create the invite
     let invite =
-        models::invites::create(&state.db, create_invite, &conversation_id, &user.id).await?;
+        models::invites::create(&state.db, create_invite, &conversation_id, Some(user.id)).await?;
 
     // Send out an email notification if we can
     match &invite.invite_type {
@@ -158,7 +158,7 @@ async fn create_conversation_invite(
 async fn create_event_invite(
     State(state): State<Arc<ComhairleState>>,
     Path(conversation_id): Path<Uuid>,
-    RequiredUser(user): RequiredUser,
+    OptionalUser(user): OptionalUser,
     Json(create_invite): Json<CreateInviteDTO>,
 ) -> Result<(StatusCode, Json<InviteDto>), ComhairleError> {
     if create_invite.event_id.is_none() {
@@ -168,8 +168,13 @@ async fn create_event_invite(
     let conversation = models::conversation::get_by_id(&state.db, &conversation_id).await?;
 
     // Create the invite
-    let invite =
-        models::invites::create(&state.db, create_invite, &conversation_id, &user.id).await?;
+    let invite = models::invites::create(
+        &state.db,
+        create_invite,
+        &conversation_id,
+        user.map(|u| u.id),
+    )
+    .await?;
 
     let InviteType::Email(email) = &invite.invite_type else {
         return Err(ComhairleError::InvalidInviteType);

--- a/api/src/routes/invites/dto.rs
+++ b/api/src/routes/invites/dto.rs
@@ -18,7 +18,7 @@ use crate::models::invites::{Invite, InviteStatus, InviteType, LoginBehaviour};
 pub struct InviteDto {
     pub id: Uuid,
     pub invite_type: InviteType,
-    pub created_by: Uuid,
+    pub created_by: Option<Uuid>,
     pub status: InviteStatus,
     pub expires_at: Option<DateTime<Utc>>,
     pub conversation_id: Uuid,

--- a/ui/packages/api-client/src/api.ts
+++ b/ui/packages/api-client/src/api.ts
@@ -1041,7 +1041,7 @@ export const InviteDto = z
     acceptCount: z.number().int(),
     conversationId: z.string().uuid(),
     createdAt: z.string().datetime({ offset: true }),
-    createdBy: z.string().uuid(),
+    createdBy: z.union([z.string(), z.null()]).optional(),
     eventId: z.union([z.string(), z.null()]).optional(),
     expiresAt: z.union([z.string(), z.null()]).optional(),
     id: z.string().uuid(),
@@ -1069,7 +1069,6 @@ export const PartialInvite = z
   .object({
     accept_count: z.union([z.number(), z.null()]),
     conversation_id: z.union([z.string(), z.null()]),
-    created_by: z.union([z.string(), z.null()]),
     event_id: z.union([z.string(), z.null()]),
     expires_at: z.union([z.string(), z.null()]),
     invite_type: z.union([InviteType, z.null()]),

--- a/ui/packages/api-client/src/api.ts
+++ b/ui/packages/api-client/src/api.ts
@@ -2730,6 +2730,21 @@ Use query param withUserProgress&#x3D;true to get the active user&#x27;s progres
     response: z.array(DailyResponseStats),
   },
   {
+    method: "post",
+    path: "/conversation/:conversation_id/invite/events",
+    alias: "CreateEventInvite",
+    description: `Create an invite for a given event`,
+    requestFormat: "json",
+    parameters: [
+      {
+        name: "body",
+        type: "Body",
+        schema: CreateInviteDTO,
+      },
+    ],
+    response: InviteDto,
+  },
+  {
     method: "get",
     path: "/conversation/:conversation_id/invite/events/:event_id",
     alias: "ListInvitesForEvent",

--- a/ui/packages/comhairle/src/lib/components/ui/email-invites/EmailInviteForm.svelte
+++ b/ui/packages/comhairle/src/lib/components/ui/email-invites/EmailInviteForm.svelte
@@ -52,11 +52,20 @@
 		try {
 			await Promise.all(
 				splitEmails(result.data.emails).map(async (email) => {
+					if (eventId) {
+						return await apiClient.CreateEventInvite(
+							{
+								invite_type: { email },
+								expires_at: expireDate?.toDate(getLocalTimeZone()).toISOString(),
+								event_id: eventId
+							},
+							{ params: { conversation_id: conversationId } }
+						);
+					}
 					return await apiClient.CreateInvite(
 						{
 							invite_type: { email },
-							expires_at: expireDate?.toDate(getLocalTimeZone()).toISOString(),
-							...(eventId && { event_id: eventId })
+							expires_at: expireDate?.toDate(getLocalTimeZone()).toISOString()
 						},
 						{ params: { conversation_id: conversationId } }
 					);


### PR DESCRIPTION
Actions:

- split invite creation into separate route handlers
- set `created_by` field on invites as optional and update usage

Motivation:

- increasingly divergent functionality
- cannot guarantee logged in user for event invite creation