### PR TITLE
Add image preview support to document viewer dialog

### DIFF
--- a/ui/packages/comhairle/src/lib/components/PdfViewer/PdfDocumentDialog.svelte
+++ b/ui/packages/comhairle/src/lib/components/PdfViewer/PdfDocumentDialog.svelte
@@ -10,16 +10,23 @@
 		src: string | null;
 		name?: string;
 		downloadHref?: string | null;
+		kind?: 'pdf' | 'image';
 	};
 
-	let { open = $bindable(false), src, name = 'Document', downloadHref = null }: Props = $props();
+	let {
+		open = $bindable(false),
+		src,
+		name = 'Document',
+		downloadHref = null,
+		kind = 'pdf'
+	}: Props = $props();
 
 	// pdfjs-dist is heavy (~1MB) and not SSR-safe, so the viewer is loaded
 	// lazily in the browser the first time a document is opened.
 	let PdfViewer = $state<Component<{ src: string }> | null>(null);
 
 	$effect(() => {
-		if (browser && open && !PdfViewer) {
+		if (browser && open && kind === 'pdf' && !PdfViewer) {
 			import('./PdfViewer.svelte').then((m) => {
 				PdfViewer = m.default as unknown as Component<{ src: string }>;
 			});
@@ -53,7 +60,11 @@
 
 		<div class="bg-muted min-h-0 flex-1 overflow-hidden">
 			{#if browser && open && src}
-				{#if PdfViewer}
+				{#if kind === 'image'}
+					<div class="flex h-full w-full items-center justify-center overflow-auto p-4">
+						<img {src} alt={name} class="max-h-full max-w-full object-contain" />
+					</div>
+				{:else if PdfViewer}
 					<PdfViewer {src} />
 				{:else}
 					<div

--- a/ui/packages/comhairle/src/lib/components/RichTextEditor/ContentRenderer/ContentRenderer.svelte
+++ b/ui/packages/comhairle/src/lib/components/RichTextEditor/ContentRenderer/ContentRenderer.svelte
@@ -36,19 +36,25 @@
 	let editor = $state<Editor>();
 	let lastDocMapKey = $state('');
 
-	let pdfDialog = $state<{
+	let previewDialog = $state<{
 		open: boolean;
+		kind: 'pdf' | 'image';
 		src: string | null;
 		name: string;
 		downloadHref: string | null;
-	}>({ open: false, src: null, name: '', downloadHref: null });
+	}>({ open: false, kind: 'pdf', src: null, name: '', downloadHref: null });
 
-	function isPdf(fileName: string): boolean {
-		return fileName.toLowerCase().endsWith('.pdf');
+	const IMAGE_EXTENSIONS = ['.jpg', '.jpeg', '.png', '.gif', '.webp', '.bmp', '.svg', '.avif'];
+
+	function getPreviewKind(fileName: string): 'pdf' | 'image' | null {
+		const lower = fileName.toLowerCase();
+		if (lower.endsWith('.pdf')) return 'pdf';
+		if (IMAGE_EXTENSIONS.some((ext) => lower.endsWith(ext))) return 'image';
+		return null;
 	}
 
-	/* Intercept source-document badge clicks: open PDFs in an in-page viewer
-	 * instead of downloading. Non-PDF files keep the default download behaviour. */
+	/* Intercept source-document badge clicks: open PDFs and images in an in-page
+	 * viewer instead of downloading. Other file types keep default download. */
 	function handleContentClick(event: MouseEvent) {
 		if (event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey) return;
 
@@ -60,13 +66,15 @@
 		if (!documentId) return;
 
 		const doc = availableDocuments.find((d) => d.id === documentId);
-		if (!doc || !isPdf(doc.name)) return;
+		if (!doc) return;
+		const kind = getPreviewKind(doc.name);
+		if (!kind) return;
 
 		const href = badge.getAttribute('href');
 		if (!href || href === '#') return;
 
 		event.preventDefault();
-		pdfDialog = { open: true, src: href, name: doc.name, downloadHref: href };
+		previewDialog = { open: true, kind, src: href, name: doc.name, downloadHref: href };
 	}
 
 	function createRenderer() {
@@ -160,10 +168,11 @@
 </div>
 
 <PdfDocumentDialog
-	bind:open={pdfDialog.open}
-	src={pdfDialog.src}
-	name={pdfDialog.name}
-	downloadHref={pdfDialog.downloadHref}
+	bind:open={previewDialog.open}
+	kind={previewDialog.kind}
+	src={previewDialog.src}
+	name={previewDialog.name}
+	downloadHref={previewDialog.downloadHref}
 />
 
 <style>


### PR DESCRIPTION
Before:


https://github.com/user-attachments/assets/5b3b26b0-56af-49e7-ac39-8b919f8a36d6


After:

https://github.com/user-attachments/assets/e0daf9a7-5464-4d0b-9fd3-a2788f8d96e2


+ add kind prop ('pdf' | 'image') to PdfDocumentDialog component
+ add image rendering branch in dialog with centered, contained layout
+ rename pdfDialog to previewDialog in ContentRenderer
+ add getPreviewKind helper to detect both PDF and image file types
+ update click handler to support image preview alongside PDF
+ conditionally load PdfViewer only for PDF kind
+ update comments to reflect support for both PDFs and images
