### PR TITLE
"Tutor bot" -> "Learning assistant" rename

### DIFF
--- a/ui/packages/comhairle/src/lib/components/Chatbot/ChatBot.svelte
+++ b/ui/packages/comhairle/src/lib/components/Chatbot/ChatBot.svelte
@@ -13,7 +13,7 @@
 		knowledgeBaseIds = [],
 		title = 'Chat with Bot',
 		subtitle = 'Try answer some questions from Comhairle and explore your views.',
-		botName = 'Tutor bot',
+		botName = 'Learning assistant',
 		botSubtitle = 'Ask questions',
 		messages: initialMessages = [
 			// TODO: add back with better wording once we know where how to configure default questions

--- a/ui/packages/comhairle/src/lib/components/Chatbot/CollapsibleChat.svelte
+++ b/ui/packages/comhairle/src/lib/components/Chatbot/CollapsibleChat.svelte
@@ -14,7 +14,7 @@
 		chatId,
 		conversationId,
 		userId,
-		botName = 'Tutor bot',
+		botName = 'Learning assistant',
 		botSubtitle = 'Ask questions'
 	}: Props = $props();
 

--- a/ui/packages/comhairle/src/lib/components/ConversationSupportSidebar.svelte
+++ b/ui/packages/comhairle/src/lib/components/ConversationSupportSidebar.svelte
@@ -13,7 +13,7 @@
 		$props();
 
 	let activeTab = $state(
-		conversation?.chatBotId && conversation.enableQaChatBot ? 'tutorBot' : 'faqs'
+		conversation?.chatBotId && conversation.enableQaChatBot ? 'learningAssistant' : 'faqs'
 	);
 
 	let tabs = [
@@ -45,9 +45,9 @@
 			<div class="bg-sidebar mb-4 flex shrink-0 flex-row gap-0.5 rounded-xl p-1">
 				{#if conversation?.chatBotId && conversation.enableQaChatBot}
 					<Tabs.Trigger
-						value="tutorBot"
+						value="learningAssistant"
 						class="text-sidebar-foreground data-[state=active]:text-foreground border-none"
-						>Tutor bot</Tabs.Trigger
+						>Learning assistant</Tabs.Trigger
 					>
 				{/if}
 				{#each tabs as tab (tab.value)}
@@ -72,15 +72,15 @@
 					</Tabs.Content>
 				{/each}
 				{#if conversation?.chatBotId && conversation.enableQaChatBot}
-					<Tabs.Content value="tutorBot" class="flex min-h-0 flex-1 flex-col">
+					<Tabs.Content value="learningAssistant" class="flex min-h-0 flex-1 flex-col">
 						<div class="flex min-h-0 flex-1 flex-col">
 							<ChatBot
 								chatId={conversation.chatBotId}
 								conversationId={conversation.id}
 								userId={user?.id}
-								botName="Tutor bot"
+								botName="Learning assistant"
 								botSubtitle="Ask questions"
-								active={activeTab === 'tutorBot'}
+								active={activeTab === 'learningAssistant'}
 							/>
 						</div>
 					</Tabs.Content>

--- a/ui/packages/comhairle/src/lib/tools/learn/LearnTutor.svelte
+++ b/ui/packages/comhairle/src/lib/tools/learn/LearnTutor.svelte
@@ -404,7 +404,7 @@
 			<p
 				class="text-muted-foreground border-border rounded-md border border-dashed p-3 text-center text-xs"
 			>
-				Enable the tutor bot above to ask questions about this page.
+				Enable the learning assistant above to ask questions about this page.
 			</p>
 		{/if}
 	</div>

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/configure/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/configure/+page.svelte
@@ -595,11 +595,13 @@
 					{#snippet children({ props })}
 						<div class="flex items-center justify-between gap-4">
 							<div class="flex flex-col gap-1">
-								<Form.Label class="text-sm font-medium">Show Tutor Bot</Form.Label>
+								<Form.Label class="text-sm font-medium"
+									>Show Learning Assistant</Form.Label
+								>
 								<p class="text-muted-foreground text-sm">
-									Display a Q&A Tutor Bot on the conversation.<br />
+									Display a Q&A Learning Assistant on the conversation.<br />
 									{#if !conversation.isLive}
-										(Configure Tutor Bot on the
+										(Configure Learning Assistant on the
 										<a
 											href={`/admin/conversations/${conversation.id}/knowledge-base`}
 											class="underline">Knowledge Base page</a


### PR DESCRIPTION
Actions:
+ rename "Tutor bot" to "Learning assistant" across chatbot components
+ update tab value from "tutorBot" to "learningAssistant" in ConversationSupportSidebar
+ update configuration page labels and help text to use new terminology

Motivation:
+ improve clarity and accessibility of chatbot feature naming