### PR TITLE
On return take compleated users to the first returnable step

### DIFF
--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/workflow/[workflow_id]/next/+page.ts
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/workflow/[workflow_id]/next/+page.ts
@@ -29,7 +29,19 @@ export const load: PageLoad = async ({ parent, params, url }) => {
 					preview
 				);
 			} else {
-				redirect_url = thank_you_page(conversation.id, workflow_id, preview);
+				const firstRevisitableStep = [...workflowSteps]
+					.sort((a, b) => a.stepOrder - b.stepOrder)
+					.find((s) => s.canRevisit);
+				if (firstRevisitableStep) {
+					redirect_url = workflow_step_url(
+						conversation.id,
+						workflow_id,
+						firstRevisitableStep.id,
+						preview
+					);
+				} else {
+					redirect_url = thank_you_page(conversation.id, workflow_id, preview);
+				}
 			}
 		} else {
 			const firstStep = workflowSteps.find((s) => s.stepOrder === 1);


### PR DESCRIPTION
Motivation. 

Some users where confused as they return to a conversation once completed and they are taken to a thank you page. Instead if there are any returnable steps we should send them to the first one.
