### PR TITLE
Shows a list of returnable steps on the thank you page to allow folks to go back

### DIFF
--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/workflow/[workflow_id]/+layout.ts
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/workflow/[workflow_id]/+layout.ts
@@ -1,0 +1,30 @@
+import type { LayoutLoad } from './$types';
+import type {
+	LocalizedWorkflowStepDto,
+	LocalizedWorkflowStepWithProgressDto
+} from '@crownshy/api-client/api';
+
+export const load: LayoutLoad = async ({ parent, params, depends }) => {
+	const { api, conversation, preview } = await parent();
+	const workflow_id = params.workflow_id;
+
+	depends('app:workflow-steps');
+
+	let workflowSteps: LocalizedWorkflowStepWithProgressDto[];
+	if (conversation.isLive) {
+		workflowSteps = (await api.ListConversationWorkflowSteps({
+			params: { conversation_id: conversation.id, workflow_id },
+			queries: { withUserProgress: true }
+		})) as LocalizedWorkflowStepWithProgressDto[];
+	} else {
+		const steps = (await api.ListConversationWorkflowSteps({
+			params: { conversation_id: conversation.id, workflow_id }
+		})) as LocalizedWorkflowStepDto[];
+		workflowSteps = steps.map((s) => ({
+			...s,
+			progressStatus: 'not_started' as const
+		}));
+	}
+
+	return { workflowSteps, workflow_id, preview };
+};

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/workflow/[workflow_id]/next/+page.ts
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/workflow/[workflow_id]/next/+page.ts
@@ -1,13 +1,12 @@
 import { redirect } from '@sveltejs/kit';
 import type { PageLoad } from './$types';
 import { thank_you_page, workflow_step_url } from '$lib/urls';
-import type { LocalizedWorkflowStepDto } from '@crownshy/api-client/api';
 
 export const ssr = false;
 export const csr = true;
 
 export const load: PageLoad = async ({ parent, params, url }) => {
-	const { api, conversation, preview } = await parent();
+	const { api, conversation, preview, workflowSteps } = await parent();
 	const workflow_id = params.workflow_id;
 
 	// Preserve query parameters for redirects
@@ -33,10 +32,7 @@ export const load: PageLoad = async ({ parent, params, url }) => {
 				redirect_url = thank_you_page(conversation.id, workflow_id, preview);
 			}
 		} else {
-			const steps: LocalizedWorkflowStepDto[] = await api.ListConversationWorkflowSteps({
-				params: { conversation_id: conversation.id, workflow_id: workflow_id }
-			});
-			const firstStep = steps.find((s) => s.stepOrder === 1);
+			const firstStep = workflowSteps.find((s) => s.stepOrder === 1);
 			redirect_url = workflow_step_url(conversation.id, workflow_id, firstStep.id, preview);
 		}
 	} catch (e) {}

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/workflow/[workflow_id]/s/[workflow_step_id]/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/workflow/[workflow_id]/s/[workflow_step_id]/+page.svelte
@@ -15,7 +15,7 @@
 
 	import { Button } from '$lib/components/ui/button';
 	import { Spinner } from '$lib/components/ui/spinner';
-	import { goto } from '$app/navigation';
+	import { goto, invalidate } from '$app/navigation';
 	import { thank_you_page, next_workflow_step_url, workflow_step_url } from '$lib/urls';
 	import { page, navigating } from '$app/state';
 	import LearnArticleSkeleton from '$lib/tools/learn/LearnArticleSkeleton.svelte';
@@ -187,6 +187,8 @@
 						headers: { 'Content-Type': 'application/json' }
 					}
 				);
