### PR TITLE
Aux polis data table

### DIFF
--- a/api/migrations/20260611155735_create_polis_statement_aux_table.sql
+++ b/api/migrations/20260611155735_create_polis_statement_aux_table.sql
@@ -1,0 +1,15 @@
+-- Create polis_statement_aux table
+
+CREATE TABLE polis_statement_aux (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    workflow_step_id UUID NOT NULL REFERENCES workflow_step(id) ON DELETE CASCADE,
+    user_id UUID NOT NULL REFERENCES comhairle_user(id) ON DELETE CASCADE,
+    zid INTEGER NOT NULL,
+    polis_conversation_id TEXT NOT NULL,
+    polis_statement_id INTEGER NOT NULL,
+    themes TEXT[] NOT NULL DEFAULT '{}',
+    visible_statement_when_submitted TEXT,
+    moderation_reason TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/api/migrations/20260612104027_add_statement_text_and_moderation_status_to_polis_statement_aux.sql
+++ b/api/migrations/20260612104027_add_statement_text_and_moderation_status_to_polis_statement_aux.sql
@@ -1,0 +1,6 @@
+-- Add statement_text and moderation_status to polis_statement_aux
+
+ALTER TABLE polis_statement_aux
+    ADD COLUMN statement_text TEXT NOT NULL,
+    ADD COLUMN moderation_status TEXT NOT NULL DEFAULT 'pending'
+        CHECK (moderation_status IN ('accepted', 'rejected', 'pending'));

--- a/api/migrations/20260612105413_add_is_seed_to_polis_statement_aux.sql
+++ b/api/migrations/20260612105413_add_is_seed_to_polis_statement_aux.sql
@@ -1,0 +1,4 @@
+-- Add is_seed flag to polis_statement_aux
+
+ALTER TABLE polis_statement_aux
+    ADD COLUMN is_seed BOOLEAN NOT NULL DEFAULT FALSE;

--- a/api/migrations/20260612114331_polis_statement_aux_nullable_user_unique_statement.sql
+++ b/api/migrations/20260612114331_polis_statement_aux_nullable_user_unique_statement.sql
@@ -1,0 +1,9 @@
+-- Make user_id nullable (synced statements may have no comhairle user) and
+-- add a unique constraint so sync can upsert by (workflow_step_id, polis_statement_id).
+
+ALTER TABLE polis_statement_aux
+    ALTER COLUMN user_id DROP NOT NULL;
+
+ALTER TABLE polis_statement_aux
+    ADD CONSTRAINT polis_statement_aux_workflow_statement_key
+    UNIQUE (workflow_step_id, polis_statement_id);

--- a/api/src/models.rs
+++ b/api/src/models.rs
@@ -14,6 +14,7 @@ pub mod notification_delivery;
 pub mod organization;
 pub mod otp;
 pub mod pagination;
+pub mod polis_statement_aux;
 pub mod proposal;
 pub mod proposal_response;
 pub mod region;

--- a/api/src/models/polis_statement_aux.rs
+++ b/api/src/models/polis_statement_aux.rs
@@ -1,0 +1,386 @@
+use chrono::{DateTime, Utc};
+use schemars::JsonSchema;
+use sea_query::{enum_def, Expr, PostgresQueryBuilder, Query, SelectStatement, SimpleExpr};
+use sea_query_binder::SqlxBinder;
+use serde::{Deserialize, Serialize};
+use sqlx::{prelude::FromRow, query_as_with, PgPool};
+use tracing::instrument;
+use uuid::Uuid;
+
+use crate::error::ComhairleError;
+
+#[derive(Debug, Deserialize, Serialize, PartialEq, sqlx::Type, Clone, JsonSchema)]
+#[sqlx(type_name = "TEXT")]
+#[serde(rename_all = "snake_case")]
+pub enum ModerationStatus {
+    #[sqlx(rename = "accepted")]
+    Accepted,
+    #[sqlx(rename = "rejected")]
+    Rejected,
+    #[sqlx(rename = "pending")]
+    Pending,
+}
+
+impl Default for ModerationStatus {
+    fn default() -> Self {
+        Self::Pending
+    }
+}
+
+impl std::fmt::Display for ModerationStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let value = match self {
+            ModerationStatus::Accepted => "accepted",
+            ModerationStatus::Rejected => "rejected",
+            ModerationStatus::Pending => "pending",
+        };
+        write!(f, "{}", value)
+    }
+}
+
+impl From<ModerationStatus> for sea_query::Value {
+    fn from(val: ModerationStatus) -> Self {
+        sea_query::Value::String(Some(Box::new(val.to_string())))
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, FromRow, Clone, JsonSchema)]
+#[enum_def(table_name = "polis_statement_aux")]
+pub struct PolisStatementAux {
+    pub id: Uuid,
+    pub workflow_step_id: Uuid,
+    pub user_id: Uuid,
+    pub zid: i32,
+    pub polis_conversation_id: String,
+    pub polis_statement_id: i32,
+    pub statement_text: String,
+    pub moderation_status: ModerationStatus,
+    pub is_seed: bool,
+    pub themes: Vec<String>,
+    pub visible_statement_when_submitted: Option<String>,
+    pub moderation_reason: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+const DEFAULT_COLUMNS: [PolisStatementAuxIden; 14] = [
+    PolisStatementAuxIden::Id,
+    PolisStatementAuxIden::WorkflowStepId,
+    PolisStatementAuxIden::UserId,
+    PolisStatementAuxIden::Zid,
+    PolisStatementAuxIden::PolisConversationId,
+    PolisStatementAuxIden::PolisStatementId,
+    PolisStatementAuxIden::StatementText,
+    PolisStatementAuxIden::ModerationStatus,
+    PolisStatementAuxIden::IsSeed,
+    PolisStatementAuxIden::Themes,
+    PolisStatementAuxIden::VisibleStatementWhenSubmitted,
+    PolisStatementAuxIden::ModerationReason,
+    PolisStatementAuxIden::CreatedAt,
+    PolisStatementAuxIden::UpdatedAt,
+];
+
+#[derive(Deserialize, Debug, JsonSchema, Default)]
+pub struct CreatePolisStatementAux {
+    pub workflow_step_id: Uuid,
+    pub zid: i32,
+    pub polis_conversation_id: String,
+    pub polis_statement_id: i32,
+    pub statement_text: String,
+    #[serde(default)]
+    pub moderation_status: ModerationStatus,
+    pub is_seed: bool,
+    pub themes: Vec<String>,
+    pub visible_statement_when_submitted: Option<String>,
+    pub moderation_reason: Option<String>,
+}
+
+impl CreatePolisStatementAux {
+    fn columns(&self) -> Vec<PolisStatementAuxIden> {
+        vec![
+            PolisStatementAuxIden::WorkflowStepId,
+            PolisStatementAuxIden::Zid,
+            PolisStatementAuxIden::PolisConversationId,
+            PolisStatementAuxIden::PolisStatementId,
+            PolisStatementAuxIden::StatementText,
+            PolisStatementAuxIden::ModerationStatus,
+            PolisStatementAuxIden::IsSeed,
+            PolisStatementAuxIden::Themes,
+            PolisStatementAuxIden::VisibleStatementWhenSubmitted,
+            PolisStatementAuxIden::ModerationReason,
+        ]
+    }
+
+    fn values(&self) -> Vec<SimpleExpr> {
+        vec![
+            self.workflow_step_id.into(),
+            self.zid.into(),
+            self.polis_conversation_id.clone().into(),
+            self.polis_statement_id.into(),
+            self.statement_text.clone().into(),
+            self.moderation_status.clone().into(),
+            self.is_seed.into(),
+            self.themes.clone().into(),
+            self.visible_statement_when_submitted.clone().into(),
+            self.moderation_reason.clone().into(),
+        ]
+    }
+}
+
+#[instrument(err(Debug))]
+pub async fn create(
+    db: &PgPool,
+    user_id: Uuid,
+    create_aux: &CreatePolisStatementAux,
+) -> Result<PolisStatementAux, ComhairleError> {
+    let mut columns = create_aux.columns();
+    let mut values = create_aux.values();
+
+    columns.push(PolisStatementAuxIden::UserId);
+    values.push(user_id.into());
+
+    let (sql, values) = Query::insert()
+        .into_table(PolisStatementAuxIden::Table)
+        .columns(columns)
+        .values(values)?
+        .returning(Query::returning().columns(DEFAULT_COLUMNS))
+        .build_sqlx(PostgresQueryBuilder);
+
+    let aux = query_as_with(&sql, values).fetch_one(db).await?;
+
+    Ok(aux)
+}
+
+#[derive(Deserialize, Debug, JsonSchema)]
+pub struct UpdatePolisStatementAux {
+    pub statement_text: Option<String>,
+    pub moderation_status: Option<ModerationStatus>,
+    pub themes: Option<Vec<String>>,
+    pub visible_statement_when_submitted: Option<String>,
+    pub moderation_reason: Option<String>,
+}
+
+#[instrument(err(Debug))]
+pub async fn update(
+    db: &PgPool,
+    id: Uuid,
+    update_aux: &UpdatePolisStatementAux,
+) -> Result<PolisStatementAux, ComhairleError> {
+    let mut values: Vec<(PolisStatementAuxIden, SimpleExpr)> = vec![];
+
+    if let Some(text) = &update_aux.statement_text {
+        values.push((PolisStatementAuxIden::StatementText, text.clone().into()));
+    }
+    if let Some(status) = &update_aux.moderation_status {
+        values.push((
+            PolisStatementAuxIden::ModerationStatus,
+            status.clone().into(),
+        ));
+    }
+    if let Some(themes) = &update_aux.themes {
+        values.push((PolisStatementAuxIden::Themes, themes.clone().into()));
+    }
+    if let Some(visible) = &update_aux.visible_statement_when_submitted {
+        values.push((
+            PolisStatementAuxIden::VisibleStatementWhenSubmitted,
+            visible.clone().into(),
+        ));
+    }
+    if let Some(reason) = &update_aux.moderation_reason {
+        values.push((
+            PolisStatementAuxIden::ModerationReason,
+            reason.clone().into(),
+        ));
+    }
+
+    let (sql, values) = Query::update()
+        .table(PolisStatementAuxIden::Table)
+        .values(values)
+        .and_where(Expr::col(PolisStatementAuxIden::Id).eq(id))
+        .returning(Query::returning().columns(DEFAULT_COLUMNS))
+        .build_sqlx(PostgresQueryBuilder);
+
+    let aux = query_as_with(&sql, values).fetch_one(db).await?;
+
+    Ok(aux)
+}
+
+#[instrument(err(Debug))]
+pub async fn get_by_id(db: &PgPool, id: Uuid) -> Result<PolisStatementAux, ComhairleError> {
+    let (sql, values) = Query::select()
+        .from(PolisStatementAuxIden::Table)
+        .columns(DEFAULT_COLUMNS)
+        .and_where(Expr::col(PolisStatementAuxIden::Id).eq(id))
+        .build_sqlx(PostgresQueryBuilder);
+
+    let aux = query_as_with(&sql, values)
+        .fetch_one(db)
+        .await
+        .map_err(|e| match e {
+            sqlx::Error::RowNotFound => {
+                ComhairleError::ResourceNotFound("Polis statement aux".into())
+            }
+            other => ComhairleError::DatabaseError(other),
+        })?;
+
+    Ok(aux)
+}
+
+#[derive(Deserialize, Debug, JsonSchema, Default)]
+pub struct PolisStatementAuxFilterOptions {
+    user_id: Option<Uuid>,
+    polis_conversation_id: Option<String>,
+    polis_statement_id: Option<i32>,
+}
+
+impl PolisStatementAuxFilterOptions {
+    fn apply(&self, mut query: SelectStatement) -> SelectStatement {
+        if let Some(value) = self.user_id {
+            query = query
+                .and_where(
+                    Expr::col((PolisStatementAuxIden::Table, PolisStatementAuxIden::UserId))
+                        .eq(value),
+                )
+                .to_owned();
+        }
+        if let Some(value) = &self.polis_conversation_id {
+            query = query
+                .and_where(
+                    Expr::col((
+                        PolisStatementAuxIden::Table,
+                        PolisStatementAuxIden::PolisConversationId,
+                    ))
+                    .eq(value.clone()),
+                )
+                .to_owned();
+        }
+        if let Some(value) = self.polis_statement_id {
+            query = query
+                .and_where(
+                    Expr::col((
+                        PolisStatementAuxIden::Table,
+                        PolisStatementAuxIden::PolisStatementId,
+                    ))
+                    .eq(value),
+                )
+                .to_owned();
+        }
+
+        query
+    }
+}
+
+#[instrument(err(Debug))]
+pub async fn list(
+    db: &PgPool,
+    workflow_step_id: &Uuid,
+    filter_options: PolisStatementAuxFilterOptions,
+) -> Result<Vec<PolisStatementAux>, ComhairleError> {
+    let query = Query::select()
+        .from(PolisStatementAuxIden::Table)
+        .columns(DEFAULT_COLUMNS.map(|col| (PolisStatementAuxIden::Table, col)))
+        .and_where(
+            Expr::col((
+                PolisStatementAuxIden::Table,
+                PolisStatementAuxIden::WorkflowStepId,
+            ))
+            .eq(workflow_step_id.to_owned()),
+        )
+        .to_owned();
+
+    let query = filter_options.apply(query);
+
+    let (sql, values) = query.build_sqlx(PostgresQueryBuilder);
+
+    let aux = query_as_with(&sql, values).fetch_all(db).await?;
+
+    Ok(aux)
+}
+
+#[instrument(err(Debug))]
+pub async fn list_filtered(
+    db: &PgPool,
+    workflow_step_id: Option<Uuid>,
+    polis_conversation_id: Option<String>,
+) -> Result<Vec<PolisStatementAux>, ComhairleError> {
+    let mut query = Query::select()
+        .from(PolisStatementAuxIden::Table)
+        .columns(DEFAULT_COLUMNS.map(|col| (PolisStatementAuxIden::Table, col)))
+        .to_owned();
+
+    if let Some(id) = workflow_step_id {
+        query = query
+            .and_where(
+                Expr::col((
+                    PolisStatementAuxIden::Table,
+                    PolisStatementAuxIden::WorkflowStepId,
+                ))
+                .eq(id),
+            )
+            .to_owned();
+    }
+    if let Some(conversation_id) = polis_conversation_id {
+        query = query
+            .and_where(
+                Expr::col((
+                    PolisStatementAuxIden::Table,
+                    PolisStatementAuxIden::PolisConversationId,
+                ))
+                .eq(conversation_id),
+            )
+            .to_owned();
+    }
+
+    let (sql, values) = query.build_sqlx(PostgresQueryBuilder);
+
+    let aux = query_as_with(&sql, values).fetch_all(db).await?;
+
+    Ok(aux)
+}
+
+#[derive(Debug, Serialize, FromRow, JsonSchema)]
+pub struct ThemeStatistic {
+    pub theme: String,
+    pub count: i64,
+}
+
+#[instrument(err(Debug))]
+pub async fn theme_stats(
+    db: &PgPool,
+    workflow_step_id: Option<Uuid>,
+    polis_conversation_id: Option<String>,
+) -> Result<Vec<ThemeStatistic>, ComhairleError> {
+    let mut builder = sqlx::QueryBuilder::new(
+        "SELECT theme, COUNT(*)::BIGINT AS count \
+         FROM polis_statement_aux, UNNEST(themes) AS theme \
+         WHERE TRUE",
+    );
+
+    if let Some(id) = workflow_step_id {
+        builder.push(" AND workflow_step_id = ").push_bind(id);
+    }
+    if let Some(conversation_id) = polis_conversation_id {
+        builder
+            .push(" AND polis_conversation_id = ")
+            .push_bind(conversation_id);
+    }
+
+    builder.push(" GROUP BY theme ORDER BY count DESC");
+
+    let stats = builder.build_query_as::<ThemeStatistic>().fetch_all(db).await?;
+
+    Ok(stats)
+}
+
+#[instrument(err(Debug))]
+pub async fn delete(db: &PgPool, id: Uuid) -> Result<PolisStatementAux, ComhairleError> {
+    let (sql, values) = Query::delete()
+        .from_table(PolisStatementAuxIden::Table)
+        .and_where(Expr::col(PolisStatementAuxIden::Id).eq(id))
+        .returning(Query::returning().columns(DEFAULT_COLUMNS))
+        .build_sqlx(PostgresQueryBuilder);
+
+    let aux = query_as_with(&sql, values).fetch_one(db).await?;
+
+    Ok(aux)
+}

--- a/api/src/models/polis_statement_aux.rs
+++ b/api/src/models/polis_statement_aux.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, Utc};
 use schemars::JsonSchema;
