### PR TITLE
365/Video calls: Allow breakout room configuration on the spot 

### DIFF
--- a/ui/packages/comhairle/src/lib/components/LiveEvent/CreateBreakoutDialog.svelte
+++ b/ui/packages/comhairle/src/lib/components/LiveEvent/CreateBreakoutDialog.svelte
@@ -2,7 +2,7 @@
 	import * as Dialog from '$lib/components/ui/dialog';
 	import Button from '$lib/components/ui/button/button.svelte';
 	import type { VideoCallParticipant } from '$lib/services/videoCallService.svelte';
-	import { X, RefreshCw, Clock, Pin } from 'lucide-svelte';
+	import { X, RefreshCw, Clock, Pin, Users } from 'lucide-svelte';
 
 	interface Props {
 		open: boolean;
@@ -115,6 +115,14 @@
 		}
 
 		roomAssignments = newAssignments.filter((room) => room.length > 0);
+	}
+
+	function handleMaxPerRoomChange(e: Event) {
+		const next = Math.max(1, Math.min(50, Number((e.target as HTMLInputElement).value) || 1));
+		maxPerRoom = next;
+		if (roomAssignments.length > 0) {
+			handleReshuffle();
+		}
 	}
 
 	function togglePin(userId: string) {
@@ -240,18 +248,33 @@
 				Create breakout rooms
 			</h2>
 
-			<!-- Time left row -->
-			<div class="flex shrink-0 items-center gap-2">
-				<Clock class="text-foreground h-5 w-5" />
-				<span class="text-foreground text-sm font-normal">Time left</span>
-				<input
-					type="number"
-					bind:value={durationMinutes}
-					min={1}
-					max={120}
-					class="border-input bg-background h-8 w-14 rounded-lg border px-3 text-center text-sm shadow-sm"
-				/>
-				<span class="text-foreground text-sm font-normal">minutes</span>
+			<!-- Time left + room size row -->
+			<div class="flex shrink-0 flex-wrap items-center gap-x-6 gap-y-2">
+				<div class="flex items-center gap-2">
+					<Clock class="text-foreground h-5 w-5" />
+					<span class="text-foreground text-sm font-normal">Time left</span>
+					<input
+						type="number"
+						bind:value={durationMinutes}
+						min={1}
+						max={120}
+						class="border-input bg-background h-8 w-14 rounded-lg border px-3 text-center text-sm shadow-sm"
+					/>
+					<span class="text-foreground text-sm font-normal">minutes</span>
+				</div>
+				<div class="flex items-center gap-2">
+					<Users class="text-foreground h-5 w-5" />
+					<span class="text-foreground text-sm font-normal">Max per room</span>
+					<input
+						type="number"
+						value={maxPerRoom}
+						onchange={handleMaxPerRoomChange}
+						min={1}
+						max={50}
+						class="border-input bg-background h-8 w-14 rounded-lg border px-3 text-center text-sm shadow-sm"
+					/>
+					<span class="text-foreground text-sm font-normal">people</span>
+				</div>
 			</div>
 
 			<!-- Rooms container (dark blue) -->

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
@@ -897,26 +897,14 @@
 								Recording
 							</span>
 						</div>
-						<!-- Desktop-only: moderator status + dev info -->
-						<div class="hidden items-center gap-2 md:flex">
-							<div class="flex items-center gap-1.5">
-								<span
-									class="{jitsiModeratorStatus
-										? 'bg-green-500'
-										: 'bg-yellow-500'} h-2.5 w-2.5 rounded-full"
-								></span>
-								<span
-									class="text-sidebar-foreground text-center text-xs leading-6 font-normal"
-								>
-									{jitsiModeratorStatus ? 'Moderator' : 'Participant'}
-								</span>
-							</div>
-							{#if currentJitsiRoomName && dev}
+						<!-- Desktop-only: dev info -->
+						{#if currentJitsiRoomName && dev}
+							<div class="hidden items-center gap-2 md:flex">
 								<span class="text-sidebar-foreground/60 text-xs">
 									Room: {currentJitsiRoomName.slice(0, 8)}...
 								</span>
-							{/if}
-						</div>
+							</div>
+						{/if}
 						<!-- Desktop chip inline -->
 						{#if currentJitsiRoomName}
 							<div class="hidden md:block">


### PR DESCRIPTION
Currently we set this in the agenda, and moderators cannot configure it on the fly


Actions: 
+ add maxPerRoom input field with handleMaxPerRoomChange handler
+ clamp maxPerRoom value between 1-50 and reshuffle rooms when changed
+ restructure time/room size controls into flex-wrap row layout

Motivation:
+ allow organizers to control maximum participants per breakout room


(also covers this tiny one #361 - Remove Participant/Moderator label on top)