### PR TITLE
191/event registration auth

### DIFF
--- a/api/src/models/otp.rs
+++ b/api/src/models/otp.rs
@@ -179,6 +179,7 @@ mod tests {
         let user = users::create_otp_user(
             &OtpSignupRequest {
                 email: "test@user.com".to_string(),
+                username: None,
             },
             &pool,
         )
@@ -207,6 +208,7 @@ mod tests {
         let user = users::create_otp_user(
             &OtpSignupRequest {
                 email: "test@user.com".to_string(),
+                username: None,
             },
             &pool,
         )
@@ -243,6 +245,7 @@ mod tests {
         let user = users::create_otp_user(
             &OtpSignupRequest {
                 email: "test@user.com".to_string(),
+                username: None,
             },
             &pool,
         )
@@ -262,6 +265,7 @@ mod tests {
         let user = users::create_otp_user(
             &OtpSignupRequest {
                 email: "test@user.com".to_string(),
+                username: None,
             },
             &pool,
         )
@@ -284,6 +288,7 @@ mod tests {
         let user = users::create_otp_user(
             &OtpSignupRequest {
                 email: "test@user.com".to_string(),
+                username: None,
             },
             &pool,
         )
@@ -317,6 +322,7 @@ mod tests {
         let user = users::create_otp_user(
             &OtpSignupRequest {
                 email: "test@user.com".to_string(),
+                username: None,
             },
             &pool,
         )

--- a/api/src/models/users.rs
+++ b/api/src/models/users.rs
@@ -232,52 +232,71 @@ pub async fn create_annon_user(db: &PgPool) -> Result<User, ComhairleError> {
     ))
 }
 
-/// Create a user from a signup request
 pub async fn create_otp_user(user: &OtpSignupRequest, db: &PgPool) -> Result<User, ComhairleError> {
-    let mut retries = 5; // Retry up to 5 times to generate a unique username
-    while retries > 0 {
+    match &user.username {
+        Some(username) => create_otp_user_with_username(&user.email, username, db).await,
+        None => create_otp_user_random_username(&user.email, db).await,
+    }
+}
+
+async fn create_otp_user_with_username(
+    email: &str,
+    username: &str,
+    db: &PgPool,
+) -> Result<User, ComhairleError> {
+    insert_otp_user(email, username, db)
+        .await?
+        .ok_or_else(|| ComhairleError::DuplicateUsername(username.to_string()))
+}
+
+async fn create_otp_user_random_username(email: &str, db: &PgPool) -> Result<User, ComhairleError> {
+    for _ in 0..5 {
         let sudo_random_name = gen_id();
-
-        let (sql, values) = Query::insert()
-            .into_table(UserIden::Table)
-            .columns([UserIden::AuthType, UserIden::Email, UserIden::Username])
-            .values([
-                UserAuthType::Otp.into(),
-                user.email.clone().into(),
-                sudo_random_name.into(),
-            ])
-            .unwrap()
-            .returning(Query::returning().columns(DEFAULT_COLUMNS))
-            .build_sqlx(PostgresQueryBuilder);
-
-        let user_result = sqlx::query_as_with::<_, User, _>(&sql, values)
-            .fetch_one(db)
-            .await;
-
-        // Check to see if the either a unique username or email has been
-        // duplicated
-        match user_result {
-            Ok(user) => return Ok(user),
-            Err(sqlx::Error::Database(db_err)) => {
-                let pg_err = db_err.downcast_ref::<sqlx::postgres::PgDatabaseError>();
-                if pg_err.code() == "23505" {
-                    if let Some(constraint) = pg_err.constraint() {
-                        if constraint.contains("username") {
-                            retries -= 1;
-                            continue;
-                        } else if constraint.contains("email") {
-                            return Err(ComhairleError::DuplicateEmail(user.email.clone()));
-                        }
-                    }
-                }
-                return Err(ComhairleError::DatabaseError(sqlx::Error::Database(db_err)));
-            }
-            Err(e) => return Err(ComhairleError::DatabaseError(e)),
+        match insert_otp_user(email, &sudo_random_name, db).await? {
+            Some(user) => return Ok(user),
+            None => continue, // username collision so retry
         }
     }
     Err(ComhairleError::DuplicateUsername(
-        "too many retires".to_string(),
+        "too many retries".to_string(),
     ))
+}
+
+/// Returns Ok(Some(user)) on success, Ok(None) on duplicate username,
+/// Err on duplicate email or any other DB error.
+async fn insert_otp_user(
+    email: &str,
+    username: &str,
+    db: &PgPool,
+) -> Result<Option<User>, ComhairleError> {
+    let (sql, values) = Query::insert()
+        .into_table(UserIden::Table)
+        .columns([UserIden::AuthType, UserIden::Email, UserIden::Username])
+        .values([UserAuthType::Otp.into(), email.into(), username.into()])?
+        .returning(Query::returning().columns(DEFAULT_COLUMNS))
+        .build_sqlx(PostgresQueryBuilder);
+
+    let user_result = sqlx::query_as_with::<_, User, _>(&sql, values)
+        .fetch_one(db)
+        .await;
+
+    match user_result {
+        Ok(user) => Ok(Some(user)),
+        Err(sqlx::Error::Database(db_err)) => {
+            let pg_err = db_err.downcast_ref::<sqlx::postgres::PgDatabaseError>();
+            if pg_err.code() == "23505" {
+                if let Some(constraint) = pg_err.constraint() {
+                    if constraint.contains("username") {
+                        return Ok(None);
+                    } else if constraint.contains("email") {
+                        return Err(ComhairleError::DuplicateEmail(email.to_string()));
+                    }
+                }
+            }
+            Err(ComhairleError::DatabaseError(sqlx::Error::Database(db_err)))
+        }
+        Err(e) =>  Err(ComhairleError::DatabaseError(e))
+    }
 }
 
 /// Return a user by ID
@@ -560,6 +579,7 @@ mod tests {
         let user = create_otp_user(
             &OtpSignupRequest {
                 email: "test_otp@test.com".to_string(),
+                username: None,
             },
             &pool,
         )

--- a/api/src/routes/auth.rs
+++ b/api/src/routes/auth.rs
@@ -321,6 +321,7 @@ async fn signup_annon(
 #[cfg_attr(test, derive(Dummy))]
 pub struct OtpSignupRequest {
     pub email: String,
+    pub username: Option<String>,
 }
 
 #[instrument(err(Debug), skip(state, payload))]

--- a/api/src/routes/event_attendances.rs
+++ b/api/src/routes/event_attendances.rs
@@ -66,9 +66,10 @@ pub async fn get(
     Ok((StatusCode::OK, Json(event_attendance)))
 }
 
-#[derive(Serialize, Deserialize, JsonSchema, Debug)]
+#[derive(Serialize, Deserialize, JsonSchema, Debug, Default)]
 pub struct CreateEventAttendanceRequest {
     role: String,
+    user_email: Option<String>,
 }
 
 #[instrument(err(Debug), skip(state))]
@@ -78,8 +79,15 @@ pub async fn create(
     RequiredUser(user): RequiredUser,
     Json(payload): Json<CreateEventAttendanceRequest>,
 ) -> Result<(StatusCode, Json<EventAttendanceDto>), ComhairleError> {
+    // Search for user by email if passed, otherwise create attendence from
+    // logged in user (session cookie)
+    let user_id = match payload.user_email {
+        Some(email) => users::get_user_by_email(&email, &state.db).await?.id,
+        None => user.id,
+    };
+
     let create_event_attendance = CreateEventAttendance {
-        user_id: user.id,
+        user_id,
         event_id,
         role: payload.role,
     };
@@ -236,7 +244,7 @@ mod tests {
 
     use crate::{
         models::model_test_helpers::{get_random_conversation_id, setup_default_app_and_session},
-        routes::events::dto::EventDto,
+        routes::{auth::SignupRequest, events::dto::EventDto},
     };
 
     use super::*;
@@ -252,6 +260,7 @@ mod tests {
 
         let new_attendance = CreateEventAttendanceRequest {
             role: "facilitator".to_string(),
+            ..Default::default()
         };
 
         let body = serde_json::to_vec(&new_attendance)?;
@@ -274,6 +283,59 @@ mod tests {
             "incorrect role"
         );
         assert_eq!(event_attendance.event_id, event.id, "incorrect event_id");
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn should_create_an_event_attendance_from_email_address(
+        pool: PgPool,
+    ) -> Result<(), Box<dyn Error>> {
+        let (app, mut session) = setup_default_app_and_session(&pool).await?;
+        let conversation_id = get_random_conversation_id(&app, &mut session).await?;
+        let (_, response, _) = session
+            .create_random_event(&app, &conversation_id.to_string())
+            .await?;
+        let event: EventDto = serde_json::from_value(response)?;
+        let (_, logged_in_user, _) = session.current_user(&app).await?;
+
+        let user = users::create_user(
+            &SignupRequest {
+                email: "test-user-abc@foo.com".to_string(),
+                username: "test_user".to_string(),
+                password: "asdQWE)(*UIOOPOI".to_string(),
+                avatar_url: None,
+            },
+            &pool,
+        )
+        .await?;
+
+        let new_attendance = CreateEventAttendanceRequest {
+            role: "participant".to_string(),
+            user_email: user.email,
+        };
+
+        let body = serde_json::to_vec(&new_attendance)?;
+        let (_, response, _) = session
+            .post(
+                &app,
+                &format!(
+                    "/conversation/{conversation_id}/events/{}/attendances",
+                    event.id
+                ),
+                body.into(),
+            )
+            .await?;
+        let event_attendance: EventAttendanceDto = serde_json::from_value(response)?;
+
+        assert_eq!(
+            event_attendance.user_id, user.id,
+            "user_id does not match email user"
+        );
+        assert_ne!(
+            event_attendance.user_id, logged_in_user.id,
+            "user_id matches logged in user"
+        );
 
         Ok(())
     }

--- a/api/src/routes/event_attendances.rs
+++ b/api/src/routes/event_attendances.rs
@@ -16,6 +16,7 @@ use uuid::Uuid;
 use crate::{
     error::ComhairleError,
     models::{
+        conversation, event,
         event_attendance::{
             self, CreateEventAttendance, EventAttendanceEtx, EventAttendanceFilterOptions,
             EventAttendanceOrderOptions, UpdateEventAttendance,
@@ -81,13 +82,13 @@ pub async fn create(
 ) -> Result<(StatusCode, Json<EventAttendanceDto>), ComhairleError> {
     // Search for user by email if passed, otherwise create attendence from
     // logged in user (session cookie)
-    let user_id = match payload.user_email {
-        Some(email) => users::get_user_by_email(&email, &state.db).await?.id,
-        None => user.id,
+    let user = match payload.user_email {
+        Some(email) => users::get_user_by_email(&email, &state.db).await?,
+        None => user,
     };
 
     let create_event_attendance = CreateEventAttendance {
-        user_id,
+        user_id: user.id,
         event_id,
         role: payload.role,
     };
@@ -95,6 +96,21 @@ pub async fn create(
     let event_attendance = event_attendance::create(&state.db, &create_event_attendance)
         .await?
         .into();
+
+    if let Some(email) = user.email {
+        let conversation = conversation::get_by_id(&state.db, &conversation_id).await?;
+        let event =
+            event::get_localized_by_id(&state.db, &event_id, &conversation.primary_locale).await?;
+
+        let event_link = format!(
+            "{}/conversations/{}/events/{}",
+            state.config.domain, conversation.id, event.id
+        );
+
+        state
+            .mailer
+            .send_event_confirmation_email(email.to_string(), &event, &None, event_link)?;
+    }
 
     Ok((StatusCode::CREATED, Json(event_attendance)))
 }
@@ -243,15 +259,31 @@ mod tests {
     use std::error::Error;
 
     use crate::{
+        mailer::MockComhairleMailer,
         models::model_test_helpers::{get_random_conversation_id, setup_default_app_and_session},
         routes::{auth::SignupRequest, events::dto::EventDto},
+        setup_server,
+        test_helpers::{test_state, UserSession},
     };
 
     use super::*;
 
     #[sqlx::test]
     async fn should_create_an_event_attendance(pool: PgPool) -> Result<(), Box<dyn Error>> {
-        let (app, mut session) = setup_default_app_and_session(&pool).await?;
+        let mut mailer = MockComhairleMailer::new();
+        mailer
+            .expect_send_welcome_email()
+            .once()
+            .returning(|_, _| Ok(()));
+        mailer
+            .expect_send_event_confirmation_email()
+            .once()
+            .returning(|_, _, _, _| Ok(()));
+        let state = test_state().db(pool).mailer(Arc::new(mailer)).call()?;
+        let app = setup_server(Arc::new(state)).await?;
+        let mut session = UserSession::new_admin();
+        session.signup(&app).await?;
+
         let conversation_id = get_random_conversation_id(&app, &mut session).await?;
         let (_, response, _) = session
             .create_random_event(&app, &conversation_id.to_string())

--- a/api/src/routes/event_attendances.rs
+++ b/api/src/routes/event_attendances.rs
@@ -80,10 +80,19 @@ pub async fn create(
     RequiredUser(user): RequiredUser,
     Json(payload): Json<CreateEventAttendanceRequest>,
 ) -> Result<(StatusCode, Json<EventAttendanceDto>), ComhairleError> {
-    // Search for user by email if passed, otherwise create attendence from
+    let conversation = conversation::get_by_id(&state.db, &conversation_id).await?;
+    // Search for user by email if provided, otherwise create attendence from
     // logged in user (session cookie)
     let user = match payload.user_email {
-        Some(email) => users::get_user_by_email(&email, &state.db).await?,
+        Some(email) => {
+            // Registering a different user can only be performed by the
+            // conversation owner
+            if conversation.owner_id == user.id {
+                users::get_user_by_email(&email, &state.db).await?
+            } else {
+                return Err(ComhairleError::UserIsNotConversationOwner);
+            }
+        }
         None => user,
     };
 
@@ -93,26 +102,29 @@ pub async fn create(
         role: payload.role,
     };
 
-    let event_attendance = event_attendance::create(&state.db, &create_event_attendance)
-        .await?
-        .into();
+    let event_attendance = event_attendance::create(&state.db, &create_event_attendance).await?;
 
     if let Some(email) = user.email {
-        let conversation = conversation::get_by_id(&state.db, &conversation_id).await?;
-        let event =
-            event::get_localized_by_id(&state.db, &event_id, &conversation.primary_locale).await?;
+        if &event_attendance.role == "participant" {
+            let event =
+                event::get_localized_by_id(&state.db, &event_id, &conversation.primary_locale)
+                    .await?;
 
-        let event_link = format!(
-            "{}/conversations/{}/events/{}",
-            state.config.domain, conversation.id, event.id
-        );
+            let event_link = format!(
+                "{}/conversations/{}/events/{}",
+                state.config.domain, conversation.id, event.id
+            );
 
-        state
-            .mailer
-            .send_event_confirmation_email(email.to_string(), &event, &None, event_link)?;
+            state.mailer.send_event_confirmation_email(
+                email.to_string(),
+                &event,
+                &None,
+                event_link,
+            )?;
+        }
     }
 
-    Ok((StatusCode::CREATED, Json(event_attendance)))
+    Ok((StatusCode::CREATED, Json(event_attendance.into())))
 }
 
 #[derive(Deserialize, JsonSchema, Debug)]
@@ -291,7 +303,7 @@ mod tests {
         let event: EventDto = serde_json::from_value(response)?;
 
         let new_attendance = CreateEventAttendanceRequest {
-            role: "facilitator".to_string(),
+            role: "participant".to_string(),
             ..Default::default()
         };
 
@@ -311,7 +323,7 @@ mod tests {
         assert!(status.is_success(), "error response status");
         assert_eq!(
             event_attendance.role,
-            "facilitator".to_string(),
+            "participant".to_string(),
             "incorrect role"
         );
         assert_eq!(event_attendance.event_id, event.id, "incorrect event_id");

--- a/api/src/routes/invites.rs
+++ b/api/src/routes/invites.rs
@@ -317,6 +317,7 @@ async fn auto_register_event_attendance(
             users::create_otp_user(
                 &OtpSignupRequest {
                     email: email.to_string(),
+                    username: None,
                 },
                 &state.db,
             )

--- a/api/src/routes/invites.rs
+++ b/api/src/routes/invites.rs
@@ -46,25 +46,7 @@ async fn accept_invite(
     invite.is_still_valid()?;
     invite.is_for_user(&user)?;
 
-    if let Some(event_id) = &invite.event_id {
-        // Send confirmation email for event invites
-        let email = match &invite.invite_type {
-            InviteType::Email(ref email) => email,
-            _ => return Err(ComhairleError::InvalidInviteType),
-        };
-
-        let event =
-            event::get_localized_by_id(&state.db, event_id, &conversation.primary_locale).await?;
-
-        let event_link = format!(
-            "{}/conversations/{}/events/{}",
-            state.config.domain, conversation.id, event.id
-        );
-
-        state
-            .mailer
-            .send_event_confirmation_email(email.to_string(), &event, &None, event_link)?;
-    } else {
+    if invite.event_id.is_none() {
         // Get the workflow to sign up to either explicitly from the invite
         // or from the default conversation workflow
         let workflow_id = match (invite.workflow_id, conversation.default_workflow_id) {

--- a/ui/packages/api-client/src/api.ts
+++ b/ui/packages/api-client/src/api.ts
@@ -47,7 +47,12 @@ export const SignupRequest = z
   })
   .passthrough();
 export type SignupRequest = z.infer<typeof SignupRequest>;
-export const OtpSignupRequest = z.object({ email: z.string() }).passthrough();
+export const OtpSignupRequest = z
+  .object({
+    email: z.string(),
+    username: z.union([z.string(), z.null()]).optional(),
+  })
+  .passthrough();
 export type OtpSignupRequest = z.infer<typeof OtpSignupRequest>;
 export const CreateOtpRequest = z
   .object({
@@ -1422,7 +1427,10 @@ export type PaginatedResults_for_EventAttendanceEtx = z.infer<
   typeof PaginatedResults_for_EventAttendanceEtx
 >;
 export const CreateEventAttendanceRequest = z
-  .object({ role: z.string() })
+  .object({
+    role: z.string(),
+    user_email: z.union([z.string(), z.null()]).optional(),
+  })
   .passthrough();
 export type CreateEventAttendanceRequest = z.infer<
   typeof CreateEventAttendanceRequest
@@ -2007,7 +2015,7 @@ const endpoints = makeApi([
       {
         name: "body",
         type: "Body",
-        schema: z.object({ email: z.string() }).passthrough(),
+        schema: OtpSignupRequest,
       },
     ],
     response: UserDto,
@@ -2452,7 +2460,7 @@ curl -X POST \
       {
         name: "body",
         type: "Body",
-        schema: z.object({ role: z.string() }).passthrough(),
+        schema: CreateEventAttendanceRequest,
       },
     ],
     response: EventAttendanceDto,


### PR DESCRIPTION
Actions:

- move event confirmation out of invite acceptance and into attendance creation route
- refactor otp creation to optionally take username
- refactor event attendance to optionally take email param and create attendance for associated user with fallback to logged in user

Motivation:

- allow for event registration flows that don't involve invites