-use sea_query::{enum_def, Expr, PostgresQueryBuilder, Query, SelectStatement, SimpleExpr};
+use sea_query::{enum_def, Expr, OnConflict, PostgresQueryBuilder, Query, SelectStatement, SimpleExpr};
 use sea_query_binder::SqlxBinder;
 use serde::{Deserialize, Serialize};
 use sqlx::{prelude::FromRow, query_as_with, PgPool};
@@ -49,7 +49,7 @@ impl From<ModerationStatus> for sea_query::Value {
 pub struct PolisStatementAux {
     pub id: Uuid,
     pub workflow_step_id: Uuid,
-    pub user_id: Uuid,
+    pub user_id: Option<Uuid>,
     pub zid: i32,
     pub polis_conversation_id: String,
     pub polis_statement_id: i32,
@@ -143,6 +143,69 @@ pub async fn create(
         .into_table(PolisStatementAuxIden::Table)
         .columns(columns)
         .values(values)?
+        .returning(Query::returning().columns(DEFAULT_COLUMNS))
+        .build_sqlx(PostgresQueryBuilder);
+
+    let aux = query_as_with(&sql, values).fetch_one(db).await?;
+
+    Ok(aux)
+}
+
+#[derive(Debug)]
+pub struct UpsertFromPolis {
+    pub workflow_step_id: Uuid,
+    pub user_id: Option<Uuid>,
+    pub zid: i32,
+    pub polis_conversation_id: String,
+    pub polis_statement_id: i32,
+    pub statement_text: String,
+    pub is_seed: bool,
+}
+
+/// Upsert a row from polis. On conflict (workflow_step_id, polis_statement_id),
+/// only `statement_text` and `is_seed` are updated — `moderation_reason`,
+/// `themes`, `visible_statement_when_submitted`, `moderation_status` and
+/// `user_id` are preserved.
+#[instrument(err(Debug), skip(db))]
+pub async fn upsert_from_polis(
+    db: &PgPool,
+    record: &UpsertFromPolis,
+) -> Result<PolisStatementAux, ComhairleError> {
+    let columns = [
+        PolisStatementAuxIden::WorkflowStepId,
+        PolisStatementAuxIden::UserId,
+        PolisStatementAuxIden::Zid,
+        PolisStatementAuxIden::PolisConversationId,
+        PolisStatementAuxIden::PolisStatementId,
+        PolisStatementAuxIden::StatementText,
+        PolisStatementAuxIden::IsSeed,
+    ];
+    let values: Vec<SimpleExpr> = vec![
+        record.workflow_step_id.into(),
+        record.user_id.into(),
+        record.zid.into(),
+        record.polis_conversation_id.clone().into(),
+        record.polis_statement_id.into(),
+        record.statement_text.clone().into(),
+        record.is_seed.into(),
+    ];
+
+    let (sql, values) = Query::insert()
+        .into_table(PolisStatementAuxIden::Table)
+        .columns(columns)
+        .values(values)?
+        .on_conflict(
+            OnConflict::columns([
+                PolisStatementAuxIden::WorkflowStepId,
+                PolisStatementAuxIden::PolisStatementId,
+            ])
+            .update_columns([
+                PolisStatementAuxIden::StatementText,
+                PolisStatementAuxIden::IsSeed,
+            ])
+            .value(PolisStatementAuxIden::UpdatedAt, Expr::current_timestamp())
+            .to_owned(),
+        )
         .returning(Query::returning().columns(DEFAULT_COLUMNS))
         .build_sqlx(PostgresQueryBuilder);
 

--- a/api/src/models/polis_statement_aux.rs
+++ b/api/src/models/polis_statement_aux.rs
@@ -289,7 +289,6 @@ pub async fn get_by_id(db: &PgPool, id: Uuid) -> Result<PolisStatementAux, Comha
 #[derive(Deserialize, Debug, JsonSchema, Default)]
 pub struct PolisStatementAuxFilterOptions {
     user_id: Option<Uuid>,
-    polis_conversation_id: Option<String>,
     polis_statement_id: Option<i32>,
 }
 
@@ -300,17 +299,6 @@ impl PolisStatementAuxFilterOptions {
                 .and_where(
                     Expr::col((PolisStatementAuxIden::Table, PolisStatementAuxIden::UserId))
                         .eq(value),
-                )
-                .to_owned();
-        }
-        if let Some(value) = &self.polis_conversation_id {
-            query = query
-                .and_where(
-                    Expr::col((
-                        PolisStatementAuxIden::Table,
-                        PolisStatementAuxIden::PolisConversationId,
-                    ))
-                    .eq(value.clone()),
                 )
                 .to_owned();
         }
@@ -333,35 +321,9 @@ impl PolisStatementAuxFilterOptions {
 #[instrument(err(Debug))]
 pub async fn list(
     db: &PgPool,
-    workflow_step_id: &Uuid,
-    filter_options: PolisStatementAuxFilterOptions,
-) -> Result<Vec<PolisStatementAux>, ComhairleError> {
-    let query = Query::select()
-        .from(PolisStatementAuxIden::Table)
-        .columns(DEFAULT_COLUMNS.map(|col| (PolisStatementAuxIden::Table, col)))
-        .and_where(
-            Expr::col((
-                PolisStatementAuxIden::Table,
-                PolisStatementAuxIden::WorkflowStepId,
-            ))
-            .eq(workflow_step_id.to_owned()),
-        )
-        .to_owned();
-
-    let query = filter_options.apply(query);
-
-    let (sql, values) = query.build_sqlx(PostgresQueryBuilder);
-
-    let aux = query_as_with(&sql, values).fetch_all(db).await?;
-
-    Ok(aux)
-}
-
-#[instrument(err(Debug))]
-pub async fn list_filtered(
-    db: &PgPool,
     workflow_step_id: Option<Uuid>,
     polis_conversation_id: Option<String>,
+    filter_options: PolisStatementAuxFilterOptions,
 ) -> Result<Vec<PolisStatementAux>, ComhairleError> {
     let mut query = Query::select()
         .from(PolisStatementAuxIden::Table)
@@ -390,6 +352,8 @@ pub async fn list_filtered(
             )
             .to_owned();
     }
+
+    let query = filter_options.apply(query);
 
     let (sql, values) = query.build_sqlx(PostgresQueryBuilder);
 

--- a/api/src/models/polis_statement_aux.rs
+++ b/api/src/models/polis_statement_aux.rs
@@ -1,6 +1,8 @@
 use chrono::{DateTime, Utc};
 use schemars::JsonSchema;
-use sea_query::{enum_def, Expr, OnConflict, PostgresQueryBuilder, Query, SelectStatement, SimpleExpr};
+use sea_query::{
+    enum_def, Expr, OnConflict, PostgresQueryBuilder, Query, SelectStatement, SimpleExpr,
+};
 use sea_query_binder::SqlxBinder;
 use serde::{Deserialize, Serialize};
 use sqlx::{prelude::FromRow, query_as_with, PgPool};
@@ -9,7 +11,7 @@ use uuid::Uuid;
 
 use crate::error::ComhairleError;
 
-#[derive(Debug, Deserialize, Serialize, PartialEq, sqlx::Type, Clone, JsonSchema)]
+#[derive(Debug, Deserialize, Serialize, PartialEq, sqlx::Type, Clone, JsonSchema, Default)]
 #[sqlx(type_name = "TEXT")]
 #[serde(rename_all = "snake_case")]
 pub enum ModerationStatus {
@@ -18,13 +20,8 @@ pub enum ModerationStatus {
     #[sqlx(rename = "rejected")]
     Rejected,
     #[sqlx(rename = "pending")]
+    #[default]
     Pending,
-}
-
-impl Default for ModerationStatus {
-    fn default() -> Self {
-        Self::Pending
-    }
 }
 
 impl std::fmt::Display for ModerationStatus {
@@ -430,7 +427,10 @@ pub async fn theme_stats(
 
     builder.push(" GROUP BY theme ORDER BY count DESC");
 
-    let stats = builder.build_query_as::<ThemeStatistic>().fetch_all(db).await?;
+    let stats = builder
+        .build_query_as::<ThemeStatistic>()
+        .fetch_all(db)
+        .await?;
 
     Ok(stats)
 }

--- a/api/src/tools/polis.rs
+++ b/api/src/tools/polis.rs
@@ -13,7 +13,7 @@ use axum_extra::extract::cookie::{Cookie, CookieJar};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use tracing::instrument;
+use tracing::{info, instrument};
 use uuid::Uuid;
 
 use crate::{
@@ -22,6 +22,7 @@ use crate::{
         self,
         polis_statement_aux::{
             CreatePolisStatementAux, PolisStatementAux, ThemeStatistic, UpdatePolisStatementAux,
+            UpsertFromPolis,
         },
     },
     routes::auth::RequiredUser,
@@ -160,6 +161,21 @@ impl ToolImpl for PolisTool {
                 }),
             )
             .api_route(
+                "/polis/statement_aux/sync",
+                post_with(sync_statement_aux, |op| {
+                    op.id("PolisSyncStatementAux")
+                        .tag("Tools")
+                        .summary("Sync polis_statement_aux with the live Polis poll")
+                        .description(
+                            "Fetches comments and xid mappings from Polis and upserts a row \
+                             per statement. Existing rows have their statement_text and \
+                             is_seed refreshed; moderation_status, moderation_reason, themes, \
+                             visible_statement_when_submitted and user_id are preserved.",
+                        )
+                        .response::<200, Json<SyncStatementAuxResponse>>()
+                }),
+            )
+            .api_route(
                 "/polis/statement_aux/theme_stats",
                 get_with(theme_stats, |op| {
                     op.id("PolisStatementAuxThemeStats")
@@ -193,6 +209,9 @@ pub enum PolisError {
 
     #[error("Failed to get comments {0}")]
     FailedToGetComments(String),
+
+    #[error("Failed to get xids {0}")]
+    FailedToGetXIDs(String),
 
     #[error("Failed to post seed comment {0}")]
     FailedToPostSeedComment(String),
@@ -332,6 +351,85 @@ async fn list_statement_aux(
     )
     .await?;
     Ok((StatusCode::OK, Json(aux)))
+}
+
+#[derive(Serialize, Deserialize, JsonSchema, Debug)]
+pub struct SyncStatementAuxRequest {
+    pub workflow_step_id: Uuid,
+}
+
+#[derive(Serialize, Deserialize, JsonSchema, Debug)]
+pub struct SyncStatementAuxResponse {
+    pub synced: usize,
+    pub skipped_invalid_xid: usize,
+    pub statements: Vec<PolisStatementAux>,
+}
+
+#[instrument(err(Debug), skip(state))]
+async fn sync_statement_aux(
+    State(state): State<Arc<ComhairleState>>,
+    RequiredUser(_user): RequiredUser,
+    Json(SyncStatementAuxRequest { workflow_step_id }): Json<SyncStatementAuxRequest>,
+) -> Result<(StatusCode, Json<SyncStatementAuxResponse>), ComhairleError> {
+    let workflow_step = models::workflow_step::get_by_id(&state.db, &workflow_step_id).await?;
+
+    let config = match (workflow_step.tool_config, workflow_step.preview_tool_config) {
+        (Some(ToolConfig::Polis(config)), _) => config,
+        (None, ToolConfig::Polis(config)) => config,
+        _ => return Err(ComhairleError::WorkflowStepHasWrongType("Polis".into())),
+    };
+
+    let client = &state.wiki_poll_service;
+    let auth_cookies = client
+        .login(&WikiPollLogin {
+            email: config.admin_user.clone(),
+            password: config.admin_password.clone(),
+        })
+        .await?;
+    info!("LOGGED IN");
+
+    let xid_rows = client.get_xids(&config.poll_id, &auth_cookies).await?;
+
+    info!("XID ROWS: {xid_rows:#?}");
+
+    let pid_to_user_id: std::collections::HashMap<u32, Uuid> = xid_rows
+        .into_iter()
+        .filter_map(|row| Uuid::parse_str(&row.xid).ok().map(|u| (row.pid, u)))
+        .collect();
+
+    let comments = client.get_comments(&config.poll_id).await?;
+
+    let mut statements = Vec::with_capacity(comments.len());
+    let mut skipped_invalid_xid = 0;
+    for comment in comments {
+        let user_id = pid_to_user_id.get(&comment.pid).copied();
+        if user_id.is_none() && !comment.is_seed {
+            skipped_invalid_xid += 1;
+        }
+        let aux = models::polis_statement_aux::upsert_from_polis(
+            &state.db,
+            &UpsertFromPolis {
+                workflow_step_id,
+                user_id,
+                zid: comment.pid as i32,
+                polis_conversation_id: config.poll_id.clone(),
+                polis_statement_id: comment.tid as i32,
+                statement_text: comment.txt,
+                is_seed: comment.is_seed,
+            },
+        )
+        .await?;
+        statements.push(aux);
+    }
+
+    Ok((
+        StatusCode::OK,
+        Json(SyncStatementAuxResponse {
+            synced: statements.len(),
+            skipped_invalid_xid,
+            statements,
+        }),
+    ))
 }
 
 #[instrument(err(Debug), skip(state))]

--- a/api/src/tools/polis.rs
+++ b/api/src/tools/polis.rs
@@ -1,12 +1,12 @@
 use std::sync::Arc;
 
 use aide::axum::{
-    routing::{get_with, post_with},
+    routing::{get_with, post_with, put_with},
     ApiRouter,
 };
 use async_trait::async_trait;
 use axum::{
-    extract::{Json, Query, State},
+    extract::{Json, Path, Query, State},
     http::StatusCode,
 };
 use axum_extra::extract::cookie::{Cookie, CookieJar};
@@ -18,7 +18,13 @@ use uuid::Uuid;
 
 use crate::{
     error::ComhairleError,
-    models,
+    models::{
+        self,
+        polis_statement_aux::{
+            CreatePolisStatementAux, PolisStatementAux, ThemeStatistic, UpdatePolisStatementAux,
+        },
+    },
+    routes::auth::RequiredUser,
     wiki_poll_service::{polis_service::WikiPollReport, WikiPollLogin, WikiPollService},
     ComhairleState,
 };
@@ -111,6 +117,60 @@ impl ToolImpl for PolisTool {
                         .tag("Tools")
                         .summary("Get Polis report data for a workflow step")
                         .description("Fetches the polis data export for a given workflow step")
+                }),
+            )
+            .api_route(
+                "/polis/statement_aux",
+                post_with(create_statement_aux, |op| {
+                    op.id("PolisCreateStatementAux")
+                        .tag("Tools")
+                        .summary("Create auxiliary data for a Polis statement")
+                        .description(
+                            "Creates a polis_statement_aux row capturing statement text, \
+                             moderation status, themes and the visible statement at \
+                             submission time",
+                        )
+                        .response::<201, Json<PolisStatementAux>>()
+                }),
+            )
+            .api_route(
+                "/polis/statement_aux/{id}",
+                put_with(update_statement_aux, |op| {
+                    op.id("PolisUpdateStatementAux")
+                        .tag("Tools")
+                        .summary("Update auxiliary data for a Polis statement")
+                        .description(
+                            "Updates statement_text, moderation_status, themes, \
+                             visible_statement_when_submitted, or moderation_reason",
+                        )
+                        .response::<200, Json<PolisStatementAux>>()
+                }),
+            )
+            .api_route(
+                "/polis/statement_aux",
+                get_with(list_statement_aux, |op| {
+                    op.id("PolisListStatementAux")
+                        .tag("Tools")
+                        .summary("List polis_statement_aux rows for a poll")
+                        .description(
+                            "Returns auxiliary statement data filtered by workflow_step_id \
+                             and/or polis_conversation_id (at least one is required)",
+                        )
+                        .response::<200, Json<Vec<PolisStatementAux>>>()
+                }),
+            )
+            .api_route(
+                "/polis/statement_aux/theme_stats",
+                get_with(theme_stats, |op| {
+                    op.id("PolisStatementAuxThemeStats")
+                        .tag("Tools")
+                        .summary("Statement counts per theme for a poll")
+                        .description(
+                            "Returns the count of polis_statement_aux rows tagged with each \
+                             theme, filtered by workflow_step_id and/or polis_conversation_id \
+                             (at least one is required)",
+                        )
+                        .response::<200, Json<Vec<ThemeStatistic>>>()
                 }),
             )
             .with_state(state.clone())
@@ -225,6 +285,73 @@ async fn get_report_data(
         .await?;
 
     Ok((StatusCode::OK, Json(data)))
+}
+
+#[instrument(err(Debug), skip(state))]
+async fn create_statement_aux(
+    State(state): State<Arc<ComhairleState>>,
+    RequiredUser(user): RequiredUser,
+    Json(create_request): Json<CreatePolisStatementAux>,
+) -> Result<(StatusCode, Json<PolisStatementAux>), ComhairleError> {
+    let aux = models::polis_statement_aux::create(&state.db, user.id, &create_request).await?;
+    Ok((StatusCode::CREATED, Json(aux)))
+}
+
+#[instrument(err(Debug), skip(state))]
+async fn update_statement_aux(
+    State(state): State<Arc<ComhairleState>>,
+    RequiredUser(_user): RequiredUser,
+    Path(id): Path<Uuid>,
+    Json(update_request): Json<UpdatePolisStatementAux>,
+) -> Result<(StatusCode, Json<PolisStatementAux>), ComhairleError> {
+    let aux = models::polis_statement_aux::update(&state.db, id, &update_request).await?;
+    Ok((StatusCode::OK, Json(aux)))
+}
+
+#[derive(Serialize, Deserialize, JsonSchema, Debug)]
+struct StatementAuxFilterQuery {
+    pub workflow_step_id: Option<Uuid>,
+    pub polis_conversation_id: Option<String>,
+}
+
+#[instrument(err(Debug), skip(state))]
+async fn list_statement_aux(
+    State(state): State<Arc<ComhairleState>>,
+    RequiredUser(_user): RequiredUser,
+    Query(filter): Query<StatementAuxFilterQuery>,
+) -> Result<(StatusCode, Json<Vec<PolisStatementAux>>), ComhairleError> {
+    if filter.workflow_step_id.is_none() && filter.polis_conversation_id.is_none() {
+        return Err(ComhairleError::BadRequest(
+            "workflow_step_id or polis_conversation_id is required".into(),
+        ));
+    }
+    let aux = models::polis_statement_aux::list_filtered(
+        &state.db,
+        filter.workflow_step_id,
+        filter.polis_conversation_id,
+    )
+    .await?;
+    Ok((StatusCode::OK, Json(aux)))
+}
+
+#[instrument(err(Debug), skip(state))]
+async fn theme_stats(
+    State(state): State<Arc<ComhairleState>>,
+    RequiredUser(_user): RequiredUser,
+    Query(filter): Query<StatementAuxFilterQuery>,
+) -> Result<(StatusCode, Json<Vec<ThemeStatistic>>), ComhairleError> {
+    if filter.workflow_step_id.is_none() && filter.polis_conversation_id.is_none() {
+        return Err(ComhairleError::BadRequest(
+            "workflow_step_id or polis_conversation_id is required".into(),
+        ));
+    }
+    let stats = models::polis_statement_aux::theme_stats(
+        &state.db,
+        filter.workflow_step_id,
+        filter.polis_conversation_id,
+    )
+    .await?;
+    Ok((StatusCode::OK, Json(stats)))
 }
 
 /// Logs a user into polis and proxies the cookie

--- a/api/src/tools/polis.rs
+++ b/api/src/tools/polis.rs
@@ -13,7 +13,7 @@ use axum_extra::extract::cookie::{Cookie, CookieJar};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
-use tracing::{info, instrument};
+use tracing::instrument;
 use uuid::Uuid;
 
 use crate::{
@@ -386,11 +386,8 @@ async fn sync_statement_aux(
             password: config.admin_password.clone(),
         })
         .await?;
-    info!("LOGGED IN");
 
     let xid_rows = client.get_xids(&config.poll_id, &auth_cookies).await?;
-
-    info!("XID ROWS: {xid_rows:#?}");
 
     let pid_to_user_id: std::collections::HashMap<u32, Uuid> = xid_rows
         .into_iter()

--- a/api/src/tools/polis.rs
+++ b/api/src/tools/polis.rs
@@ -21,8 +21,8 @@ use crate::{
     models::{
         self,
         polis_statement_aux::{
-            CreatePolisStatementAux, PolisStatementAux, ThemeStatistic, UpdatePolisStatementAux,
-            UpsertFromPolis,
+            CreatePolisStatementAux, PolisStatementAux, PolisStatementAuxFilterOptions,
+            ThemeStatistic, UpdatePolisStatementAux, UpsertFromPolis,
         },
     },
     routes::auth::RequiredUser,
@@ -344,10 +344,11 @@ async fn list_statement_aux(
             "workflow_step_id or polis_conversation_id is required".into(),
         ));
     }
-    let aux = models::polis_statement_aux::list_filtered(
+    let aux = models::polis_statement_aux::list(
         &state.db,
         filter.workflow_step_id,
         filter.polis_conversation_id,
+        PolisStatementAuxFilterOptions::default(),
     )
     .await?;
     Ok((StatusCode::OK, Json(aux)))

--- a/api/src/wiki_poll_service.rs
+++ b/api/src/wiki_poll_service.rs
@@ -30,6 +30,12 @@ pub trait WikiPollService: Send + Sync {
         poll_id: &str,
     ) -> Result<Vec<WikiPollComment>, WikiPollServiceError>;
 
+    async fn get_xids(
+        &self,
+        poll_id: &str,
+        auth_cookies: &str,
+    ) -> Result<Vec<WikiPollXid>, WikiPollServiceError>;
+
     async fn get_report_data(&self, poll_id: &str) -> Result<WikiPollReport, WikiPollServiceError>;
 }
 
@@ -49,6 +55,12 @@ pub struct WikiPollComment {
     pub pid: u32,
     pub quote_src_url: Option<String>,
     pub created: String,
+}
+
+#[derive(Deserialize, Serialize, Debug, Default)]
+pub struct WikiPollXid {
+    pub pid: u32,
+    pub xid: String,
 }
 
 #[cfg(test)]
@@ -76,6 +88,9 @@ impl MockWikiPollService {
                 }])
             })
         });
