### PR TITLE
Thinking Space: add intent field to Thinking Space questions + some loading improvements

### DIFF
--- a/api/src/tools/thinking_space.rs
+++ b/api/src/tools/thinking_space.rs
@@ -41,6 +41,10 @@ use super::{ToolConfigSanitize, ToolImpl};
 pub struct ThinkingSpaceQuestion {
     pub id: Uuid,
     pub text: String,
+    /// Admin-authored description of *why* this question is being asked — fed to
+    /// the AI as `question_intent` so it can generate sharper follow-ups. Never
+    /// shown to participants.
+    pub intent: String,
 }
 
 #[derive(Clone, Deserialize, Serialize, Debug, JsonSchema, PartialEq)]
@@ -59,6 +63,7 @@ impl ToolConfigSanitize for ThinkingSpaceToolConfig {
 #[derive(Clone, Deserialize, Serialize, Debug, JsonSchema, PartialEq)]
 pub struct ThinkingSpaceSetupQuestion {
     pub text: String,
+    pub intent: String,
 }
 
 impl From<ThinkingSpaceSetupQuestion> for ThinkingSpaceQuestion {
@@ -66,6 +71,7 @@ impl From<ThinkingSpaceSetupQuestion> for ThinkingSpaceQuestion {
         Self {
             id: Uuid::new_v4(),
             text: q.text,
+            intent: q.intent,
         }
     }
 }

--- a/ui/packages/api-client/src/api.ts
+++ b/ui/packages/api-client/src/api.ts
@@ -714,7 +714,7 @@ export const Question = z
   .passthrough();
 export type Question = z.infer<typeof Question>;
 export const ThinkingSpaceQuestion = z
-  .object({ id: z.string().uuid(), text: z.string() })
+  .object({ id: z.string().uuid(), intent: z.string(), text: z.string() })
   .passthrough();
 export type ThinkingSpaceQuestion = z.infer<typeof ThinkingSpaceQuestion>;
 export const ToolConfig = z.union([
@@ -923,7 +923,7 @@ export const SetupQuestion = z
   .passthrough();
 export type SetupQuestion = z.infer<typeof SetupQuestion>;
 export const ThinkingSpaceSetupQuestion = z
-  .object({ text: z.string() })
+  .object({ intent: z.string(), text: z.string() })
   .passthrough();
 export type ThinkingSpaceSetupQuestion = z.infer<
   typeof ThinkingSpaceSetupQuestion

--- a/ui/packages/comhairle/src/lib/tools/thinking_space/FollowUpLoading.svelte
+++ b/ui/packages/comhairle/src/lib/tools/thinking_space/FollowUpLoading.svelte
@@ -1,0 +1,59 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { Skeleton } from '$lib/components/ui/skeleton';
+	import { Sparkles } from 'lucide-svelte';
+
+	const messages = [
+		'Your answers are shaping the questions, that’s why this takes a moment.',
+		'How often do you actually pause to reflect on this?',
+		'Taking time to think is important. You don’t get this space often.',
+		'Good thinking takes time. The next question will be worth it.'
+	];
+
+	// Card line widths — varied so the skeleton doesn't look like a flat block.
+	const lineLayouts: Array<{ first: string; second: string | null }> = [
+		{ first: 'w-full', second: 'w-2/3' },
+		{ first: 'w-11/12', second: null },
+		{ first: 'w-full', second: 'w-1/2' },
+		{ first: 'w-10/12', second: null }
+	];
+
+	let index = $state(0);
+	let fading = $state(false);
+
+	onMount(() => {
+		const interval = setInterval(() => {
+			fading = true;
+			setTimeout(() => {
+				index = (index + 1) % messages.length;
+				fading = false;
+			}, 300);
+		}, 4000);
+		return () => clearInterval(interval);
+	});
+</script>
+
+<section class="border-border space-y-4 border-t pt-6">
+	<div class="flex items-start gap-2">
+		<Sparkles class="text-primary mt-0.5 size-4 shrink-0 animate-pulse" />
+		<p
+			class="text-muted-foreground text-sm leading-relaxed transition-opacity duration-300"
+			class:opacity-0={fading}
+			class:opacity-100={!fading}
+			aria-live="polite"
+		>
+			{messages[index]}
+		</p>
+	</div>
+
+	<div class="space-y-2" aria-hidden="true">
+		{#each lineLayouts as layout, i (i)}
+			<div class="border-border bg-card rounded-lg border px-4 py-3">
+				<Skeleton class="h-4 {layout.first}" />
+				{#if layout.second}
+					<Skeleton class="mt-2 h-4 {layout.second}" />
+				{/if}
+			</div>
+		{/each}
+	</div>
+</section>

--- a/ui/packages/comhairle/src/lib/tools/thinking_space/QuestionEditorDialog.svelte
+++ b/ui/packages/comhairle/src/lib/tools/thinking_space/QuestionEditorDialog.svelte
@@ -44,7 +44,7 @@
 </script>
 
 <Dialog.Root {open} onOpenChange={(o) => onOpenChange(o)}>
-	<Dialog.Content class="min-w-[70vw]">
+	<Dialog.Content class="min-w-[95vw] md:min-w-[70vw] xl:min-w-[1000px]">
 		<Dialog.Header>
 			<Dialog.Title>{isEditing ? 'Edit question' : 'New question'}</Dialog.Title>
 			<Dialog.Description>

--- a/ui/packages/comhairle/src/lib/tools/thinking_space/QuestionEditorDialog.svelte
+++ b/ui/packages/comhairle/src/lib/tools/thinking_space/QuestionEditorDialog.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
 	import * as Dialog from '$lib/components/ui/dialog';
+	import * as Tooltip from '$lib/components/ui/tooltip';
 	import { Button } from '$lib/components/ui/button';
 	import { Textarea } from '$lib/components/ui/textarea';
 	import { Label } from '$lib/components/ui/label';
+	import { HelpCircle } from 'lucide-svelte';
 	import type { QuestionConfig } from './types';
 
 	type Props = {
@@ -15,30 +17,34 @@
 	let { open, question = null, onOpenChange, onSave }: Props = $props();
 
 	let draftText = $state('');
-	let errorMessage = $state<string | null>(null);
+	let draftIntent = $state('');
+	let textError = $state<string | null>(null);
+	let intentError = $state<string | null>(null);
 
 	const isEditing = $derived(!!question);
 
 	$effect(() => {
 		if (open) {
 			draftText = question?.text ?? '';
-			errorMessage = null;
+			draftIntent = question?.intent ?? '';
+			textError = null;
+			intentError = null;
 		}
 	});
 
 	function save() {
 		const text = draftText.trim();
-		if (!text) {
-			errorMessage = 'Question text is required.';
-			return;
-		}
-		onSave({ id: question?.id ?? crypto.randomUUID(), text });
+		const intent = draftIntent.trim();
+		textError = text ? null : 'Question text is required.';
+		intentError = intent ? null : 'Intent is required so the AI can generate good follow-ups.';
+		if (textError || intentError) return;
+		onSave({ id: question?.id ?? crypto.randomUUID(), text, intent });
 		onOpenChange(false);
 	}
 </script>
 
 <Dialog.Root {open} onOpenChange={(o) => onOpenChange(o)}>
-	<Dialog.Content class="sm:max-w-lg">
+	<Dialog.Content class="w-[70vw] max-w-[70vw] sm:max-w-[70vw]">
 		<Dialog.Header>
 			<Dialog.Title>{isEditing ? 'Edit question' : 'New question'}</Dialog.Title>
 			<Dialog.Description>
@@ -46,17 +52,49 @@
 			</Dialog.Description>
 		</Dialog.Header>
 
-		<div class="space-y-2 py-2">
-			<Label for="ts-question-text">Question</Label>
-			<Textarea
-				id="ts-question-text"
-				bind:value={draftText}
-				placeholder="Write your question…"
-				rows={3}
-			/>
-			{#if errorMessage}
-				<p class="text-destructive text-sm">{errorMessage}</p>
-			{/if}
+		<div class="space-y-5 py-2">
+			<div class="space-y-2">
+				<Label for="ts-question-text">Question</Label>
+				<Textarea
+					id="ts-question-text"
+					bind:value={draftText}
+					placeholder="e.g. How financially supported do you feel as a farmer in Scotland today?"
+					rows={3}
+				/>
+				{#if textError}
+					<p class="text-destructive text-sm">{textError}</p>
+				{/if}
+			</div>
+
+			<div class="space-y-2">
+				<div class="flex items-center gap-1.5">
+					<Label for="ts-question-intent">Why are you asking this? (for the AI)</Label>
+					<Tooltip.Provider delayDuration={150}>
+						<Tooltip.Root>
+							<Tooltip.Trigger
+								class="text-muted-foreground hover:text-foreground"
+								aria-label="What is this for?"
+							>
+								<HelpCircle class="size-4" />
+							</Tooltip.Trigger>
+							<Tooltip.Content class="max-w-xs text-sm">
+								This is private. Participants never see it. It guides the AI's
+								follow-up questions, so the more specific you are about what you
+								want to learn, the sharper the follow-ups will be.
+							</Tooltip.Content>
+						</Tooltip.Root>
+					</Tooltip.Provider>
+				</div>
+				<Textarea
+					id="ts-question-intent"
+					bind:value={draftIntent}
+					placeholder={'e.g. I want to understand whether they feel financially supported, not just whether they’re farming successfully. I’m especially interested in subsidies, market access, and whether the next generation can afford to take over.'}
+					rows={4}
+				/>
+				{#if intentError}
+					<p class="text-destructive text-sm">{intentError}</p>
+				{/if}
+			</div>
 		</div>
 
 		<Dialog.Footer>

--- a/ui/packages/comhairle/src/lib/tools/thinking_space/QuestionEditorDialog.svelte
+++ b/ui/packages/comhairle/src/lib/tools/thinking_space/QuestionEditorDialog.svelte
@@ -44,7 +44,7 @@
 </script>
 
 <Dialog.Root {open} onOpenChange={(o) => onOpenChange(o)}>
-	<Dialog.Content class="w-[70vw] max-w-[70vw] sm:max-w-[70vw]">
+	<Dialog.Content class="min-w-[70vw]">
 		<Dialog.Header>
 			<Dialog.Title>{isEditing ? 'Edit question' : 'New question'}</Dialog.Title>
 			<Dialog.Description>

--- a/ui/packages/comhairle/src/lib/tools/thinking_space/QuestionFlow.svelte
+++ b/ui/packages/comhairle/src/lib/tools/thinking_space/QuestionFlow.svelte
@@ -3,9 +3,10 @@
 	import { Button } from '$lib/components/ui/button';
 	import { Textarea } from '$lib/components/ui/textarea';
 	import { Progress } from '$lib/components/ui/progress';
-	import { CornerDownRight, Shuffle, Check, Loader2, RotateCcw } from 'lucide-svelte';
+	import { CornerDownRight, Shuffle, Check, RotateCcw } from 'lucide-svelte';
 	import type { QuestionConfig, QuestionAnswers } from './types';
 	import { QuestionFlowState } from './questionFlowState.svelte';
+	import FollowUpLoading from './FollowUpLoading.svelte';
 
 	type Props = {
 		topic: string;
@@ -94,9 +95,6 @@
 	<div class="border-border bg-card/60 border-b px-6 py-4 backdrop-blur">
 		<div class="mx-auto max-w-2xl">
 			<div class="text-muted-foreground mb-2 flex items-center justify-between text-xs">
-				<span class="font-medium tracking-wide uppercase">
-					Thinking space · {topic}
-				</span>
 				<span>
 					Question {flow.currentQuestionIndex + 1} of {questions.length} · {Math.round(
 						flow.progress
@@ -190,10 +188,7 @@
 
 			<!-- Picker: loading -->
 			{#if flow.currentState.phase === 'picking' && flow.currentState.pickerLoading}
-				<section class="border-border flex items-center gap-2 border-t pt-6">
-					<Loader2 class="text-primary size-4 animate-spin" />
-					<p class="text-muted-foreground text-sm">Generating follow-up questions…</p>
-				</section>
+				<FollowUpLoading />
 			{/if}
 
 			<!-- Picker: failed to load -->
@@ -210,8 +205,8 @@
 			<!-- Picker -->
 			{#if flow.currentState.phase === 'picking' && flow.currentState.picker.length > 0 && !flow.currentState.pickerLoading}
 				<section class="border-border space-y-3 border-t pt-6">
-					<div class="flex items-baseline justify-between gap-3">
-						<div>
+					<div class="flex items-start justify-between gap-3">
+						<div class="min-w-0">
 							<p class="text-foreground text-sm font-semibold">
 								{flow.minReached
 									? 'Or keep deepening your views'
@@ -231,6 +226,15 @@
 								</p>
 							{/if}
 						</div>
+						<Button
+							variant="secondary"
+							size="sm"
+							class="shrink-0"
+							onclick={() => flow.pickRandom()}
+						>
+							<Shuffle class="size-3.5" />
+							Pick one for me
+						</Button>
 					</div>
 					<div class="space-y-2">
 						{#each flow.currentState.picker.slice(0, 5) as followUpQuestion, i (followUpQuestion + i)}
@@ -243,10 +247,6 @@
 							</button>
 						{/each}
 					</div>
-					<Button variant="secondary" size="sm" onclick={() => flow.pickRandom()}>
-						<Shuffle class="size-3.5" />
-						Pick one for me
-					</Button>
 				</section>
 			{/if}
 

--- a/ui/packages/comhairle/src/lib/tools/thinking_space/QuestionFlow.svelte
+++ b/ui/packages/comhairle/src/lib/tools/thinking_space/QuestionFlow.svelte
@@ -94,7 +94,7 @@
 	<!-- Header / progress -->
 	<div class="border-border bg-card/60 border-b px-6 py-4 backdrop-blur">
 		<div class="mx-auto max-w-2xl">
-			<div class="text-muted-foreground mb-2 flex items-center justify-between text-xs">
+			<div class="text-muted-foreground mb-2 flex items-center justify-end text-xs">
 				<span>
 					Question {flow.currentQuestionIndex + 1} of {questions.length} · {Math.round(
 						flow.progress

--- a/ui/packages/comhairle/src/lib/tools/thinking_space/ThinkingSpaceManage.svelte
+++ b/ui/packages/comhairle/src/lib/tools/thinking_space/ThinkingSpaceManage.svelte
@@ -43,7 +43,12 @@
 			| undefined;
 		topic = cfg?.topic ?? '';
 		config = {
-			questions: cfg?.root_questions?.map((q) => ({ id: q.id, text: q.text })) ?? [],
+			questions:
+				cfg?.root_questions?.map((q) => ({
+					id: q.id,
+					text: q.text,
+					intent: q.intent
+				})) ?? [],
 			followUpRoundsCount:
 				typeof cfg?.follow_up_rounds_count === 'number'
 					? Math.max(0, Math.min(5, cfg.follow_up_rounds_count))
@@ -80,6 +85,14 @@
 		if (topic.trim().length < 3) {
 			notifications.send({
 				message: 'Topic must be at least 3 characters.',
+				priority: 'ERROR'
+			});
+			return;
+		}
+		const missingIntent = config.questions.find((q) => !q.intent.trim());
+		if (missingIntent) {
+			notifications.send({
+				message: `Every question needs an intent. Add one to "${missingIntent.text.trim() || 'Untitled question'}".`,
 				priority: 'ERROR'
 			});
 			return;
@@ -219,13 +232,25 @@
 							>
 								<GripVertical class="size-4" />
 							</button>
-							<p
-								class="min-w-0 flex-1 text-base leading-relaxed"
-								class:text-foreground={q.text.trim()}
-								class:text-muted-foreground={!q.text.trim()}
-							>
-								{q.text.trim() || 'Untitled question'}
-							</p>
+							<div class="min-w-0 flex-1 space-y-1">
+								<p
+									class="text-base leading-relaxed"
+									class:text-foreground={q.text.trim()}
+									class:text-muted-foreground={!q.text.trim()}
+								>
+									{q.text.trim() || 'Untitled question'}
+								</p>
+								{#if q.intent.trim()}
+									<p class="text-muted-foreground line-clamp-2 text-xs">
+										<span class="font-medium">Intent:</span>
+										{q.intent.trim()}
+									</p>
+								{:else}
+									<p class="text-destructive text-xs">
+										Intent missing — add one before saving.
+									</p>
+								{/if}
+							</div>
 							<div class="flex shrink-0 gap-2">
 								<Button
 									variant="outline"

--- a/ui/packages/comhairle/src/lib/tools/thinking_space/questionFlowState.svelte.ts
+++ b/ui/packages/comhairle/src/lib/tools/thinking_space/questionFlowState.svelte.ts
@@ -187,13 +187,11 @@ export class QuestionFlowState {
 			pickerError: false
 		};
 		try {
+			const question = this.questions[questionIndex];
 			const followUps = await fetchFollowUps({
 				workflowStepId: this.workflowStepId,
-				startingQuestion: this.questions[questionIndex].text,
-				// The root question config has no separate `intent` field yet,
-				// so we send the question text here as a proxy. If the config
-				// schema grows an explicit intent, use that instead.
-				questionIntent: this.questions[questionIndex].text,
+				startingQuestion: question.text,
+				questionIntent: question.intent,
 				history: this.buildHistory(questionIndex)
 			});
 			const picker = followUps.map((followUp) => followUp.question);

--- a/ui/packages/comhairle/src/lib/tools/thinking_space/types.ts
+++ b/ui/packages/comhairle/src/lib/tools/thinking_space/types.ts
@@ -9,6 +9,10 @@
 export interface QuestionConfig {
 	id: string;
 	text: string;
+	intent: string;
+	// Matches the api-client's `passthrough()` shape so this type is assignable
+	// when sent back as part of an UpdateConversationWorkflowStep payload.
+	[key: string]: unknown;
 }
 
 export interface FollowUpAnswer {


### PR DESCRIPTION
- add intent field to admin config



Extra while I was there:
- Add loading skeletons and some loading text, so stuff doesn't seem broken
<img width="350" height="452" alt="image" src="https://github.com/user-attachments/assets/b20e88b4-f292-43d5-94a8-17984e09e5a9" />
<img width="1054" height="855" alt="image" src="https://github.com/user-attachments/assets/4adb15f7-f6dd-4f85-bac2-138a21d82ed2" />


<img width="1440" height="929" alt="image" src="https://github.com/user-attachments/assets/9e4ba1af-3681-4101-8297-452acfc36cce" />
