### PR TITLE
AdminPrevNextControls: improve responsive layout

### DIFF
--- a/ui/packages/comhairle/src/lib/components/AdminPrevNextControls.svelte
+++ b/ui/packages/comhairle/src/lib/components/AdminPrevNextControls.svelte
@@ -46,7 +46,7 @@
 			</Button>
 			<div class="flex min-w-0 flex-col items-start">
 				<h3 class="text-primary text-xs">Next</h3>
-				<h3 class="max-w-[36ch] truncate" title={next.name}>{next.name}</h3>
+				<h3 class="max-w-[60ch] truncate" title={next.name}>{next.name}</h3>
 			</div>
 		</div>
 	{/if}

--- a/ui/packages/comhairle/src/lib/components/AdminPrevNextControls.svelte
+++ b/ui/packages/comhairle/src/lib/components/AdminPrevNextControls.svelte
@@ -10,34 +10,43 @@
 	type Props = {
 		prev?: NamedLink;
 		next?: NamedLink;
+		hidePrevLabel?: boolean;
 	};
-	let { prev, next }: Props = $props();
+	let { prev, next, hidePrevLabel = false }: Props = $props();
 </script>
 
-<div class="flex flex-row gap-4">
+<div class="flex min-w-0 flex-row gap-4">
 	{#if prev}
-		<div class="flex flex-row items-center gap-2">
-			<div class="flex flex-col items-end">
-				<h3 class="text-primary text-xs">Previous</h3>
-				<h3>{prev.name}</h3>
-			</div>
+		<div class="flex min-w-0 flex-row items-center gap-2">
+			{#if !hidePrevLabel}
+				<div class="flex min-w-0 flex-col items-end">
+					<h3 class="text-primary text-xs">Previous</h3>
+					<h3 class="max-w-[36ch] truncate" title={prev.name}>{prev.name}</h3>
+				</div>
+			{/if}
 
-			<Button href={prev.url} class="rounded-full bg-white text-black ring-1 ring-[#E5E7EB] "
-				><ArrowLeft /></Button
+			<Button
+				href={prev.url}
+				class="shrink-0 rounded-full bg-white text-black ring-1 ring-[#E5E7EB]"
 			>
+				<ArrowLeft />
+			</Button>
 		</div>
 	{/if}
 	{#if prev && next}
 		<Separator class="text-black" decorative orientation="vertical" />
 	{/if}
 	{#if next}
-		<div class="flex flex-row items-center gap-2">
-			<Button href={next.url} class="rounded-full bg-white text-black ring-1 ring-[#E5E7EB] "
-				><ArrowRight /></Button
+		<div class="flex min-w-0 flex-row items-center gap-2">
+			<Button
+				href={next.url}
+				class="shrink-0 rounded-full bg-white text-black ring-1 ring-[#E5E7EB]"
 			>
-			<div class="flex flex-col items-start">
+				<ArrowRight />
+			</Button>
+			<div class="flex min-w-0 flex-col items-start">
 				<h3 class="text-primary text-xs">Next</h3>
-				<h3>{next.name}</h3>
+				<h3 class="max-w-[36ch] truncate" title={next.name}>{next.name}</h3>
 			</div>
 		</div>
 	{/if}

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/+layout.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/+layout.svelte
@@ -12,24 +12,36 @@
 		CircleX
 	} from 'lucide-svelte';
 	import { setContext, type Snippet } from 'svelte';
-	import type { AdminPageSlots } from './slotTypes';
+	import type { AdminPageSlots, BreadcrumbCrumb } from './slotTypes';
 	import LaunchConversationModal from '$lib/components/LaunchConversationModal.svelte';
 	import EndConversationModal from '$lib/components/EndConversationModal.svelte';
 
-	let breadcrumbContent = $state<Snippet | null>(null);
+	let breadcrumbTrail = $state<BreadcrumbCrumb[] | null>(null);
 	let titleContent = $state<Snippet | null>(null);
 
 	setContext<AdminPageSlots>('adminLayoutSlots', {
-		breadcrumbContent: (content: Snippet | null) => (breadcrumbContent = content),
+		breadcrumbTrail: (trail: BreadcrumbCrumb[] | null) => (breadcrumbTrail = trail),
 		titleContent: (content: Snippet | null) => (titleContent = content),
 		clearTitleContent: () => (titleContent = null),
-		clearBreadcrumbContent: () => (breadcrumbContent = null)
+		clearBreadcrumbTrail: () => (breadcrumbTrail = null)
 	});
 
 	let { data, children } = $props();
 
 	let conversation = $derived(data.conversation);
 	let endModalOpen = $state(false);
+
+	let allCrumbs = $derived<BreadcrumbCrumb[]>([
+		{ label: 'Workspace', href: '/admin' },
+		{ label: 'Conversations' },
+		{
+			label: conversation.title,
+			href: `/admin/conversations/${conversation.id}/configure`
+		},
+		...(breadcrumbTrail ?? [])
+	]);
+	let currentCrumb = $derived(allCrumbs[allCrumbs.length - 1]);
+	let parentCrumbs = $derived(allCrumbs.slice(0, -1));
 </script>
 
 <!-- Top bar: breadcrumb + conversation name + launch controls -->
@@ -44,24 +56,37 @@
 		<Breadcrumb.Root class="min-w-0 xl:max-w-[50%]">
 			<Breadcrumb.List class="flex-nowrap">
 				<Breadcrumb.Item class="shrink-0">
-					<Breadcrumb.Link href="/admin">Workspace</Breadcrumb.Link>
+					<DropdownMenu.Root>
+						<DropdownMenu.Trigger
+							class="hover:text-foreground focus-visible:ring-ring text-muted-foreground flex size-7 items-center justify-center rounded-md focus-visible:ring-1 focus-visible:outline-none"
+							aria-label="Show breadcrumb trail"
+						>
+							<Breadcrumb.Ellipsis class="size-4" />
+						</DropdownMenu.Trigger>
+						<DropdownMenu.Content align="start">
+							{#each parentCrumbs as crumb (crumb.label)}
+								{#if crumb.href}
+									<DropdownMenu.Item>
+										{#snippet child({ props })}
+											<a {...props} href={crumb.href}>{crumb.label}</a>
+										{/snippet}
+									</DropdownMenu.Item>
+								{:else}
+									<DropdownMenu.Item disabled>{crumb.label}</DropdownMenu.Item>
+								{/if}
+							{/each}
+						</DropdownMenu.Content>
+					</DropdownMenu.Root>
 				</Breadcrumb.Item>
-				<Breadcrumb.Separator class="shrink-0" />
-				<Breadcrumb.Item class="shrink-0">Conversations</Breadcrumb.Item>
 				<Breadcrumb.Separator class="shrink-0" />
 				<Breadcrumb.Item class="min-w-0">
-					<Breadcrumb.Link
-						href={`/admin/conversations/${conversation.id}/configure`}
-						class="block max-w-[12ch] truncate sm:max-w-[20ch] lg:max-w-[24ch]"
-						title={conversation.title}
+					<Breadcrumb.Page
+						class="block max-w-[20ch] truncate sm:max-w-[32ch] lg:max-w-[40ch]"
+						title={currentCrumb.label}
 					>
-						{conversation.title}
-					</Breadcrumb.Link>
+						{currentCrumb.label}
+					</Breadcrumb.Page>
 				</Breadcrumb.Item>
-				{#if breadcrumbContent}
-					<Breadcrumb.Separator class="shrink-0" />
-					{@render breadcrumbContent()}
-				{/if}
 			</Breadcrumb.List>
 		</Breadcrumb.Root>
 		<div class="flex w-full min-w-0 items-center gap-3 xl:ml-auto xl:w-auto">
@@ -169,7 +194,7 @@
 		class="border-base-border bg-background flex w-full flex-col items-center border-b px-4 py-6 sm:px-8 lg:px-16"
 	>
 		<div
-			class="flex w-full max-w-[1200px] flex-col items-start justify-between gap-4 lg:flex-row lg:items-center"
+			class="flex w-full max-w-[1200px] min-w-0 flex-col items-start justify-between gap-4 lg:flex-row lg:items-center"
 		>
 			{@render titleContent()}
 		</div>

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/configure/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/configure/+page.svelte
@@ -12,7 +12,6 @@
 	import TranslatableField from '$lib/components/Translation/TranslatableField.svelte';
 	import { autoTranslateNewLanguage } from '$lib/components/Translation/translationUtils';
 	import { LanguageSelector } from '$lib/components/ui/language-selector';
-	import * as Breadcrumb from '$lib/components/ui/breadcrumb';
 	import { useAdminLayoutSlots } from '../useAdminLayoutSlots.svelte';
 	import AdminPrevNextControls from '$lib/components/AdminPrevNextControls.svelte';
 	import type { ConversationWithTranslations, WorkflowDto } from '@crownshy/api-client/api';
@@ -238,17 +237,13 @@
 
 	useAdminLayoutSlots({
 		title: titleContentSnippet,
-		breadcrumbs: breadcrumbSnippet
+		breadcrumbs: [{ label: 'Configure' }]
 	});
 </script>
 
 <svelte:head>
 	<title>{pageTitle} - Comhairle Admin</title>
 </svelte:head>
-
-{#snippet breadcrumbSnippet()}
-	<Breadcrumb.Item>Configure</Breadcrumb.Item>
-{/snippet}
 
 {#snippet titleContentSnippet()}
 	<h1 class="text-4xl font-bold">Configure</h1>

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/design/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/design/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import type { WorkflowStepWithTranslations } from '@crownshy/api-client/api';
 	import { infoURLForTool } from '$lib/utils';
-	import * as Breadcrumb from '$lib/components/ui/breadcrumb';
 	import {
 		basic_learn_config,
 		basic_polis_config,
@@ -136,7 +135,7 @@
 	}
 	useAdminLayoutSlots({
 		title: titleSnippet,
-		breadcrumbs: breadcrumbSnippet
+		breadcrumbs: [{ label: 'Design' }]
 	});
 	let pageTitle = $derived(`Design ${conversation.title}`);
 </script>
@@ -154,10 +153,6 @@
 		}}
 		prev={{ name: 'Configure', url: `/admin/conversations/${conversation.id}/configure` }}
 	/>
-{/snippet}
-
-{#snippet breadcrumbSnippet()}
-	<Breadcrumb.Item>Design</Breadcrumb.Item>
 {/snippet}
 
 <h2 class="mb-5 text-2xl">Process steps</h2>

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/design/step/[step_id]/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/design/step/[step_id]/+page.svelte
@@ -8,7 +8,6 @@
 	import LivedExperienceManage from '$lib/tools/lived_experince/LivedExperinceManage.svelte';
 	import { useAdminLayoutSlots } from '../../../useAdminLayoutSlots.svelte.js';
 	import AdminPrevNextControls from '$lib/components/AdminPrevNextControls.svelte';
-	import * as Breadcrumb from '$lib/components/ui/breadcrumb';
 	import { Button } from '$lib/components/ui/button';
 	import { Pencil } from 'lucide-svelte';
 	import ContentRenderer from '$lib/components/RichTextEditor/ContentRenderer/ContentRenderer.svelte';
@@ -51,9 +50,19 @@
 
 	useAdminLayoutSlots({
 		title: titleSnippet,
-		breadcrumbs: breadcrumbSnippet
+		breadcrumbs: () => [
+			{ label: 'Design', href: `/admin/conversations/${conversation.id}/design` },
+			{ label: step?.name ?? 'Step' }
+		]
 	});
 	let pageTitle = $derived(`Edit Step: ${step?.name ?? 'Step'}`);
+	let stepName = $derived(
+		getTextInLocale(
+			step?.translations?.name,
+			conversation.primaryLocale ?? 'en',
+			step?.name ?? ''
+		) || 'Unnamed step'
+	);
 </script>
 
 <svelte:head>
@@ -61,63 +70,57 @@
 </svelte:head>
 
 {#snippet titleSnippet()}
-	<div class="flex min-w-0 flex-1 flex-col gap-2">
-		<div class="flex flex-wrap items-center gap-3">
-			<h1 class="text-3xl font-semibold sm:text-4xl">
-				{getTextInLocale(
-					step?.translations?.name,
-					conversation.primaryLocale ?? 'en',
-					step?.name ?? ''
-				) || 'Unnamed step'}
+	<div class="flex w-full min-w-0 flex-col">
+		<div class="flex w-full min-w-0 items-center gap-3">
+			<h1
+				class="min-w-0 flex-1 truncate text-3xl font-semibold sm:max-w-[40ch] sm:text-4xl"
+				title={stepName}
+			>
+				{stepName}
 			</h1>
 			<Button
 				onclick={() => (editMetadataOpen = true)}
-				class="bg-sidebar text-sidebar-foreground hover:bg-sidebar/90 h-8 rounded-full px-3 text-xs"
+				class="bg-sidebar text-sidebar-foreground hover:bg-sidebar/90 h-8 shrink-0 rounded-full px-3 text-xs"
 			>
 				<Pencil class="size-3.5" />
 				Edit
 			</Button>
 		</div>
 		{#if step?.description || step?.translations?.description}
-			<ContentRenderer
-				content={getTextInLocale(
-					step?.translations?.description,
-					conversation.primaryLocale ?? 'en',
-					step?.description ?? ''
-				)}
-				class="text-muted-foreground text-base"
-				{availableDocuments}
-				conversationId={conversation.id}
-			/>
+			<div class="mt-2">
+				<ContentRenderer
+					content={getTextInLocale(
+						step?.translations?.description,
+						conversation.primaryLocale ?? 'en',
+						step?.description ?? ''
+					)}
+					class="text-muted-foreground text-base"
+					{availableDocuments}
+					conversationId={conversation.id}
+				/>
+			</div>
 		{/if}
+		<div class="border-base-border mt-5 flex w-full border-t pt-4">
+			<AdminPrevNextControls
+				hidePrevLabel
+				next={nextStep
+					? {
+							name: nextStep.name,
+							url: `/admin/conversations/${conversation.id}/design/step/${nextStep.id}`
+						}
+					: {
+							name: 'Setup Knowledge base',
+							url: `/admin/conversations/${conversation.id}/knowledge-base`
+						}}
+				prev={prevStep
+					? {
+							name: prevStep.name,
+							url: `/admin/conversations/${conversation.id}/design/step/${prevStep.id}`
+						}
+					: { name: 'Design', url: `/admin/conversations/${conversation.id}/design` }}
+			/>
+		</div>
 	</div>
-	<AdminPrevNextControls
-		next={nextStep
-			? {
-					name: nextStep.name,
-					url: `/admin/conversations/${conversation.id}/design/step/${nextStep.id}`
-				}
-			: {
-					name: 'Setup Knowledge base',
-					url: `/admin/conversations/${conversation.id}/knowledge-base`
-				}}
-		prev={prevStep
-			? {
-					name: prevStep.name,
-					url: `/admin/conversations/${conversation.id}/design/step/${prevStep.id}`
-				}
-			: { name: 'Design', url: `/admin/conversations/${conversation.id}/design` }}
-	/>
-{/snippet}
-
-{#snippet breadcrumbSnippet()}
-	<Breadcrumb.Item>
-		<Breadcrumb.Link href={`/admin/conversations/${conversation.id}/design`}>
-			Design
-		</Breadcrumb.Link>
-	</Breadcrumb.Item>
-	<Breadcrumb.Separator />
-	<Breadcrumb.Item>{step?.name}</Breadcrumb.Item>
 {/snippet}
 
 {#if step}

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/events/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/events/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import AdminPrevNextControls from '$lib/components/AdminPrevNextControls.svelte';
-	import * as Breadcrumb from '$lib/components/ui/breadcrumb';
 	import Button from '$lib/components/ui/button/button.svelte';
 	import { Plus } from 'lucide-svelte';
 	import { useAdminLayoutSlots } from '../useAdminLayoutSlots.svelte';
@@ -13,7 +12,7 @@
 
 	useAdminLayoutSlots({
 		title: titleSnippet,
-		breadcrumbs: breadcrumbSnippet
+		breadcrumbs: [{ label: 'Events' }]
 	});
 	let pageTitle = $derived(`Manage Events - ${conversation.title}`);
 </script>
@@ -36,10 +35,6 @@
 				}
 			: undefined}
 	/>
-{/snippet}
-
-{#snippet breadcrumbSnippet()}
-	<Breadcrumb.Item>Events</Breadcrumb.Item>
 {/snippet}
 
 <p class="text-muted-foreground mb-10 text-base font-medium">

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/events/[event_id]/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/events/[event_id]/+page.svelte
@@ -14,7 +14,6 @@
 	import { zodClient } from 'sveltekit-superforms/adapters';
 	import EventSchema from './schema.js';
 	import { useAdminLayoutSlots } from '../../useAdminLayoutSlots.svelte.js';
-	import * as Breadcrumb from '$lib/components/ui/breadcrumb';
 	import AdminPrevNextControls from '$lib/components/AdminPrevNextControls.svelte';
 	import { cn } from '$lib/utils';
 	import { buttonVariants } from '$lib/components/ui/button';
@@ -165,7 +164,10 @@
 
 	useAdminLayoutSlots({
 		title: titleContentSnippet,
-		breadcrumbs: breadcrumbSnippet
+		breadcrumbs: () => [
+			{ label: 'Events', href: `/admin/conversations/${conversation.id}/events` },
+			{ label: event?.name ?? 'Event' }
+		]
 	});
 
 	let eventDate = $derived($form.start_date ? parseDate($form.start_date) : undefined);
@@ -319,10 +321,6 @@
 <svelte:head>
 	<title>{pageTitle} - Comhairle Admin</title>
 </svelte:head>
-
-{#snippet breadcrumbSnippet()}
-	<Breadcrumb.Item>{event?.name}</Breadcrumb.Item>
-{/snippet}
 
 {#snippet titleContentSnippet()}
 	<h1 class="text-4xl font-bold">Event: {event?.name}</h1>

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/events/new/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/events/new/+page.svelte
@@ -22,7 +22,6 @@
 	import { apiClient } from '@crownshy/api-client/client';
 	import { goto } from '$app/navigation';
 	import { basic_learn_config } from '$lib/workflow_templates';
-	import * as Breadcrumb from '$lib/components/ui/breadcrumb';
 	import BadgeInput from '$lib/components/ui/badge-input/badge-input.svelte';
 	import * as Alert from '$lib/components/ui/alert';
 	import { useAdminLayoutSlots } from '../../useAdminLayoutSlots.svelte';
@@ -154,23 +153,16 @@
 
 	useAdminLayoutSlots({
 		title: titleContentSnippet,
-		breadcrumbs: breadcrumbSnippet
+		breadcrumbs: [
+			{ label: 'Events', href: `/admin/conversations/${conversation.id}/events` },
+			{ label: 'New' }
+		]
 	});
 </script>
 
 <svelte:head>
 	<title>Create New Event - Comhairle Admin</title>
 </svelte:head>
-
-{#snippet breadcrumbSnippet()}
-	<Breadcrumb.Item>
-		<Breadcrumb.Link href="/admin/conversations/{conversation.id}/events"
-			>Events</Breadcrumb.Link
-		>
-	</Breadcrumb.Item>
-	<Breadcrumb.Separator />
-	<Breadcrumb.Item>New</Breadcrumb.Item>
-{/snippet}
 
 {#snippet titleContentSnippet()}
 	<h1 class="text-4xl font-bold">New Event</h1>

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/invites/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/invites/+page.svelte
@@ -16,7 +16,6 @@
 	import * as Table from '$lib/components/ui/table/index.js';
 	import CopyButton from '$lib/components/CopyButton.svelte';
 	import OpenInviteStatsBarChart from '$lib/components/OpenInviteStatsBarChart.svelte';
-	import { BreadcrumbItem } from '$lib/components/ui/breadcrumb';
 	import { useAdminLayoutSlots } from '../useAdminLayoutSlots.svelte.js';
 	import EmailInvitesList from '$lib/components/ui/email-invites/EmailInvitesList.svelte';
 	import { inviteUrl } from '$lib/utils/invites.js';
@@ -61,7 +60,7 @@
 	}
 	useAdminLayoutSlots({
 		title: titleContentSnippet,
-		breadcrumbs: breadcrumbSnippet
+		breadcrumbs: [{ label: 'Recruit' }]
 	});
 </script>
 
@@ -73,10 +72,6 @@
 	<div class="flex flex-row gap-x-2">
 		<CopyButton copyText={inviteUrl(url, invite, conversation)}>{label}</CopyButton>
 	</div>
-{/snippet}
-
-{#snippet breadcrumbSnippet()}
-	<BreadcrumbItem>Recruit</BreadcrumbItem>
 {/snippet}
 
 {#snippet titleContentSnippet()}

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/knowledge-base/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/knowledge-base/+page.svelte
@@ -4,7 +4,6 @@
 	import FileUpload from '$lib/components/KnowledgeBase/FileUpload.svelte';
 	import ParsedFileList from '$lib/components/KnowledgeBase/ParsedFileList.svelte';
 	import ParsingFileList from '$lib/components/KnowledgeBase/ParsingFileList.svelte';
-	import { BreadcrumbItem } from '$lib/components/ui/breadcrumb';
 	import { useAdminLayoutSlots } from '../useAdminLayoutSlots.svelte';
 
 	type Props = {
@@ -31,7 +30,7 @@
 
 	useAdminLayoutSlots({
 		title: titleSnippet,
-		breadcrumbs: breadcrumbSnippet
+		breadcrumbs: [{ label: 'Knowledge Base' }]
 	});
 </script>
 
@@ -46,10 +45,6 @@
 		prev={{ name: 'Design', url: `/admin/conversations/${conversation.id}/design` }}
 		next={{ name: 'Events', url: `/admin/conversations/${conversation.id}/events` }}
 	/>
-{/snippet}
-
-{#snippet breadcrumbSnippet()}
-	<BreadcrumbItem>Knowledge Base</BreadcrumbItem>
 {/snippet}
 
 <p class="mb-10">Use this space to manage your conversation's knowledge base</p>

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/moderate/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/moderate/+page.svelte
@@ -2,7 +2,6 @@
 	import { BookOpen, ListChecks, MessagesSquare, Video } from 'lucide-svelte';
 	import * as Card from '$lib/components/ui/card';
 	import { Button } from '$lib/components/ui/button';
-	import { BreadcrumbItem } from '$lib/components/ui/breadcrumb/index.js';
 	import { useAdminLayoutSlots } from '../useAdminLayoutSlots.svelte.js';
 	import type { ToolConfig, WorkflowStepWithTranslations } from '@crownshy/api-client/api';
 
@@ -15,7 +14,7 @@
 
 	useAdminLayoutSlots({
 		title: titleSnippet,
-		breadcrumbs: breadcrumbSnippet
+		breadcrumbs: [{ label: 'Moderate' }]
 	});
 </script>
 
@@ -25,10 +24,6 @@
 
 {#snippet titleSnippet()}
 	<h1 class="text-4xl font-bold">Moderate</h1>
-{/snippet}
-
-{#snippet breadcrumbSnippet()}
-	<BreadcrumbItem>Moderate</BreadcrumbItem>
 {/snippet}
 
 <p class="mb-10">Use this space to moderate the conversation</p>

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/monitor/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/monitor/+page.svelte
@@ -7,7 +7,6 @@
 	import { Button } from '$lib/components/ui/button';
 
 	import type { PageProps } from './$types';
-	import { BreadcrumbItem } from '$lib/components/ui/breadcrumb';
 	import { useAdminLayoutSlots } from '../useAdminLayoutSlots.svelte';
 
 	let { data }: PageProps = $props();
@@ -40,7 +39,7 @@
 
 	useAdminLayoutSlots({
 		title: titleSnippet,
-		breadcrumbs: breadcrumbSnippet
+		breadcrumbs: [{ label: 'Monitor' }]
 	});
 </script>
 
@@ -52,10 +51,6 @@
 	<div class="flex items-center justify-between">
 		<h1 class="text-4xl font-bold">Monitor</h1>
 	</div>
-{/snippet}
-
-{#snippet breadcrumbSnippet()}
-	<BreadcrumbItem>Monitor</BreadcrumbItem>
 {/snippet}
 
 <p class="mb-10">

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/notifications/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/notifications/+page.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import NotificationForm from '$lib/components/NotificationForm.svelte';
 	import type { PageData } from './$types';
-	import { BreadcrumbItem } from '$lib/components/ui/breadcrumb';
 	import { useAdminLayoutSlots } from '../useAdminLayoutSlots.svelte';
 
 	let { data } = $props() as { data: PageData };
@@ -9,7 +8,7 @@
 
 	useAdminLayoutSlots({
 		title: titleSnippet,
-		breadcrumbs: breadcrumbSnippet
+		breadcrumbs: [{ label: 'Notifications' }]
 	});
 </script>
 
@@ -19,10 +18,6 @@
 
 {#snippet titleSnippet()}
 	<h1 class="text-4xl font-bold">Notifications</h1>
-{/snippet}
-
-{#snippet breadcrumbSnippet()}
-	<BreadcrumbItem>Notifications</BreadcrumbItem>
 {/snippet}
 
 <p class="mb-10">

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/report/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/report/+page.svelte
@@ -23,7 +23,6 @@
 	import '@cartamd/plugin-slash/default.css';
 	import 'carta-plugin-video/default.css';
 	import { useAdminLayoutSlots } from '../useAdminLayoutSlots.svelte.js';
-	import { BreadcrumbItem } from '$lib/components/ui/breadcrumb/index.js';
 
 	let { data } = $props();
 	let report = $derived(data.report);
@@ -70,7 +69,7 @@
 	}
 	useAdminLayoutSlots({
 		title: titleSnippet,
-		breadcrumbs: breadcrumbSnippet
+		breadcrumbs: [{ label: 'Report' }]
 	});
 </script>
 
@@ -80,10 +79,6 @@
 
 {#snippet titleSnippet()}
 	<h1 class="text-4xl font-bold">Report</h1>
-{/snippet}
-
-{#snippet breadcrumbSnippet()}
-	<BreadcrumbItem>Report</BreadcrumbItem>
 {/snippet}
 
 <p class="mb-10">Use this space to edit the report for this conversation</p>

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/slotTypes.ts
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/slotTypes.ts
@@ -1,8 +1,13 @@
-import type { Snippet } from "svelte";
+import type { Snippet } from 'svelte';
+
+export type BreadcrumbCrumb = {
+	label: string;
+	href?: string;
+};
 
 export interface AdminPageSlots {
-	breadcrumbContent: (snippet: Snippet | null) => void;
+	breadcrumbTrail: (trail: BreadcrumbCrumb[] | null) => void;
 	titleContent: (snippet: Snippet | null) => void;
 	clearTitleContent: () => void;
-	clearBreadcrumbContent: () => void;
+	clearBreadcrumbTrail: () => void;
 }

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/useAdminLayoutSlots.svelte.ts
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/useAdminLayoutSlots.svelte.ts
@@ -1,9 +1,9 @@
 import { getContext } from 'svelte';
 import type { Snippet } from 'svelte';
-import type { AdminPageSlots } from './slotTypes';
+import type { AdminPageSlots, BreadcrumbCrumb } from './slotTypes';
 
 interface UseAdminLayoutSlotsOptions {
-	breadcrumbs?: Snippet | null;
+	breadcrumbs?: BreadcrumbCrumb[] | (() => BreadcrumbCrumb[]) | null;
 	title?: Snippet | null;
 }
 
@@ -12,7 +12,11 @@ export function useAdminLayoutSlots(options: UseAdminLayoutSlotsOptions = {}): A
 
 	$effect(() => {
 		if (options.breadcrumbs) {
-			layoutSlots.breadcrumbContent(options.breadcrumbs);
+			const trail =
+				typeof options.breadcrumbs === 'function'
+					? options.breadcrumbs()
+					: options.breadcrumbs;
+			layoutSlots.breadcrumbTrail(trail);
 		}
 		if (options.title) {
 			layoutSlots.titleContent(options.title);
@@ -20,7 +24,7 @@ export function useAdminLayoutSlots(options: UseAdminLayoutSlotsOptions = {}): A
 
 		return () => {
 			if (options.breadcrumbs) {
-				layoutSlots.clearBreadcrumbContent();
+				layoutSlots.clearBreadcrumbTrail();
 			}
 			if (options.title) {
 				layoutSlots.clearTitleContent();


### PR DESCRIPTION
We will revisit this later this week, but for now -> 

(these are extreme cases, but ok)

Before:
<img width="1460" height="559" alt="image" src="https://github.com/user-attachments/assets/b0daef31-79f8-456e-a508-b2c843d7e18c" />

After:
<img width="1473" height="320" alt="image" src="https://github.com/user-attachments/assets/8eed98d2-b508-43ed-89c9-a4aa65bf8bb6" />

Before:
<img width="1481" height="880" alt="image" src="https://github.com/user-attachments/assets/73d91d26-efd5-42d6-9adb-52892bc5e542" />


After:


<img width="1469" height="569" alt="image" src="https://github.com/user-attachments/assets/7cc2235c-bdc8-4528-816b-fbc79e5209e1" />

<img width="1471" height="420" alt="image" src="https://github.com/user-attachments/assets/593cce68-5b68-4caa-aff5-2da35effaffb" />
