### PR TITLE
Email receipiants blast

### DIFF
--- a/api/src/email_templates/conversation_broadcast.html
+++ b/api/src/email_templates/conversation_broadcast.html
@@ -1,0 +1,6 @@
+{% extends "email_layout.html" %}
+{% block content %}
+  <div style="text-align: left;">
+    {{ body | safe }}
+  </div>
+{% endblock %}

--- a/api/src/mailer.rs
+++ b/api/src/mailer.rs
@@ -76,6 +76,13 @@ pub trait ComhairleMailer: Send + Sync {
         organization: &Option<Organization>,
         link_href: String,
     ) -> Result<(), ComhairleError>;
+
+    fn send_conversation_broadcast_email(
+        &self,
+        email: &str,
+        subject: &str,
+        html_body: &str,
+    ) -> Result<(), ComhairleError>;
 }
 
 #[derive(Debug)]
@@ -110,6 +117,9 @@ impl MockComhairleMailer {
         mailer
             .expect_send_event_reminder()
             .returning(|_, _, _, _| Ok(()));
+        mailer
+            .expect_send_conversation_broadcast_email()
+            .returning(|_, _, _| Ok(()));
 
         mailer
     }
@@ -171,9 +181,10 @@ impl ComhairleMailer for Mailer {
             .credentials(self.creds.clone())
             .build();
 
-        if let Err(e) = mailer.send(&email) {
+        mailer.send(&email).map_err(|e| {
             warn!("Mailer error: {e}");
-        }
+            e
+        })?;
 
         Ok(())
     }
@@ -327,6 +338,21 @@ impl ComhairleMailer for Mailer {
                 event_link => link_href,
             },
             Some(calendar_invite),
+        )
+    }
+
+    fn send_conversation_broadcast_email(
+        &self,
+        email: &str,
+        subject: &str,
+        html_body: &str,
+    ) -> Result<(), ComhairleError> {
+        self.send_email(
+            email,
+            subject,
+            "conversation_broadcast.html",
+            context! { subject, body => html_body },
+            None,
         )
     }
 }

--- a/api/src/models/user_conversation_preferences.rs
+++ b/api/src/models/user_conversation_preferences.rs
@@ -1,7 +1,9 @@
 use crate::error::ComhairleError;
+use crate::models::conversation_email_notification_recipients::ConversationEmailNotificationRecipientsIden;
+use crate::models::users::UserIden;
 use chrono::{DateTime, Utc};
 use schemars::JsonSchema;
-use sea_query::{enum_def, Expr, PostgresQueryBuilder, Query};
+use sea_query::{enum_def, Expr, JoinType, PostgresQueryBuilder, Query, UnionType};
 use sea_query_binder::SqlxBinder;
 use serde::{Deserialize, Serialize};
 use sqlx::{prelude::FromRow, PgPool};
@@ -244,6 +246,50 @@ pub async fn delete(
         .map_err(|_| ComhairleError::ResourceNotFound("UserConversationPreferences".into()))?;
 
     Ok(preferences)
+}
+
+pub async fn get_opted_in_broadcast_emails(
+    db: &PgPool,
+    conversation_id: &Uuid,
+) -> Result<Vec<String>, ComhairleError> {
+    let mut logged_in = Query::select()
+        .expr(Expr::col((UserIden::Table, UserIden::Email)))
+        .from(UserConversationPreferencesIden::Table)
+        .join(
+            JoinType::InnerJoin,
+            UserIden::Table,
+            Expr::col((UserIden::Table, UserIden::Id)).equals((
+                UserConversationPreferencesIden::Table,
+                UserConversationPreferencesIden::UserId,
+            )),
+        )
+        .and_where(
+            Expr::col(UserConversationPreferencesIden::ConversationId)
+                .eq(conversation_id.to_owned()),
+        )
+        .and_where(Expr::col(UserConversationPreferencesIden::ReceiveUpdatesByEmail).eq(true))
+        .and_where(Expr::col((UserIden::Table, UserIden::Email)).is_not_null())
+        .to_owned();
+
+    let anonymous = Query::select()
+        .column(ConversationEmailNotificationRecipientsIden::Email)
+        .from(ConversationEmailNotificationRecipientsIden::Table)
+        .and_where(
+            Expr::col(ConversationEmailNotificationRecipientsIden::ConversationId)
+                .eq(conversation_id.to_owned()),
+        )
+        .and_where(
+            Expr::col(ConversationEmailNotificationRecipientsIden::ReceiveUpdatesByEmail).eq(true),
+        )
+        .to_owned();
+
+    let (sql, values) = logged_in
+        .union(UnionType::Distinct, anonymous)
+        .build_sqlx(PostgresQueryBuilder);
+
+    let rows: Vec<(String,)> = sqlx::query_as_with(&sql, values).fetch_all(db).await?;
+
+    Ok(rows.into_iter().map(|(email,)| email).collect())
 }
 
 pub async fn get_contacts_for_export(

--- a/api/src/routes/conversations.rs
+++ b/api/src/routes/conversations.rs
@@ -237,6 +237,45 @@ pub struct SendEmailNotificationResponse {
     failed_recipients: Vec<String>,
 }
 
+#[derive(Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct NotificationRecipientsResponse {
+    /// Number of distinct workflow participants (in-app delivery target count).
+    pub participant_count: i32,
+    /// Email addresses opted in to broadcast emails for this conversation.
+    pub email_recipients: Vec<String>,
+    /// Convenience count of `email_recipients`.
+    pub email_recipient_count: i32,
+}
+
+/// Preview the recipient lists for the notify page (count + email list).
+async fn get_notification_recipients(
+    State(state): State<Arc<ComhairleState>>,
+    RequiredAdminUser(user): RequiredAdminUser,
+    Path(conversation_id): Path<Uuid>,
+) -> Result<(StatusCode, Json<NotificationRecipientsResponse>), ComhairleError> {
+    let conversation = conversation::get_by_id(&state.db, &conversation_id).await?;
+    if conversation.owner_id != user.id {
+        return Err(ComhairleError::UserNotAuthorized);
+    }
+
+    let participant_ids =
+        user_participation::get_participant_user_ids_for_conversation(&state.db, &conversation_id)
+            .await?;
+    let email_recipients =
+        user_conversation_preferences::get_opted_in_broadcast_emails(&state.db, &conversation_id)
+            .await?;
+
+    Ok((
+        StatusCode::OK,
+        Json(NotificationRecipientsResponse {
+            participant_count: participant_ids.len() as i32,
+            email_recipient_count: email_recipients.len() as i32,
+            email_recipients,
+        }),
+    ))
+}
+
 /// Send notification to all conversation participants
 async fn send_notification_to_participants(
     State(state): State<Arc<ComhairleState>>,
@@ -676,6 +715,16 @@ pub fn router(state: Arc<ComhairleState>) -> ApiRouter {
                     .summary("Send notification to all conversation participants")
                     .description("Creates a notification and sends it to all users participating in workflows within the conversation. Only conversation owners can send notifications.")
                     .response::<201, Json<SendEmailNotificationResponse>>()
+                    .tag("Notifications")
+            }),
+        )
+        .api_route(
+            "/{conversation_id}/notifications/recipients",
+            get_with(get_notification_recipients, |op| {
+                op.id("GetNotificationRecipients")
+                    .summary("Preview notification recipients")
+                    .description("Returns participant count for in-app delivery and the list of email addresses opted in to broadcast emails. Owner-only.")
+                    .response::<200, Json<NotificationRecipientsResponse>>()
                     .tag("Notifications")
             }),
         )