+
+				await invalidate('app:workflow-steps');
 
 				goto(
 					next_workflow_step_url(conversation.id, workflowStep.workflowId) + queryString

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/workflow/[workflow_id]/s/[workflow_step_id]/+page.ts
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/workflow/[workflow_id]/s/[workflow_step_id]/+page.ts
@@ -2,13 +2,9 @@ import { isRedirect, redirect } from '@sveltejs/kit';
 import type { PageLoad } from './$types';
 import { notifications } from '$lib/notifications.svelte';
 import { next_workflow_step_url } from '$lib/urls';
-import type {
-	LocalizedWorkflowStepDto,
-	LocalizedWorkflowStepWithProgressDto
-} from '@crownshy/api-client/api';
 
 export const load: PageLoad = async (event) => {
-	const { api, conversation, preview } = await event.parent();
+	const { api, conversation, preview, workflowSteps } = await event.parent();
 
 	const conversation_id = conversation.id;
 	const { workflow_id, workflow_step_id } = event.params;
@@ -17,23 +13,6 @@ export const load: PageLoad = async (event) => {
 	const queryString = event.url.search;
 
 	try {
-		let workflowSteps: LocalizedWorkflowStepWithProgressDto[];
-
-		if (conversation.isLive) {
-			workflowSteps = (await api.ListConversationWorkflowSteps({
-				params: { conversation_id, workflow_id },
-				queries: { withUserProgress: true }
-			})) as LocalizedWorkflowStepWithProgressDto[];
-		} else {
-			const steps = (await api.ListConversationWorkflowSteps({
-				params: { conversation_id, workflow_id }
-			})) as LocalizedWorkflowStepDto[];
-			workflowSteps = steps.map((s) => ({
-				...s,
-				progressStatus: 'not_started' as const
-			}));
-		}
-
 		const thisStep =
 			workflow_step_id === 'revisit'
 				? workflowSteps.find((s) => s.canRevisit)

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/workflow/[workflow_id]/thank_you/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/workflow/[workflow_id]/thank_you/+page.svelte
@@ -12,6 +12,8 @@
 	let user = $derived(data.user);
 	let conversation = $derived(data.conversation);
 	let workflow = $derived(data.workflow);
+	let revisitableSteps = $derived(data.revisitableSteps);
+	let isPreview = $derived(data.preview);
 </script>
 
 <svelte:head>
@@ -48,13 +50,24 @@
 		<h2>Next steps</h2>
 		You can continue to contribute, let us know what you thought of the process or sign up for updates
 		on this project and others which you might be interested in.
-		<div class="mx-auto mt-10 flex flex-col justify-center gap-2 text-center md:flex-row">
-			<Button
-				class="no-underline"
-				variant="secondary"
-				href={workflow_step_url(conversation.id, workflow.id, 'revisit')}
-				>Contribute some more</Button
-			>
+
+		{#if revisitableSteps.length > 0}
+			<p>Return to a previous step to update your contribution:</p>
+			<div class="mx-auto mt-4 flex flex-row items-center gap-2">
+				<p>Click to contribute more:</p>
+				{#each revisitableSteps as step (step.id)}
+					<Button
+						class="no-underline"
+						variant="secondary"
+						href={workflow_step_url(conversation.id, workflow.id, step.id, isPreview)}
+					>
+						{step.name}
+					</Button>
+				{/each}
+			</div>
+		{/if}
+
+		<div class="mx-auto mt-6 flex flex-col justify-center gap-2 text-center md:flex-row">
 			<FeedbackModal conversationId={conversation.id} />
 		</div>
 
@@ -85,13 +98,8 @@
 		{/if}
 	{:else}
 		<h2>Next steps</h2>
-		<div class="mx-auto mt-10 flex flex-col justify-center gap-2 text-center md:flex-row">
-			<Button
-				class="no-underline"
-				variant="secondary"
-				href={workflow_step_url(conversation.id, workflow.id, 'revisit')}
-				>Contribute some more</Button
-			>
+		{@render revisitStepList()}
+		<div class="mx-auto mt-6 flex flex-col justify-center gap-2 text-center md:flex-row">
 			<FeedbackModal conversationId={conversation.id} />
 		</div>
 	{/if}

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/workflow/[workflow_id]/thank_you/+page.ts
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/workflow/[workflow_id]/thank_you/+page.ts
@@ -1,6 +1,11 @@
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent }) => {
-	const { conversation, user, workflows } = await parent();
-	return { conversation, user, workflow: workflows[0] };
+	const { conversation, user, workflows, workflowSteps, preview } = await parent();
+
+	const revisitableSteps = workflowSteps
+		.filter((s) => s.canRevisit)
+		.sort((a, b) => a.stepOrder - b.stepOrder);
+
+	return { conversation, user, workflow: workflows[0], revisitableSteps, preview };
 };


### PR DESCRIPTION
This adds a list of returnable steps to the thank you page. Clicking on each allows the user to return directly to that step

It also refactors the fetching of the workflow_steps to fetch at the once at the layout level and invalidate when navigation changes (user progress updates)

<img width="1260" height="1118" alt="image" src="https://github.com/user-attachments/assets/79a970ee-ad73-4bbe-91c1-efbe383290c9" />
