### PR TITLE
Create new permissions system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,7 +201,7 @@ dependencies = [
  "chrono",
  "futures",
  "log",
- "redis",
+ "redis 0.32.7",
  "serde",
  "thiserror 2.0.17",
  "tokio",
@@ -218,12 +218,18 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.9.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a07d1f37ff60921c83bdfc7407723bdefe89b44b98a9b772f225c8f9d67141a6"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
 dependencies = [
  "rustversion",
 ]
+
+[[package]]
+name = "arcstr"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03918c3dbd7701a85c6b9887732e2921175f26c350b4563841d0958c21d57e6d"
 
 [[package]]
 name = "argon2"
@@ -1544,6 +1550,7 @@ dependencies = [
  "ragflow",
  "rand 0.8.5",
  "rand_core 0.6.4",
+ "redis 1.2.3",
  "regex",
  "reqwest 0.12.28",
  "schemars 0.8.22",
@@ -5145,6 +5152,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "redis"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9fd510128eda94d1d49b9f81487744d5c451422431cce41238fe2853d29f4cc"
+dependencies = [
+ "arc-swap",
+ "arcstr",
+ "async-lock 3.4.2",
+ "backon",
+ "bytes",
+ "cfg-if",
+ "combine",
+ "futures-channel",
+ "futures-util",
+ "itoa",
+ "num-bigint",
+ "percent-encoding",
+ "pin-project-lite",
+ "ryu",
+ "sha1_smol",
+ "socket2 0.6.1",
+ "tokio",
+ "tokio-util",
+ "url",
+ "xxhash-rust",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7922,6 +7957,12 @@ name = "xmlparser"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "yaml-rust2"

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -153,6 +153,7 @@ sha2 = "0.11.0"
 hex = "0.4.3"
 base64 = "0.22.1"
 hmac = "0.13.0"
+redis = { version = "1.2.3", features = ["tokio-comp", "connection-manager", "aio"] }
 
 [dev-dependencies]
 fake = { version = "4", features = ["derive"] }

--- a/api/migrations/20260611124139_create_resource_permissions_table.sql
+++ b/api/migrations/20260611124139_create_resource_permissions_table.sql
@@ -1,0 +1,39 @@
+CREATE TABLE resource_permissions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    -- Exclusive arc relationship is enfoced by check constraint below.
+    -- NOTE: Not open for extension. Additional ID fields will require a new constraint.
+    user_id         UUID REFERENCES comhairle_user(id) ON DELETE CASCADE,
+    organization_id UUID REFERENCES organization(id)   ON DELETE CASCADE,
+
+    resource_id   UUID          NOT NULL,
+    resource_type VARCHAR(100)  NOT NULL,
+
+    role_name VARCHAR(50) NOT NULL,
+
+    granted_by  UUID REFERENCES comhairle_user(id) ON DELETE SET NULL,
+    grant_reason TEXT         NOT NULL,
+    granted_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT chk_grantee_exclusive CHECK (
+        (user_id IS NOT NULL AND organization_id IS NULL) OR
+        (user_id IS NULL    AND organization_id IS NOT NULL)
+    )
+);
+
+CREATE UNIQUE INDEX idx_unique_user_resource_role
+    ON resource_permissions (user_id, resource_id, resource_type, role_name)
+    WHERE user_id IS NOT NULL;
+
+CREATE UNIQUE INDEX idx_unique_org_resource_role
+    ON resource_permissions (organization_id, resource_id, resource_type, role_name)
+    WHERE organization_id IS NOT NULL;
+
+CREATE INDEX idx_resource_lookup
+    ON resource_permissions (resource_type, resource_id);
+
+CREATE INDEX idx_permissions_keyset
+    ON resource_permissions (granted_at DESC, id DESC);
+
+CREATE INDEX idx_permissions_resource_keyset
+    ON resource_permissions (resource_type, resource_id, granted_at DESC, id DESC);

--- a/api/src/config.rs
+++ b/api/src/config.rs
@@ -14,6 +14,7 @@ pub fn load() -> Result<ComhairleConfig, ComhairleError> {
             "jwt_secret",
             "ababa039cc54b5df83e8899c3c5839e096379d507263c732eb54c52477bf8087",
         )?
+        .set_default("redis_cache_ttl_secs", 300)?
         .set_default("domain", "http://localhost:5173")?
         .set_default("enable_rate_limiting", true)?
         .set_default("mailer.host", "")?
@@ -57,6 +58,8 @@ pub struct VideoCallConfig {
 #[derive(Clone, Debug, Deserialize)]
 pub struct ComhairleConfig {
     pub database_url: String,
+    pub redis_cache_url: Option<String>,
+    pub redis_cache_ttl_secs: u64,
     pub jwt_secret: String,
     pub resource_bucket: String,
     pub admin_users: Option<Vec<String>>,

--- a/api/src/error.rs
+++ b/api/src/error.rs
@@ -130,7 +130,7 @@ pub enum ComhairleError {
     #[error("Password does not meet security requirements: {0}")]
     WeakPassword(String),
 
-    #[error("User Required for this route")]
+    #[error("User required for this route")]
     UserRequired,
 
     #[error("Auth Error {0}")]
@@ -327,6 +327,15 @@ pub enum ComhairleError {
 
     #[error("Unsupported Content-Type: {0}")]
     UnsupportedContentType(String),
+
+    #[error("Role '{0}' is already granted on this resource")]
+    RoleAlreadyGranted(String),
+
+    #[error("Role '{0}' is not granted on this resource")]
+    RoleNotFound(String),
+
+    #[error("Cannot revoke the last system admin role")]
+    CannotRevokeLastAdmin,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]
@@ -348,7 +357,10 @@ impl IntoResponse for ComhairleError {
             | ComhairleError::DuplicateSlug(_)
             | ComhairleError::DuplicateRecordingName(_)
             | ComhairleError::UserAlreadyRegisteredForEvent(_)
-            | ComhairleError::UserAlreadyParticipatingInWorkflow(_) => StatusCode::CONFLICT,
+            | ComhairleError::UserAlreadyParticipatingInWorkflow(_)
+            | ComhairleError::RoleAlreadyGranted(_) => StatusCode::CONFLICT,
+            ComhairleError::RoleNotFound(_) => StatusCode::NOT_FOUND,
+            ComhairleError::CannotRevokeLastAdmin => StatusCode::FORBIDDEN,
             ComhairleError::ResourceNotFound(_)
             | ComhairleError::NoUserFound
             | ComhairleError::NoUserFoundForEmail(_)

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -8,8 +8,11 @@ pub mod error;
 pub mod mailer;
 mod middleware;
 pub mod models;
+pub mod redis_connection;
 mod routes;
 pub mod schema_helpers;
+#[cfg(test)]
+mod test_helpers;
 mod tools;
 pub mod transcription_service;
 pub mod translation_service;
@@ -17,45 +20,41 @@ pub mod websockets;
 pub mod wiki_poll_service;
 pub mod worker_service;
 
-use bot_service::ComhairleBotService;
-use clap::Parser;
-use docs::docs_routes;
-use mailer::ComhairleMailer;
-use routes::auth::AUTH_KEY;
-pub use routes::auth::hash_pw;
-use tokio::fs;
-use translation_service::TranslationService;
-use websockets::WebSocketService;
-
-#[cfg(test)]
-mod test_helpers;
-#[cfg(test)]
-// sqlx::test expands every migration into the test binary for every invocation.
-// So, it massively bloats both the binary size and compile time.
-// Using a common migrator for all tests avoids this issue.
-const SQLX_MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!();
-
-use std::sync::Arc;
-
+use aide::{axum::ApiRouter, openapi::OpenApi, transform::TransformOpenApi};
 use axum::{
     Extension, Router,
     extract::DefaultBodyLimit,
     http::{HeaderValue, Method, header},
 };
-
-use aide::{axum::ApiRouter, openapi::OpenApi, transform::TransformOpenApi};
-
+use bot_service::ComhairleBotService;
+use clap::Parser;
 use config::ComhairleConfig;
 use db::run_migrations;
+use docs::docs_routes;
 use error::ComhairleError;
+use mailer::ComhairleMailer;
+pub use routes::auth::hash_pw;
+use routes::auth::AUTH_KEY;
 use sqlx_postgres::PgPool;
+use std::sync::Arc;
+use tokio::fs;
 use tower_http::cors::CorsLayer;
+use translation_service::TranslationService;
+use websockets::WebSocketService;
 
-use crate::{
-    bulk_storage_service::BulkStorageService, categorization_service::CategorizationService,
-    routes::workflows::WorkflowRouterContext, transcription_service::Transcriber,
-    wiki_poll_service::WikiPollService, worker_service::WorkerService,
-};
+use crate::bulk_storage_service::BulkStorageService;
+use crate::categorization_service::CategorizationService;
+use crate::redis_connection::RedisConnection;
+use crate::routes::workflows::WorkflowRouterContext;
+use crate::transcription_service::Transcriber;
+use crate::wiki_poll_service::WikiPollService;
+use crate::worker_service::WorkerService;
+
+#[cfg(test)]
+// sqlx::test expands every migration into the test binary for every invocation.
+// So, it massively bloats both the binary size and compile time.
+// Using a common migrator for all tests avoids this issue.
+const SQLX_MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!();
 
 #[derive(Clone)]
 pub struct ComhairleState {
@@ -70,6 +69,7 @@ pub struct ComhairleState {
     pub transcription_service: Option<Arc<dyn Transcriber>>,
     pub worker_service: Option<Arc<dyn WorkerService>>,
     pub categorization_service: Option<Arc<dyn CategorizationService>>,
+    pub redis_conn: Option<Arc<dyn RedisConnection>>,
 }
 
 impl ComhairleState {
@@ -305,6 +305,7 @@ pub async fn setup_server(state: Arc<ComhairleState>) -> Result<Router<()>, Comh
             "/email_template_configs",
             routes::email_template_configs::router(state.clone()),
         )
+        .nest_api_service("/permissions", routes::permissions::router(state.clone()))
         .nest_api_service("/docs", docs_routes(state.clone()))
         .finish_api_with(&mut api, api_docs)
         .layer(Extension(Arc::new(api.clone()))) // Arc is very important here or you will face massive memory and performance issues

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -1,4 +1,5 @@
 use aws_config::BehaviorVersion;
+use comhairle::redis_connection::RedisImpl;
 use comhairle::{
     ComhairleState,
     bot_service::{ComhairleBotService, ComhairleRagBotService},
@@ -14,6 +15,7 @@ use comhairle::{
     wiki_poll_service::polis_service::PolisClient,
     worker_service::{init_monitor, init_worker_service},
 };
+use redis::aio::ConnectionManagerConfig;
 use std::{error::Error, sync::Arc};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
@@ -109,6 +111,34 @@ async fn main() -> Result<(), Box<dyn Error>> {
             as Arc<dyn CategorizationService>
     });
 
+    // Setup Redis connection for permissions cache
+    let redis_conn = if let Some(ref redis_url) = config.redis_cache_url {
+        match redis::Client::open(redis_url.as_str()) {
+            Ok(client) => {
+                let timeout = std::time::Duration::from_secs(5);
+                let config =
+                    ConnectionManagerConfig::default().set_connection_timeout(Some(timeout));
+                match client.get_connection_manager_lazy(config) {
+                    Ok(manager) => {
+                        tracing::info!("Redis permissions cache connected");
+                        Some(Arc::new(RedisImpl::new(manager))
+                            as Arc<dyn comhairle::redis_connection::RedisConnection>)
+                    }
+                    Err(e) => {
+                        tracing::warn!("Redis permissions cache unavailable: {e}");
+                        None
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::warn!("Invalid Redis URL for permissions cache: {e}");
+                None
+            }
+        }
+    } else {
+        None
+    };
+
     let state = Arc::new(ComhairleState {
         db,
         mailer,
@@ -121,6 +151,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         worker_service,
         bulk_storage_service,
         categorization_service,
+        redis_conn,
     });
 
     // Register WebSocket message handlers

--- a/api/src/models.rs
+++ b/api/src/models.rs
@@ -18,6 +18,7 @@ pub mod notification_delivery;
 pub mod organization;
 pub mod otp;
 pub mod pagination;
+pub mod permissions;
 pub mod polis_statement_aux;
 pub mod proposal;
 pub mod proposal_response;

--- a/api/src/models/model_test_helpers.rs
+++ b/api/src/models/model_test_helpers.rs
@@ -1,17 +1,18 @@
 use std::{error::Error, sync::Arc};
 
-use crate::{
-    routes::{
-        conversations::dto::ConversationDto, user::dto::UserDto, workflows::dto::WorkflowDto,
-    },
-    setup_server,
-    test_helpers::{UserSession, test_state},
-};
+use crate::models::users::{update_user, UpdateUserRequest};
+use crate::routes::conversations::dto::ConversationDto;
+use crate::routes::organizations::dto::OrganizationDto;
+use crate::routes::user::dto::UserDto;
+use crate::routes::workflows::dto::WorkflowDto;
+use crate::setup_server;
+use crate::test_helpers::{test_state, UserSession};
 
 use axum::Router;
 use sqlx::PgPool;
 use uuid::Uuid;
 
+/// Sets up a default app `Router` and `UserSession` for testing.
 pub async fn setup_default_app_and_session(
     pool: &PgPool,
 ) -> Result<(Router, UserSession), Box<dyn Error>> {
@@ -24,6 +25,7 @@ pub async fn setup_default_app_and_session(
     Ok((app, session))
 }
 
+/// Creates a new workflow with a random name and returns the ID.
 pub async fn get_random_workflow_id(
     app: &Router,
     session: &mut UserSession,
@@ -38,6 +40,7 @@ pub async fn get_random_workflow_id(
     Ok(workflow.id)
 }
 
+/// Creates a new conversation with a random name and returns the ID.
 pub async fn get_random_conversation_id(
     app: &Router,
     session: &mut UserSession,
@@ -48,6 +51,7 @@ pub async fn get_random_conversation_id(
     Ok(conversation.id)
 }
 
+/// Creates a new anonymous user and returns the ID.
 pub async fn get_random_user_id(
     app: &Router,
     session: &mut UserSession,
@@ -56,4 +60,34 @@ pub async fn get_random_user_id(
     let user: UserDto = serde_json::from_value(serde_json::to_value(response)?)?;
 
     Ok(user.id)
+}
+
+/// Creates a new organization and returns the ID.
+pub async fn get_random_organization_id(
+    app: &Router,
+    session: &mut UserSession,
+) -> Result<Uuid, Box<dyn Error>> {
+    let (_, response, _) = session.create_random_organization(app).await?;
+    eprintln!("Organization creation response: {:?}", response);
+    let organization: OrganizationDto = serde_json::from_value(response)?;
+
+    Ok(organization.id)
+}
+
+/// Adds a user to an organization by updating the user's organization_id field.
+pub async fn add_user_to_organization(
+    user_id: Uuid,
+    organization_id: Uuid,
+    db: &PgPool,
+) -> Result<(), Box<dyn Error>> {
+    update_user(
+        &user_id,
+        &UpdateUserRequest {
+            organization_id: Some(organization_id),
+            ..Default::default()
+        },
+        db,
+    )
+    .await?;
+    Ok(())
 }

--- a/api/src/models/pagination.rs
+++ b/api/src/models/pagination.rs
@@ -47,7 +47,7 @@ where
     }
 }
 
-#[derive(Deserialize, Debug, Serialize, JsonSchema, Clone)]
+#[derive(Deserialize, Debug, Default, Serialize, JsonSchema, Clone)]
 pub struct PageOptions {
     pub offset: Option<u64>,
     pub limit: Option<u64>,

--- a/api/src/models/permissions.rs
+++ b/api/src/models/permissions.rs
@@ -1,0 +1,1180 @@
+use std::sync::Arc;
+
+use crate::redis_connection::RedisConnection;
+use axum::extract::FromRequestParts;
+use chrono::{DateTime, Utc};
+use schemars::JsonSchema;
+use sea_query::IdenStatic;
+use sea_query::{enum_def, Expr, OnConflict, PostgresQueryBuilder, Query};
+use sea_query_binder::SqlxBinder;
+use serde::{Deserialize, Serialize};
+use sqlx::prelude::FromRow;
+use sqlx::Row;
+use uuid::Uuid;
+
+use crate::error::ComhairleError;
+use crate::models::pagination::{PageOptions, PaginatedResults};
+use crate::ComhairleState;
+
+/// Represents the system administrator role.
+#[derive(Debug)]
+pub struct SystemAdminRole;
+
+impl NamedRole for SystemAdminRole {
+    fn name() -> &'static str {
+        "admin"
+    }
+}
+
+impl SystemResourceRole for SystemAdminRole {}
+
+/// Represents the system resource, which is a global resource used for system-level permissions.
+#[derive(Debug)]
+pub struct SystemResource;
+
+impl FromRequestParts<Arc<ComhairleState>> for SystemResource {
+    type Rejection = ComhairleError;
+
+    async fn from_request_parts(
+        _parts: &mut axum::http::request::Parts,
+        _state: &Arc<ComhairleState>,
+    ) -> Result<Self, Self::Rejection> {
+        Ok(SystemResource)
+    }
+}
+
+/// A trait for extracting a resource ID from a request.
+pub trait ExtractResourceId: FromRequestParts<Arc<ComhairleState>> + 'static + Send + Sync {
+    fn resource_id(&self) -> Uuid;
+}
+
+impl ExtractResourceId for SystemResource {
+    fn resource_id(&self) -> Uuid {
+        SYSTEM_RESOURCE_ID
+    }
+}
+
+/// The triplet associated with a permission for a resource.
+#[derive(Debug)]
+pub struct PermissionTriplet<'a>(
+    pub &'a str,  // resource_type
+    pub &'a Uuid, // resource_id
+    pub &'a str,  // role_name
+);
+
+/// A trait for roles that have a name, used for permission checks.
+pub trait NamedRole: Send + Sync {
+    /// Returns the name of the role as a static string.
+    fn name() -> &'static str;
+}
+
+/// The resource type associated with system-level permissions.
+pub const SYSTEM_RESOURCE_TYPE: &str = "system";
+/// The global system resource uses a fixed ID as a workaround to avoid having a
+/// separate table for system-level permissions.
+pub const SYSTEM_RESOURCE_ID: Uuid = Uuid::nil();
+
+/// Represents a role that can be assigned to a user or organization on the global
+/// system resource.
+pub trait SystemResourceRole: NamedRole {
+    /// Returns a `PermissionTriplet` for the global system resource.
+    fn make_system_triplet() -> PermissionTriplet<'static> {
+        PermissionTriplet(SYSTEM_RESOURCE_TYPE, &SYSTEM_RESOURCE_ID, Self::name())
+    }
+}
+
+/// Represents a role that can be assigned to a user or organization on a specific
+/// resource.
+pub trait ResourceRole: NamedRole {
+    /// Returns a `PermissionTriplet` for the given resource ID, combining the
+    /// resource type, resource ID, and role name.
+    fn make_triplet<'a>(resource_id: &'a Uuid) -> PermissionTriplet<'a> {
+        PermissionTriplet(Self::resource_type(), resource_id, Self::name())
+    }
+
+    /// Returns the resource type associated with the role.
+    fn resource_type() -> &'static str;
+}
+
+// Automatically implement `ResourceRole` for any type that implements `SystemResourceRole`.
+impl<SystemRole: SystemResourceRole> ResourceRole for SystemRole {
+    fn resource_type() -> &'static str {
+        SYSTEM_RESOURCE_TYPE
+    }
+}
+
+/// Represents a role assignment for a user or organization on a specific resource.
+#[derive(Debug, Deserialize, Serialize, FromRow, Clone, JsonSchema)]
+#[enum_def(table_name = "resource_permissions")]
+pub struct ResourcePermission {
+    pub id: Uuid,
+    pub user_id: Option<Uuid>,
+    pub organization_id: Option<Uuid>,
+    pub resource_id: Uuid,
+    pub resource_type: String,
+    pub role_name: String,
+    pub granted_by: Option<Uuid>,
+    pub grant_reason: String,
+    pub granted_at: DateTime<Utc>,
+}
+
+const DEFAULT_COLUMNS: [ResourcePermissionIden; 9] = [
+    ResourcePermissionIden::Id,
+    ResourcePermissionIden::UserId,
+    ResourcePermissionIden::OrganizationId,
+    ResourcePermissionIden::ResourceId,
+    ResourcePermissionIden::ResourceType,
+    ResourcePermissionIden::RoleName,
+    ResourcePermissionIden::GrantedBy,
+    ResourcePermissionIden::GrantReason,
+    ResourcePermissionIden::GrantedAt,
+];
+
+/// Represents either a user or an organization for role assignment purposes.
+#[derive(Debug)]
+pub enum UserOrOrganizationId<'request> {
+    User(&'request Uuid),
+    Org(&'request Uuid),
+}
+
+/// Request struct for granting a role to a user or organization on a resource.
+#[derive(Debug)]
+pub struct GrantRoleRequest<'request> {
+    pub actor_id: UserOrOrganizationId<'request>,
+    pub granted_by: &'request Uuid,
+    pub grant_reason: &'request str,
+    pub permission_triplet: PermissionTriplet<'request>,
+}
+
+/// Request struct for revoking a role from a user or organization on a resource.
+#[derive(Debug)]
+pub struct RevokeRoleRequest<'request> {
+    pub actor_id: UserOrOrganizationId<'request>,
+    pub permission_triplet: PermissionTriplet<'request>,
+}
+
+/// Generates a cache key for storing permission checks in Redis.
+fn permission_cache_key(
+    permission_triplet: &PermissionTriplet<'_>,
+    actor_id: &UserOrOrganizationId<'_>,
+) -> String {
+    let PermissionTriplet(resource_type, resource_id, role_name) = *permission_triplet;
+    match *actor_id {
+        UserOrOrganizationId::User(user_id) => {
+            format!("perm:v1:{resource_type}:{resource_id}:{role_name}:user:{user_id}")
+        }
+        UserOrOrganizationId::Org(org_id) => {
+            format!("perm:v1:{resource_type}:{resource_id}:{role_name}:org:{org_id}")
+        }
+    }
+}
+
+/// Checks the Redis cache for a permission check result.
+async fn cache_get(
+    conn: &dyn RedisConnection,
+    user_key: &str,
+    org_key: Option<&str>,
+) -> Option<bool> {
+    let mut keys = vec![user_key];
+    if let Some(k) = org_key {
+        keys.push(k);
+    }
+    let results = match conn.get_multi(&keys).await {
+        Ok(v) => v,
+        Err(_) => return None,
+    };
+    let user_result = results.first().cloned().flatten();
+    let org_result = if results.len() > 1 {
+        results.get(1).cloned().flatten()
+    } else {
+        None
+    };
+
+    match (user_result.as_deref(), org_result.as_deref()) {
+        (Some("1"), _) | (_, Some("1")) => Some(true),
+        (None, None) => None,
+        _ => Some(false),
+    }
+}
+
+/// Sets a permission check result in the Redis cache.
+async fn cache_set(conn: &dyn RedisConnection, key: &str, value: bool, ttl_secs: u64) {
+    let val = if value { "1" } else { "0" };
+    let _ = conn.set_ex(key, val, ttl_secs).await;
+}
+
+/// Deletes a permission check result from the Redis cache.
+async fn cache_delete(conn: &dyn RedisConnection, key: &str) {
+    let _ = conn.del(key).await;
+}
+
+/// Grants a role to a user or organization on a specific resource.
+///
+/// # Errors
+///
+/// * Returns [`ComhairleError::RoleAlreadyGranted`] if the role is already
+/// assigned.
+/// * Returns [`ComhairleError::DatabaseError`] if there is an error interacting
+/// with the database.
+pub async fn grant_role(
+    state: &Arc<ComhairleState>,
+    request: GrantRoleRequest<'_>,
+) -> Result<ResourcePermission, ComhairleError> {
+    let (user_id, organization_id) = match request.actor_id {
+        UserOrOrganizationId::User(user_id) => (Some(*user_id), None),
+        UserOrOrganizationId::Org(org_id) => (None, Some(*org_id)),
+    };
+
+    let PermissionTriplet(resource_type, resource_id, role_name) = request.permission_triplet;
+
+    let mut query = Query::insert();
+    query
+        .into_table(ResourcePermissionIden::Table)
+        .columns([
+            ResourcePermissionIden::UserId,
+            ResourcePermissionIden::OrganizationId,
+            ResourcePermissionIden::ResourceId,
+            ResourcePermissionIden::ResourceType,
+            ResourcePermissionIden::RoleName,
+            ResourcePermissionIden::GrantedBy,
+            ResourcePermissionIden::GrantReason,
+        ])
+        .values_panic([
+            user_id.into(),
+            organization_id.into(),
+            (*resource_id).into(),
+            resource_type.into(),
+            role_name.into(),
+            (*request.granted_by).into(),
+            request.grant_reason.to_owned().into(),
+        ])
+        .on_conflict(OnConflict::new().do_nothing().to_owned())
+        .returning(Query::returning().columns(DEFAULT_COLUMNS));
+
+    let (sql, values) = query.build_sqlx(PostgresQueryBuilder);
+
+    let response = sqlx::query_as_with::<_, ResourcePermission, _>(&sql, values)
+        .fetch_optional(&state.db)
+        .await
+        .map_err(ComhairleError::DatabaseError)?;
+
+    let permission =
+        response.ok_or_else(|| ComhairleError::RoleAlreadyGranted(role_name.to_string()))?;
+
+    if let Some(conn) = &state.redis_conn {
+        let key = permission_cache_key(&request.permission_triplet, &request.actor_id);
+        cache_delete(conn.as_ref(), &key).await;
+    }
+
+    Ok(permission)
+}
+
+/// Revokes a role from a user or organization on a specific resource.
+///
+/// # Errors
+///
+/// * Returns [`ComhairleError::RoleNotFound`] if the role was not previously
+/// granted.
+/// * Returns [`ComhairleError::DatabaseError`] if there is an error interactin
+/// with the database.
+pub async fn revoke_role(
+    state: &Arc<ComhairleState>,
+    request: RevokeRoleRequest<'_>,
+) -> Result<(), ComhairleError> {
+    let PermissionTriplet(resource_type, resource_id, role_name) = request.permission_triplet;
+
+    let mut tx = state
+        .db
+        .begin()
+        .await
+        .map_err(ComhairleError::DatabaseError)?;
+
+    if resource_type == SYSTEM_RESOURCE_TYPE && role_name == "admin" {
+        let mut count_query = Query::select();
+        count_query
+            .expr(sea_query::Expr::cust("count(*)"))
+            .from(ResourcePermissionIden::Table)
+            .and_where(Expr::col(ResourcePermissionIden::ResourceType).eq(SYSTEM_RESOURCE_TYPE))
+            .and_where(Expr::col(ResourcePermissionIden::RoleName).eq("admin"));
+
+        let (sql, values) = count_query.build_sqlx(PostgresQueryBuilder);
+
+        let count: i64 = sqlx::query_scalar_with(&sql, values)
+            .fetch_one(&mut *tx)
+            .await
+            .map_err(ComhairleError::DatabaseError)?;
+
+        if count <= 1 {
+            return Err(ComhairleError::CannotRevokeLastAdmin);
+        }
+    }
+
+    let mut query = Query::delete();
+    query
+        .from_table(ResourcePermissionIden::Table)
+        .and_where(Expr::col(ResourcePermissionIden::ResourceId).eq(*resource_id))
+        .and_where(Expr::col(ResourcePermissionIden::ResourceType).eq(resource_type))
+        .and_where(Expr::col(ResourcePermissionIden::RoleName).eq(role_name));
+
+    match request.actor_id {
+        UserOrOrganizationId::User(user_id) => {
+            query.and_where(Expr::col(ResourcePermissionIden::UserId).eq(*user_id));
+        }
+        UserOrOrganizationId::Org(org_id) => {
+            query.and_where(Expr::col(ResourcePermissionIden::OrganizationId).eq(*org_id));
+        }
+    };
+
+    let (sql, values) = query.build_sqlx(PostgresQueryBuilder);
+
+    let response = sqlx::query_with(&sql, values)
+        .execute(&mut *tx)
+        .await
+        .map_err(ComhairleError::DatabaseError)?;
+
+    if response.rows_affected() == 0 {
+        return Err(ComhairleError::RoleNotFound(role_name.to_string()));
+    }
+
+    tx.commit().await.map_err(ComhairleError::DatabaseError)?;
+
+    if let Some(conn) = &state.redis_conn {
+        let key = permission_cache_key(&request.permission_triplet, &request.actor_id);
+        cache_delete(conn.as_ref(), &key).await;
+    }
+
+    Ok(())
+}
+
+/// Filters for listing permissions, allowing optional filtering and pagination
+/// via `page_options`.
+#[derive(Debug, Default)]
+pub struct ListPermissionsFilters<'request> {
+    pub resource_type: Option<&'request str>,
+    pub resource_id: Option<&'request Uuid>,
+    pub actor: Option<UserOrOrganizationId<'request>>,
+    pub role_name: Option<&'request str>,
+    pub page_options: PageOptions,
+}
+
+/// Lists permissions using optional page-based pagination, with optional
+/// filtering by resource, actor (user or organization), and role name.
+///
+/// # Errors
+///
+/// Returns [`ComhairleError::DatabaseError`] if there is an error querying the database.
+pub async fn list_permissions(
+    state: &Arc<ComhairleState>,
+    request: ListPermissionsFilters<'_>,
+) -> Result<PaginatedResults<ResourcePermission>, ComhairleError> {
+    let mut query = Query::select();
+    query
+        .from(ResourcePermissionIden::Table)
+        .columns(DEFAULT_COLUMNS);
+
+    if let Some(resource_type) = request.resource_type {
+        query.and_where(Expr::col(ResourcePermissionIden::ResourceType).eq(resource_type));
+    }
+    if let Some(resource_id) = request.resource_id {
+        query.and_where(Expr::col(ResourcePermissionIden::ResourceId).eq(*resource_id));
+    }
+
+    match request.actor {
+        Some(UserOrOrganizationId::User(user_id)) => {
+            query.and_where(Expr::col(ResourcePermissionIden::UserId).eq(*user_id));
+        }
+        Some(UserOrOrganizationId::Org(org_id)) => {
+            query.and_where(Expr::col(ResourcePermissionIden::OrganizationId).eq(*org_id));
+        }
+        None => {}
+    }
+
+    if let Some(role_name) = request.role_name {
+        query.and_where(Expr::col(ResourcePermissionIden::RoleName).eq(role_name));
+    }
+
+    request
+        .page_options
+        .fetch_paginated_results(&state.db, query)
+        .await
+        .map_err(ComhairleError::DatabaseError)
+}
+
+/// Check whether a user, or their organization, has a specific role on a resource.
+pub async fn has_resource_permission(
+    state: &Arc<ComhairleState>,
+    permission_triplet: PermissionTriplet<'_>,
+    user_id: &Uuid,
+    organization_id: Option<&Uuid>,
+) -> Result<bool, ComhairleError> {
+    let redis_conn = state.redis_conn.clone();
+    if let Some(ref conn) = redis_conn {
+        let key = permission_cache_key(&permission_triplet, &UserOrOrganizationId::User(user_id));
+        let org_key = organization_id.map(|org_id| {
+            permission_cache_key(&permission_triplet, &UserOrOrganizationId::Org(org_id))
+        });
+        if let Some(cached) = cache_get(conn.as_ref(), &key, org_key.as_deref()).await {
+            return Ok(cached);
+        }
+    }
+
+    let PermissionTriplet(resource_type, resource_id, role_name) = permission_triplet;
+
+    let mut query = Query::select();
+    query
+        .expr(Expr::val(1))
+        .from(ResourcePermissionIden::Table)
+        .and_where(Expr::col(ResourcePermissionIden::ResourceId).eq(*resource_id))
+        .and_where(Expr::col(ResourcePermissionIden::ResourceType).eq(resource_type))
+        .and_where(Expr::col(ResourcePermissionIden::RoleName).eq(role_name))
+        .limit(1);
+
+    match organization_id {
+        Some(organization_id) => {
+            query.and_where(
+                Expr::col(ResourcePermissionIden::UserId)
+                    .eq(*user_id)
+                    .or(Expr::col(ResourcePermissionIden::OrganizationId).eq(*organization_id)),
+            );
+        }
+        None => {
+            query.and_where(Expr::col(ResourcePermissionIden::UserId).eq(*user_id));
+        }
+    }
+
+    let (sql, values) = query.build_sqlx(PostgresQueryBuilder);
+
+    let response = sqlx::query_with(&sql, values)
+        .fetch_optional(&state.db)
+        .await
+        .map_err(ComhairleError::DatabaseError)?;
+
+    let result = response.is_some();
+
+    if let Some(ref conn) = redis_conn {
+        // If organization_id is not None and the returned PgRow has a populated organization_id, cache the result for the organization only.
+        // Otherwise, cache the result for the user only.
+        let is_user = if organization_id.is_some() {
+            match response {
+                Some(row) => {
+                    let org_id_in_row: Option<Uuid> = row
+                        .try_get(ResourcePermissionIden::OrganizationId.as_str())
+                        .unwrap_or(None);
+                    org_id_in_row.is_none()
+                }
+                None => true,
+            }
+        } else {
+            true
+        };
+        let key = if is_user {
+            permission_cache_key(&permission_triplet, &UserOrOrganizationId::User(user_id))
+        } else {
+            permission_cache_key(
+                &permission_triplet,
+                &UserOrOrganizationId::Org(organization_id.unwrap()),
+            )
+        };
+        cache_set(conn.as_ref(), &key, result, state.config.redis_cache_ttl_secs).await;
+    }
+
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::ComhairleError;
+    use crate::models::model_test_helpers::{
+        get_random_organization_id, get_random_user_id, setup_default_app_and_session,
+    };
+    use crate::redis_connection::{MockRedis, RedisConnection};
+    use crate::test_helpers::test_state;
+
+    use sqlx::PgPool;
+
+    const TEST_RESOURCE_TYPE: &str = "test_resource_type";
+    const TEST_ROLE_NAME: &str = "tester";
+    const OTHER_ROLE_NAME: &str = "other_role";
+    struct TestRole;
+
+    impl NamedRole for TestRole {
+        fn name() -> &'static str {
+            TEST_ROLE_NAME
+        }
+    }
+
+    impl ResourceRole for TestRole {
+        fn resource_type() -> &'static str {
+            TEST_RESOURCE_TYPE
+        }
+    }
+
+    struct OtherRole;
+
+    impl NamedRole for OtherRole {
+        fn name() -> &'static str {
+            OTHER_ROLE_NAME
+        }
+    }
+
+    impl ResourceRole for OtherRole {
+        fn resource_type() -> &'static str {
+            TEST_RESOURCE_TYPE
+        }
+    }
+
+    #[sqlx::test]
+    async fn test_grant_and_check_user_role(
+        pool: PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let state = Arc::new(test_state().db(pool).call()?);
+        let (app, mut session) = setup_default_app_and_session(&state.db).await?;
+
+        // Create test user and organization
+        let user_id = get_random_user_id(&app, &mut session).await?;
+
+        // Mock conversation
+        let resource_id = Uuid::new_v4();
+
+        // Grant a role to the user
+        let grant_request = GrantRoleRequest {
+            actor_id: UserOrOrganizationId::User(&user_id),
+            permission_triplet: TestRole::make_triplet(&resource_id),
+            granted_by: &session.id.unwrap(),
+            grant_reason: "Testing",
+        };
+
+        let assignment = grant_role(&state, grant_request).await?;
+        assert_eq!(assignment.user_id, Some(user_id));
+        assert_eq!(assignment.organization_id, None);
+        assert_eq!(assignment.resource_type, TestRole::resource_type());
+        assert_eq!(assignment.role_name, TestRole::name());
+
+        // Check that the user has the role
+        let has_permission =
+            has_resource_permission(&state, TestRole::make_triplet(&resource_id), &user_id, None)
+                .await?;
+        assert!(has_permission);
+
+        // Check that the user does not have a different role
+        let has_wrong_permission = has_resource_permission(
+            &state,
+            OtherRole::make_triplet(&resource_id),
+            &user_id,
+            None,
+        )
+        .await?;
+        assert!(!has_wrong_permission);
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn test_grant_and_check_organization_role(
+        pool: PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let state = Arc::new(test_state().db(pool).call()?);
+
+        let (app, mut session) = setup_default_app_and_session(&state.db).await?;
+
+        assert!(
+            session.id.is_some(),
+            "Session should have a user ID after signup"
+        );
+        let user_id = session.id.unwrap();
+
+        // Create test organization and user
+        let org_id = get_random_organization_id(&app, &mut session).await?;
+
+        // Mock conversation
+        let resource_id = Uuid::new_v4();
+
+        // Grant a role to the organization
+        let grant_request = GrantRoleRequest {
+            actor_id: UserOrOrganizationId::Org(&org_id),
+            permission_triplet: TestRole::make_triplet(&resource_id),
+            granted_by: &session.id.unwrap(),
+            grant_reason: "Testing",
+        };
+
+        let assignment = grant_role(&state, grant_request).await?;
+        assert_eq!(assignment.user_id, None);
+        assert_eq!(assignment.organization_id, Some(org_id));
+        assert_eq!(assignment.resource_type, TestRole::resource_type());
+        assert_eq!(assignment.role_name, TestRole::name());
+
+        // Check that the user has the role through the organization
+        let has_permission = has_resource_permission(
+            &state,
+            TestRole::make_triplet(&resource_id),
+            &user_id,
+            Some(&org_id),
+        )
+        .await?;
+        assert!(has_permission);
+
+        // Check that the user does not have a different role
+        let has_wrong_permission = has_resource_permission(
+            &state,
+            OtherRole::make_triplet(&resource_id),
+            &user_id,
+            Some(&org_id),
+        )
+        .await?;
+        assert!(!has_wrong_permission);
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn test_unauthorized_access(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
+        let state = Arc::new(test_state().db(pool).call()?);
+        let (app, mut session) = setup_default_app_and_session(&state.db).await?;
+
+        // Create test user and organization
+        let organization_id = get_random_organization_id(&app, &mut session).await?;
+        let user_id = get_random_user_id(&app, &mut session).await?;
+
+        // Mock conversation
+        let resource_id = Uuid::new_v4();
+
+        // Check that the user does not have any roles on a random resource
+        let has_permission =
+            has_resource_permission(&state, TestRole::make_triplet(&resource_id), &user_id, None)
+                .await?;
+        assert!(!has_permission);
+
+        // Check that the user does not have any roles through the organization
+        let has_org_permission = has_resource_permission(
+            &state,
+            TestRole::make_triplet(&resource_id),
+            &user_id,
+            Some(&organization_id),
+        )
+        .await?;
+        assert!(!has_org_permission);
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn test_grant_role_already_granted(
+        pool: PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let state = Arc::new(test_state().db(pool).call()?);
+        let (app, mut session) = setup_default_app_and_session(&state.db).await?;
+
+        let user_id = get_random_user_id(&app, &mut session).await?;
+        let resource_id = Uuid::new_v4();
+
+        // Grant the role for the first time.
+        grant_role(
+            &state,
+            GrantRoleRequest {
+                actor_id: UserOrOrganizationId::User(&user_id),
+                permission_triplet: TestRole::make_triplet(&resource_id),
+                granted_by: &session.id.unwrap(),
+                grant_reason: "Testing",
+            },
+        )
+        .await?;
+
+        // Granting the same role again should return RoleAlreadyGranted.
+        let err = grant_role(
+            &state,
+            GrantRoleRequest {
+                actor_id: UserOrOrganizationId::User(&user_id),
+                permission_triplet: TestRole::make_triplet(&resource_id),
+                granted_by: &session.id.unwrap(),
+                grant_reason: "Testing",
+            },
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            matches!(err, ComhairleError::RoleAlreadyGranted(_)),
+            "Expected RoleAlreadyGranted, got {err:?}"
+        );
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn test_revoke_user_role(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
+        let state = Arc::new(test_state().db(pool).call()?);
+        let (app, mut session) = setup_default_app_and_session(&state.db).await?;
+
+        let user_id = get_random_user_id(&app, &mut session).await?;
+        let resource_id = Uuid::new_v4();
+
+        // Grant the role first.
+        grant_role(
+            &state,
+            GrantRoleRequest {
+                actor_id: UserOrOrganizationId::User(&user_id),
+                permission_triplet: TestRole::make_triplet(&resource_id),
+                granted_by: &session.id.unwrap(),
+                grant_reason: "Testing",
+            },
+        )
+        .await?;
+
+        // Confirm permission is granted.
+        assert!(
+            has_resource_permission(&state, TestRole::make_triplet(&resource_id), &user_id, None,)
+                .await?
+        );
+
+        // Revoke the role.
+        revoke_role(
+            &state,
+            RevokeRoleRequest {
+                actor_id: UserOrOrganizationId::User(&user_id),
+                permission_triplet: TestRole::make_triplet(&resource_id),
+            },
+        )
+        .await?;
+
+        // Confirm permission no longer granted.
+        assert!(
+            !has_resource_permission(&state, TestRole::make_triplet(&resource_id), &user_id, None,)
+                .await?
+        );
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn test_revoke_last_admin_fails(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
+        let state = Arc::new(test_state().db(pool).call()?);
+        let (app, mut session) = setup_default_app_and_session(&state.db).await?;
+
+        let (_, user, _) = session.current_user(&app).await?;
+
+        // Attempt to revoke the admin role, which should be the only one
+        let result = revoke_role(
+            &state,
+            RevokeRoleRequest {
+                actor_id: UserOrOrganizationId::User(&user.id),
+                permission_triplet: SystemAdminRole::make_system_triplet(),
+            },
+        )
+        .await;
+
+        assert!(
+            matches!(result, Err(ComhairleError::CannotRevokeLastAdmin)),
+            "Expected CannotRevokeLastAdmin, got {result:?}"
+        );
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn test_revoke_role_not_found(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
+        let state = Arc::new(test_state().db(pool).call()?);
+        let (app, mut session) = setup_default_app_and_session(&state.db).await?;
+
+        let user_id = get_random_user_id(&app, &mut session).await?;
+        let resource_id = Uuid::new_v4();
+
+        // Revoking a role that was never granted should return RoleNotFound.
+        let err = revoke_role(
+            &state,
+            RevokeRoleRequest {
+                actor_id: UserOrOrganizationId::User(&user_id),
+                permission_triplet: TestRole::make_triplet(&resource_id),
+            },
+        )
+        .await
+        .unwrap_err();
+
+        assert!(
+            matches!(err, ComhairleError::RoleNotFound(_)),
+            "Expected RoleNotFound, got {err:?}"
+        );
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn test_list_permissions(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
+        let state = Arc::new(test_state().db(pool).call()?);
+        let (app, mut session) = setup_default_app_and_session(&state.db).await?;
+
+        let org_id = get_random_organization_id(&app, &mut session).await?;
+        let user_id = get_random_user_id(&app, &mut session).await?;
+        let resource_1_id = Uuid::new_v4();
+        let resource_2_id = Uuid::new_v4();
+
+        // Grant roles to both user and organization
+        grant_role(
+            &state,
+            GrantRoleRequest {
+                actor_id: UserOrOrganizationId::User(&user_id),
+                permission_triplet: TestRole::make_triplet(&resource_1_id),
+                granted_by: &session.id.unwrap(),
+                grant_reason: "Testing",
+            },
+        )
+        .await?;
+
+        grant_role(
+            &state,
+            GrantRoleRequest {
+                actor_id: UserOrOrganizationId::Org(&org_id),
+                permission_triplet: OtherRole::make_triplet(&resource_1_id),
+                granted_by: &session.id.unwrap(),
+                grant_reason: "Testing",
+            },
+        )
+        .await?;
+
+        grant_role(
+            &state,
+            GrantRoleRequest {
+                actor_id: UserOrOrganizationId::User(&user_id),
+                permission_triplet: OtherRole::make_triplet(&resource_2_id),
+                granted_by: &session.id.unwrap(),
+                grant_reason: "Testing",
+            },
+        )
+        .await?;
+
+        // List all permissions without filters
+        let request = ListPermissionsFilters::default();
+        let all_permissions = list_permissions(&state, request).await?;
+        assert!(
+            all_permissions.records.len() >= 3,
+            "Expected at least 3 permissions, got {}",
+            all_permissions.records.len()
+        );
+
+        // List all permissions for the resource
+        let request = ListPermissionsFilters {
+            resource_id: Some(&resource_1_id),
+            ..Default::default()
+        };
+        let permissions = list_permissions(&state, request).await?;
+        assert_eq!(permissions.records.len(), 2);
+
+        // List permissions for the user
+        let request = ListPermissionsFilters {
+            actor: Some(UserOrOrganizationId::User(&user_id)),
+            ..Default::default()
+        };
+        let user_permissions = list_permissions(&state, request).await?;
+        assert_eq!(user_permissions.records.len(), 2);
+        assert!(user_permissions
+            .records
+            .iter()
+            .any(|p| p.resource_id == resource_1_id && p.role_name == TEST_ROLE_NAME));
+        assert!(user_permissions
+            .records
+            .iter()
+            .any(|p| p.resource_id == resource_2_id && p.role_name == OTHER_ROLE_NAME));
+
+        // List permissions for the organization
+        let request = ListPermissionsFilters {
+            actor: Some(UserOrOrganizationId::Org(&org_id)),
+            ..Default::default()
+        };
+        let org_permissions = list_permissions(&state, request).await?;
+        assert_eq!(org_permissions.records.len(), 1);
+        assert_eq!(org_permissions.records[0].resource_id, resource_1_id);
+        assert_eq!(org_permissions.records[0].role_name, OTHER_ROLE_NAME);
+
+        // Filter by role_name: only the two OtherRole assignments granted above.
+        let request = ListPermissionsFilters {
+            role_name: Some(OTHER_ROLE_NAME),
+            ..Default::default()
+        };
+        let viewer_permissions = list_permissions(&state, request).await?;
+        assert_eq!(viewer_permissions.records.len(), 2);
+        assert!(viewer_permissions
+            .records
+            .iter()
+            .all(|p| p.role_name == OTHER_ROLE_NAME));
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn test_list_permissions_offset_pagination(
+        pool: PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let state = Arc::new(test_state().db(pool).call()?);
+        let (app, mut session) = setup_default_app_and_session(&state.db).await?;
+
+        let user_id = get_random_user_id(&app, &mut session).await?;
+        let resource_id = Uuid::new_v4();
+
+        // Grant distinct roles on the same resource.
+        grant_role(
+            &state,
+            GrantRoleRequest {
+                actor_id: UserOrOrganizationId::User(&user_id),
+                permission_triplet: TestRole::make_triplet(&resource_id),
+                granted_by: &session.id.unwrap(),
+                grant_reason: "Testing",
+            },
+        )
+        .await?;
+
+        grant_role(
+            &state,
+            GrantRoleRequest {
+                actor_id: UserOrOrganizationId::User(&user_id),
+                permission_triplet: OtherRole::make_triplet(&resource_id),
+                granted_by: &session.id.unwrap(),
+                grant_reason: "Testing",
+            },
+        )
+        .await?;
+
+        // Walk the resource scoped listing two records at a time.
+        let mut seen = Vec::new();
+        let mut offset: Option<u64> = None;
+        const LIMIT: usize = 1;
+        loop {
+            let request = ListPermissionsFilters {
+                resource_type: Some(TEST_RESOURCE_TYPE),
+                resource_id: Some(&resource_id),
+                actor: Some(UserOrOrganizationId::User(&user_id)),
+                page_options: PageOptions {
+                    offset,
+                    limit: Some(LIMIT as u64),
+                },
+                ..Default::default()
+            };
+            let page = list_permissions(&state, request).await?;
+
+            assert!(page.records.len() <= LIMIT, "page should respect the limit");
+            seen.extend(page.records.iter().map(|p| p.role_name.clone()));
+
+            match page.records.len() {
+                0 => break,                                                     // no more records
+                1..=LIMIT => offset = Some(offset.unwrap_or(0) + LIMIT as u64), // more pages to fetch
+                _ => unreachable!("should never return more than the limit"),
+            }
+        }
+
+        // Every role should be returned exactly once across all pages.
+        assert_eq!(seen.len(), 2);
+        assert_eq!(
+            seen.iter()
+                .filter(|r| r.as_str() == TestRole::name())
+                .count(),
+            1,
+            "role {} should appear exactly once across pages",
+            TestRole::name()
+        );
+        assert_eq!(
+            seen.iter()
+                .filter(|r| r.as_str() == OtherRole::name())
+                .count(),
+            1,
+            "role {} should appear exactly once across pages",
+            OtherRole::name()
+        );
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn test_permission_is_cached_after_first_call(
+        pool: PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let mock = Arc::new(MockRedis::new());
+        let (app, mut session) = setup_default_app_and_session(&pool).await?;
+        let state = Arc::new(
+            test_state()
+                .db(pool.clone())
+                .redis_conn(mock.clone())
+                .call()?,
+        );
+
+        let user_id = get_random_user_id(&app, &mut session).await?;
+        let resource_id = Uuid::new_v4();
+
+        // Grant the role so a permission exists.
+        grant_role(
+            &state,
+            GrantRoleRequest {
+                actor_id: UserOrOrganizationId::User(&user_id),
+                permission_triplet: TestRole::make_triplet(&resource_id),
+                granted_by: &session.id.unwrap(),
+                grant_reason: "Testing cache",
+            },
+        )
+        .await?;
+
+        // First check: hits the DB and populates the cache.
+        let first =
+            has_resource_permission(&state, TestRole::make_triplet(&resource_id), &user_id, None)
+                .await?;
+        assert!(first, "expected permission to be present");
+
+        let key = permission_cache_key(
+            &TestRole::make_triplet(&resource_id),
+            &UserOrOrganizationId::User(&user_id),
+        );
+        let cached = mock.get_value(&key).await;
+        assert_eq!(
+            cached.as_deref(),
+            Some("1"),
+            "expected cache key to hold \"1\" after first positive check"
+        );
+
+        // Remove the DB row directly – bypassing the permission model so the
+        // cache entry is NOT invalidated.
+        sqlx::query("DELETE FROM resource_permissions WHERE user_id = $1 AND resource_id = $2 AND resource_type = $3 AND role_name = $4")
+            .bind(user_id)
+            .bind(resource_id)
+            .bind(TestRole::resource_type())
+            .bind(TestRole::name())
+            .execute(&pool)
+            .await?;
+
+        // Second check: DB row is gone but result should still come from cache.
+        let second =
+            has_resource_permission(&state, TestRole::make_triplet(&resource_id), &user_id, None)
+                .await?;
+        assert!(
+            second,
+            "expected cached positive result to be returned even though DB row was deleted"
+        );
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn test_cache_invalidated_on_grant(
+        pool: PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let mock = Arc::new(MockRedis::new());
+        let (app, mut session) = setup_default_app_and_session(&pool).await?;
+        let state = Arc::new(
+            test_state()
+                .db(pool)
+                .redis_conn(mock.clone() as Arc<dyn RedisConnection>)
+                .call()?,
+        );
+
+        let user_id = get_random_user_id(&app, &mut session).await?;
+        let resource_id = Uuid::new_v4();
+
+        // First check: no permission exists; false result is cached.
+        let first =
+            has_resource_permission(&state, TestRole::make_triplet(&resource_id), &user_id, None)
+                .await?;
+        assert!(!first, "expected no permission to exist yet");
+
+        let key = permission_cache_key(
+            &TestRole::make_triplet(&resource_id),
+            &UserOrOrganizationId::User(&user_id),
+        );
+        let cached = mock.get_value(&key).await;
+        assert_eq!(
+            cached.as_deref(),
+            Some("0"),
+            "expected cache key to hold \"0\" after first negative check"
+        );
+
+        // Grant the role, which should invalidate the cache.
+        grant_role(
+            &state,
+            GrantRoleRequest {
+                actor_id: UserOrOrganizationId::User(&user_id),
+                permission_triplet: TestRole::make_triplet(&resource_id),
+                granted_by: &session.id.unwrap(),
+                grant_reason: "Testing cache invalidation",
+            },
+        )
+        .await?;
+
+        let after_grant = mock.get_value(&key).await;
+        assert!(
+            after_grant.is_none(),
+            "expected cache key to be deleted after grant_role, got {after_grant:?}"
+        );
+
+        // Permission check now re-queries the DB and should return true.
+        let second =
+            has_resource_permission(&state, TestRole::make_triplet(&resource_id), &user_id, None)
+                .await?;
+        assert!(second, "expected permission to be present after grant");
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn test_cache_invalidated_on_revoke(
+        pool: PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let mock = Arc::new(MockRedis::new());
+        let (app, mut session) = setup_default_app_and_session(&pool).await?;
+        let state = Arc::new(
+            test_state()
+                .db(pool)
+                .redis_conn(mock.clone() as Arc<dyn RedisConnection>)
+                .call()?,
+        );
+
+        let user_id = get_random_user_id(&app, &mut session).await?;
+        let resource_id = Uuid::new_v4();
+
+        // Grant the role and confirm it is cached.
+        grant_role(
+            &state,
+            GrantRoleRequest {
+                actor_id: UserOrOrganizationId::User(&user_id),
+                permission_triplet: TestRole::make_triplet(&resource_id),
+                granted_by: &session.id.unwrap(),
+                grant_reason: "Testing cache invalidation",
+            },
+        )
+        .await?;
+
+        let first =
+            has_resource_permission(&state, TestRole::make_triplet(&resource_id), &user_id, None)
+                .await?;
+        assert!(first, "expected permission to be present");
+
+        let key = permission_cache_key(
+            &TestRole::make_triplet(&resource_id),
+            &UserOrOrganizationId::User(&user_id),
+        );
+        let cached = mock.get_value(&key).await;
+        assert_eq!(
+            cached.as_deref(),
+            Some("1"),
+            "expected cache key to hold \"1\" after positive check"
+        );
+
+        // Revoke the role, which should invalidate the cache.
+        revoke_role(
+            &state,
+            RevokeRoleRequest {
+                actor_id: UserOrOrganizationId::User(&user_id),
+                permission_triplet: TestRole::make_triplet(&resource_id),
+            },
+        )
+        .await?;
+
+        let after_revoke = mock.get_value(&key).await;
+        assert!(
+            after_revoke.is_none(),
+            "expected cache key to be deleted after revoke_role, got {after_revoke:?}"
+        );
+
+        // Permission check now re-queries the DB and should return false.
+        let second =
+            has_resource_permission(&state, TestRole::make_triplet(&resource_id), &user_id, None)
+                .await?;
+        assert!(!second, "expected no permission after revoke");
+
+        Ok(())
+    }
+}

--- a/api/src/redis_connection.rs
+++ b/api/src/redis_connection.rs
@@ -1,0 +1,151 @@
+#[cfg(test)]
+use std::collections::HashMap;
+use std::ops::Deref;
+#[cfg(test)]
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use redis::aio::ConnectionManager;
+use redis::AsyncCommands;
+use redis::RedisError;
+#[cfg(test)]
+use tokio::sync::Mutex;
+
+/// Abstracts over a Redis connection.
+///
+/// Both the production [`RedisImpl`] (backed by a real `ConnectionManager`)
+/// and the test-only [`MockRedis`] (backed by an in-memory `HashMap`)
+/// implement this trait.
+#[async_trait]
+pub trait RedisConnection: Send + Sync {
+    /// Retrieve the value stored at `key`, or `None` if absent.
+    async fn get(&self, key: &str) -> Result<Option<String>, RedisError>;
+
+    /// Retrieve values for multiple keys in a single round-trip.
+    /// Missing keys are represented as `None`.
+    async fn get_multi(&self, keys: &[&str]) -> Result<Vec<Option<String>>, RedisError>;
+
+    /// Store `value` at `key` with a TTL of `ttl_secs` seconds.
+    async fn set_ex(&self, key: &str, value: &str, ttl_secs: u64) -> Result<(), RedisError>;
+
+    /// Delete the entry at `key`.
+    async fn del(&self, key: &str) -> Result<(), RedisError>;
+}
+
+/// Production Redis connection backed by a [`redis::aio::ConnectionManager`].
+#[derive(Debug)]
+pub struct RedisImpl(ConnectionManager);
+
+impl RedisImpl {
+    pub fn new(conn: ConnectionManager) -> Self {
+        Self(conn)
+    }
+}
+
+impl Deref for RedisImpl {
+    type Target = ConnectionManager;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[async_trait]
+impl RedisConnection for RedisImpl {
+    async fn get(&self, key: &str) -> Result<Option<String>, RedisError> {
+        let mut conn = (*self).clone();
+        conn.get::<_, Option<String>>(key).await.map_err(|e| {
+            tracing::error!("Redis get error for key {key}: {e}");
+            e
+        })
+    }
+
+    async fn get_multi(&self, keys: &[&str]) -> Result<Vec<Option<String>>, RedisError> {
+        if keys.is_empty() {
+            return Ok(vec![]);
+        }
+        let mut conn = (*self).clone();
+        let mut pipe = redis::pipe();
+        for key in keys {
+            pipe.get(*key);
+        }
+        pipe.query_async::<Vec<Option<String>>>(&mut conn)
+            .await
+            .map_err(|e| {
+                tracing::error!("Redis get_multi error: {e}");
+                e
+            })
+    }
+
+    async fn set_ex(&self, key: &str, value: &str, ttl_secs: u64) -> Result<(), RedisError> {
+        let mut conn = (*self).clone();
+        conn.set_ex::<_, _, ()>(key, value, ttl_secs)
+            .await
+            .map_err(|e| {
+                tracing::error!("Redis set_ex error for key {key}: {e}");
+                e
+            })
+    }
+
+    async fn del(&self, key: &str) -> Result<(), RedisError> {
+        let mut conn = (*self).clone();
+        conn.del::<_, ()>(key).await.map_err(|e| {
+            tracing::error!("Redis del error for key {key}: {e}");
+            e
+        })
+    }
+}
+
+/// In-memory Redis mock backed by a `HashMap<String, String>`.
+#[cfg(test)]
+pub struct MockRedis(Arc<Mutex<HashMap<String, String>>>);
+
+#[cfg(test)]
+impl MockRedis {
+    pub fn new() -> Self {
+        Self(Arc::new(Mutex::new(HashMap::new())))
+    }
+
+    /// Directly read a value from the in-memory store.
+    ///
+    /// Useful in tests to assert that the cache has been populated or
+    /// invalidated without going through the trait interface.
+    pub async fn get_value(&self, key: &str) -> Option<String> {
+        self.lock().await.get(key).cloned()
+    }
+}
+
+#[cfg(test)]
+impl Deref for MockRedis {
+    type Target = Arc<Mutex<HashMap<String, String>>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[cfg(test)]
+#[async_trait]
+impl RedisConnection for MockRedis {
+    async fn get(&self, key: &str) -> Result<Option<String>, RedisError> {
+        Ok(self.lock().await.get(key).cloned())
+    }
+
+    async fn get_multi(&self, keys: &[&str]) -> Result<Vec<Option<String>>, RedisError> {
+        let store = self.lock().await;
+        Ok(keys.iter().map(|k| store.get(*k).cloned()).collect())
+    }
+
+    async fn set_ex(&self, key: &str, value: &str, _ttl_secs: u64) -> Result<(), RedisError> {
+        self
+            .lock()
+            .await
+            .insert(key.to_string(), value.to_string());
+        Ok(())
+    }
+
+    async fn del(&self, key: &str) -> Result<(), RedisError> {
+        self.lock().await.remove(key);
+        Ok(())
+    }
+}

--- a/api/src/routes.rs
+++ b/api/src/routes.rs
@@ -14,6 +14,7 @@ pub mod media;
 pub mod notifications;
 pub mod organizations;
 pub mod recruitment_targets;
+pub mod permissions;
 pub mod regions;
 pub mod report_impacts;
 pub mod reports;

--- a/api/src/routes/api_keys.rs
+++ b/api/src/routes/api_keys.rs
@@ -26,7 +26,7 @@ async fn create(
     RequiredAdminUser(user): RequiredAdminUser,
     Json(payload): Json<CreateApiKeyRequest>,
 ) -> Result<(StatusCode, Json<CreateResponse>), ComhairleError> {
-    if !is_user_admin(&user, &state.config) {
+    if !is_user_admin(&state, &user).await {
         return Err(ComhairleError::UserNotAuthorized);
     }
 

--- a/api/src/routes/auth.rs
+++ b/api/src/routes/auth.rs
@@ -1,10 +1,6 @@
-use aide::{
-    OperationIo,
-    axum::{
-        ApiRouter,
-        routing::{get_with, post_with},
-    },
-};
+use aide::OperationIo;
+use aide::axum::ApiRouter;
+use aide::axum::routing::{get_with, post_with};
 
 use argon2::{Argon2, PasswordHash, PasswordHasher, PasswordVerifier, password_hash::SaltString};
 use axum::{
@@ -29,12 +25,24 @@ use sha2::Sha256;
 use time::Duration;
 
 /// Helper function to check if a user is admin
-pub fn is_user_admin(
+pub async fn is_user_admin(
+    state: &Arc<ComhairleState>,
     user: &crate::models::users::User,
-    config: &crate::config::ComhairleConfig,
 ) -> bool {
+    // Check if the user has the system admin role
+    if has_resource_permission(
+        &state,
+        SystemAdminRole::make_system_triplet(),
+        &user.id,
+        user.organization_id.as_ref(),
+    )
+    .await
+    .unwrap_or(false) {
+        return true;
+    }
+
     let re = Regex::new(r"^test(?:[1-9]|10)@crown-shy\.com$").unwrap();
-    if let (Some(admin_users), Some(email)) = (&config.admin_users, &user.email) {
+    if let (Some(admin_users), Some(email)) = (&state.config.admin_users, &user.email) {
         let downcase_admin_users: Vec<String> =
             admin_users.iter().map(|a| a.to_lowercase()).collect();
         return downcase_admin_users.contains(&email.to_lowercase())
@@ -50,19 +58,16 @@ use std::{collections::HashMap, sync::Arc};
 use tracing::{instrument, warn};
 use uuid::Uuid;
 
-use crate::{
-    ComhairleState,
-    error::ComhairleError,
-    models::{
-        api_key, otp,
-        users::{
-            self, Resource, Role, UpdateUserRequest, User, UserAuthType, UserResourceRole,
-            create_annon_user, create_otp_user, create_user, get_user_by_email, get_user_by_id,
-            get_user_by_username, get_user_resource_roles, update_user,
-        },
-    },
-    routes::user::dto::UserDto,
+use crate::{error::ComhairleError, models::permissions::{ExtractResourceId, GrantRoleRequest, SystemAdminRole, SystemResourceRole, UserOrOrganizationId, grant_role}};
+use crate::models::permissions::{has_resource_permission, ResourceRole};
+use crate::models::users::{
+    self, create_annon_user, create_otp_user, create_user, get_user_by_email, get_user_by_id,
+    get_user_by_username, get_user_resource_roles, update_user, Resource, Role, UpdateUserRequest,
+    User, UserAuthType, UserResourceRole,
 };
+use crate::models::{api_key, otp};
+use crate::routes::user::dto::UserDto;
+use crate::ComhairleState;
 
 #[cfg(test)]
 use fake::Dummy;
@@ -283,7 +288,6 @@ pub struct SignupRequest {
 }
 
 /// Signup handler
-
 #[instrument(err(Debug), skip(state, payload))]
 async fn signup(
     State(state): State<Arc<ComhairleState>>,
@@ -296,6 +300,21 @@ async fn signup(
     let user = create_user(&payload, &state.db).await?;
 
     send_verification_email(&user, &state)?;
+
+    if let Some(admin_users) = &state.config.admin_users {
+        if admin_users.contains(&user.email.clone().unwrap_or_default()) {
+            grant_role(
+                &state,
+                GrantRoleRequest {
+                    actor_id: UserOrOrganizationId::User(&user.id),
+                    permission_triplet: SystemAdminRole::make_system_triplet(),
+                    grant_reason: "Admin signup",
+                    granted_by: &user.id,
+                },
+            )
+            .await?;
+        }
+    }
 
     let cookie = create_session_cookie(&user, &state);
 
@@ -843,6 +862,58 @@ async fn resolve_user_from_request(
     }
 }
 
+/// An extractor to get a required role for the current user and target resource.
+#[derive(OperationIo)]
+pub struct RequiredUserPermission<Role: ResourceRole, Id: ExtractResourceId> {
+    pub user: User,
+    pub _phantom_data: PhantomData<(Role, Id)>,
+}
+
+impl<Role, Id> FromRequestParts<Arc<ComhairleState>> for RequiredUserPermission<Role, Id>
+where
+    Role: ResourceRole,
+    Id: ExtractResourceId,
+{
+    type Rejection = ComhairleError;
+
+    /// Extracts the current user and resource ID from the request, then checks if
+    /// the user has the required role for that resource.
+    ///
+    /// # Errors
+    ///
+    /// * Returns [`ComhairleError::UserRequired`] if no user is logged in.
+    /// * Returns [`ComhairleError::ResourceNotFound`] if the resource ID cannot be
+    ///   extracted from the request.
+    /// * Returns [`ComhairleError::UserNotAuthorized`] if the user does not have
+    ///   the required role.
+    async fn from_request_parts(
+        parts: &mut Parts,
+        state: &Arc<ComhairleState>,
+    ) -> Result<Self, Self::Rejection> {
+        let user = resolve_user_from_request(parts, state).await?;
+
+        let id = Id::from_request_parts(parts, state).await.map_err(|_| {
+            ComhairleError::ResourceNotFound("Path must contain a resource id".to_string())
+        })?;
+
+        if has_resource_permission(
+            &state,
+            Role::make_triplet(&id.resource_id()),
+            &user.id,
+            user.organization_id.as_ref(),
+        )
+        .await?
+        {
+            Ok(RequiredUserPermission {
+                user,
+                _phantom_data: PhantomData,
+            })
+        } else {
+            Err(ComhairleError::UserNotAuthorized)
+        }
+    }
+}
+
 /// An extractor to get a required current user.
 /// If no user is logged in then this will fail and
 /// Return a Not Found response
@@ -858,7 +929,7 @@ impl FromRequestParts<Arc<ComhairleState>> for RequiredAdminUser {
     ) -> Result<Self, Self::Rejection> {
         let user = resolve_user_from_request(parts, state).await?;
 
-        if is_user_admin(&user, &state.config) {
+        if is_user_admin(&state, &user).await {
             Ok(RequiredAdminUser(user.clone()))
         } else {
             Err(ComhairleError::RequiresAuthUser)

--- a/api/src/routes/conversations.rs
+++ b/api/src/routes/conversations.rs
@@ -156,10 +156,8 @@ async fn get_conversation(
 
     // Check if user is admin and withTranslations is requested
     let should_return_with_translations = query.with_translations
-        && user
-            .as_ref()
-            .map(|u| is_user_admin(u, &state.config))
-            .unwrap_or(false);
+        && user.is_some()
+        && is_user_admin(&state, user.as_ref().unwrap()).await;
 
     if should_return_with_translations {
         // Convert to ConversationWithTranslations

--- a/api/src/routes/documents.rs
+++ b/api/src/routes/documents.rs
@@ -48,7 +48,7 @@ async fn require_conversation_document_access(
         return Err(ComhairleError::UserNotAuthorized);
     };
 
-    if is_user_admin(user, &state.config) {
+    if is_user_admin(&state, user).await {
         return Ok(());
     }
 

--- a/api/src/routes/events.rs
+++ b/api/src/routes/events.rs
@@ -81,7 +81,7 @@ async fn get(
     let event = event::get_by_id(&state.db, &event_id).await?;
 
     let should_return_with_translations =
-        query.with_translations && is_user_admin(&user, &state.config);
+        query.with_translations && is_user_admin(&state, &user).await;
 
     if should_return_with_translations {
         let event_with_translations =

--- a/api/src/routes/permissions.rs
+++ b/api/src/routes/permissions.rs
@@ -1,0 +1,805 @@
+use std::sync::Arc;
+
+use aide::axum::{
+    routing::{delete_with, get_with, post_with},
+    ApiRouter,
+};
+use axum::{
+    extract::{Json, Path, Query, State},
+    http::StatusCode,
+};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use tracing::instrument;
+use uuid::Uuid;
+
+use crate::models::pagination::{PageOptions, PaginatedResults};
+use crate::models::permissions::{
+    self, list_permissions, GrantRoleRequest, ListPermissionsFilters, PermissionTriplet,
+    RevokeRoleRequest, SystemAdminRole, SystemResource, UserOrOrganizationId,
+};
+use crate::routes::auth::RequiredUserPermission;
+use crate::{
+    error::ComhairleError,
+    models::permissions::{grant_role, revoke_role},
+    ComhairleState,
+};
+
+/// Represents the resource type and ID for a permission operation.
+#[derive(Debug, Deserialize, JsonSchema)]
+pub struct TargetResourceId {
+    pub resource_type: String,
+    pub resource_id: Uuid,
+}
+
+/// Represents a request body for granting a permission to a user or organization.
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+pub struct GrantPermissionBody {
+    pub user_id: Option<Uuid>,
+    pub organization_id: Option<Uuid>,
+    pub role_name: String,
+    pub grant_reason: String,
+}
+
+/// Represents a request query for revoking a permission from a user or organization.
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+pub struct RevokePermissionQuery {
+    pub user_id: Option<Uuid>,
+    pub organization_id: Option<Uuid>,
+    pub role_name: String,
+}
+
+/// Represents a request query for listing permissions with optional filters.
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+pub struct ListPermissionsQuery {
+    pub user_id: Option<Uuid>,
+    pub organization_id: Option<Uuid>,
+    pub role_name: Option<String>,
+    pub offset: Option<u64>,
+    pub limit: Option<u64>,
+}
+
+/// Resolves the actor from the optional user_id / organization_id fields.
+///
+/// # Errors
+///
+/// Returns [`ComhairleError::BadRequest`] if both user_id and organization_id are provided.
+fn resolve_actor<'actor>(
+    user_id: &'actor Option<Uuid>,
+    organization_id: &'actor Option<Uuid>,
+    allow_none: bool,
+) -> Result<Option<UserOrOrganizationId<'actor>>, ComhairleError> {
+    match (user_id, organization_id) {
+        (Some(uid), None) => Ok(Some(UserOrOrganizationId::User(uid))),
+        (None, Some(oid)) => Ok(Some(UserOrOrganizationId::Org(oid))),
+        (None, None) if allow_none => Ok(None),
+        _ => Err(ComhairleError::BadRequest(
+            "Only one of user_id or organization_id can be provided".into(),
+        )),
+    }
+}
+
+/// Grants a role to a user or organization on a specific resource.
+///
+/// # Errors
+///
+/// * Returns [`ComhairleError::RoleAlreadyGranted`] if the role was already granted to the actor.
+/// * Returns [`ComhairleError::BadRequest`] if both user_id and organization_id are provided in the request body.
+/// * Returns [`ComhairleError::DatabaseError`] if there is an error querying the database.
+#[instrument(err(Debug), skip(state))]
+async fn grant(
+    State(state): State<Arc<ComhairleState>>,
+    RequiredUserPermission { user: caller, .. }: RequiredUserPermission<
+        SystemAdminRole,
+        SystemResource,
+    >,
+    Path(path): Path<TargetResourceId>,
+    Json(body): Json<GrantPermissionBody>,
+) -> Result<(StatusCode, Json<permissions::ResourcePermission>), ComhairleError> {
+    let actor_id = resolve_actor(&body.user_id, &body.organization_id, false)?.unwrap();
+
+    let permission_triplet =
+        PermissionTriplet(&path.resource_type, &path.resource_id, &body.role_name);
+    let permission = grant_role(
+        &state,
+        GrantRoleRequest {
+            actor_id,
+            permission_triplet,
+            granted_by: &caller.id,
+            grant_reason: &body.grant_reason,
+        },
+    )
+    .await?;
+
+    Ok((StatusCode::CREATED, Json(permission)))
+}
+
+/// Revokes a role from a user or organization on a specific resource.
+///
+/// # Errors
+///
+/// * Returns [`ComhairleError::RoleNotFound`] if the role does not exist for the resource type.
+/// * Returns [`ComhairleError::BadRequest`] if both user_id and organization_id are provided in the query parameters.
+/// * Returns [`ComhairleError::DatabaseError`] if there is an error querying the database.
+#[instrument(err(Debug), skip(state))]
+async fn revoke(
+    State(state): State<Arc<ComhairleState>>,
+    RequiredUserPermission { .. }: RequiredUserPermission<SystemAdminRole, SystemResource>,
+    Path(path): Path<TargetResourceId>,
+    Query(query): Query<RevokePermissionQuery>,
+) -> Result<StatusCode, ComhairleError> {
+    let actor_id = resolve_actor(&query.user_id, &query.organization_id, false)?.unwrap();
+
+    let permission_triplet =
+        PermissionTriplet(&path.resource_type, &path.resource_id, &query.role_name);
+    revoke_role(
+        &state,
+        RevokeRoleRequest {
+            actor_id,
+            permission_triplet,
+        },
+    )
+    .await?;
+
+    Ok(StatusCode::OK)
+}
+
+/// Lists permissions for all resources with optional filtering. Supports pagination via offset and limit query parameters.
+///
+/// # Errors
+///
+/// * Returns [`ComhairleError::BadRequest`] if both user_id and organization_id are provided.
+/// * Returns [`ComhairleError::DatabaseError`] if there is an error querying the database.
+#[instrument(err(Debug), skip(state))]
+async fn list(
+    State(state): State<Arc<ComhairleState>>,
+    RequiredUserPermission { .. }: RequiredUserPermission<SystemAdminRole, SystemResource>,
+    Query(query): Query<ListPermissionsQuery>,
+) -> Result<
+    (
+        StatusCode,
+        Json<PaginatedResults<permissions::ResourcePermission>>,
+    ),
+    ComhairleError,
+> {
+    let actor = resolve_actor(&query.user_id, &query.organization_id, true)?;
+    let page_options = PageOptions {
+        limit: query.limit,
+        offset: query.offset,
+    };
+
+    let request = ListPermissionsFilters {
+        actor,
+        role_name: query.role_name.as_deref(),
+        page_options,
+        ..Default::default()
+    };
+
+    let page = list_permissions(&state, request).await?;
+
+    Ok((StatusCode::OK, Json(page)))
+}
+
+/// Lists permissions for a specific resource with optional filtering. Supports pagination via offset and limit query parameters.
+///
+/// # Errors
+///
+/// * Returns [`ComhairleError::BadRequest`] if both user_id and organization_id are provided.
+/// * Returns [`ComhairleError::DatabaseError`] if there is an error querying the database.
+#[instrument(err(Debug), skip(state))]
+async fn list_for_resource(
+    State(state): State<Arc<ComhairleState>>,
+    RequiredUserPermission { .. }: RequiredUserPermission<SystemAdminRole, SystemResource>,
+    Path(path): Path<TargetResourceId>,
+    Query(query): Query<ListPermissionsQuery>,
+) -> Result<
+    (
+        StatusCode,
+        Json<PaginatedResults<permissions::ResourcePermission>>,
+    ),
+    ComhairleError,
+> {
+    let actor = resolve_actor(&query.user_id, &query.organization_id, true)?;
+    let page_options = PageOptions {
+        limit: query.limit,
+        offset: query.offset,
+    };
+
+    let request = ListPermissionsFilters {
+        actor,
+        role_name: query.role_name.as_deref(),
+        page_options,
+        resource_type: Some(&path.resource_type),
+        resource_id: Some(&path.resource_id),
+    };
+
+    let page = list_permissions(&state, request).await?;
+
+    Ok((StatusCode::OK, Json(page)))
+}
+
+/// Creates the permissions API router with all the defined routes and their corresponding handlers.
+pub fn router(state: Arc<ComhairleState>) -> ApiRouter {
+    ApiRouter::new()
+        .api_route(
+            "/",
+            get_with(list, |op| {
+                op.id("ListPermissions")
+                    .tag("Permissions")
+                    .summary("List all permissions")
+                    .description(
+                        "Returns role assignments using offset-based pagination. \
+                        Optionally filter by user_id, organization_id, or role_name. \
+                        Use the `offset` and `limit` query params to page through results.",
+                    )
+                    .security_requirement("JWT")
+                    .response::<200, Json<PaginatedResults<permissions::ResourcePermission>>>()
+            }),
+        )
+        .api_route(
+            "/{resource_type}/{resource_id}",
+            get_with(list_for_resource, |op| {
+                op.id("ListResourcePermissions")
+                    .tag("Permissions")
+                    .summary("List permissions for a resource")
+                    .description(
+                        "Returns role assignments for a specific resource using \
+                        offset-based pagination. Optionally filter by user_id, \
+                        organization_id, or role_name. The caller must hold the \
+                        Owner role on the resource.",
+                    )
+                    .security_requirement("JWT")
+                    .response::<200, Json<PaginatedResults<permissions::ResourcePermission>>>()
+            }),
+        )
+        .api_route(
+            "/{resource_type}/{resource_id}",
+            post_with(grant, |op| {
+                op.id("GrantPermission")
+                    .tag("Permissions")
+                    .summary("Grant a role on a resource")
+                    .description(
+                        "Grants a role to a user or organisation on a resource. \
+                        The caller must hold the Owner role on the resource.",
+                    )
+                    .security_requirement("JWT")
+                    .response::<201, Json<permissions::ResourcePermission>>()
+            }),
+        )
+        .api_route(
+            "/{resource_type}/{resource_id}",
+            delete_with(revoke, |op| {
+                op.id("RevokePermission")
+                    .tag("Permissions")
+                    .summary("Revoke a role from a resource")
+                    .description(
+                        "Revokes a role from a user or organisation on a resource. \
+                        The actor (user_id or organization_id) and role_name are \
+                        provided as query parameters. The caller must hold the \
+                        Owner role on the resource.",
+                    )
+                    .security_requirement("JWT")
+                    .response::<200, ()>()
+            }),
+        )
+        .with_state(state)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::models::pagination::PaginatedResults;
+    use crate::models::permissions::{
+        grant_role, has_resource_permission, list_permissions, GrantRoleRequest,
+        ListPermissionsFilters, NamedRole, PermissionTriplet, ResourcePermission, ResourceRole,
+        SystemResourceRole, UserOrOrganizationId,
+    };
+    use crate::routes::permissions::{
+        GrantPermissionBody, ListPermissionsQuery, RevokePermissionQuery, SystemAdminRole,
+    };
+    use crate::test_helpers::{test_config, test_state};
+    use crate::{setup_server, test_helpers::UserSession};
+
+    use axum::body::Body;
+    use hyper::StatusCode;
+    use sqlx::PgPool;
+    use std::sync::Arc;
+
+    // Role definitions for testing
+    const RESOURCE_TYPE: &str = "test_resource";
+
+    struct TestRole;
+
+    impl NamedRole for TestRole {
+        fn name() -> &'static str {
+            "editor"
+        }
+    }
+
+    impl ResourceRole for TestRole {
+        fn resource_type() -> &'static str {
+            RESOURCE_TYPE
+        }
+    }
+
+    // Helper functions
+    fn revoke_url(resource: (&str, &uuid::Uuid), query: &RevokePermissionQuery) -> String {
+        let mut url = format!("/permissions/{}/{}?", resource.0, resource.1);
+        if let Some(user_id) = query.user_id {
+            url.push_str(&format!("user_id={}&", user_id));
+        }
+        if let Some(org_id) = query.organization_id {
+            url.push_str(&format!("organization_id={}&", org_id));
+        }
+        url.push_str(&format!("role_name={}&", query.role_name));
+        // Remove trailing '&' or '?' if present
+        url.trim_end_matches('&').trim_end_matches('?').to_string()
+    }
+
+    fn list_query_url(base_url: &str, query: &ListPermissionsQuery) -> String {
+        let mut url = format!("{base_url}?");
+        if let Some(user_id) = query.user_id {
+            url.push_str(&format!("user_id={}&", user_id));
+        }
+        if let Some(org_id) = query.organization_id {
+            url.push_str(&format!("organization_id={}&", org_id));
+        }
+        if let Some(role_name) = &query.role_name {
+            url.push_str(&format!("role_name={}&", role_name));
+        }
+        if let Some(offset) = query.offset {
+            url.push_str(&format!("offset={}&", offset));
+        }
+        if let Some(limit) = query.limit {
+            url.push_str(&format!("limit={}&", limit));
+        }
+        // Remove trailing '&' or '?' if present
+        url.trim_end_matches('&').trim_end_matches('?').to_string()
+    }
+
+    #[sqlx::test]
+    async fn test_admin_user_should_have_system_admin_role(
+        pool: PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let mut config = test_config()?;
+        config.bot_service = None;
+        let state = Arc::new(test_state().db(pool).config(config).call()?);
+        let app = setup_server(state.clone()).await?;
+
+        let mut session = UserSession::new_admin();
+        session.signup(&app).await?;
+
+        let (_, user, _) = session.current_user(&app).await?;
+
+        // Check if the user has the system admin role
+        let has_admin_role = has_resource_permission(
+            &state,
+            SystemAdminRole::make_system_triplet(),
+            &user.id,
+            user.organization_id.as_ref(),
+        )
+        .await?;
+
+        assert!(
+            has_admin_role,
+            "Admin users should be auto-assigned the system admin role"
+        );
+
+        Ok(())
+    }
+
+    // Grant permission
+    #[sqlx::test]
+    async fn test_post_permission(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
+        let mut config = test_config()?;
+        config.bot_service = None;
+        let state = Arc::new(test_state().db(pool).config(config).call()?);
+        let app = setup_server(state.clone()).await?;
+
+        let mut session = UserSession::new_admin();
+        session.signup(&app).await?;
+
+        let (_, user, _) = session.current_user(&app).await?;
+
+        // Create a resource to grant permissions on
+        let resource_id = uuid::Uuid::new_v4();
+
+        // Grant a permission
+        let grant_body = GrantPermissionBody {
+            user_id: Some(user.id),
+            organization_id: None,
+            role_name: "editor".into(),
+            grant_reason: "Testing".into(),
+        };
+
+        let body = Body::from(serde_json::to_string(&grant_body)?);
+
+        let (status, _response, _message) = session
+            .post(
+                &app,
+                &format!("/permissions/{}/{}", RESOURCE_TYPE, resource_id),
+                body,
+            )
+            .await?;
+
+        assert_eq!(status, StatusCode::CREATED);
+
+        let body = Body::from(serde_json::to_string(&grant_body)?);
+
+        // Re-grant the same permission and expect a 400 Bad Request
+        let (status, _response, _message) = session
+            .post(
+                &app,
+                &format!("/permissions/{}/{}", RESOURCE_TYPE, resource_id),
+                body,
+            )
+            .await?;
+
+        assert_eq!(status, StatusCode::CONFLICT);
+
+        Ok(())
+    }
+
+    // Revoke permission
+    #[sqlx::test]
+    async fn test_delete_permission(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
+        let mut config = test_config()?;
+        config.bot_service = None;
+        let state = Arc::new(test_state().db(pool).config(config).call()?);
+        let app = setup_server(state.clone()).await?;
+
+        let mut session = UserSession::new_admin();
+        session.signup(&app).await?;
+
+        let (_, user, _) = session.current_user(&app).await?;
+
+        // Create a resource to grant permissions on
+        let resource_id = uuid::Uuid::new_v4();
+
+        // Grant editor role to revoke
+        grant_role(
+            &state,
+            GrantRoleRequest {
+                actor_id: UserOrOrganizationId::User(&user.id),
+                permission_triplet: TestRole::make_triplet(&resource_id),
+                granted_by: &user.id,
+                grant_reason: "Testing".into(),
+            },
+        )
+        .await?;
+
+        // Revoke the permission via query parameters
+        let revoke_query = RevokePermissionQuery {
+            user_id: Some(user.id),
+            organization_id: None,
+            role_name: "editor".into(),
+        };
+
+        let revoke_url = revoke_url((RESOURCE_TYPE, &resource_id), &revoke_query);
+
+        let (status, _response, _message) = session.delete(&app, &revoke_url).await?;
+
+        assert_eq!(status, StatusCode::OK);
+
+        // Revoking again should return NOT_FOUND
+        let (status, _response, _message) = session.delete(&app, &revoke_url).await?;
+
+        assert_eq!(status, StatusCode::NOT_FOUND);
+
+        Ok(())
+    }
+
+    // List permissions (general)
+    #[sqlx::test]
+    async fn test_get_permissions(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
+        let mut config = test_config()?;
+        config.bot_service = None;
+        let state = Arc::new(test_state().db(pool).config(config).call()?);
+        let app = setup_server(state.clone()).await?;
+
+        let mut session = UserSession::new_admin();
+        session.signup(&app).await?;
+
+        let (_, user, _) = session.current_user(&app).await?;
+
+        // Create a resource to grant permissions on
+        let resource_id = uuid::Uuid::new_v4();
+
+        // Grant additional permissions
+        for i in 0..5 {
+            let permission_triplet =
+                PermissionTriplet(&RESOURCE_TYPE, &resource_id, &format!("Role{}", i));
+            grant_role(
+                &state,
+                GrantRoleRequest {
+                    actor_id: UserOrOrganizationId::User(&user.id),
+                    permission_triplet,
+                    granted_by: &user.id,
+                    grant_reason: "Testing".into(),
+                },
+            )
+            .await?;
+        }
+
+        // List permissions with pagination
+        let query = ListPermissionsQuery {
+            user_id: None,
+            organization_id: None,
+            role_name: None,
+            offset: Some(0),
+            limit: Some(4),
+        };
+
+        let list_url = list_query_url("/permissions", &query);
+
+        let (status, response, _message) = session.get(&app, &list_url).await?;
+
+        assert_eq!(status, StatusCode::OK);
+
+        let permissions_page =
+            serde_json::from_value::<PaginatedResults<ResourcePermission>>(response)?;
+
+        assert_eq!(permissions_page.total, 6);
+        assert_eq!(permissions_page.records.len(), 4);
+
+        let next_query = ListPermissionsQuery {
+            offset: Some(4),
+            ..query
+        };
+        let next_list_url = list_query_url("/permissions", &next_query);
+
+        let (status, response, _message) = session.get(&app, &next_list_url).await?;
+
+        assert_eq!(status, StatusCode::OK);
+
+        let next_permissions_page =
+            serde_json::from_value::<PaginatedResults<ResourcePermission>>(response)?;
+
+        assert_eq!(next_permissions_page.records.len(), 2);
+
+        Ok(())
+    }
+
+    // List permissions (for resource)
+    #[sqlx::test]
+    async fn test_get_permissions_for_resource(
+        pool: PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let mut config = test_config()?;
+        config.bot_service = None;
+        let state = Arc::new(test_state().db(pool).config(config).call()?);
+        let app = setup_server(state.clone()).await?;
+
+        let mut session = UserSession::new_admin();
+        session.signup(&app).await?;
+
+        let (_, user, _) = session.current_user(&app).await?;
+
+        // Create two resources to grant permissions on
+        let resource_id = uuid::Uuid::new_v4();
+        let resource_id_2 = uuid::Uuid::new_v4();
+
+        // Grant additional permissions
+        for i in 0..5 {
+            let permission_triplet =
+                PermissionTriplet(&RESOURCE_TYPE, &resource_id, &format!("Role{}", i));
+            grant_role(
+                &state,
+                GrantRoleRequest {
+                    actor_id: UserOrOrganizationId::User(&user.id),
+                    permission_triplet,
+                    granted_by: &user.id,
+                    grant_reason: "Testing".into(),
+                },
+            )
+            .await?;
+        }
+
+        for i in 0..3 {
+            let permission_triplet =
+                PermissionTriplet(&RESOURCE_TYPE, &resource_id_2, &format!("OtherRole{}", i));
+            grant_role(
+                &state,
+                GrantRoleRequest {
+                    actor_id: UserOrOrganizationId::User(&user.id),
+                    permission_triplet,
+                    granted_by: &user.id,
+                    grant_reason: "Testing".into(),
+                },
+            )
+            .await?;
+        }
+
+        // List permissions for the resource with pagination
+        let query = ListPermissionsQuery {
+            user_id: None,
+            organization_id: None,
+            role_name: None,
+            offset: Some(0),
+            limit: Some(4),
+        };
+
+        let list_url = list_query_url(
+            &format!("/permissions/{}/{}", RESOURCE_TYPE, resource_id),
+            &query,
+        );
+
+        let (status, response, _message) = session.get(&app, &list_url).await?;
+
+        assert_eq!(status, StatusCode::OK);
+
+        let permissions_page =
+            serde_json::from_value::<PaginatedResults<ResourcePermission>>(response)?;
+
+        assert_eq!(permissions_page.total, 5);
+        assert_eq!(permissions_page.records.len(), 4);
+
+        let next_query = ListPermissionsQuery {
+            offset: Some(4),
+            ..query
+        };
+        let next_list_url = list_query_url(
+            &format!("/permissions/{}/{}", RESOURCE_TYPE, resource_id),
+            &next_query,
+        );
+
+        let (status, response, _message) = session.get(&app, &next_list_url).await?;
+
+        assert_eq!(status, StatusCode::OK);
+
+        let next_permissions_page =
+            serde_json::from_value::<PaginatedResults<ResourcePermission>>(response)?;
+
+        assert_eq!(next_permissions_page.records.len(), 1);
+
+        Ok(())
+    }
+
+    // List permissions for a resource with filters
+    #[sqlx::test]
+    async fn test_get_permissions_for_resource_with_filters(
+        pool: PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let mut config = test_config()?;
+        config.bot_service = None;
+        let state = Arc::new(test_state().db(pool).config(config).call()?);
+        let app = setup_server(state.clone()).await?;
+
+        let mut session = UserSession::new_admin();
+        session.signup(&app).await?;
+
+        let (_, user, _) = session.current_user(&app).await?;
+
+        // Create a resource to grant permissions on
+        let resource_id = uuid::Uuid::new_v4();
+        let resource_2_id = uuid::Uuid::new_v4();
+
+        // Grant additional permissions
+        for i in 0..5 {
+            let permission_triplet =
+                PermissionTriplet(RESOURCE_TYPE, &resource_id, &format!("Role{}", i));
+            grant_role(
+                &state,
+                GrantRoleRequest {
+                    actor_id: UserOrOrganizationId::User(&user.id),
+                    permission_triplet,
+                    granted_by: &user.id,
+                    grant_reason: "Testing".into(),
+                },
+            )
+            .await?;
+        }
+
+        // Grant role "Role1" on a different resource to ensure filtering works
+        grant_role(
+            &state,
+            GrantRoleRequest {
+                actor_id: UserOrOrganizationId::User(&user.id),
+                permission_triplet: PermissionTriplet(RESOURCE_TYPE, &resource_2_id, "Role1"),
+                granted_by: &user.id,
+                grant_reason: "Testing".into(),
+            },
+        )
+        .await?;
+
+        // List permissions for the resource with a filter on role_name
+        let query = ListPermissionsQuery {
+            user_id: None,
+            organization_id: None,
+            role_name: Some("Role1".into()),
+            offset: Some(0),
+            limit: Some(10),
+        };
+
+        let list_url = list_query_url(
+            &format!("/permissions/{}/{}", RESOURCE_TYPE, resource_id),
+            &query,
+        );
+
+        let (status, response, _message) = session.get(&app, &list_url).await?;
+
+        assert_eq!(status, StatusCode::OK);
+
+        let permissions_page =
+            serde_json::from_value::<PaginatedResults<ResourcePermission>>(response)?;
+
+        assert_eq!(permissions_page.total, 1);
+        assert_eq!(permissions_page.records.len(), 1);
+        assert_eq!(permissions_page.records[0].role_name, "Role1");
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn test_permissions_audit_trail(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
+        let mut config = test_config()?;
+        config.bot_service = None;
+        let state = Arc::new(test_state().db(pool).config(config).call()?);
+        let app = setup_server(state.clone()).await?;
+
+        let mut session = UserSession::new_admin();
+        session.signup(&app).await?;
+
+        let (_, user, _) = session.current_user(&app).await?;
+
+        // Create a resource to grant permissions on
+        let resource_id = uuid::Uuid::new_v4();
+
+        // Grant a permission
+        let grant_body = GrantPermissionBody {
+            user_id: Some(user.id),
+            organization_id: None,
+            role_name: TestRole::name().into(),
+            grant_reason: "Testing".into(),
+        };
+
+        let body = Body::from(serde_json::to_string(&grant_body)?);
+
+        let pre_grant = chrono::Utc::now();
+        let (status, _response, _message) = session
+            .post(
+                &app,
+                &format!("/permissions/{}/{}", RESOURCE_TYPE, resource_id),
+                body,
+            )
+            .await?;
+        let post_grant = chrono::Utc::now();
+
+        assert_eq!(status, StatusCode::CREATED);
+
+        // Get the permission from the database to check the audit trail
+        let permissions = list_permissions(
+            &state,
+            ListPermissionsFilters {
+                actor: Some(UserOrOrganizationId::User(&user.id)),
+                role_name: Some(TestRole::name()),
+                resource_type: Some(RESOURCE_TYPE),
+                resource_id: Some(&resource_id),
+                page_options: Default::default(),
+            },
+        )
+        .await?;
+
+        assert!(permissions.records.len() > 0);
+
+        let permission = &permissions.records[0];
+        assert_eq!(
+            permission.granted_by,
+            Some(user.id),
+            "granted by does not match"
+        );
+        assert_eq!(
+            permission.grant_reason, "Testing",
+            "grant reason does not match"
+        );
+        assert!(
+            permission.granted_at >= pre_grant,
+            "permission granted_at is before pre_grant"
+        );
+        assert!(
+            permission.granted_at <= post_grant,
+            "permission granted_at is after post_grant"
+        );
+
+        Ok(())
+    }
+}

--- a/api/src/routes/user.rs
+++ b/api/src/routes/user.rs
@@ -88,7 +88,7 @@ pub async fn get_user_roles(
 ) -> Result<(StatusCode, Json<Vec<UserRoles>>), ComhairleError> {
     let mut roles = vec![];
 
-    if is_user_admin(&user, &state.config) {
+    if is_user_admin(&state, &user).await {
         roles.push(UserRoles {
             resource: ResourceType::Site,
             roles: vec![ResourceRole::Admin],

--- a/api/src/routes/workflow_steps.rs
+++ b/api/src/routes/workflow_steps.rs
@@ -166,7 +166,7 @@ async fn list_workflows_step(
         .map_err(|_| ComhairleError::UserIsNotParticipatingInTheConversation)?;
 
     let should_return_with_translations =
-        query.with_translations && is_user_admin(&user, &state.config);
+        query.with_translations && is_user_admin(&state, &user).await;
 
     if should_return_with_translations {
         let steps_with_translations =

--- a/api/src/test_helpers.rs
+++ b/api/src/test_helpers.rs
@@ -1,3 +1,4 @@
+use crate::redis_connection::RedisConnection;
 use chrono::Utc;
 use hyper::header::AUTHORIZATION;
 use std::{collections::HashMap, error::Error, sync::Arc};
@@ -101,6 +102,7 @@ pub fn test_state(
     bulk_storage_service: Option<Arc<dyn BulkStorageService>>,
     worker_service: Option<Arc<dyn WorkerService>>,
     categorization_service: Option<Arc<dyn CategorizationService>>,
+    redis_conn: Option<Arc<dyn RedisConnection>>,
 ) -> Result<ComhairleState, Box<dyn Error>> {
     let state = ComhairleState {
         db,
@@ -122,6 +124,7 @@ pub fn test_state(
         bulk_storage_service: bulk_storage_service
             .map(Some)
             .unwrap_or_else(mock_bulk_storage),
+        redis_conn,
     };
     Ok(state)
 }

--- a/api/src/tools/prioritization.rs
+++ b/api/src/tools/prioritization.rs
@@ -348,7 +348,7 @@ async fn list_proposals(
         with_translations,
     }): Query<ListProposalsQuery>,
 ) -> Result<(StatusCode, Json<ProposalsListResponse>), ComhairleError> {
-    if with_translations && is_user_admin(&user, &state.config) {
+    if with_translations && is_user_admin(&state, &user).await {
         let proposals =
             proposal::list_with_translations(&state.db, &workflow_step_id, &locale).await?;
         return Ok((

--- a/scripts/backfill-admin-permissions.sh
+++ b/scripts/backfill-admin-permissions.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Backfill system admin role into resource_permissions for existing admin users.
+#
+# Finds users in comhairle_user whose email matches ADMIN_USERS_REGEX and inserts
+# a system admin permission row for each one, skipping any that already have it.
+#
+# Usage: ./scripts/backfill-admin-permissions.sh
+#
+# Env:
+#   DATABASE_URL        Postgres connection string (required)
+#                       e.g. postgres://user:pass@localhost:5432/comhairle
+#   ADMIN_USERS_REGEX   Postgres regular expression matched against email (required)
+#                       e.g. '@example\.com$' or '^(alice|bob)@example\.com$'
+
+set -euo pipefail
+
+: "${DATABASE_URL:?DATABASE_URL must be set}"
+: "${ADMIN_USERS_REGEX:?ADMIN_USERS_REGEX must be set (Postgres regex matched against email)}"
+
+command -v psql >/dev/null || { echo "missing psql"; exit 1; }
+
+echo "→ Checking users matching: $ADMIN_USERS_REGEX"
+
+# Dry-run: show which users would be affected and how many lack the role already
+AFFECTED=$(psql "$DATABASE_URL" --tuples-only --no-align <<SQL
+SELECT COUNT(*), string_agg(email, ', ' ORDER BY email)
+FROM comhairle_user
+WHERE LOWER(email) ~* ${ADMIN_USERS_REGEX@Q}
+  AND id NOT IN (
+      SELECT user_id
+      FROM resource_permissions
+      WHERE resource_type = 'system'
+        AND resource_id   = '00000000-0000-0000-0000-000000000000'
+        AND role_name     = 'admin'
+        AND user_id IS NOT NULL
+  );
+SQL
+)
+
+AFFECTED_COUNT=$(echo "$AFFECTED" | awk -F'|' '{print $1}' | xargs)
+AFFECTED_EMAILS=$(echo "$AFFECTED" | awk -F'|' '{print $2}' | xargs)
+
+if [[ "$AFFECTED_COUNT" -eq 0 ]]; then
+    echo "No users to backfill — all matching users already have the system admin role."
+    exit 0
+fi
+
+echo ""
+echo "WARNING: This will grant the system admin role to $AFFECTED_COUNT user(s):"
+echo "$AFFECTED_EMAILS"
+echo ""
+read -r -p "Type 'yes' to continue: " CONFIRM
+
+if [[ "$CONFIRM" != "yes" ]]; then
+    echo "Aborted."
+    exit 1
+fi
+
+echo ""
+echo "→ Backfilling system admin role for emails matching: $ADMIN_USERS_REGEX"
+
+GRANTED=$(psql "$DATABASE_URL" --tuples-only --no-align <<SQL
+WITH target_users AS (
+    SELECT id
+    FROM comhairle_user
+    WHERE LOWER(email) ~* ${ADMIN_USERS_REGEX@Q}
+),
+inserted AS (
+    INSERT INTO resource_permissions (
+        user_id,
+        resource_id,
+        resource_type,
+        role_name,
+        granted_by,
+        grant_reason,
+        granted_at
+    )
+    SELECT
+        id,
+        '00000000-0000-0000-0000-000000000000'::UUID,
+        'system',
+        'admin',
+        '00000000-0000-0000-0000-000000000000'::UUID,
+        'Backfilled by backfill-admin-permissions script',
+        NOW()
+    FROM target_users
+    ON CONFLICT DO NOTHING
+    RETURNING user_id
+)
+SELECT COUNT(*) FROM inserted;
+SQL
+)
+
+GRANTED=$(echo "$GRANTED" | xargs)
+echo "Granted $GRANTED new system admin permission(s)"


### PR DESCRIPTION
Motivations:

 - We would like to introduce the concept of organisations, and organisation wide permissions for resources.
 - We would like to move away from the fixed CrownShy admin emails for system administrators.
 - We would like to keep the ease-of-use of the previous user and admin level extractors when gating endpoints behind user permissions.

Actions:

 - Added permissions system core.
 - Added permissions system API.
 - Added pagination and filtering based on role
 - Added system admin role to replace existing fixed admin email format.
 - Implemented extractor for resource IDs and user roles.