+        wiki_poll_service
+            .expect_get_xids()
+            .returning(|_, _| Box::pin(async move { Ok(vec![]) }));
 
         wiki_poll_service
     }

--- a/api/src/wiki_poll_service/polis_service.rs
+++ b/api/src/wiki_poll_service/polis_service.rs
@@ -10,12 +10,12 @@ use reqwest::{
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
-use tracing::{instrument, warn};
+use tracing::{info, instrument, warn};
 
 use crate::{
     tools::polis::PolisError,
     wiki_poll_service::{
-        error::WikiPollServiceError, WikiPollComment, WikiPollLogin, WikiPollService,
+        error::WikiPollServiceError, WikiPollComment, WikiPollLogin, WikiPollService, WikiPollXid,
     },
 };
 
@@ -187,22 +187,27 @@ impl PolisClient {
             self.base_url, poll_id
         );
 
+        info!("Attempting to get comments at {url}");
+
         let response = self.client.get(&url).send().await.map_err(|e| {
             warn!("Failed to get comments: {e}");
             PolisError::FailedToGetComments(format!("Failed to get comments: {e}"))
         })?;
 
-        let data = response.json::<Vec<PolisCommentWithVoting>>().await.map_err(|e| {
-            warn!("Failed to parse comments: {e}");
-            PolisError::FailedToGetComments(format!("Failed to parse comments: {e}"))
-        })?;
+        let data = response
+            .json::<Vec<PolisCommentWithVoting>>()
+            .await
+            .map_err(|e| {
+                warn!("Failed to parse comments: {e}");
+                PolisError::FailedToGetComments(format!("Failed to parse comments: {e}"))
+            })?;
 
         Ok(data)
     }
 
     pub async fn get_comments(&self, poll_id: &str) -> Result<Vec<PolisComment>, PolisError> {
         let url = format!(
-            "{}/api/v3/comments?conversation_id={poll_id}",
+            "https://{}/api/v3/comments?conversation_id={poll_id}",
             self.base_url
         );
         let comments: Vec<PolisComment> =
@@ -287,7 +292,10 @@ impl PolisClient {
                 }
             }
 
