### PR TITLE
Thinking Space: follow up questions + coming back: improve UI and UX

### DIFF
--- a/ui/packages/comhairle/src/lib/tools/thinking_space/FollowUpLoading.svelte
+++ b/ui/packages/comhairle/src/lib/tools/thinking_space/FollowUpLoading.svelte
@@ -48,8 +48,8 @@
 
 	<div class="space-y-2" aria-hidden="true">
 		{#each lineLayouts as layout, i (i)}
-			<div class="border-border bg-card rounded-lg border px-4 py-3">
-				<Skeleton class="h-4 {layout.first}" />
+			<div class="border-primary/20 bg-primary/5 rounded-lg border px-4 py-3">
+				<Skeleton class="bg-primary/15 h-4 {layout.first}" />
 				{#if layout.second}
 					<Skeleton class="mt-2 h-4 {layout.second}" />
 				{/if}

--- a/ui/packages/comhairle/src/lib/tools/thinking_space/QuestionFlow.svelte
+++ b/ui/packages/comhairle/src/lib/tools/thinking_space/QuestionFlow.svelte
@@ -9,8 +9,7 @@
 		Check,
 		RotateCcw,
 		ChevronLeft,
-		ChevronRight,
-		ArrowLeft
+		ChevronRight
 	} from 'lucide-svelte';
 	import type { QuestionConfig, QuestionAnswers } from './types';
 	import { QuestionFlowState, type FlowMode } from './questionFlowState.svelte';
@@ -24,14 +23,6 @@
 		initialAnswers?: QuestionAnswers[];
 		mode?: FlowMode;
 		onComplete: (answers: QuestionAnswers[]) => void;
-		/**
-		 * Back-out affordance, currently only used in extension mode so the
-		 * participant can return to the summary screen without finishing the
-		 * full second pass. Any follow-ups they've already submitted are
-		 * persisted; the parent decides whether to generate a new round based
-		 * on whether new answers were actually added.
-		 */
-		onBack?: () => void;
 	};
 
 	let {
@@ -41,8 +32,7 @@
 		followUpCount,
 		initialAnswers = [],
 		mode = 'initial',
-		onComplete,
-		onBack
+		onComplete
 	}: Props = $props();
 
 	const flow = new QuestionFlowState({
@@ -127,18 +117,7 @@
 	<div class="border-border bg-card/60 border-b px-6 py-4 backdrop-blur">
 		<div class="mx-auto max-w-2xl">
 			<div class="text-muted-foreground mb-2 flex items-center justify-between gap-3 text-xs">
-				{#if onBack}
-					<button
-						type="button"
-						onclick={() => onBack?.()}
-						class="text-muted-foreground hover:text-foreground inline-flex items-center gap-1 transition-colors"
-					>
-						<ArrowLeft class="size-3.5" />
-						Back to summary
-					</button>
-				{:else}
-					<span></span>
-				{/if}
+				<span></span>
 				<span>
 					{#if inExtensionPicker}
 						Pick a question to explore further
@@ -330,6 +309,18 @@
 					<!-- Picker: loading -->
 					{#if flow.currentState.pickerLoading}
 						<FollowUpLoading />
+						{#if inExtensionChain}
+							<div class="flex justify-end pt-2">
+								<Button
+									variant="outline"
+									size="sm"
+									onclick={() => flow.doneWithRoot()}
+								>
+									<Check class="size-3.5" />
+									Done with this question
+								</Button>
+							</div>
+						{/if}
 					{/if}
 
 					<!-- Picker: failed to load -->
@@ -420,7 +411,7 @@
 									<button
 										type="button"
 										onclick={() => flow.pickFollowUp(followUpQuestion)}
-										class="border-border bg-card hover:border-primary hover:bg-primary/5 w-full rounded-lg border px-4 py-3 text-left text-sm leading-relaxed transition-colors"
+										class="border-primary/20 bg-primary/5 hover:border-primary hover:bg-primary/10 w-full rounded-lg border px-4 py-3 text-left text-sm leading-relaxed transition-colors"
 									>
 										{followUpQuestion}
 									</button>

--- a/ui/packages/comhairle/src/lib/tools/thinking_space/Summary.svelte
+++ b/ui/packages/comhairle/src/lib/tools/thinking_space/Summary.svelte
@@ -254,14 +254,14 @@
 					</p>
 				</div>
 				<div
-					class="border-border bg-card space-y-3 rounded-lg border px-4 py-4"
+					class="border-primary/20 bg-primary/5 space-y-3 rounded-lg border px-4 py-4"
 					aria-hidden="true"
 				>
 					{#each skeletonLines as layout, i (i)}
 						<div>
-							<Skeleton class="h-4 {layout.first}" />
+							<Skeleton class="bg-primary/15 h-4 {layout.first}" />
 							{#if layout.second}
-								<Skeleton class="mt-2 h-4 {layout.second}" />
+								<Skeleton class="bg-primary/15 mt-2 h-4 {layout.second}" />
 							{/if}
 						</div>
 					{/each}

--- a/ui/packages/comhairle/src/lib/tools/thinking_space/ThinkingSpaceEmbed.svelte
+++ b/ui/packages/comhairle/src/lib/tools/thinking_space/ThinkingSpaceEmbed.svelte
@@ -130,13 +130,6 @@
 		phase = 'questions';
 	}
 
-	function handleBackFromExtension() {
-		// Participant changed their mind mid-extension. Any follow-ups they
-		// did answer are already persisted; if any new ones were added, mint
-		// a new summary round, otherwise just return to the existing stack.
-		void finishExtension(answers);
-	}
-
 	async function finishExtension(final: QuestionAnswers[]) {
 		const before = answerCountAtExtensionStart;
 		const after = totalAnswerCount(final);
@@ -220,7 +213,6 @@
 				initialAnswers={answers}
 				mode={flowMode}
 				onComplete={handleQuestionFlowComplete}
-				onBack={flowMode === 'extension' ? handleBackFromExtension : undefined}
 			/>
 		{:else if phase === 'summary'}
 			<Summary


### PR DESCRIPTION

<img width="1031" height="430" alt="2026-06-08_15-57-33" src="https://github.com/user-attachments/assets/3acec4fa-c83c-4de7-b886-acbfcd0fd410" />
<img width="815" height="628" alt="2026-06-08_15-56-27" src="https://github.com/user-attachments/assets/d2843ef1-70a2-4800-8aed-fd6d3a51e3c1" />


Actions: 

+ remove onBack prop and back button from QuestionFlow component
+ add "Done with this question" button during picker loading in extension chain
+ update skeleton and picker option styling to use primary color variants
+ remove handleBackFromExtension function from ThinkingSpaceEmbed
+ remove unused ArrowLeft import

Motivation:

+ simplify extension flow UX by removing mid-flow