### PR TITLE
456 webhook report deserialization

### DIFF
--- a/api/src/routes/auth.rs
+++ b/api/src/routes/auth.rs
@@ -913,30 +913,26 @@ impl FromRequestParts<Arc<ComhairleState>> for OptionalUser {
     }
 }
 
-pub fn build_webhook_signature<T: Serialize>(
+pub fn build_webhook_signature(
     timestamp: &str,
-    body: &T,
+    body: &str,
     secret: &str,
 ) -> Result<String, ComhairleError> {
-    let body_str = serde_json::to_string(body)?;
-
     let mut mac = Hmac::<Sha256>::new_from_slice(secret.as_bytes())
         .map_err(|e| ComhairleError::AuthWebhookSignatureError(e.to_string()))?;
 
-    let signed_payload = format!("{}.{}", timestamp, body_str);
+    let signed_payload = format!("{}.{}", timestamp, body);
 
     mac.update(signed_payload.as_bytes());
+    let signature = format!("sha256={}", hex::encode(mac.finalize().into_bytes()));
 
-    Ok(format!(
-        "sha256={}",
-        hex::encode(mac.finalize().into_bytes())
-    ))
+    Ok(signature)
 }
 
-pub fn verify_webhook_signature<T: Serialize>(
+pub fn verify_webhook_signature(
     signature: &str,
     timestamp: &str,
-    body: &T,
+    body: &str,
     secret: &str,
 ) -> Result<bool, ComhairleError> {
     let expected = build_webhook_signature(timestamp, body, secret)?;

--- a/api/src/routes/events.rs
+++ b/api/src/routes/events.rs
@@ -325,7 +325,7 @@ async fn submit_report(
     Query(params): Query<SubmitReportParams>,
     headers: HeaderMap,
     Path((conversation_id, event_id)): Path<(Uuid, Uuid)>,
-    Json(payload): Json<serde_json::Value>,
+    payload: String,
 ) -> Result<(StatusCode, Json<SubmitReportResponse>), ComhairleError> {
     let bulk_storage_service = state.required_bulk_storage_service()?;
     let webhook_secret = &state
@@ -1064,8 +1064,7 @@ mod tests {
         let timestamp_hval = HeaderValue::from_str(&timestamp.to_string())?;
 
         let body_str = include_str!("../../../fixtures/tttc-report.json");
-        let body: serde_json::Value = serde_json::from_str(body_str)?;
-        let signature = build_webhook_signature(&timestamp.to_string(), &body, secret)?;
+        let signature = build_webhook_signature(&timestamp.to_string(), body_str, secret)?;
         let signature_hname = HeaderName::from_str("X-Webhook-Signature")?;
         let signature_hval = HeaderValue::from_str(&signature)?;
         let (_, value, _) = session

--- a/ui/packages/api-client/src/api.ts
+++ b/ui/packages/api-client/src/api.ts
@@ -2700,11 +2700,6 @@ curl -X POST \
     requestFormat: "json",
     parameters: [
       {
-        name: "body",
-        type: "Body",
-        schema: z.unknown(),
-      },
-      {
         name: "room_id",
         type: "Query",
         schema: created_after,


### PR DESCRIPTION
Actions:

+ extract request body as string for webhook url and use string in webhook signature verification

Motivation:

+ extracting to serde_json::Value changes order of key / value pairs breaking hash verification