-            let consensus = math_pca.group_aware_consensus.get(&tid.to_string()).copied();
+            let consensus = math_pca
+                .group_aware_consensus
+                .get(&tid.to_string())
+                .copied();
             let divisiveness = math_pca.pca.comment_extremity.get(idx).copied();
 
             if let (Some(overall_votes), Some(is_seed)) =
@@ -306,11 +314,7 @@ impl PolisClient {
         }
 
         // Build groups report
-        let group_sizes: Vec<u64> = math_pca
-            .group_votes
-            .values()
-            .map(|g| g.n_members)
-            .collect();
+        let group_sizes: Vec<u64> = math_pca.group_votes.values().map(|g| g.n_members).collect();
 
         println!("{:#?}", math_pca.group_votes);
 
@@ -537,6 +541,7 @@ impl WikiPollService for PolisClient {
             "https://{}/api/v3/comments?conversation_id={poll_id}",
             self.base_url
         );
+        info!("Attempting to get comments at {url}");
         let comments: Vec<WikiPollComment> = self
             .client
             .get(url)
@@ -547,6 +552,31 @@ impl WikiPollService for PolisClient {
             .map_err(|e| PolisError::FailedToGetComments(e.to_string()))?;
 
         Ok(comments)
+    }
+
+    async fn get_xids(
+        &self,
+        poll_id: &str,
+        auth_cookies: &str,
+    ) -> Result<Vec<WikiPollXid>, WikiPollServiceError> {
+        let url = format!(
+            "https://{}/api/v3/xids?conversation_id={poll_id}",
+            self.base_url
+        );
+
+        info!("attempting to get xids at {url}");
+
+        let xids: Vec<WikiPollXid> = self
+            .client
+            .get(url)
+            .header(COOKIE, auth_cookies)
+            .send()
+            .await?
+            .json()
+            .await
+            .map_err(|e| PolisError::FailedToGetXIDs(e.to_string()))?;
+
+        Ok(xids)
     }
 
     async fn get_report_data(&self, poll_id: &str) -> Result<WikiPollReport, WikiPollServiceError> {

--- a/ui/packages/api-client/src/api.ts
+++ b/ui/packages/api-client/src/api.ts
@@ -358,7 +358,7 @@ export const PolisStatementAux = z
     statement_text: z.string(),
     themes: z.array(z.string()),
     updated_at: z.string().datetime({ offset: true }),
-    user_id: z.string().uuid(),
+    user_id: z.union([z.string(), z.null()]).optional(),
     visible_statement_when_submitted: z
       .union([z.string(), z.null()])
       .optional(),
@@ -395,6 +395,18 @@ export const UpdatePolisStatementAux = z
   .partial()
   .passthrough();
 export type UpdatePolisStatementAux = z.infer<typeof UpdatePolisStatementAux>;
+export const SyncStatementAuxRequest = z
+  .object({ workflow_step_id: z.string().uuid() })
+  .passthrough();
+export type SyncStatementAuxRequest = z.infer<typeof SyncStatementAuxRequest>;
+export const SyncStatementAuxResponse = z
+  .object({
+    skipped_invalid_xid: z.number().int().gte(0),
+    statements: z.array(PolisStatementAux),
+    synced: z.number().int().gte(0),
+  })
+  .passthrough();
+export type SyncStatementAuxResponse = z.infer<typeof SyncStatementAuxResponse>;
 export const ThemeStatistic = z
   .object({ count: z.number().int(), theme: z.string() })
   .passthrough();
@@ -1904,6 +1916,8 @@ export const schemas: Record<string, z.ZodType<any>> = {
   PolisStatementAux,
   CreatePolisStatementAux,
   UpdatePolisStatementAux,
+  SyncStatementAuxRequest,
+  SyncStatementAuxResponse,
   ThemeStatistic,
   Story,
   ComhairleMessageReference,
@@ -3825,6 +3839,21 @@ Use a raw HTTP request and process the response body incrementally.
       },
     ],
     response: PolisStatementAux,
