### PR TITLE
407 api key extraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1044,6 +1044,7 @@ dependencies = [
  "bytes",
  "cookie",
  "futures-util",
+ "headers",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -22,8 +22,12 @@ path = "src/data_loader/main.rs"
 axum = { version = "0.8.3", features = ["ws", "multipart"] }
 async-trait = "0.1.83"
 config = "0.15.8"
-sea-query = {version = "0.32.3", features=["attr","postgres-array","chrono"] }
-sea-query-binder = {version="0.7.0", features=[
+sea-query = { version = "0.32.3", features = [
+    "attr",
+    "postgres-array",
+    "chrono",
+] }
+sea-query-binder = { version = "0.7.0", features = [
     "sqlx-postgres",
     "with-chrono",
     "with-json",
@@ -34,20 +38,30 @@ sea-query-binder = {version="0.7.0", features=[
     "with-time",
     "with-ipnetwork",
     "with-mac_address",
-    "runtime-async-std-native-tls"
-    ]}
+    "runtime-async-std-native-tls",
+] }
 rand = "0.8"
 serde = { version = "1.0.218", features = ["derive"] }
 # serde = {version="1.0.217", features=['derive']}
-sqlx = { version = "0.8.3", features = ["runtime-tokio-native-tls", "macros", "postgres", "chrono"] }
-sqlx-postgres = { version = "0.8.3", features = ["chrono", "json", "time", "uuid"] }
+sqlx = { version = "0.8.3", features = [
+    "runtime-tokio-native-tls",
+    "macros",
+    "postgres",
+    "chrono",
+] }
+sqlx-postgres = { version = "0.8.3", features = [
+    "chrono",
+    "json",
+    "time",
+    "uuid",
+] }
 thiserror = "2.0.11"
-tokio = {version= "1.43.0", features=["full"]}
-tower-http = {version="0.6.2", features=["trace","cors","auth"]}
+tokio = { version = "1.43.0", features = ["full"] }
+tower-http = { version = "0.6.2", features = ["trace", "cors", "auth"] }
 tower_governor = "0.8"
 governor = "0.10"
 tracing = "0.1.41"
-tracing-subscriber = {version ="0.3.19", features=["env-filter"]}
+tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 
 hyper = { version = "1.0.0", features = ["full"] }
 hyper-util = { version = "0.1.1", features = ["client-legacy"] }
@@ -75,12 +89,24 @@ apalis-cron = "0.7.4"
 #API documentation
 
 schemars = { version = "0.8.10", features = ["uuid1", "chrono"] }
-aide = { version = "0.14.0", features = ["redoc", "swagger", "scalar", "axum", "axum-tokio", "axum-json", "axum-query", "axum-matched-path", "macros", "axum-extra-cookie", "axum-multipart"] }
-axum-extra = { version = "0.10.1", features = ["cookie"] }
+aide = { version = "0.14.0", features = [
+    "redoc",
+    "swagger",
+    "scalar",
+    "axum",
+    "axum-tokio",
+    "axum-json",
+    "axum-query",
+    "axum-matched-path",
+    "macros",
+    "axum-extra-cookie",
+    "axum-multipart",
+] }
+axum-extra = { version = "0.10.1", features = ["cookie", "typed-header"] }
 aws-sdk-s3 = "1.82.0"
 aws-config = "1.6.1"
-reqwest = {version = "0.12.15", features=["cookies", "json", "gzip"]}
-axum-proxy = {version="0.4.1", features=["http2","https","axum"]}
+reqwest = { version = "0.12.15", features = ["cookies", "json", "gzip"] }
+axum-proxy = { version = "0.4.1", features = ["http2", "https", "axum"] }
 regex = "1.11.1"
 fancy-regex = "0.14.0"
 lettre = "0.11.16"
@@ -98,11 +124,11 @@ dashmap = "6.1.0"
 
 # adaptors
 
-heyform-sdk = {path="../adaptors/heyform-rust-sdk"}
-ragflow = {path="../adaptors/ragflow"}
+heyform-sdk = { path = "../adaptors/heyform-rust-sdk" }
+ragflow = { path = "../adaptors/ragflow" }
 
 # Macros
-comhairle-macros = {path="../comhairle_macros"}
+comhairle-macros = { path = "../comhairle_macros" }
 tracing-test = "0.2.5"
 dotenvy = "0.15.7"
 fake = { version = "4", features = ["chrono", "derive", "uuid"] }
@@ -115,7 +141,7 @@ bytes = "1.4"
 aws-sdk-transcribestreaming = "1.95.0"
 aws-sdk-transcribe = "1.96.0"
 aws-smithy-types = "1.2.11"
-aws-smithy-http = {version="0.62.6", features=["event-stream"]}
+aws-smithy-http = { version = "0.62.6", features = ["event-stream"] }
 async-stream = "0.3.6"
 urlencoding = "2.1.3"
 css-inline = "0.20.2"
@@ -130,4 +156,3 @@ fake = { version = "4", features = ["derive"] }
 
 [build-dependencies]
 minijinja-embed = "2.10.2"
-

--- a/api/src/error.rs
+++ b/api/src/error.rs
@@ -199,6 +199,9 @@ pub enum ComhairleError {
     #[error("Requires Auth User")]
     RequiresAuthUser,
 
+    #[error("Invalid api key")]
+    InvalidApiKey,
+
     #[error("Only the owner of the conversation can perform this action")]
     UserIsNotConversationOwner,
 
@@ -339,6 +342,7 @@ impl IntoResponse for ComhairleError {
             | ComhairleError::NoUserFoundForId(_) => StatusCode::NOT_FOUND,
             ComhairleError::UserRequired
             | ComhairleError::WrongPassword
+            | ComhairleError::InvalidApiKey
             | ComhairleError::RequiresAuthUser
             | ComhairleError::InviteDoesNotMatchUser
             | ComhairleError::UserIsNotConversationOwner

--- a/api/src/models/api_key.rs
+++ b/api/src/models/api_key.rs
@@ -2,11 +2,11 @@ use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use chrono::{DateTime, Utc};
 use rand::RngCore;
 use schemars::JsonSchema;
-use sea_query::{enum_def, PostgresQueryBuilder, Query};
+use sea_query::{enum_def, Expr, PostgresQueryBuilder, Query};
 use sea_query_binder::SqlxBinder;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use sqlx::{prelude::FromRow, query_with, PgPool};
+use sqlx::{prelude::FromRow, query_scalar_with, query_with, PgPool};
 use uuid::Uuid;
 
 use crate::error::ComhairleError;
@@ -42,14 +42,17 @@ fn generate_api_key(prefix: &str) -> (String, String) {
 }
 
 #[derive(Deserialize, Debug, JsonSchema)]
-pub struct CreateRequest {
-    user_id: Uuid,
-    name: String,
-    prefix: String,
+pub struct CreateApiKeyRequest {
+    pub name: String,
+    pub prefix: String,
 }
 
 // No tracing to avoid keys being exposed in logs
-pub async fn create(db: &PgPool, create_key: CreateRequest) -> Result<String, ComhairleError> {
+pub async fn create(
+    db: &PgPool,
+    user_id: Uuid,
+    create_key: CreateApiKeyRequest,
+) -> Result<String, ComhairleError> {
     let (raw, hash) = generate_api_key(&create_key.prefix);
 
     let columns = vec![
@@ -61,7 +64,7 @@ pub async fn create(db: &PgPool, create_key: CreateRequest) -> Result<String, Co
     let key_prefix = raw[..16].to_string();
     let values = vec![
         hash.into(),
-        create_key.user_id.into(),
+        user_id.into(),
         key_prefix.into(),
         create_key.name.into(),
     ];
@@ -78,9 +81,36 @@ pub async fn create(db: &PgPool, create_key: CreateRequest) -> Result<String, Co
     Ok(raw)
 }
 
+pub async fn get_matching_user_id(db: &PgPool, key: &str) -> Result<Uuid, ComhairleError> {
+    let hash = hash_api_key(key);
+
+    let (sql, values) = Query::select()
+        .column(ApiKeyIden::UserId)
+        .from(ApiKeyIden::Table)
+        .and_where(Expr::col(ApiKeyIden::Hash).eq(hash))
+        .and_where(Expr::col(ApiKeyIden::RevokedAt).is_null())
+        .and_where(
+            Expr::col(ApiKeyIden::ExpiredAt)
+                .is_null()
+                .or(Expr::col(ApiKeyIden::ExpiredAt).gt(Expr::current_timestamp())),
+        )
+        .build_sqlx(PostgresQueryBuilder);
+
+    let user_id = query_scalar_with::<_, Uuid, _>(&sql, values)
+        .fetch_optional(db)
+        .await?
+        .ok_or(ComhairleError::InvalidApiKey)?;
+
+    Ok(user_id)
+}
+
 #[cfg(test)]
 mod tests {
+    use crate::models::users;
+
     use super::*;
+
+    use std::error::Error;
 
     #[test]
     fn same_keys_produce_same_hashes() {
@@ -119,5 +149,26 @@ mod tests {
     fn hash_matches_generated_key() {
         let (raw, hash) = generate_api_key("sk_test");
         assert_eq!(hash, hash_api_key(&raw));
+    }
+
+    #[sqlx::test]
+    async fn should_return_matching_user_id(pool: PgPool) -> Result<(), Box<dyn Error>> {
+        let user = users::create_annon_user(&pool).await?;
+
+        let key = create(
+            &pool,
+            user.id,
+            CreateApiKeyRequest {
+                name: "test_api_key".to_string(),
+                prefix: "sk_test".to_string(),
+            },
+        )
+        .await?;
+
+        let user_id = get_matching_user_id(&pool, &key).await?;
+
+        assert_eq!(user_id, user.id, "ids don't match");
+
+        Ok(())
     }
 }

--- a/api/src/routes/api_keys.rs
+++ b/api/src/routes/api_keys.rs
@@ -10,8 +10,8 @@ use serde::Serialize;
 
 use crate::{
     error::ComhairleError,
-    models::api_key::{self, CreateRequest},
-    routes::auth::RequiredAdminUser,
+    models::api_key::{self, CreateApiKeyRequest},
+    routes::auth::{is_user_admin, RequiredAdminUser},
     ComhairleState,
 };
 
@@ -23,10 +23,14 @@ pub struct CreateResponse {
 // No tracing to avoid keys being exposed in logs
 async fn create(
     State(state): State<Arc<ComhairleState>>,
-    RequiredAdminUser(_user): RequiredAdminUser,
-    Json(payload): Json<CreateRequest>,
+    RequiredAdminUser(user): RequiredAdminUser,
+    Json(payload): Json<CreateApiKeyRequest>,
 ) -> Result<(StatusCode, Json<CreateResponse>), ComhairleError> {
-    let key = api_key::create(&state.db, payload).await?;
+    if !is_user_admin(&user, &state.config) {
+        return Err(ComhairleError::UserNotAuthorized);
+    }
+
+    let key = api_key::create(&state.db, user.id, payload).await?;
 
     Ok((StatusCode::CREATED, Json(CreateResponse { key })))
 }

--- a/api/src/routes/auth.rs
+++ b/api/src/routes/auth.rs
@@ -13,7 +13,11 @@ use axum::{
     response::{IntoResponse, Response},
     RequestPartsExt,
 };
-use axum_extra::extract::cookie::{Cookie, CookieJar, SameSite};
+use axum_extra::{
+    extract::cookie::{Cookie, CookieJar, SameSite},
+    headers::{authorization::Bearer, Authorization},
+    TypedHeader,
+};
 use bon::builder;
 use chrono::{TimeDelta, Utc};
 use cookie::CookieBuilder;
@@ -49,11 +53,11 @@ use uuid::Uuid;
 use crate::{
     error::ComhairleError,
     models::{
-        otp,
+        api_key, otp,
         users::{
-            create_annon_user, create_otp_user, create_user, get_user_by_email, get_user_by_id,
-            get_user_by_username, get_user_resource_roles, update_user, Resource, Role,
-            UpdateUserRequest, User, UserAuthType, UserResourceRole,
+            self, create_annon_user, create_otp_user, create_user, get_user_by_email,
+            get_user_by_id, get_user_by_username, get_user_resource_roles, update_user, Resource,
+            Role, UpdateUserRequest, User, UserAuthType, UserResourceRole,
         },
     },
     routes::user::dto::UserDto,
@@ -801,6 +805,43 @@ impl RequiredRoleResource for Conversation {
     }
 }
 
+/// Resolves a [`User`] from an incoming request by checking two authentication
+/// methods in order:
+///
+/// 1. **API key** - if an `Authorization: Bearer <token>` header is present,
+///    the token is treated as an API key. It is hashed and looked up in the
+///    database. If a matching, valid key is found the associated user is
+///    returned.
+///
+/// 2. **Session cookie** - if no bearer token is present, the request falls
+///    back to the [`OptionalUser`] extractor, which checks for a valid session
+///    cookie. If a session is found the associated user is returned.
+///
+/// # Errors
+///
+/// Returns [`ComhairleError::InvalidApiKey`] if a bearer token is present but
+/// does not match any active API key in the database.
+///
+/// Returns [`ComhairleError::UserRequired`] if no bearer token is present and
+/// no valid session cookie is found.
+async fn resolve_user_from_request(
+    parts: &mut Parts,
+    state: &Arc<ComhairleState>,
+) -> Result<User, ComhairleError> {
+    if let Ok(TypedHeader(Authorization(bearer))) =
+        TypedHeader::<Authorization<Bearer>>::from_request_parts(parts, state).await
+    {
+        let user_id = api_key::get_matching_user_id(&state.db, bearer.token()).await?;
+        users::get_user_by_id(&user_id, &state.db).await
+    } else {
+        parts
+            .extract_with_state::<OptionalUser, _>(state)
+            .await?
+            .0
+            .ok_or(ComhairleError::UserRequired)
+    }
+}
+
 /// An extractor to get a required current user.
 /// If no user is logged in then this will fail and
 /// Return a Not Found response
@@ -814,10 +855,10 @@ impl FromRequestParts<Arc<ComhairleState>> for RequiredAdminUser {
         parts: &mut Parts,
         state: &Arc<ComhairleState>,
     ) -> Result<Self, Self::Rejection> {
-        let user = parts.extract_with_state::<RequiredUser, _>(state).await?;
+        let user = resolve_user_from_request(parts, state).await?;
 
-        if is_user_admin(&user.0, &state.config) {
-            Ok(RequiredAdminUser(user.0.clone()))
+        if is_user_admin(&user, &state.config) {
+            Ok(RequiredAdminUser(user.clone()))
         } else {
             Err(ComhairleError::RequiresAuthUser)
         }
@@ -843,13 +884,9 @@ impl FromRequestParts<Arc<ComhairleState>> for RequiredUser {
         parts: &mut Parts,
         state: &Arc<ComhairleState>,
     ) -> Result<Self, Self::Rejection> {
-        let poss_user = parts.extract_with_state::<OptionalUser, _>(state).await?;
-
-        if let Some(user) = poss_user.0 {
-            Ok(RequiredUser(user))
-        } else {
-            Err(ComhairleError::UserRequired)
-        }
+        resolve_user_from_request(parts, state)
+            .await
+            .map(RequiredUser)
     }
 }
 
@@ -969,6 +1006,14 @@ pub async fn current_user(
 pub async fn test_requires_roles(
     RequiredRole(_, _, _): RequiredRole<Conversation, (Owner, (Contributor,))>,
     RequiredUser(user): RequiredUser,
+) -> Result<(StatusCode, Json<UserDto>), ComhairleError> {
+    let user: UserDto = user.into();
+    Ok((StatusCode::OK, Json(user)))
+}
+
+/// Handler for testing RequiredApiKeyUser
+pub async fn test_api_key(
+    RequiredAdminUser(user): RequiredAdminUser,
 ) -> Result<(StatusCode, Json<UserDto>), ComhairleError> {
     let user: UserDto = user.into();
     Ok((StatusCode::OK, Json(user)))
@@ -1156,6 +1201,15 @@ pub async fn router(state: Arc<ComhairleState>) -> ApiRouter {
                     .response::<200, Json<UserDto>>()
             }),
         )
+        // TODO: this route is used for testing only. Once we have authorisation logic locekd down
+        // in other endpoints, this can be removed and those auth requirements tested.
+        .api_route(
+            "/test_api_key_extraction",
+            get_with(test_api_key, |op| {
+                op.summary("Test the api key extraction")
+                    .response::<200, Json<UserDto>>()
+            }),
+        )
         .with_state(state)
 }
 
@@ -1166,6 +1220,8 @@ mod tests {
     use crate::{
         mailer::MockComhairleMailer,
         models::{
+            api_key::CreateApiKeyRequest,
+            model_test_helpers::setup_default_app_and_session,
             otp,
             users::{
                 self, add_user_resource_role, get_user_by_email, Resource, Role, UpdateUserRequest,
@@ -1177,7 +1233,7 @@ mod tests {
             user::dto::UserDto,
         },
         setup_server,
-        test_helpers::{test_state, UserSession},
+        test_helpers::{test_state, UserSession, TEST_PASSWORD},
     };
 
     use argon2::{Argon2, PasswordHash, PasswordVerifier};
@@ -1961,6 +2017,44 @@ mod tests {
         .await?;
         let (status, _, _) = session.get(&app, &url).await?;
         assert_eq!(status, StatusCode::OK, "User with role should have access");
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn should_return_user_from_api_key(pool: PgPool) -> Result<(), Box<dyn Error>> {
+        let (app, mut session) = setup_default_app_and_session(&pool).await?;
+        session
+            .login(&app, "admin@crown-shy.com", TEST_PASSWORD)
+            .await?;
+
+        let (_, admin_user, _) = session.current_user(&app).await?;
+        session.logout(&app).await?;
+
+        let api_key = api_key::create(
+            &pool,
+            admin_user.id,
+            CreateApiKeyRequest {
+                prefix: "sk_test".to_string(),
+                name: "test_key".to_string(),
+            },
+        )
+        .await?;
+
+        let (_, value, _) = session.get(&app, "/auth/current_user").await?;
+
+        assert_eq!(
+            value.get("err").and_then(|v| v.as_str()).unwrap(),
+            "No user logged in",
+            "incorrect error message"
+        );
+
+        let (_, value) = session
+            .get_with_api_key(&app, "/auth/test_api_key_extraction", &api_key)
+            .await?;
+        let extracted_user: UserDto = serde_json::from_value(value)?;
+
+        assert_eq!(extracted_user.id, admin_user.id, "ids don't match");
 
         Ok(())
     }

--- a/api/src/test_helpers.rs
+++ b/api/src/test_helpers.rs
@@ -1,4 +1,5 @@
 use chrono::Utc;
+use hyper::header::AUTHORIZATION;
 use std::{collections::HashMap, error::Error, sync::Arc};
 use uuid::Uuid;
 
@@ -286,6 +287,24 @@ impl UserSession {
 
         let value = response_to_json(response).await;
         Ok((status, value, cookie))
+    }
+
+    pub async fn get_with_api_key(
+        &mut self,
+        app: &Router,
+        url: &str,
+        api_key: &str,
+    ) -> Result<(StatusCode, Value), Box<dyn Error>> {
+        let mut request = Request::builder().uri(url).method("GET");
+
+        request = request.header(AUTHORIZATION, format!("Bearer {api_key}"));
+
+        let request = request.body(Body::empty()).unwrap();
+        let response = app.clone().oneshot(request).await?;
+        let status = response.status();
+
+        let value = response_to_json(response).await;
+        Ok((status, value))
     }
 
     pub async fn delete(

--- a/ui/packages/api-client/src/api.ts
+++ b/ui/packages/api-client/src/api.ts
@@ -1634,10 +1634,10 @@ export const ComhairleServices = z
   .object({ botService: z.boolean(), translationService: z.boolean() })
   .passthrough();
 export type ComhairleServices = z.infer<typeof ComhairleServices>;
-export const CreateRequest = z
-  .object({ name: z.string(), prefix: z.string(), user_id: z.string().uuid() })
+export const CreateApiKeyRequest = z
+  .object({ name: z.string(), prefix: z.string() })
   .passthrough();
-export type CreateRequest = z.infer<typeof CreateRequest>;
+export type CreateApiKeyRequest = z.infer<typeof CreateApiKeyRequest>;
 export const CreateResponse2 = z.object({ key: z.string() }).passthrough();
 export type CreateResponse2 = z.infer<typeof CreateResponse2>;
 
@@ -1828,7 +1828,7 @@ export const schemas: Record<string, z.ZodType<any>> = {
   PaginatedResults_for_Job,
   CreateJob,
   ComhairleServices,
-  CreateRequest,
+  CreateApiKeyRequest,
   CreateResponse2,
 };
 
@@ -1842,7 +1842,7 @@ const endpoints = makeApi([
       {
         name: "body",
         type: "Body",
-        schema: CreateRequest,
+        schema: CreateApiKeyRequest,
       },
     ],
     response: z.object({ key: z.string() }).passthrough(),
@@ -2010,6 +2010,13 @@ const endpoints = makeApi([
         schema: z.object({ email: z.string() }).passthrough(),
       },
     ],
+    response: UserDto,
+  },
+  {
+    method: "get",
+    path: "/auth/test_api_key_extraction",
+    alias: "getAuthtest_api_key_extraction",
+    requestFormat: "json",
     response: UserDto,
   },
   {


### PR DESCRIPTION
Actions:

+ method to get user id from api key
+ prevent non-admin users from generating api keys
+ refactor RequiredUser and RequiredAdminUser extractors to check user first from api key bearer token with fallback to session cookie

Motivation:

+ allow developers and external apps to authenticate requests with api keys instead of session cookies