### PR TITLE
Add better loading states and submission guards to live participant flow

### DIFF
--- a/ui/packages/comhairle/src/lib/components/StepHeader.svelte
+++ b/ui/packages/comhairle/src/lib/components/StepHeader.svelte
@@ -13,6 +13,7 @@
 		onPrev?: () => void;
 		onNext?: () => void;
 		nextDisabled?: boolean;
+		nextLoading?: boolean;
 		boldDescription?: boolean;
 		availableDocuments?: ComhairleDocument[];
 		conversationId?: string;
@@ -28,6 +29,7 @@
 		onPrev,
 		onNext,
 		nextDisabled = false,
+		nextLoading = false,
 		boldDescription = true,
 		availableDocuments = [],
 		conversationId
@@ -78,11 +80,13 @@
 				</p>
 			</div>
 
-			{#if onNext && !nextDisabled}
+			{#if onNext}
 				<button
 					onclick={onNext}
-					class="text-muted-foreground shrink-0 p-2"
+					disabled={nextDisabled || nextLoading}
+					class="text-muted-foreground shrink-0 p-2 disabled:cursor-not-allowed disabled:opacity-40"
 					aria-label="Next step"
+					aria-busy={nextLoading}
 				>
 					<ChevronRight class="h-6 w-6 md:h-8 md:w-8" />
 				</button>

--- a/ui/packages/comhairle/src/lib/tools/learn/LearnUI.svelte
+++ b/ui/packages/comhairle/src/lib/tools/learn/LearnUI.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { Button } from '$lib/components/ui/button';
+	import { Spinner } from '$lib/components/ui/spinner';
 	import { Progress } from '$lib/components/ui/progress';
 	import ContentRenderer from '$lib/components/RichTextEditor/ContentRenderer/ContentRenderer.svelte';
 	import * as m from '$lib/paraglide/messages';
@@ -20,13 +21,15 @@
 		onDone,
 		onNextAction,
 		onPrevAction,
-		conversation
+		conversation,
+		isSubmitting = false
 	}: {
 		pages: Array<Page>;
 		onDone: () => void;
 		onNextAction?: (fn: () => void) => void;
 		onPrevAction?: (fn: (() => void) | undefined) => void;
 		conversation?: LocalizedConversationDto;
+		isSubmitting?: boolean;
 	} = $props();
 
 	let tutorAvailable = $derived(
@@ -34,12 +37,15 @@
 	);
 
 	let availableDocuments = $state<ComhairleDocument[]>([]);
+	let documentsLoading = $state(true);
 
 	$effect(() => {
 		if (!conversation?.id) {
 			availableDocuments = [];
+			documentsLoading = false;
 			return;
 		}
+		documentsLoading = true;
 		apiClient
 			.ListDocuments({ params: { conversation_id: conversation.id } })
 			.then((docs) => {
@@ -47,6 +53,9 @@
 			})
 			.catch(() => {
 				availableDocuments = [];
+			})
+			.finally(() => {
+				documentsLoading = false;
 			});
 	});
 
@@ -75,8 +84,8 @@
 		});
 	}
 
-	/** True while SvelteKit is routing to another step / page. */
-	let showSkeleton = $derived(!!navigating.to);
+	/** True while SvelteKit is routing OR documents for embeds are still being fetched. */
+	let showSkeleton = $derived(!!navigating.to || documentsLoading);
 
 	$effect(() => {
 		if (onNextAction) {
@@ -123,9 +132,12 @@
 	{/if}
 
 	{#if currentPageNo == pages.length - 1}
-		<Button class="mx-auto mt-10" onclick={onDone} disabled={showSkeleton}
-			>{m.continue_()}</Button
-		>
+		<Button class="mx-auto mt-10" onclick={onDone} disabled={showSkeleton || isSubmitting}>
+			{#if isSubmitting}
+				<Spinner class="mr-2 size-4" />
+			{/if}
+			{m.continue_()}
+		</Button>
 	{:else}
 		<Button class="mx-auto mt-10" onclick={nextPage} disabled={showSkeleton}>{m.next()}</Button>
 	{/if}

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/+page.svelte
@@ -2,6 +2,7 @@
 	import type { PageProps } from '../$types.js';
 	import Breadcrumbs from '$lib/components/Breadcrumbs.svelte';
 	import Button from '$lib/components/ui/button/button.svelte';
+	import { Spinner } from '$lib/components/ui/spinner';
 	import * as m from '$lib/paraglide/messages';
 	import { notifications } from '$lib/notifications.svelte.js';
 	import { goto, invalidateAll } from '$app/navigation';
@@ -17,9 +18,14 @@
 	let pageTitle = $derived(conversation?.title ?? 'Conversation');
 
 	let privacyPolicyOpen = $state(false);
+	let isSubmitting = $state(false);
+	let privacyAccepted = $state(false);
 
 	function handleJoin() {
+		if (isSubmitting) return;
+		isSubmitting = true;
 		if (conversation.shortPrivacyPolicy) {
+			privacyAccepted = false;
 			privacyPolicyOpen = true;
 		} else {
 			doJoin();
@@ -35,8 +41,15 @@
 	}
 
 	function handlePrivacyPolicyAccept() {
+		privacyAccepted = true;
 		doJoin();
 	}
+
+	$effect(() => {
+		if (!privacyPolicyOpen && !privacyAccepted && isSubmitting) {
+			isSubmitting = false;
+		}
+	});
 
 	let firstWorkflow = $derived(workflows[0]);
 
@@ -47,6 +60,8 @@
 	);
 
 	async function redirectToLogin() {
+		if (isSubmitting) return;
+		isSubmitting = true;
 		loginRedirect(url.pathname, 'Login to join the conversation');
 	}
 
@@ -64,6 +79,8 @@
 	}
 
 	async function redirectToSignIn() {
+		if (isSubmitting) return;
+		isSubmitting = true;
 		signupRedirect(url.pathname, 'Signup to join the conversation');
 	}
 
@@ -90,6 +107,7 @@
 				message: 'Failed to sign you up for the conversation, try again later',
 				priority: 'ERROR'
 			});
+			isSubmitting = false;
 		}
 	}
 </script>