+  },
+  {
+    method: "post",
+    path: "/tools/polis/statement_aux/sync",
+    alias: "PolisSyncStatementAux",
+    description: `Fetches comments and xid mappings from Polis and upserts a row per statement. Existing rows have their statement_text and is_seed refreshed; moderation_status, moderation_reason, themes, visible_statement_when_submitted and user_id are preserved.`,
+    requestFormat: "json",
+    parameters: [
+      {
+        name: "body",
+        type: "Body",
+        schema: z.object({ workflow_step_id: z.string().uuid() }).passthrough(),
+      },
+    ],
+    response: SyncStatementAuxResponse,
   },
   {
     method: "get",

--- a/ui/packages/api-client/src/api.ts
+++ b/ui/packages/api-client/src/api.ts
@@ -344,6 +344,61 @@ export const CreateOrUpdateTextTranslationRequest = z
 export type CreateOrUpdateTextTranslationRequest = z.infer<
   typeof CreateOrUpdateTextTranslationRequest
 >;
+export const ModerationStatus = z.enum(["accepted", "rejected", "pending"]);
+export type ModerationStatus = z.infer<typeof ModerationStatus>;
+export const PolisStatementAux = z
+  .object({
+    created_at: z.string().datetime({ offset: true }),
+    id: z.string().uuid(),
+    is_seed: z.boolean(),
+    moderation_reason: z.union([z.string(), z.null()]).optional(),
+    moderation_status: ModerationStatus,
+    polis_conversation_id: z.string(),
+    polis_statement_id: z.number().int(),
+    statement_text: z.string(),
+    themes: z.array(z.string()),
+    updated_at: z.string().datetime({ offset: true }),
+    user_id: z.string().uuid(),
+    visible_statement_when_submitted: z
+      .union([z.string(), z.null()])
+      .optional(),
+    workflow_step_id: z.string().uuid(),
+    zid: z.number().int(),
+  })
+  .passthrough();
+export type PolisStatementAux = z.infer<typeof PolisStatementAux>;
+export const CreatePolisStatementAux = z
+  .object({
+    is_seed: z.boolean(),
+    moderation_reason: z.union([z.string(), z.null()]).optional(),
+    moderation_status: ModerationStatus.optional(),
+    polis_conversation_id: z.string(),
+    polis_statement_id: z.number().int(),
+    statement_text: z.string(),
+    themes: z.array(z.string()),
+    visible_statement_when_submitted: z
+      .union([z.string(), z.null()])
+      .optional(),
+    workflow_step_id: z.string().uuid(),
+    zid: z.number().int(),
+  })
+  .passthrough();
+export type CreatePolisStatementAux = z.infer<typeof CreatePolisStatementAux>;
+export const UpdatePolisStatementAux = z
+  .object({
+    moderation_reason: z.union([z.string(), z.null()]),
+    moderation_status: z.union([ModerationStatus, z.null()]),
+    statement_text: z.union([z.string(), z.null()]),
+    themes: z.union([z.array(z.string()), z.null()]),
+    visible_statement_when_submitted: z.union([z.string(), z.null()]),
+  })
+  .partial()
+  .passthrough();
+export type UpdatePolisStatementAux = z.infer<typeof UpdatePolisStatementAux>;
+export const ThemeStatistic = z
+  .object({ count: z.number().int(), theme: z.string() })
+  .passthrough();
+export type ThemeStatistic = z.infer<typeof ThemeStatistic>;
 export const Story = z
   .object({
     id: z.string().uuid(),
@@ -1845,6 +1900,11 @@ export const schemas: Record<string, z.ZodType<any>> = {
   UpdateTextContent,
   UpdateTextTranslation,
   CreateOrUpdateTextTranslationRequest,
+  ModerationStatus,
+  PolisStatementAux,
+  CreatePolisStatementAux,
+  UpdatePolisStatementAux,
+  ThemeStatistic,
   Story,
   ComhairleMessageReference,
   ComhairleSessionMessage,
@@ -3715,6 +3775,76 @@ Use a raw HTTP request and process the response body incrementally.
       },
     ],
     response: z.void(),
+  },
+  {
+    method: "get",
+    path: "/tools/polis/statement_aux",
+    alias: "PolisListStatementAux",
+    description: `Returns auxiliary statement data filtered by workflow_step_id and/or polis_conversation_id (at least one is required)`,
+    requestFormat: "json",
+    parameters: [
+      {
+        name: "polis_conversation_id",
+        type: "Query",
+        schema: created_after,
+      },
+      {
+        name: "workflow_step_id",
+        type: "Query",
+        schema: created_after,
+      },
+    ],
+    response: z.array(PolisStatementAux),
+  },
+  {
+    method: "post",
+    path: "/tools/polis/statement_aux",
+    alias: "PolisCreateStatementAux",
+    description: `Creates a polis_statement_aux row capturing statement text, moderation status, themes and the visible statement at submission time`,
+    requestFormat: "json",
+    parameters: [
+      {
+        name: "body",
+        type: "Body",
+        schema: CreatePolisStatementAux,
+      },
+    ],
+    response: PolisStatementAux,
+  },
+  {
+    method: "put",
+    path: "/tools/polis/statement_aux/:id",
+    alias: "PolisUpdateStatementAux",
+    description: `Updates statement_text, moderation_status, themes, visible_statement_when_submitted, or moderation_reason`,
+    requestFormat: "json",
+    parameters: [
+      {
+        name: "body",
+        type: "Body",
+        schema: UpdatePolisStatementAux,
+      },
+    ],
+    response: PolisStatementAux,
+  },
+  {
+    method: "get",
+    path: "/tools/polis/statement_aux/theme_stats",
+    alias: "PolisStatementAuxThemeStats",
+    description: `Returns the count of polis_statement_aux rows tagged with each theme, filtered by workflow_step_id and/or polis_conversation_id (at least one is required)`,
+    requestFormat: "json",
+    parameters: [
+      {
+        name: "polis_conversation_id",
+        type: "Query",
+        schema: created_after,
+      },
+      {
+        name: "workflow_step_id",
+        type: "Query",
+        schema: created_after,
+      },
+    ],
+    response: z.array(ThemeStatistic),
   },
   {
     method: "get",

--- a/ui/packages/comhairle/src/lib/tools/polis/PolisApi.ts
+++ b/ui/packages/comhairle/src/lib/tools/polis/PolisApi.ts
@@ -122,43 +122,42 @@ export default class PolisApi {
 			});
 	}
 
