### PR TITLE
Add quickstart docs and make it easier to onboard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,9 @@ ADMIN_USERS=admin@crown-shy.com
 # TRANSCRIPTION_SERVICE__AMAZON_TRANSCRIBE_API_KEY=
 
 # ---- Worker service (background jobs via Redis) ----
-# WORKER_SERVICE__REDIS_URL=redis://localhost:6379
+# Started by `just start-redis` (and `just all`) on port 63793.
+# Without this set, the API hangs ~10s on startup waiting for Redis before
+# giving up and running without the worker service.
+WORKER_SERVICE__REDIS_URL=redis://127.0.0.1:63793
 
 # TODO: Add the rest

--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,7 @@
 DATABASE_URL=postgres://comhairle:comhairle@localhost:5434/comhairle
 RUST_LOG=debug
 RESOURCE_BUCKET=comhairle_resources
-ADMIN_USERS=admin@example.com
+ADMIN_USERS=admin@crown-shy.com
 # ENABLE_RATE_LIMITING=false
 
 # ---- Mailer (SMTP) ----

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,47 @@
+# Comhairle local environment.
+#
+# Copy this file to `.env` and fill in values for the services you need.
+# `.env` is gitignored.
+#
+# Naming: the `config` crate maps double-underscores (`__`) to nested
+# fields, so `MAILER__HOST` -> `mailer.host`. Comma-separated lists are
+# parsed for `ADMIN_USERS` and `WHITELISTED_DOMAINS`.
+
+# ---- Core (required for local dev) ----
+DATABASE_URL=postgres://comhairle:comhairle@localhost:5434/comhairle
+RUST_LOG=debug
+RESOURCE_BUCKET=comhairle_resources
+ADMIN_USERS=admin@example.com
+# ENABLE_RATE_LIMITING=false
+
+# ---- Mailer (SMTP) ----
+# MAILER__HOST=
+# MAILER__USER=
+# MAILER__PASSWORD=
+# MAILER__FROM_EMAIL=invites@comhairle.scot
+
+# ---- Translator (Google Translate) ----
+# TRANSLATOR__TYPE=google
+# TRANSLATOR__API_KEY=
+
+# ---- Bot service (RAG) ----
+# BOT_SERVICE_HOST=
+# BOT_SERVICE_API_KEY=
+# DEFAULT_KNOWLEDGE_BASE_ID=
+# ELICITATION_BOT_AGENT_ID=
+
+# ---- Video call service (JWT for Jitsi/8x8 etc.) ----
+# VIDEO_CALL_SERVICE__JWT_APP_ID=
+# VIDEO_CALL_SERVICE__JWT_APP_SECRET=
+# VIDEO_CALL_SERVICE__JWT_SUB=
+# VIDEO_CALL_SERVICE__JWT_ACCEPTED_ISSUERS=
+# VIDEO_CALL_SERVICE__JWT_ACCEPTED_AUDIENCES=
+
+# ---- Transcription service (Amazon Transcribe) ----
+# TRANSCRIPTION_SERVICE__TYPE=AmazonTranscribe
+# TRANSCRIPTION_SERVICE__AMAZON_TRANSCRIBE_API_KEY=
+
+# ---- Worker service (background jobs via Redis) ----
+# WORKER_SERVICE__REDIS_URL=redis://localhost:6379
+
+# TODO: Add the rest

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -35,7 +35,7 @@ If you just want everything running in one go:
 nix develop -c just all
 ```
 
-This spins up a `comhairle` tmux session with four windows: `postgres`, `api`, `ui`, and a `seed` shell. Once the API is up, switch to the `seed` window (`Ctrl-b 3`) and run `just seed`.
+This starts the apalis Redis container (`apalis-redis` on port 63793) and spins up a `comhairle` tmux session with four windows: `postgres`, `api`, `ui`, and a `seed` shell. Once the API is up, switch to the `seed` window (`Ctrl-b 3`) and run `just seed`.
 
 ## 1. Run DB
 ```bash

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -27,7 +27,17 @@ nix develop
 ```
 Once inside the shell you have: `cargo`, `rustc`, `clippy`, `rust-analyzer`, `rustfmt`, `sqlx`, `bacon`, `cargo-watch`, `just`, `watchexec`, `node`, `pnpm`, `psql`, `redis-cli`, `atac`, plus OpenSSL / pkg-config / cmake / clang wired up via env vars.
 
-## Run DB
+## Fast path (tmux)
+
+If you just want everything running in one go:
+
+```bash
+nix develop -c just all
+```
+
+This spins up a `comhairle` tmux session with four windows: `postgres`, `api`, `ui`, and a `seed` shell. Once the API is up, switch to the `seed` window (`Ctrl-b 3`) and run `just seed`.
+
+## 1. Run DB
 ```bash
 nix develop
 just pg
