### PR TITLE
443 bot service default page size

### DIFF
--- a/api/src/bot_service.rs
+++ b/api/src/bot_service.rs
@@ -253,13 +253,30 @@ pub trait ComhairleBotService: Send + Sync {
     ) -> Result<Vec<BotServiceSseEvent>, ComhairleError>;
 }
 
-#[derive(Deserialize, Debug, JsonSchema, Default, PartialEq)]
+fn default_page_size() -> Option<i32> {
+    Some(400)
+}
+
+#[derive(Deserialize, Debug, JsonSchema, PartialEq)]
 pub struct GetQueryParams {
     pub page: Option<i32>,
+    #[serde(default = "default_page_size")]
     pub page_size: Option<i32>,
     pub order_by: Option<String>,
     pub name: Option<String>,
     pub title: Option<String>,
+}
+
+impl Default for GetQueryParams {
+    fn default() -> Self {
+        Self {
+            page: None,
+            page_size: Some(400),
+            order_by: None,
+            name: None,
+            title: None,
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, JsonSchema, Default, Debug, Clone)]

--- a/ui/packages/api-client/src/api.ts
+++ b/ui/packages/api-client/src/api.ts
@@ -1331,6 +1331,11 @@ export const ChatConversationRequest = z
   .object({ question: z.string() })
   .passthrough();
 export type ChatConversationRequest = z.infer<typeof ChatConversationRequest>;
+export const page_size = z
+  .union([z.number(), z.null()])
+  .optional()
+  .default(400);
+export type page_size = z.infer<typeof page_size>;
 export const ComhairleDocument = z
   .object({
     id: z.string(),
@@ -1913,6 +1918,7 @@ export const schemas: Record<string, z.ZodType<any>> = {
   PartialFeedback,
   ComhairleChatSession,
   ChatConversationRequest,
+  page_size,
   ComhairleDocument,
   UploadFileResponse,
   Order,
@@ -2365,7 +2371,7 @@ Use a raw HTTP request and process the response body incrementally.`,
       {
         name: "page_size",
         type: "Query",
-        schema: limit,
+        schema: page_size,
       },
       {
         name: "title",


### PR DESCRIPTION
Actions:

+ set high default page_size for bot service requests

Motivation:

+ temporary fix to prevent documents not displaying in admin