@@ -119,21 +137,49 @@
 							href={firstWorkflowPath}>{m.jump_back_in()}</Button
 						>
 					{:else}
-						<Button class="mt-5 w-full md:w-fit" onclick={handleJoin}
-							>{conversation.callToAction || m.join_the_conversation()}</Button
+						<Button
+							class="mt-5 w-full md:w-fit"
+							onclick={handleJoin}
+							disabled={isSubmitting}
 						>
+							{#if isSubmitting}
+								<Spinner class="mr-2 size-4" />
+							{/if}
+							{conversation.callToAction || m.join_the_conversation()}
+						</Button>
 					{/if}
 				{:else if firstWorkflow.autoLogin}
-					<Button class="mt-5 w-full md:w-fit" onclick={handleJoin}
-						>{conversation.callToAction || m.join_the_conversation()}</Button
+					<Button
+						class="mt-5 w-full md:w-fit"
+						onclick={handleJoin}
+						disabled={isSubmitting}
 					>
+						{#if isSubmitting}
+							<Spinner class="mr-2 size-4" />
+						{/if}
+						{conversation.callToAction || m.join_the_conversation()}
+					</Button>
 				{:else}
-					<Button class="mt-5 w-full md:w-fit" onclick={redirectToLogin}
-						>{m.login_to_take_part()}</Button
+					<Button
+						class="mt-5 w-full md:w-fit"
+						onclick={redirectToLogin}
+						disabled={isSubmitting}
 					>
-					<Button class="mt-5 w-full md:w-fit" onclick={redirectToSignIn}
-						>{m.signup_to_take_part()}</Button
+						{#if isSubmitting}
+							<Spinner class="mr-2 size-4" />
+						{/if}
+						{m.login_to_take_part()}
+					</Button>
+					<Button
+						class="mt-5 w-full md:w-fit"
+						onclick={redirectToSignIn}
+						disabled={isSubmitting}
 					>
+						{#if isSubmitting}
+							<Spinner class="mr-2 size-4" />
+						{/if}
+						{m.signup_to_take_part()}
+					</Button>
 				{/if}
 			</ConversationSummary>
 

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/workflow/[workflow_id]/s/[workflow_step_id]/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/workflow/[workflow_id]/s/[workflow_step_id]/+page.svelte
@@ -13,6 +13,7 @@
 	import StepHeaderSkeleton from '$lib/components/StepHeaderSkeleton.svelte';
 
 	import { Button } from '$lib/components/ui/button';
+	import { Spinner } from '$lib/components/ui/spinner';
 	import { goto } from '$app/navigation';
 	import { thank_you_page, next_workflow_step_url, workflow_step_url } from '$lib/urls';
 	import { page, navigating } from '$app/state';
@@ -116,6 +117,12 @@
 	let currentNextAction = $state<(() => void) | undefined>(undefined);
 	let currentPrevAction = $state<(() => void) | undefined>(undefined);
 	let canProceed = $state(false);
+	let isSubmitting = $state(false);
+
+	$effect(() => {
+		workflowStep.id;
+		isSubmitting = false;
+	});
 
 	$effect(() => {
 		const type = toolConfig.type;
@@ -147,6 +154,9 @@
 	}
 
 	async function stepComplete() {
+		if (isSubmitting) return;
+		isSubmitting = true;
+
 		if (isRevisiting) {
 			const isPreview = !conversation.isLive;
 			const currentIdx = sortedSteps.findIndex((ws) => ws.id === workflowStep.id);
@@ -199,6 +209,7 @@
 				message: 'Something unexpected happened. Try again shortly',
 				priority: 'ERROR'
 			});
+			isSubmitting = false;
 		}
 	}
 </script>
@@ -228,6 +239,7 @@
 					onPrev={currentPrevAction}
 					onNext={currentNextAction ?? stepComplete}
 					nextDisabled={!canProceed}
+					nextLoading={isSubmitting}
 					boldDescription={toolConfig.type === Polis.TOOL_NAME}
 					{availableDocuments}
 					conversationId={conversation.id}
@@ -238,9 +250,17 @@
 		<div class="flex w-full grow flex-col gap-y-2 md:order-3">
 			<div class="flex grow flex-col">
 				{#if !workflowStep.required}
-					<Button onclick={stepComplete} class="mx-auto" variant="secondary"
-						>Skip this step</Button
+					<Button
+						onclick={stepComplete}
+						disabled={isSubmitting}
+						class="mx-auto"
+						variant="secondary"
 					>
+						{#if isSubmitting}
+							<Spinner class="mr-2 size-4" />
+						{/if}
+						Skip this step
+					</Button>
 				{/if}
 				<div class="mb-10 w-full grow">
 					{#if navigating.to}
@@ -259,6 +279,7 @@
 								onNextAction={handleNextAction}
 								onPrevAction={handlePrevAction}
 								{conversation}
+								{isSubmitting}
 							/>
 						{/key}
 					{/if}


### PR DESCRIPTION
- Add `isSubmitting` state tracking and loading indicators (spinners) to prevent duplicate submissions across conversation join, workflow step completion, and Learn UI.
- Add `nextLoading` prop to StepHeader to show loading state on next button.
- Improve document loading state tracking in LearnUI


https://github.com/user-attachments/assets/45f62b0b-ee7d-4aa0-b587-2e1fa0ce0f4e