@@ -35,7 +45,7 @@ just pg
 
 This runs `postgres:16` on `localhost:5434` with user/password/db all set to `comhairle`. Data is persisted to `./pg_data` in the repo (already gitignored).
 
-## Run API
+## 2. Run API
 
 In a second shell, start the API (migrations run automatically on boot):
 
@@ -44,13 +54,13 @@ nix develop
 just api-dev
 ```
 
-### Seed DB
+### 3. Seed DB
 
 Run `just seed` to populate the database with initial data including:
 - **Default admin login:** `admin@crown-shy.com` / `adminPassword123!`
 
 
-## Run UI
+## 4. Run UI
 
 In a third shell:
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -10,17 +10,26 @@ You only need two things on the host. Everything else comes from Nix.
 
 ## Setup
 
+Clone the repository:
 ```bash
 git clone <repo> comhairle
 cd comhairle
-nix develop          # first run downloads the toolchain (a few minutes)
+```
+
+Set up environment variables:
+```bash
 cp .env.example .env
+```
+
+Enter the Nix development shell. First run downloads the toolchain (a few minutes)
+```bash
+nix develop 
 ```
 Once inside the shell you have: `cargo`, `rustc`, `clippy`, `rust-analyzer`, `rustfmt`, `sqlx`, `bacon`, `cargo-watch`, `just`, `watchexec`, `node`, `pnpm`, `psql`, `redis-cli`, `atac`, plus OpenSSL / pkg-config / cmake / clang wired up via env vars.
 
 ## Run DB
-
 ```bash
+nix develop
 just pg
 ```
 
@@ -31,6 +40,7 @@ This runs `postgres:16` on `localhost:5434` with user/password/db all set to `co
 In a second shell, start the API (migrations run automatically on boot):
 
 ```bash
+nix develop
 just api-dev
 ```
 