-	submitStatement(statement: string) {
+	async submitStatement(statement: string): Promise<{ tid: number; pid: number } | null> {
 		this._loading = true;
 		this._error = undefined;
 		this.notify();
 
 		const authType = this._pid ? { pid: this._pid } : { xid: this.userId };
 
-		fetch(`${this.baseUrl}/api/v3/comments`, {
-			method: 'POST',
-			credentials: 'include',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify({
-				agid: 1,
-				conversation_id: this.polisId,
-				txt: statement,
-				vote: -1,
-				is_seed: false,
-				...authType
-			})
-		})
-			.then((r) => {
-				if (!r.ok) throw new Error(`submitStatement failed: ${r.status}`);
-				return r.json();
-			})
-			.then((data) => {
-				if (data.currentPid) {
-					this._pid = data.currentPid;
-				}
-			})
-			.catch((err) => {
-				console.error('[PolisApi] Error submitting statement:', err);
-				this._error = err.message;
-			})
-			.finally(() => {
-				this._loading = false;
-				this.notify();
+		try {
+			const r = await fetch(`${this.baseUrl}/api/v3/comments`, {
+				method: 'POST',
+				credentials: 'include',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					agid: 1,
+					conversation_id: this.polisId,
+					txt: statement,
+					vote: -1,
+					is_seed: false,
+					...authType
+				})
 			});
+			if (!r.ok) throw new Error(`submitStatement failed: ${r.status}`);
+			const data = await r.json();
+			if (typeof data.currentPid === 'number') {
+				this._pid = data.currentPid;
+			}
+			if (typeof data.tid !== 'number') return null;
+			return { tid: data.tid, pid: this._pid ?? 0 };
+		} catch (err) {
+			console.error('[PolisApi] Error submitting statement:', err);
+			this._error = err instanceof Error ? err.message : String(err);
+			return null;
+		} finally {
+			this._loading = false;
+			this.notify();
+		}
 	}
 
 	submitVote(vote: 'agree' | 'disagree' | 'pass') {

--- a/ui/packages/comhairle/src/lib/tools/polis/PolisEmbed.svelte
+++ b/ui/packages/comhairle/src/lib/tools/polis/PolisEmbed.svelte
@@ -16,6 +16,7 @@
 	import { getVoteData, incrementVotes, resetVoteCount } from './polisVoteStore';
 	import * as m from '$lib/paraglide/messages';
 	import Separator from '$lib/components/ui/separator/separator.svelte';
+	import { apiClient } from '@crownshy/api-client/client';
 
 	type Props = {
 		polis_id: string;
@@ -85,6 +86,28 @@
 	let opinionText = $state('');
 	let opinionSubmitted = $state(false);
 	let previousText = '';
+	let visibleStatementWhenOpened: PolisStatement | undefined = undefined;
+
+	async function createStatementAux(
+		newStatement: { tid: number; pid: number },
+		statementText: string,
+		visibleTid: number | undefined
+	) {
+		try {
+			await apiClient.PolisCreateStatementAux({
+				workflow_step_id: stepId,
+				zid: newStatement.pid,
+				polis_conversation_id: polis_id,
+				polis_statement_id: newStatement.tid,
+				statement_text: statementText,
+				is_seed: false,
+				themes: [],
+				visible_statement_when_submitted: visibleTid?.toString() ?? null
+			});
+		} catch (err) {
+			console.error('[PolisEmbed] Failed to create statement aux:', err);
+		}
+	}
 
 	const disabled = $derived(voteCooldown || waitingForNext);
 	const canContinue = $derived(hasMetThreshold);
@@ -144,25 +167,36 @@
 		screen = 'voting';
 	}
 
-	function handleSubmitOpinion() {
+	async function handleSubmitOpinion() {
 		if (!opinionText.trim()) return;
-		polis.submitStatement(opinionText.trim());
+		const text = opinionText.trim();
+		const visibleTid = visibleStatementWhenOpened?.tid;
 		opinionText = '';
 		opinionSubmitted = true;
 		setTimeout(() => {
 			screen = 'voting';
 			opinionSubmitted = false;
 		}, 2000);
+		const result = await polis.submitStatement(text);
+		if (result) {
+			await createStatementAux(result, text, visibleTid);
+		}
 	}
 
-	function handleSubmitAndAddAnother() {
+	async function handleSubmitAndAddAnother() {
 		if (!opinionText.trim()) return;
-		polis.submitStatement(opinionText.trim());
+		const text = opinionText.trim();
+		const visibleTid = visibleStatementWhenOpened?.tid;
 		opinionText = '';
 		opinionSubmitted = false;
+		const result = await polis.submitStatement(text);
+		if (result) {
+			await createStatementAux(result, text, visibleTid);
+		}
 	}
 
 	function openAddOpinion() {
+		visibleStatementWhenOpened = polisCurrentStatement;
 		screen = 'add-opinion';
 		opinionSubmitted = false;
 	}

--- a/ui/packages/comhairle/src/lib/tools/polis/PolisManage.svelte
+++ b/ui/packages/comhairle/src/lib/tools/polis/PolisManage.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { invalidateAll } from '$app/navigation';
+	import { LoadingButton } from '$lib/components/ui/button';
 	import Input from '$lib/components/ui/input/input.svelte';
 	import Label from '$lib/components/ui/label/label.svelte';
 	import Switch from '$lib/components/ui/switch/switch.svelte';
@@ -80,6 +81,30 @@
 		debouncedUpdateToolConfig(e, field);
 	}
 
+	let syncing = $state(false);
+
+	async function handleSyncStatementAux() {
+		syncing = true;
+		try {
+			const result = await apiClient.PolisSyncStatementAux({
+				workflow_step_id: workflowStepId
+			});
+			notifications.send({
+				priority: 'INFO',
+				message: `Synced ${result.synced} statements${result.skipped_invalid_xid ? ` (${result.skipped_invalid_xid} skipped)` : ''}`
+			});
+			await invalidateAll();
+		} catch (e) {
+			console.error(e);
+			notifications.send({
+				priority: 'ERROR',
+				message: 'Failed to sync statements from Polis'
+			});
+		} finally {
+			syncing = false;
+		}
+	}
+
 	async function handleToggleShowRemainingUpdate(checked: boolean, field: string) {
 		try {
 			await apiClient.UpdateConversationWorkflowStep(
@@ -141,6 +166,20 @@
 		</div>
 		<span class="mt-2 text-sm"
 			>Display the number of remaining statements to participants during voting</span
+		>
+	</div>
+
+	<div class="flex flex-col">
+		<Label class="text-lg font-semibold">Sync statements</Label>
+		<span class="mb-3 text-sm"
+			>Fetch the latest statements from Polis into the local statement table. Existing
+			moderation status, themes and notes are preserved.</span
+		>
+		<LoadingButton
+			loading={syncing}
+			onclick={handleSyncStatementAux}
+			class="w-fit"
+			variant="outline">Sync statements from Polis</LoadingButton
 		>
 	</div>
 </div>


### PR DESCRIPTION
This PR creates a new table and endpoints to save additional data associated with a polis comment. 

It  enables this on the custom polis front end by posting both to polis and the comhairle api when a new comment is added. 

It  also includes a sync endpoint that will synchronize the data in the a polis database with the new table so we can backport previous conversations (mostly for bloom)