@@ -1704,6 +1753,462 @@ mod tests {
             status,
             StatusCode::UNAUTHORIZED,
             "Non-owner should not be able to export demographics"
+        );
+
+        Ok(())
+    }
+
+    /// Returns a fresh mock mailer that records every email passed to
+    /// `send_conversation_broadcast_email` into the given shared `Vec`,
+    /// and is tolerant of unrelated mail calls triggered by signup, etc.
+    fn recording_mailer(
+        sent: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
+    ) -> crate::mailer::MockComhairleMailer {
+        use crate::mailer::MockComhairleMailer;
+        let mut mailer = MockComhairleMailer::new();
+        mailer.expect_send_welcome_email().returning(|_, _| Ok(()));
+        mailer
+            .expect_send_verification_email()
+            .returning(|_, _, _| Ok(()));
+        mailer.expect_send_email().returning(|_, _, _, _, _| Ok(()));
+        mailer
+            .expect_send_otp_email()
+            .returning(|_, _, _, _| Ok(()));
+        mailer
+            .expect_send_password_reset_email()
+            .returning(|_, _, _| Ok(()));
+        mailer
+            .expect_send_event_registration_email()
+            .returning(|_, _, _, _| Ok(()));
+        mailer
+            .expect_send_event_confirmation_email()
+            .returning(|_, _, _, _| Ok(()));
+        mailer
+            .expect_send_event_reminder()
+            .returning(|_, _, _, _| Ok(()));
+        mailer
+            .expect_send_conversation_broadcast_email()
+            .returning(move |email, _subject, _html| {
+                sent.lock().unwrap().push(email.to_string());
+                Ok(())
+            });
+        mailer
+    }
+
+    /// Helper: create the conversation and return its id.
+    async fn make_conversation(
+        session: &mut UserSession,
+        app: &axum::Router,
+        slug: &str,
+    ) -> Result<uuid::Uuid, Box<dyn Error>> {
+        let (_, conversation, _) = session
+            .create_conversation(
+                app,
+                json!({
+                    "title" : "Broadcast test",
+                    "short_description" : "A test conversation",
+                    "description" : "A longer description",
+                    "image_url" : "http://someimage.png",
+                    "tags" : ["one"],
+                    "is_public" : true,
+                    "is_live" : true,
+                    "is_invite_only" : false,
+                    "slug" : slug,
+                    "primary_locale" : "en",
+                    "supported_languages" : ["en"]
+                }),
+            )
+            .await?;
+        let conversation: ConversationDto = serde_json::from_value(conversation)?;
+        Ok(conversation.id)
+    }
+
+    #[sqlx::test]
+    async fn broadcast_email_only_sent_to_opted_in_authenticated_users(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn Error>> {
+        use crate::models::user_conversation_preferences::{
+            self, CreateUserConversationPreferences,
+        };
+        use crate::models::users::create_user;
+        use crate::routes::auth::SignupRequest;
+        use std::sync::{Arc, Mutex};
+
+        let sent: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let mailer = recording_mailer(sent.clone());
+
+        let state = test_state()
+            .db(pool.clone())
+            .mailer(Arc::new(mailer))
+            .call()?;
+        let app = setup_server(Arc::new(state)).await?;
+
+        let mut admin = UserSession::new_admin();
+        admin.signup(&app).await?;
+
+        let conversation_id = make_conversation(&mut admin, &app, "opt_in_authed").await?;
+
+        // user1 — opted in
+        let user1 = create_user(
+            &SignupRequest {
+                username: "opt_in_user".into(),
+                password: "password".into(),
+                email: "user1@test.com".into(),
+                avatar_url: None,
+            },
+            &pool,
+        )
+        .await?;
+        user_conversation_preferences::create(
+            &pool,
+            &CreateUserConversationPreferences {
+                user_id: user1.id,
+                conversation_id,
+                receive_updates_by_notification: Some(false),
+                receive_updates_by_email: Some(true),
+                receive_similar_conversation_updates_by_email: Some(false),
+                receive_similar_conversation_updates_by_notification: Some(false),
+            },
+        )
+        .await?;
+
+        // user2 — explicitly opted out (preferences row exists, flag false)
+        let user2 = create_user(
+            &SignupRequest {
+                username: "opt_out_user".into(),
+                password: "password".into(),
+                email: "user2@test.com".into(),
+                avatar_url: None,
+            },
+            &pool,
+        )
+        .await?;
+        user_conversation_preferences::create(
+            &pool,
+            &CreateUserConversationPreferences {
+                user_id: user2.id,
+                conversation_id,
+                receive_updates_by_notification: Some(true),
+                receive_updates_by_email: Some(false),
+                receive_similar_conversation_updates_by_email: Some(false),
+                receive_similar_conversation_updates_by_notification: Some(false),
+            },
+        )
+        .await?;
+
+        // user3 — no preferences row at all (default = not opted in)
+        let _user3 = create_user(
+            &SignupRequest {
+                username: "no_prefs_user".into(),
+                password: "password".into(),
+                email: "user3@test.com".into(),
+                avatar_url: None,
+            },
+            &pool,
+        )
+        .await?;
+
+        let (status, body, _) = admin
+            .post(
+                &app,
+                &format!("/conversation/{conversation_id}/notifications"),
+                json!({
+                    "title": "Hello",
+                    "content": "{}",
+                    "delivery_method": "email",
+                    "html_content": "<p>Hi</p>",
+                })
+                .to_string()
+                .into(),
+            )
+            .await?;
+
+        assert_eq!(
+            status,
+            StatusCode::CREATED,
+            "broadcast send should succeed, got body: {body:#?}"
+        );
+
+        let recorded = sent.lock().unwrap().clone();
+        assert_eq!(
+            recorded,
+            vec!["user1@test.com".to_string()],
+            "broadcast must reach only the opted-in authenticated user"
+        );
+
+        let notified = body.get("participantsNotified").and_then(|v| v.as_i64());
+        assert_eq!(notified, Some(1), "participantsNotified should be 1");
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn broadcast_email_respects_anonymous_opt_in_flag(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn Error>> {
+        use crate::models::conversation_email_notification_recipients::{
+            self as anon_model, CreateConversationEmailNotificationRecipients,
+        };
+        use std::sync::{Arc, Mutex};
+
+        let sent: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let mailer = recording_mailer(sent.clone());
+
+        let state = test_state()
+            .db(pool.clone())
+            .mailer(Arc::new(mailer))
+            .call()?;
+        let app = setup_server(Arc::new(state)).await?;
+
+        let mut admin = UserSession::new_admin();
+        admin.signup(&app).await?;
+
+        let conversation_id = make_conversation(&mut admin, &app, "opt_in_anon").await?;
+
+        // Anonymous opt-in
+        anon_model::create(
+            &pool,
+            &CreateConversationEmailNotificationRecipients {
+                conversation_id,
+                email: "anon_in@test.com".into(),
+                receive_updates_by_email: true,
+                receive_similar_conversation_updates_by_email: false,
+            },
+        )
+        .await?;
+
+        // Anonymous opt-out (e.g. registered only for similar-conversation updates)
+        anon_model::create(
+            &pool,
+            &CreateConversationEmailNotificationRecipients {
+                conversation_id,
+                email: "anon_out@test.com".into(),
+                receive_updates_by_email: false,
+                receive_similar_conversation_updates_by_email: true,
+            },
+        )
+        .await?;
+
+        let (status, _, _) = admin
+            .post(
+                &app,
+                &format!("/conversation/{conversation_id}/notifications"),
+                json!({
+                    "title": "Hello",
+                    "content": "{}",
+                    "delivery_method": "email",
+                    "html_content": "<p>Hi</p>",
+                })
+                .to_string()
+                .into(),
+            )
+            .await?;
+        assert_eq!(status, StatusCode::CREATED);
+
+        let recorded = sent.lock().unwrap().clone();
+        assert_eq!(
+            recorded,
+            vec!["anon_in@test.com".to_string()],
+            "broadcast must reach only the opted-in anonymous registrant"
+        );
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn broadcast_email_returns_zero_when_nobody_is_opted_in(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn Error>> {
+        use std::sync::{Arc, Mutex};
+
+        let sent: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let mailer = recording_mailer(sent.clone());
+
+        let state = test_state()
+            .db(pool.clone())
+            .mailer(Arc::new(mailer))
+            .call()?;
+        let app = setup_server(Arc::new(state)).await?;
+
+        let mut admin = UserSession::new_admin();
+        admin.signup(&app).await?;
+
+        let conversation_id = make_conversation(&mut admin, &app, "opt_in_empty").await?;
+
+        let (status, body, _) = admin
+            .post(
+                &app,
+                &format!("/conversation/{conversation_id}/notifications"),
+                json!({
+                    "title": "Hello",
+                    "content": "{}",
+                    "delivery_method": "email",
+                    "html_content": "<p>Hi</p>",
+                })
+                .to_string()
+                .into(),
+            )
+            .await?;
+        assert_eq!(status, StatusCode::OK);
+        assert_eq!(
+            body.get("participantsNotified").and_then(|v| v.as_i64()),
+            Some(0)
+        );
+        assert!(
+            sent.lock().unwrap().is_empty(),
+            "no mail should be sent when nobody is opted in"
+        );
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn recipients_endpoint_lists_only_opted_in_emails(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn Error>> {
+        use crate::models::conversation_email_notification_recipients::{
+            self as anon_model, CreateConversationEmailNotificationRecipients,
+        };
+        use crate::models::user_conversation_preferences::{
+            self, CreateUserConversationPreferences,
+        };
+        use crate::models::users::create_user;
+        use crate::routes::auth::SignupRequest;
+        use std::sync::{Arc, Mutex};
+
+        let sent: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let mailer = recording_mailer(sent);
+
+        let state = test_state()
+            .db(pool.clone())
+            .mailer(Arc::new(mailer))
+            .call()?;
+        let app = setup_server(Arc::new(state)).await?;
+
+        let mut admin = UserSession::new_admin();
+        admin.signup(&app).await?;
+
+        let conversation_id = make_conversation(&mut admin, &app, "recipients_preview").await?;
+
+        // Authenticated opt-in
+        let user_in = create_user(
+            &SignupRequest {
+                username: "in_user".into(),
+                password: "password".into(),
+                email: "authed_in@test.com".into(),
+                avatar_url: None,
+            },
+            &pool,
+        )
+        .await?;
+        user_conversation_preferences::create(
+            &pool,
+            &CreateUserConversationPreferences {
+                user_id: user_in.id,
+                conversation_id,
+                receive_updates_by_notification: Some(false),
+                receive_updates_by_email: Some(true),
+                receive_similar_conversation_updates_by_email: Some(false),
+                receive_similar_conversation_updates_by_notification: Some(false),
+            },
+        )
+        .await?;
+
+        // Authenticated opt-out
+        let user_out = create_user(
+            &SignupRequest {
+                username: "out_user".into(),
+                password: "password".into(),
+                email: "authed_out@test.com".into(),
+                avatar_url: None,
+            },
+            &pool,
+        )
+        .await?;
+        user_conversation_preferences::create(
+            &pool,
+            &CreateUserConversationPreferences {
+                user_id: user_out.id,
+                conversation_id,
+                receive_updates_by_notification: Some(false),
+                receive_updates_by_email: Some(false),
+                receive_similar_conversation_updates_by_email: Some(false),
+                receive_similar_conversation_updates_by_notification: Some(false),
+            },
+        )
+        .await?;
+
+        // Anonymous opt-in + opt-out
+        anon_model::create(
+            &pool,
+            &CreateConversationEmailNotificationRecipients {
+                conversation_id,
+                email: "anon_in@test.com".into(),
+                receive_updates_by_email: true,
+                receive_similar_conversation_updates_by_email: false,
+            },
+        )
+        .await?;
+        anon_model::create(
+            &pool,
+            &CreateConversationEmailNotificationRecipients {
+                conversation_id,
+                email: "anon_out@test.com".into(),
+                receive_updates_by_email: false,
+                receive_similar_conversation_updates_by_email: true,
+            },
+        )
+        .await?;
+
+        let url = format!("/conversation/{conversation_id}/notifications/recipients");
+        let (status, body, _) = admin.get(&app, &url).await?;
+        assert_eq!(status, StatusCode::OK);
+
+        let mut emails: Vec<String> = body
+            .get("emailRecipients")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .collect()
+            })
+            .unwrap_or_default();
+        emails.sort();
+
+        assert_eq!(
+            emails,
+            vec!["anon_in@test.com".to_string(), "authed_in@test.com".to_string()],
+            "recipients endpoint must list only opted-in emails (auth + anon)"
+        );
+        assert_eq!(
+            body.get("emailRecipientCount").and_then(|v| v.as_i64()),
+            Some(2)
+        );
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn recipients_endpoint_denies_non_owner(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn Error>> {
+        let state = test_state().db(pool).call()?;
+        let app = setup_server(Arc::new(state)).await?;
+
+        let mut owner = UserSession::new_admin();
+        owner.signup(&app).await?;
+        let mut intruder = UserSession::new("intruder", "password", "intruder@test.com");
+        intruder.signup(&app).await?;
+
+        let conversation_id = make_conversation(&mut owner, &app, "recipients_auth").await?;
+
+        let url = format!("/conversation/{conversation_id}/notifications/recipients");
+        let (status, _, _) = intruder.get(&app, &url).await?;
+
+        assert_eq!(
+            status,
+            StatusCode::UNAUTHORIZED,
+            "non-owner must not see recipient preview"
         );
 
         Ok(())

--- a/api/src/routes/conversations.rs
+++ b/api/src/routes/conversations.rs
@@ -204,6 +204,9 @@ pub struct SendNotificationRequest {
     pub content: String,
     pub notification_type: Option<crate::models::notification::NotificationType>,
     pub delivery_method: Option<DeliveryMethod>,
+    /// Required when delivery_method is "email". HTML body produced by the
+    /// rich text editor; rendered into a branded email template.
+    pub html_content: Option<String>,
 }
 
 #[derive(Deserialize, JsonSchema)]
@@ -228,6 +231,10 @@ pub struct SendEmailNotificationResponse {
     pub notification_id: Uuid,
     participants_notified: i32,
     message: String,
+    /// Emails that the SMTP server rejected. Only populated for the email
+    /// delivery path; always empty for in-app notifications.
+    #[serde(default)]
+    failed_recipients: Vec<String>,
 }
 
 /// Send notification to all conversation participants
@@ -244,20 +251,38 @@ async fn send_notification_to_participants(
         return Err(ComhairleError::UserNotAuthorized);
     }
 
-    // Create the notification
+    let delivery_method = request
+        .delivery_method
+        .clone()
+        .unwrap_or(DeliveryMethod::InApp);
+
+    match delivery_method {
+        DeliveryMethod::Email => {
+            send_broadcast_email_to_opted_in(&state, &conversation_id, request).await
+        }
+        DeliveryMethod::InApp => {
+            send_in_app_notification_to_participants(&state, &conversation_id, request).await
+        }
+    }
+}
+
+async fn send_in_app_notification_to_participants(
+    state: &Arc<ComhairleState>,
+    conversation_id: &Uuid,
+    request: SendNotificationRequest,
+) -> Result<(StatusCode, Json<SendEmailNotificationResponse>), ComhairleError> {
     let create_notification = CreateNotification {
         title: request.title,
         content: request.content,
         notification_type: request.notification_type,
         context_type: Some(NotificationContextType::Conversation),
-        context_id: Some(conversation_id),
+        context_id: Some(*conversation_id),
     };
 
     let notification = notification_model::create(&state.db, &create_notification).await?;
 
-    // Get all participant user IDs for this conversation
     let participant_user_ids =
-        user_participation::get_participant_user_ids_for_conversation(&state.db, &conversation_id)
+        user_participation::get_participant_user_ids_for_conversation(&state.db, conversation_id)
             .await?;
 
     if participant_user_ids.is_empty() {
@@ -267,30 +292,28 @@ async fn send_notification_to_participants(
                 notification_id: notification.id,
                 participants_notified: 0,
                 message: "No participants found for this conversation".to_string(),
+                failed_recipients: vec![],
             }),
         ));
     }
 
-    // Create deliveries for all participants
-    let delivery_method = request.delivery_method.unwrap_or(DeliveryMethod::InApp);
     let deliveries: Vec<CreateNotificationDelivery> = participant_user_ids
         .into_iter()
         .map(|user_id| CreateNotificationDelivery {
             notification_id: notification.id,
             user_id,
-            delivery_method: Some(delivery_method.clone()),
+            delivery_method: Some(DeliveryMethod::InApp),
         })
         .collect();
 
     let created_deliveries =
         notification_delivery_model::create_bulk(&state.db, &deliveries).await?;
 
-    // Send WebSocket notifications to connected users
     let notification_level = notification.notification_type.to_string();
 
     for delivery in &created_deliveries {
         let _ = crate::websockets::handlers::notifications::NotificationMessageHandler::send_notification_to_user(
-            &state,
+            state,
             &delivery.user_id,
             &notification.id,
             &notification.title,
@@ -309,6 +332,85 @@ async fn send_notification_to_participants(
                 "Notification sent to {} participants",
                 created_deliveries.len()
             ),
+            failed_recipients: vec![],
+        }),
+    ))
+}
+
+async fn send_broadcast_email_to_opted_in(
+    state: &Arc<ComhairleState>,
+    conversation_id: &Uuid,
+    request: SendNotificationRequest,
+) -> Result<(StatusCode, Json<SendEmailNotificationResponse>), ComhairleError> {
+    let html_content = request.html_content.ok_or_else(|| {
+        ComhairleError::BadRequest("html_content is required when delivery_method is email".into())
+    })?;
+
+    // Create a notification row for the audit trail. The HTML body lives in
+    // `content` so the record reflects what was actually sent; no per-user
+    // NotificationDelivery rows are created because anonymous opt-ins have
+    // no associated user.
+    let create_notification = CreateNotification {
+        title: request.title.clone(),
+        content: html_content.clone(),
+        notification_type: request.notification_type,
+        context_type: Some(NotificationContextType::Conversation),
+        context_id: Some(*conversation_id),
+    };
+
+    let notification = notification_model::create(&state.db, &create_notification).await?;
+
+    let recipient_emails =
+        user_conversation_preferences::get_opted_in_broadcast_emails(&state.db, conversation_id)
+            .await?;
+
+    if recipient_emails.is_empty() {
+        return Ok((
+            StatusCode::OK,
+            Json(SendEmailNotificationResponse {
+                notification_id: notification.id,
+                participants_notified: 0,
+                message: "No participants have opted in to email updates for this conversation"
+                    .to_string(),
+                failed_recipients: vec![],
+            }),
+        ));
+    }
+
+    let mut sent = 0i32;
+    let mut failed_recipients: Vec<String> = Vec::new();
+    let mut last_error: Option<String> = None;
+    for email in &recipient_emails {
+        match state
+            .mailer
+            .send_conversation_broadcast_email(email, &request.title, &html_content)
+        {
+            Ok(()) => sent += 1,
+            Err(e) => {
+                tracing::warn!("Failed to send broadcast email to {}: {:?}", email, e);
+                failed_recipients.push(email.clone());
+                last_error = Some(e.to_string());
+            }
+        }
+    }
+
+    let message = match (sent, failed_recipients.len()) {
+        (0, n) => format!(
+            "Failed to send to all {} recipients: {}",
+            n,
+            last_error.unwrap_or_else(|| "unknown error".into())
+        ),
+        (s, 0) => format!("Email sent to {} recipients", s),
+        (s, n) => format!("Email sent to {} of {} recipients ({} failed)", s, s + n as i32, n),
+    };
+
+    Ok((
+        StatusCode::CREATED,
+        Json(SendEmailNotificationResponse {
+            notification_id: notification.id,
+            participants_notified: sent,
+            message,
+            failed_recipients,
         }),
     ))
 }

--- a/ui/packages/api-client/src/api.ts
+++ b/ui/packages/api-client/src/api.ts
@@ -722,6 +722,16 @@ export const SendEmailNotificationResponse = z
 export type SendEmailNotificationResponse = z.infer<
   typeof SendEmailNotificationResponse
 >;
+export const NotificationRecipientsResponse = z
+  .object({
+    emailRecipientCount: z.number().int(),
+    emailRecipients: z.array(z.string()),
+    participantCount: z.number().int(),
+  })
+  .passthrough();
+export type NotificationRecipientsResponse = z.infer<
+  typeof NotificationRecipientsResponse
+>;
 export const RegisterEmailRequest = z
   .object({
     email: z.string(),
@@ -1857,6 +1867,7 @@ export const schemas: Record<string, z.ZodType<any>> = {
   PartialConversation,
   SendNotificationRequest,
   SendEmailNotificationResponse,
+  NotificationRecipientsResponse,
   RegisterEmailRequest,
   RegisterEmailResponse,
   WorkflowDto,
@@ -2965,6 +2976,14 @@ Use query param withUserProgress&#x3D;true to get the active user&#x27;s progres
       },
     ],
     response: SendEmailNotificationResponse,
+  },
+  {
+    method: "get",
+    path: "/conversation/:conversation_id/notifications/recipients",
+    alias: "GetNotificationRecipients",
+    description: `Returns participant count for in-app delivery and the list of email addresses opted in to broadcast emails. Owner-only.`,
+    requestFormat: "json",
+    response: NotificationRecipientsResponse,
   },
   {
     method: "get",

--- a/ui/packages/api-client/src/api.ts
+++ b/ui/packages/api-client/src/api.ts
@@ -705,6 +705,7 @@ export const SendNotificationRequest = z
   .object({
     content: z.string(),
     delivery_method: z.union([DeliveryMethod, z.null()]).optional(),
+    html_content: z.union([z.string(), z.null()]).optional(),
     notification_type: z.union([NotificationType, z.null()]).optional(),
     title: z.string(),
   })
@@ -712,6 +713,7 @@ export const SendNotificationRequest = z
 export type SendNotificationRequest = z.infer<typeof SendNotificationRequest>;
 export const SendEmailNotificationResponse = z
   .object({
+    failedRecipients: z.array(z.string()).optional().default([]),
     message: z.string(),
     notificationId: z.string().uuid(),
     participantsNotified: z.number().int(),

--- a/ui/packages/comhairle/src/lib/components/NotificationForm.svelte
+++ b/ui/packages/comhairle/src/lib/components/NotificationForm.svelte
@@ -2,6 +2,12 @@
 	import * as Form from '$lib/components/ui/form';
 	import { Input } from '$lib/components/ui/input';
 	import { Textarea } from '$lib/components/ui/textarea';
+	import * as RadioGroup from '$lib/components/ui/radio-group';
+	import * as Alert from '$lib/components/ui/alert';
+	import { AlertTriangle } from 'lucide-svelte';
+	import RichTextEditor from '$lib/components/RichTextEditor/RichTextEditor.svelte';
+	import { getBaseExtensions } from '$lib/components/RichTextEditor/editorConfig';
+	import { generateHTML } from '@tiptap/core';
 	import { apiClient } from '@crownshy/api-client/client';
 	import { notifications } from '$lib/notifications.svelte';
 	import { Send } from 'lucide-svelte';
@@ -14,7 +20,8 @@
 	const notificationForm = superForm(
 		{
 			title: '',
-			content: ''
+			content: '',
+			delivery_method: 'in_app' as 'in_app' | 'email'
 		},
 		{
 			validators: zodClient(notificationFormSchema),
@@ -24,82 +31,222 @@
 		}
 	);
 
-	const { form, enhance, validateForm, submitting, errors } = notificationForm;
+	const { form, enhance, validateForm, submitting, reset } = notificationForm;
 
-	async function sendNotification() {
+	let failedRecipients = $state<string[]>([]);
+	let lastSendMessage = $state<string | null>(null);
+	let lastSendStatus = $state<'partial' | 'failed' | null>(null);
+
+	function jsonToHtml(jsonString: string): string {
+		const json = JSON.parse(jsonString);
+		return generateHTML(json, getBaseExtensions({ mode: 'renderer' }));
+	}
+
+	async function sendNotification({ cancel }: { cancel: () => void }) {
+		// Prevent SvelteKit's default form submission — this page has no
+		// action handler, and letting it proceed restores the submitted
+		// values to the form (defeating our reset below).
+		cancel();
+
 		const result = await validateForm({ update: true });
 		if (!result.valid) return;
 
-		try {
-			const response = await apiClient.SendNotificationToParticipants(
-				{ ...result.data, notification_type: 'info', delivery_method: 'in_app' },
-				{
-					params: { conversation_id: conversationId }
-				}
-			);
+		// Clear any prior failure state at the start of a fresh attempt.
+		failedRecipients = [];
+		lastSendMessage = null;
+		lastSendStatus = null;
 
-			notifications.send({
-				message: response.message || 'Notification sent successfully!',
-				priority: 'SUCCESS'
+		const isEmail = $form.delivery_method === 'email';
+		try {
+			const payload = {
+				title: $form.title,
+				content: $form.content,
+				notification_type: 'info' as const,
+				delivery_method: $form.delivery_method,
+				...(isEmail ? { html_content: jsonToHtml($form.content) } : {})
+			};
+
+			const response = await apiClient.SendNotificationToParticipants(payload, {
+				params: { conversation_id: conversationId }
 			});
 
-			// Reset form
-			$form.title = '';
-			$form.content = '';
+			const failed = response.failedRecipients ?? [];
+			const sentCount = response.participantsNotified ?? 0;
+
+			if (failed.length > 0 && sentCount === 0) {
+				failedRecipients = failed;
+				lastSendMessage = response.message;
+				lastSendStatus = 'failed';
+				notifications.send({
+					message: response.message,
+					priority: 'ERROR'
+				});
+				return;
+			}
+
+			if (failed.length > 0) {
+				failedRecipients = failed;
+				lastSendMessage = response.message;
+				lastSendStatus = 'partial';
+				notifications.send({
+					message: response.message,
+					priority: 'WARNING'
+				});
+			} else {
+				notifications.send({
+					message: response.message || 'Sent successfully!',
+					priority: 'SUCCESS'
+				});
+			}
+
+			reset({ data: { title: '', content: '', delivery_method: $form.delivery_method } });
 		} catch (error: any) {
 			notifications.send({
 				message:
 					error?.response?.data?.message ||
-					'Failed to send notification. Please try again.',
+					`Failed to send ${isEmail ? 'email' : 'notification'}. Please try again.`,
 				priority: 'ERROR'
 			});
 		}
 	}
+
+	let isEmail = $derived($form.delivery_method === 'email');
+
+	let lastDeliveryMethod = $state($form.delivery_method);
+	$effect(() => {
+		if ($form.delivery_method !== lastDeliveryMethod) {
+			lastDeliveryMethod = $form.delivery_method;
+			$form.content = '';
+			failedRecipients = [];
+			lastSendMessage = null;
+			lastSendStatus = null;
+		}
+	});
 </script>
 
-<form method="POST" class="space-y-6" use:enhance>
-	<Form.Field form={notificationForm} name="title" class="space-y-2">
-		<Form.Control>
-			{#snippet children({ props })}
-				<Form.Label class="text-sm font-medium">Notification Title</Form.Label>
-				<div class="space-y-1">
-					<Input
-						{...props}
-						bind:value={$form.title}
-						placeholder="Enter notification title..."
-						disabled={$submitting}
-					/>
-					<Form.FieldErrors />
+<div class="flex flex-col gap-6 lg:flex-row lg:items-start">
+	<form method="POST" class="w-full max-w-2xl space-y-6" use:enhance>
+		<Form.Fieldset form={notificationForm} name="delivery_method" class="space-y-2">
+			<Form.Legend class="text-sm font-medium">Delivery method</Form.Legend>
+			<RadioGroup.Root
+				bind:value={$form.delivery_method}
+				class="flex flex-row gap-8"
+				name="delivery_method"
+			>
+				<div class="flex items-center gap-1.5">
+					<Form.Control>
+						{#snippet children({ props })}
+							<RadioGroup.Item value="in_app" {...props} />
+							<Form.Label class="font-normal">In-app notification</Form.Label>
+						{/snippet}
+					</Form.Control>
 				</div>
-			{/snippet}
-		</Form.Control>
-	</Form.Field>
-
-	<Form.Field form={notificationForm} name="content" class="space-y-2">
-		<Form.Control>
-			{#snippet children({ props })}
-				<Form.Label class="text-sm font-medium">Message Content</Form.Label>
-				<div class="space-y-1">
-					<Textarea
-						{...props}
-						bind:value={$form.content}
-						placeholder="Enter your notification message here..."
-						rows={4}
-						disabled={$submitting}
-					/>
-					<Form.FieldErrors />
+				<div class="flex items-center gap-1.5">
+					<Form.Control>
+						{#snippet children({ props })}
+							<RadioGroup.Item value="email" {...props} />
+							<Form.Label class="font-normal">Email</Form.Label>
+						{/snippet}
+					</Form.Control>
 				</div>
-			{/snippet}
-		</Form.Control>
-	</Form.Field>
+			</RadioGroup.Root>
+		</Form.Fieldset>
 
-	<Form.Button class="w-full" disabled={$submitting}>
-		<Send class="mr-2 h-4 w-4" />
-		{$submitting ? 'Sending notification...' : 'Send Notification to All Participants'}
-	</Form.Button>
+		<Form.Field form={notificationForm} name="title" class="space-y-2">
+			<Form.Control>
+				{#snippet children({ props })}
+					<Form.Label class="text-sm font-medium">
+						{isEmail ? 'Email subject' : 'Notification title'}
+					</Form.Label>
+					<div class="space-y-1">
+						<Input
+							{...props}
+							bind:value={$form.title}
+							placeholder={isEmail
+								? 'Enter email subject...'
+								: 'Enter notification title...'}
+							disabled={$submitting}
+						/>
+						<Form.FieldErrors />
+					</div>
+				{/snippet}
+			</Form.Control>
+		</Form.Field>
 
-	<p class="text-muted-foreground text-sm">
-		This will send the notification to all users who have participated in workflows within this
-		conversation. They will receive the notification via the selected delivery method.
-	</p>
-</form>
+		<Form.Field form={notificationForm} name="content" class="space-y-2">
+			<Form.Control>
+				{#snippet children({ props })}
+					<Form.Label class="text-sm font-medium">
+						{isEmail ? 'Email body' : 'Message content'}
+					</Form.Label>
+					<div class="space-y-1">
+						{#if isEmail}
+							<RichTextEditor
+								value={$form.content || null}
+								placeholder="Compose your email..."
+								editable={!$submitting}
+								onChange={(json) => ($form.content = json)}
+							/>
+							<input type="hidden" {...props} value={$form.content} />
+						{:else}
+							<Textarea
+								{...props}
+								bind:value={$form.content}
+								placeholder="Enter your notification message here..."
+								rows={4}
+								disabled={$submitting}
+							/>
+						{/if}
+						<Form.FieldErrors />
+					</div>
+				{/snippet}
+			</Form.Control>
+		</Form.Field>
+
+		<Form.Button class="w-full" disabled={$submitting}>
+			<Send class="mr-2 h-4 w-4" />
+			{#if $submitting}
+				Sending {isEmail ? 'email' : 'notification'}...
+			{:else}
+				Send {isEmail ? 'email' : 'notification'} to all participants
+			{/if}
+		</Form.Button>
+
+		<p class="text-muted-foreground text-sm">
+			{#if isEmail}
+				This will email all participants who have opted in to email updates for this
+				conversation.
+			{:else}
+				This will send the notification to all users who have participated in workflows
+				within this conversation.
+			{/if}
+		</p>
+	</form>
+
+	{#if failedRecipients.length > 0}
+		<aside class="w-full lg:w-96 lg:shrink-0">
+			<Alert.Root variant="destructive">
+				<AlertTriangle class="h-4 w-4" />
+				<Alert.Title>
+					{lastSendStatus === 'failed'
+						? 'Email delivery failed'
+						: 'Some recipients did not receive the email'}
+				</Alert.Title>
+				<Alert.Description>
+					{#if lastSendMessage}
+						<p class="mb-2">{lastSendMessage}</p>
+					{/if}
+					<p class="font-medium">
+						{failedRecipients.length}
+						{failedRecipients.length === 1 ? 'address' : 'addresses'} could not be reached:
+					</p>
+					<ul class="mt-1 list-inside list-disc font-mono text-sm">
+						{#each failedRecipients as email (email)}
+							<li>{email}</li>
+						{/each}
+					</ul>
+				</Alert.Description>
+			</Alert.Root>
+		</aside>
+	{/if}
+</div>

--- a/ui/packages/comhairle/src/lib/components/NotificationForm.svelte
+++ b/ui/packages/comhairle/src/lib/components/NotificationForm.svelte
@@ -4,7 +4,8 @@
 	import { Textarea } from '$lib/components/ui/textarea';
 	import * as RadioGroup from '$lib/components/ui/radio-group';
 	import * as Alert from '$lib/components/ui/alert';
-	import { AlertTriangle } from 'lucide-svelte';
+	import * as Collapsible from '$lib/components/ui/collapsible';
+	import { AlertTriangle, ChevronDown, Users } from 'lucide-svelte';
 	import RichTextEditor from '$lib/components/RichTextEditor/RichTextEditor.svelte';
 	import { getBaseExtensions } from '$lib/components/RichTextEditor/editorConfig';
 	import { generateHTML } from '@tiptap/core';
@@ -16,6 +17,32 @@
 	import { notificationFormSchema } from './NotificationForm/schema';
 
 	let { conversationId }: { conversationId: string } = $props();
+
+	let participantCount = $state<number | null>(null);
+	let emailRecipients = $state<string[]>([]);
+	let recipientsError = $state<string | null>(null);
+	let recipientsLoading = $state(true);
+	let recipientsOpen = $state(false);
+
+	async function loadRecipients() {
+		recipientsLoading = true;
+		recipientsError = null;
+		try {
+			const response = await apiClient.GetNotificationRecipients({
+				params: { conversation_id: conversationId }
+			});
+			participantCount = response.participantCount;
+			emailRecipients = response.emailRecipients;
+		} catch (error: any) {
+			recipientsError = error?.response?.data?.message || 'Could not load recipient preview.';
+		} finally {
+			recipientsLoading = false;
+		}
+	}
+
+	$effect(() => {
+		loadRecipients();
+	});
 
 	const notificationForm = superForm(
 		{
@@ -100,6 +127,7 @@
 			}
 
 			reset({ data: { title: '', content: '', delivery_method: $form.delivery_method } });
+			loadRecipients();
 		} catch (error: any) {
 			notifications.send({
 				message:
@@ -223,8 +251,64 @@
 		</p>
 	</form>
 
-	{#if failedRecipients.length > 0}
-		<aside class="w-full lg:w-96 lg:shrink-0">
+	<aside class="w-full space-y-4 lg:w-96 lg:shrink-0">
+		<div class="rounded-lg border p-4">
+			<div class="mb-3 flex items-center gap-2">
+				<Users class="h-4 w-4" />
+				<h2 class="text-sm font-semibold">Recipients preview</h2>
+			</div>
+
+			{#if recipientsLoading}
+				<p class="text-muted-foreground text-sm">Loading…</p>
+			{:else if recipientsError}
+				<p class="text-destructive text-sm">{recipientsError}</p>
+			{:else if isEmail}
+				{#if emailRecipients.length === 0}
+					<p class="text-muted-foreground text-sm">
+						No participants have opted in to email updates yet.
+					</p>
+				{:else}
+					<p class="text-sm">
+						This email will be sent to
+						<span class="font-semibold">{emailRecipients.length}</span>
+						{emailRecipients.length === 1 ? 'recipient' : 'recipients'}.
+					</p>
+					<Collapsible.Root bind:open={recipientsOpen} class="mt-2">
+						<Collapsible.Trigger
+							class="text-primary inline-flex items-center gap-1 text-sm hover:underline"
+						>
+							{recipientsOpen ? 'Hide' : 'Show'} addresses
+							<ChevronDown
+								class="h-3 w-3 transition-transform {recipientsOpen
+									? 'rotate-180'
+									: ''}"
+							/>
+						</Collapsible.Trigger>
+						<Collapsible.Content>
+							<ul
+								class="bg-muted/40 mt-2 max-h-64 list-inside list-disc overflow-y-auto rounded-md p-3 font-mono text-xs"
+							>
+								{#each emailRecipients as email (email)}
+									<li>{email}</li>
+								{/each}
+							</ul>
+						</Collapsible.Content>
+					</Collapsible.Root>
+				{/if}
+			{:else if participantCount === 0}
+				<p class="text-muted-foreground text-sm">
+					No participants have joined any workflows in this conversation yet.
+				</p>
+			{:else}
+				<p class="text-sm">
+					This notification will be sent to
+					<span class="font-semibold">{participantCount}</span>
+					workflow {participantCount === 1 ? 'participant' : 'participants'}.
+				</p>
+			{/if}
+		</div>
+
+		{#if failedRecipients.length > 0}
 			<Alert.Root variant="destructive">
 				<AlertTriangle class="h-4 w-4" />
 				<Alert.Title>
@@ -247,6 +331,6 @@
 					</ul>
 				</Alert.Description>
 			</Alert.Root>
-		</aside>
-	{/if}
+		{/if}
+	</aside>
 </div>

--- a/ui/packages/comhairle/src/lib/components/NotificationForm/schema.ts
+++ b/ui/packages/comhairle/src/lib/components/NotificationForm/schema.ts
@@ -1,8 +1,21 @@
-import { z } from "zod";
+import { z } from 'zod';
 
-export const notificationFormSchema = z.object({
-	title: z.string().min(1, "Title is required").max(200, "Title must be less than 200 characters"),
-	content: z.string().min(1, "Content is required").max(2000, "Content must be less than 2000 characters"),
-});
+export const notificationFormSchema = z
+	.object({
+		title: z
+			.string()
+			.min(1, 'Title is required')
+			.max(200, 'Title must be less than 200 characters'),
+		content: z
+			.string()
+			.min(1, 'Content is required')
+			.max(50000, 'Content must be less than 50,000 characters'),
+		delivery_method: z.enum(['in_app', 'email'], {
+			errorMap: () => ({
+				message: 'Delivery method must be either "in_app" or "email".'
+			})
+		})
+	})
+	.superRefine(() => {});
 
 export type NotificationFormData = z.infer<typeof notificationFormSchema>;

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/notifications/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/notifications/+page.svelte
@@ -25,6 +25,4 @@
 	all users who have participated in workflows within this conversation.
 </p>
 
-<div class="max-w-2xl">
-	<NotificationForm conversationId={conversation.id} />
-</div>
+<NotificationForm conversationId={conversation.id} />


### PR DESCRIPTION
This PR 

1. Adds an email recipients section to the notify pane which allows you to email all participants with a rich text email
2. Shows previews for both in app notifications and email notifications to show who was reached  