@@ -45,6 +55,7 @@ Run `just seed` to populate the database with initial data including:
 In a third shell:
 
 ```bash
+nix develop
 cd ui/packages && pnpm comhairle
 ```
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -1,0 +1,63 @@
+# Quickstart
+
+## Prerequisites
+
+You only need two things on the host. Everything else comes from Nix.
+
+- **Nix** with flakes enabled (recommended installer: <https://zero-to-nix.com/start/install> or [Determinate Nix Installer](https://install.determinate.systems/)).
+- **Docker daemon** Docker Desktop, Colima, or OrbStack. The Nix shell ships the `psql` client but not the Docker daemon.
+  - macOS: `brew install --cask docker` _or_ `brew install colima && colima start`.
+
+## Setup
+
+```bash
+git clone <repo> comhairle
+cd comhairle
+nix develop          # first run downloads the toolchain (a few minutes)
+cp .env.example .env
+```
+Once inside the shell you have: `cargo`, `rustc`, `clippy`, `rust-analyzer`, `rustfmt`, `sqlx`, `bacon`, `cargo-watch`, `just`, `watchexec`, `node`, `pnpm`, `psql`, `redis-cli`, `atac`, plus OpenSSL / pkg-config / cmake / clang wired up via env vars.
+
+## Run DB
+
+```bash
+just pg
+```
+
+This runs `postgres:16` on `localhost:5434` with user/password/db all set to `comhairle`. Data is persisted to `./pg_data` in the repo (already gitignored).
+
+## Run API
+
+In a second shell, start the API (migrations run automatically on boot):
+
+```bash
+just api-dev
+```
+
+### Seed DB
+
+Run `just seed` to populate the database with initial data including:
+- **Default admin login:** `admin@crown-shy.com` / `adminPassword123!`
+
+
+## Run UI
+
+In a third shell:
+
+```bash
+cd ui/packages && pnpm comhairle
+```
+
+That's it.
+
+| What         | URL                                |
+| ------------ | ---------------------------------- |
+| Frontend     | <http://localhost:5173>            |
+| API          | <http://localhost:3000>            |
+| Postgres     | `localhost:5434` (user/db: `comhairle`) |
+
+
+## Optional services
+
+`.env` is gitignored. Copy from `.env.example` and uncomment the sections you need. See the comments inline in `.env.example` for what each block unlocks (Mailer, Translator, Bot service, Video calls, etc.).
+

--- a/flake.lock
+++ b/flake.lock
@@ -1,57 +1,78 @@
 {
   "nodes": {
-    "nixpkgs": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1735563628,
-        "narHash": "sha256-OnSAY7XDSx7CtDoqNh8jwVwh4xNL/2HaJxGjryLWzX8=",
-        "rev": "b134951a4c9f3c995fd7be05f3243f8ecd65d798",
-        "revCount": 637546,
-        "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2405.637546%2Brev-b134951a4c9f3c995fd7be05f3243f8ecd65d798/01941dc2-2ab2-7453-8ebd-88712e28efae/source.tar.gz"
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
       },
       "original": {
-        "type": "tarball",
-        "url": "https://flakehub.com/f/NixOS/nixpkgs/0.2405.%2A.tar.gz"
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
       }
     },
-    "nixpkgs_2": {
+    "nixpkgs": {
       "locked": {
-        "lastModified": 1744536153,
-        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
+        "lastModified": 1767313136,
+        "narHash": "sha256-16KkgfdYqjaeRGBaYsNrhPRRENs0qzkQVUooNHtoy2w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
+        "rev": "ac62194c3917d5f474c1a844b6fd6da2db95077d",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
+        "ref": "nixos-25.05",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "root": {
       "inputs": {
+        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay"
       }
     },
     "rust-overlay": {
       "inputs": {
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
-        "lastModified": 1773630837,
-        "narHash": "sha256-zJhgAGnbVKeBMJOb9ctZm4BGS/Rnrz+5lfSXTVah4HQ=",
+        "lastModified": 1779765539,
+        "narHash": "sha256-2QxuD5gJcfCFsnqv54LGEHQKvd+K+DW/ecERwAvuA7w=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "f600ea449c7b5bb596fa1cf21c871cc5b9e31316",
+        "rev": "09889992e640378f7008c3302b9d4892579df610",
         "type": "github"
       },
       "original": {
         "owner": "oxalica",
-        "ref": "master",
         "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -61,6 +61,7 @@
 
             # ---- Task runner / misc ----
             just
+            tmux
             watchexec
             atac
             jq

--- a/flake.nix
+++ b/flake.nix
@@ -31,9 +31,7 @@
           env = {
             # Build-time toolchain env only.
             # Runtime/app config (DATABASE_URL, MAILER__*, secrets, etc.)
-            # lives in `.env` (gitignored) — see `.env.example` for the full
-            # list. `.envrc` loads `.env` via direnv, and the API binary
-            # itself loads it via `dotenvy::dotenv()`.
+            # lives in `.env` (gitignored) see `.env.example` for the full list
             PKG_CONFIG_PATH = "${pkgs.openssl.dev}/lib/pkgconfig";
             OPENSSL_DIR = "${pkgs.openssl.dev}";
             OPENSSL_LIB_DIR = "${pkgs.openssl.out}/lib";
@@ -90,9 +88,12 @@
             echo "  pnpm:    $(pnpm --version 2>/dev/null)"
             echo ""
             echo "Quickstart:"
-            echo "  just pg            # start Postgres in Docker (needs Docker Desktop/Colima)"
-            echo "  just api-dev       # run API"
-            echo "  cd ui/packages && pnpm comhairle   # run frontend"
+            echo "  just all           # start all services in tmux (postgres, api, ui, seed)"
+            echo ""
+            echo "  or if you prefer separate terminals:"
+            echo "    just pg          # start Postgres in Docker (needs Docker Desktop/Colima)"
+            echo "    just api-dev     # run API"
+            echo "    cd ui/packages && pnpm comhairle   # run frontend"
             echo ""
           '';
         };

--- a/flake.nix
+++ b/flake.nix
@@ -1,69 +1,102 @@
 {
-  description = "Example Rust development environment for Zero to Nix";
+  description = "Comhairle development environment (Rust API + SvelteKit UI)";
 
   # Flake inputs
   inputs = {
-    nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/0.2405.*.tar.gz";
-    rust-overlay.url = "github:oxalica/rust-overlay/master"; # A helper for Rust + Nix
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    flake-utils.url = "github:numtide/flake-utils";
   };
 
   # Flake outputs
-  outputs = { self, nixpkgs, rust-overlay }:
-    let
-      # Overlays enable you to customize the Nixpkgs attribute set
-      overlays = [
-        # Makes a `rust-bin` attribute available in Nixpkgs
-        (import rust-overlay)
-        # Provides a `rustToolchain` attribute for Nixpkgs that we can use to
-        # create a Rust environment
-        (self: super: {
-          rustToolchain = super.rust-bin.stable.latest.default.override{
-            extensions=["rust-analyzer" "clippy" "rust-src"];
-          };
-        })
-      ];
+  outputs = { self, nixpkgs, rust-overlay, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        overlays = [
+          (import rust-overlay)
+          (final: prev: {
+            rustToolchain = prev.rust-bin.stable.latest.default.override {
+              extensions = [ "rust-analyzer" "clippy" "rust-src" "rustfmt" ];
+            };
+          })
+        ];
 
-      # Systems supported
-      allSystems = [
-        "x86_64-linux" # 64-bit Intel/AMD Linux
-        "aarch64-linux" # 64-bit ARM Linux
-        "x86_64-darwin" # 64-bit Intel macOS
-        "aarch64-darwin" # 64-bit ARM macOS
-      ];
-
-      # Helper to provide system-specific attributes
-      forAllSystems = f: nixpkgs.lib.genAttrs allSystems (system: f {
-        pkgs = import nixpkgs { inherit overlays system; };
-      });
-    in
-    {
-      # Development environment output
-      devShells = forAllSystems ({ pkgs }: {
-        default = pkgs.mkShell {
-          # The Nix packages provided in the environment
-          env ={
-            DATABASE_URL="postgres://comhairle:comhairle@localhost:5434/comhairle";
-            RUST_LOG="debug";
-            RESOURCE_BUCKET="comhairle_resources";
-            ADMIN_USERS="admin@crown-shy.com, stuart@crown-shy.com,team@crown-shy.com";
+        pkgs = import nixpkgs { inherit system overlays; };
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          env = {
+            # Build-time toolchain env only.
+            # Runtime/app config (DATABASE_URL, MAILER__*, secrets, etc.)
+            # lives in `.env` (gitignored) — see `.env.example` for the full
+            # list. `.envrc` loads `.env` via direnv, and the API binary
+            # itself loads it via `dotenvy::dotenv()`.
+            PKG_CONFIG_PATH = "${pkgs.openssl.dev}/lib/pkgconfig";
+            OPENSSL_DIR = "${pkgs.openssl.dev}";
+            OPENSSL_LIB_DIR = "${pkgs.openssl.out}/lib";
+            OPENSSL_INCLUDE_DIR = "${pkgs.openssl.dev}/include";
           };
-          packages = (with pkgs; [
-            # The package provided by our custom overlay. Includes cargo, Clippy, cargo-fmt,
-            # rustdoc, rustfmt, and other tools.
-            minikube
+
+          packages = with pkgs; [
+            # ---- Rust toolchain ----
             rustToolchain
-            openssl
             sqlx-cli
-            postgresql
-            cmake 
-            clang
-            pkg-config
+            cargo-watch
+            cargo-nextest
             bacon
-            atac
-            just
-          ]) ++ pkgs.lib.optionals pkgs.stdenv.isDarwin (with pkgs; [ libiconv ]);
-        };
-      });
-    };
-}
 
+            # ---- Native build deps ----
+            openssl
+            pkg-config
+            cmake
+            clang
+            libiconv
+
+            # ---- Database / infra ----
+            postgresql_16   # provides psql client
+            redis           # provides redis-cli; runtime redis can also come from docker
+
+            # ---- Task runner / misc ----
+            just
+            watchexec
+            atac
+            jq
+            git
+
+            # ---- Frontend ----
+            nodejs_22
+            pnpm
+            corepack
+          ] ++ lib.optionals stdenv.isDarwin [
+            # macOS-specific: frameworks the aws-* and openssl crates can need
+            darwin.apple_sdk.frameworks.Security
+            darwin.apple_sdk.frameworks.SystemConfiguration
+            darwin.apple_sdk.frameworks.CoreFoundation
+          ] ++ lib.optionals stdenv.isLinux [
+            # Linux-only: minikube/kubectl for local k8s work
+            minikube
+            kubectl
+          ];
+
+          shellHook = ''
+            echo ""
+            echo "Comhairle dev shell ready"
+            echo "  rust:    $(rustc --version 2>/dev/null)"
+            echo "  node:    $(node --version 2>/dev/null)"
+            echo "  pnpm:    $(pnpm --version 2>/dev/null)"
+            echo ""
+            echo "Quickstart:"
+            echo "  just pg            # start Postgres in Docker (needs Docker Desktop/Colima)"
+            echo "  just api-dev       # run API"
+            echo "  cd ui/packages && pnpm comhairle   # run frontend"
+            echo ""
+          '';
+        };
+
+        # `nix fmt`
+        formatter = pkgs.nixpkgs-fmt;
+      });
+}

--- a/justfile
+++ b/justfile
@@ -28,3 +28,7 @@ watch-api-spec:
 
 api-watch:
     just api-dev & just watch-api-spec
+
+# Seed admin user + dev conversation (requires API running)
+seed:
+    ./scripts/seed-minimal.sh

--- a/justfile
+++ b/justfile
@@ -29,6 +29,6 @@ watch-api-spec:
 api-watch:
     just api-dev & just watch-api-spec
 
-# Seed admin user + dev conversation (requires API running)
+# Create admin user (requires API running)
 seed:
     ./scripts/seed-minimal.sh

--- a/justfile
+++ b/justfile
@@ -33,8 +33,17 @@ api-watch:
 seed:
     ./scripts/seed-minimal.sh
 
-# Run DB, API and UI in separate tmux windows
+# Start Redis for the apalis worker service (creates container on first run)
+start-redis:
+    docker start apalis-redis 2>/dev/null || docker run -d \
+        --name apalis-redis \
+        -p 63793:6379 \
+        -v apalis-redis-data:/data \
+        redis:7 redis-server --save 60 1
+
+# Run DB, Redis, API and UI in separate tmux windows
 all:
+    just start-redis
     tmux new-session -d -s comhairle -n postgres "just pg" \; \
         new-window -n api "just api-dev" \; \
         new-window -n ui "cd ui/packages && pnpm comhairle" \; \

--- a/justfile
+++ b/justfile
@@ -32,3 +32,11 @@ api-watch:
 # Create admin user (requires API running)
 seed:
     ./scripts/seed-minimal.sh
+
+# Run DB, API and UI in separate tmux windows
+all:
+    tmux new-session -d -s comhairle -n postgres "just pg" \; \
+        new-window -n api "just api-dev" \; \
+        new-window -n ui "cd ui/packages && pnpm comhairle" \; \
+        new-window -n seed "echo 'wait for api then: just seed'; exec $SHELL" \; \
+        attach-session -t comhairle

--- a/scripts/seed-minimal.sh
+++ b/scripts/seed-minimal.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Make admin + empty conversation. No workflow, no steps, no invite.
+#
+# Usage: ./scripts/seed-minimal.sh
+#
+# Env:
+#   API_URL         (default http://localhost:3000)
+#   ADMIN_EMAIL     (default admin@crown-shy.com)
+#   ADMIN_PASSWORD  (default adminPassword123!)
+#   ADMIN_USERNAME  (default devadmin)
+
+set -euo pipefail
+
+BACKEND_URL="${API_URL:-http://localhost:3000}"
+ADMIN_EMAIL="${ADMIN_EMAIL:-admin@crown-shy.com}"
+ADMIN_PASSWORD="${ADMIN_PASSWORD:-adminPassword123!}"
+ADMIN_USERNAME="${ADMIN_USERNAME:-devadmin}"
+
+command -v curl >/dev/null || { echo "missing curl"; exit 1; }
+command -v jq   >/dev/null || { echo "missing jq";   exit 1; }
+
+login() {
+  curl -s -i -X POST "$BACKEND_URL/auth/login" \
+    -H "Content-Type: application/json" \
+    --data "$(jq -nc --arg e "$ADMIN_EMAIL" --arg p "$ADMIN_PASSWORD" '{email:$e,password:$p}')" \
+    | tr -d '\r' \
+    | awk -F'auth-token=' 'tolower($0) ~ /^set-cookie:/ && NF>1 { sub(/;.*/, "", $2); print $2; exit }'
+}
+
+echo "→ login as $ADMIN_EMAIL"
+AUTH_COOKIE=$(login || true)
+
+if [ -z "$AUTH_COOKIE" ]; then
+  echo "→ no session, signing up"
+  curl -s -X POST "$BACKEND_URL/auth/signup" \
+    -H "Content-Type: application/json" \
+    --data "$(jq -nc \
+      --arg u "${ADMIN_USERNAME}-$RANDOM" \
+      --arg e "$ADMIN_EMAIL" \
+      --arg p "$ADMIN_PASSWORD" \
+      '{username:$u,email:$e,password:$p}')" >/dev/null
+  AUTH_COOKIE=$(login || true)
+fi
+
+[ -n "$AUTH_COOKIE" ] || { echo "login failed"; exit 1; }
+echo "✅ logged in"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+FIXTURE="${CONVERSATION_FIXTURE:-$SCRIPT_DIR/../fixtures/conversation.json}"
+[ -f "$FIXTURE" ] || { echo "❌ fixture not found: $FIXTURE"; exit 1; }
+
+echo "→ create conversation from $FIXTURE"
+CONV=$(curl -s -X POST "$BACKEND_URL/conversation" \
+  -H "Content-Type: application/json" \
+  -H "Cookie: auth-token=$AUTH_COOKIE" \
+  --data-binary "@$FIXTURE")
+
+CONVERSATION_ID=$(echo "$CONV" | jq -r '.id // empty')
+[ -n "$CONVERSATION_ID" ] || { echo "❌ conversation failed: $CONV"; exit 1; }
+
+echo "✅ conversation: $CONVERSATION_ID"

--- a/scripts/seed-minimal.sh
+++ b/scripts/seed-minimal.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Make admin + empty conversation. No workflow, no steps, no invite.
+# Add admin user 
 #
 # Usage: ./scripts/seed-minimal.sh
 #
@@ -43,19 +43,4 @@ if [ -z "$AUTH_COOKIE" ]; then
 fi
 
 [ -n "$AUTH_COOKIE" ] || { echo "login failed"; exit 1; }
-echo "✅ logged in"
-
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-FIXTURE="${CONVERSATION_FIXTURE:-$SCRIPT_DIR/../fixtures/conversation.json}"
-[ -f "$FIXTURE" ] || { echo "❌ fixture not found: $FIXTURE"; exit 1; }
-
-echo "→ create conversation from $FIXTURE"
-CONV=$(curl -s -X POST "$BACKEND_URL/conversation" \
-  -H "Content-Type: application/json" \
-  -H "Cookie: auth-token=$AUTH_COOKIE" \
-  --data-binary "@$FIXTURE")
-
-CONVERSATION_ID=$(echo "$CONV" | jq -r '.id // empty')
-[ -n "$CONVERSATION_ID" ] || { echo "❌ conversation failed: $CONV"; exit 1; }
-
-echo "✅ conversation: $CONVERSATION_ID"
+echo "✅ admin ready: $ADMIN_EMAIL"


### PR DESCRIPTION
I think this is the simplest way of onboarding 

```bash
cp .env.example .env   # set up env vars
nix develop            # get all deps
just all               # db, backend and frontend (in the nix env)
just seed              # add admin user (and maybe some conversations)
```

This should get everything running super quickly, I think. Example (i'd already ran `nix develop` so everything was cached, otherwise it's like 2gb download wait):

> I switch between tabs using ctrl-b + tab index (0 pg, 1 api, 2 ui, 3 free terminal)

https://github.com/user-attachments/assets/4d1c8e5d-5d3d-463b-b46c-7608729adf3a

