### PR TITLE
430/configurable emails

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1555,6 +1555,8 @@ dependencies = [
  "slugify",
  "sqlx",
  "sqlx-postgres",
+ "strum",
+ "strum_macros",
  "thiserror 2.0.17",
  "time",
  "tokio",
@@ -6493,6 +6495,24 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.113",
+]
 
 [[package]]
 name = "subtle"

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -85,6 +85,8 @@ futures = "0.3.31"
 apalis = "0.7.4"
 apalis-redis = "0.7.4"
 apalis-cron = "0.7.4"
+strum = "0.28"
+strum_macros = "0.28"
 
 #API documentation
 

--- a/api/migrations/20260609144620_add_email_template_config_table.sql
+++ b/api/migrations/20260609144620_add_email_template_config_table.sql
@@ -1,0 +1,11 @@
+-- Add email_template_config table
+
+CREATE TABLE email_template_config (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    owner_id UUID REFERENCES comhairle_user(id), 
+    organization_id UUID REFERENCES organization(id),
+    email_type TEXT NOT NULL,
+    slots JSONB NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/api/migrations/20260616150707_add_subject_column_to_email_template_config.sql
+++ b/api/migrations/20260616150707_add_subject_column_to_email_template_config.sql
@@ -1,0 +1,3 @@
+-- Add subject column to email_template_config
+
+ALTER TABLE email_template_config ADD COLUMN subject TEXT;

--- a/api/migrations/20260619082611_email_template_config_search_index.sql
+++ b/api/migrations/20260619082611_email_template_config_search_index.sql
@@ -1,0 +1,9 @@
+-- Add search indexes to email_template_config
+
+CREATE INDEX idx_email_config_user_email_type
+ON email_template_config(owner_id, email_type)
+WHERE owner_id IS NOT NULL;
+
+CREATE INDEX idx_email_config_organization_email_type
+ON email_template_config(organization_id, email_type)
+WHERE organization_id IS NOT NULL;

--- a/api/src/email_templates/conversation_invite.html
+++ b/api/src/email_templates/conversation_invite.html
@@ -1,16 +1,15 @@
 <!--
 
-Variables
-
-Optional:
+Slots:
 - heading
 - intro
 - body
 - footer
-- domain
 
-Required:
+Variables:
+- conversation_title
 - invite_link
+- domain
 
 -->
 

--- a/api/src/email_templates/conversation_invite.html
+++ b/api/src/email_templates/conversation_invite.html
@@ -18,32 +18,12 @@ Required:
 {% block content %}
 <div style="text-align: left">
 
-	{% if heading %}
-		{{heading|safe}}
-	{% else %}
-		<p>Dear Invited Participant,</p>
-	{% endif %}
+	<!-- TODO: wrap in h1 and make a text field instead of rich text -->
+	{{heading|safe}}
 
-	{% if intro %}
-		{{intro|safe}}
-	{% else %}
-		<p>You have been selected to take part in a public engagement hosted on the
-			<strong>Comhairle</strong> platform by <strong>CrownShy</strong>.
-		<p />
-	{% endif %}
+	{{intro|safe}}
 
-	{% if body %}
-		{{body|safe}}
-	{% else %}
-		<p>We’re inviting you to complete the online engagement.</p>
-		<p>We’re keen to hear your real views and reflections. If you choose to take part, we ask that you:</p>
-
-		<ul>
-			<li>Read and consider each question carefully.</li>
-			<li>Provide your own honest opinions, not blank or repetitive answers.</li>
-			<li>Complete <strong>all sections</strong> of the engagement.</li>
-		</ul>
-	{% endif %}
+	{{body|safe}}
 
 	<p>If you have any difficulties with completing the engagement or with the website please email us at <a
 			href='mailto:team@crown-shy.com'>team@crown-shy.com</a></p>
@@ -55,15 +35,6 @@ Required:
 	<p>The information you provide will be stored securely, kept confidential, and only used for the purposes explained in
 		our privacy notice, which you can read here: <a href="{% if domain %}{{domain}}{% else %}https://comhairle.scot/rights/privacy{% endif %}">privacy notice</a>.
 
-	{% if footer %}
-		{{footer|safe}}
-	{% else %}
-		<p>Thank you very much for your time and contribution to this important process.</p>
-
-		<p>Warm regards, <br />
-			<strong>The CrownShy Team.</strong>
-		</p>
-	{% endif %}
-
+	{{footer|safe}}
 </div>
 {% endblock %}

--- a/api/src/email_templates/conversation_invite.html
+++ b/api/src/email_templates/conversation_invite.html
@@ -17,9 +17,7 @@ Required:
 {% extends "email_layout.html" %}
 {% block content %}
 <div style="text-align: left">
-
-	<!-- TODO: wrap in h1 and make a text field instead of rich text -->
-	{{heading|safe}}
+	<h1>{{heading}}</h1>
 
 	{{intro|safe}}
 

--- a/api/src/email_templates/conversation_invite.html
+++ b/api/src/email_templates/conversation_invite.html
@@ -1,30 +1,69 @@
+<!--
+
+Variables
+
+Optional:
+- heading
+- intro
+- body
+- footer
+- domain
+
+Required:
+- invite_link
+
+-->
+
 {% extends "email_layout.html" %}
 {% block content %}
-<p>Dear Invited Participant,</p>
-<p>You have been selected to take part in a public engagement hosted on the
-	<strong>Comhairle</strong> platform by <strong>CrownShy</strong>.
-<p />
-<p>We’re inviting you to complete the online engagement.</p>
-<p>We’re keen to hear your real views and reflections. If you choose to take part, we ask that you:</p>
+<div style="text-align: left">
 
-<ul>
-	<li>Read and consider each question carefully.</li>
-	<li>Provide your own honest opinions, not blank or repetitive answers.</li>
-	<li>Complete <strong>all sections</strong> of the engagement.</li>
-</ul>
+	{% if heading %}
+		{{heading|safe}}
+	{% else %}
+		<p>Dear Invited Participant,</p>
+	{% endif %}
 
-<p>If you have any difficulties with completing the engagement or with the website please email us at <a
-		href='mailto:team@crown-shy.com'>team@crown-shy.com</a></p>
-<p>On the website <strong>please make sure you sign up using the email address this invitation was sent to</strong>. We
-	can only confirm your participation if you register with this address.</p>
+	{% if intro %}
+		{{intro|safe}}
+	{% else %}
+		<p>You have been selected to take part in a public engagement hosted on the
+			<strong>Comhairle</strong> platform by <strong>CrownShy</strong>.
+		<p />
+	{% endif %}
 
-<p>Here is your link to access the engagement: <a href="{{invite_link}}">{{invite_link}}</a>.
+	{% if body %}
+		{{body|safe}}
+	{% else %}
+		<p>We’re inviting you to complete the online engagement.</p>
+		<p>We’re keen to hear your real views and reflections. If you choose to take part, we ask that you:</p>
 
-<p>The information you provide will be stored securely, kept confidential, and only used for the purposes explained in
-	our privacy notice, which you can read here: <a href="{% if domain %}{{domain}}{% else %}https://comhairle.scot/rights/privacy{% endif %}">privacy notice</a>.
-<p>Thank you very much for your time and contribution to this important process.</p>
+		<ul>
+			<li>Read and consider each question carefully.</li>
+			<li>Provide your own honest opinions, not blank or repetitive answers.</li>
+			<li>Complete <strong>all sections</strong> of the engagement.</li>
+		</ul>
+	{% endif %}
 
-<p>Warm regards, <br />
-	<strong>The CrownShy Team.</strong>
-</p>
+	<p>If you have any difficulties with completing the engagement or with the website please email us at <a
+			href='mailto:team@crown-shy.com'>team@crown-shy.com</a></p>
+	<p>On the website <strong>please make sure you sign up using the email address this invitation was sent to</strong>. We
+		can only confirm your participation if you register with this address.</p>
+
+	<p>Here is your link to access the engagement: <a href="{{invite_link}}">{{invite_link}}</a>.
+
+	<p>The information you provide will be stored securely, kept confidential, and only used for the purposes explained in
+		our privacy notice, which you can read here: <a href="{% if domain %}{{domain}}{% else %}https://comhairle.scot/rights/privacy{% endif %}">privacy notice</a>.
+
+	{% if footer %}
+		{{footer|safe}}
+	{% else %}
+		<p>Thank you very much for your time and contribution to this important process.</p>
+
+		<p>Warm regards, <br />
+			<strong>The CrownShy Team.</strong>
+		</p>
+	{% endif %}
+
+</div>
 {% endblock %}

--- a/api/src/email_templates/event_confirmation.html
+++ b/api/src/email_templates/event_confirmation.html
@@ -1,3 +1,19 @@
+<!--
+
+Slots:
+- heading
+- intro
+- body
+- footer
+
+Variables:
+- event_name
+- event_time
+- event_link
+- organization_email
+
+-->
+
 {% extends "email_layout.html" %}
 {% block content %}
 	<h1>{{heading}}</h1>

--- a/api/src/email_templates/event_confirmation.html
+++ b/api/src/email_templates/event_confirmation.html
@@ -1,22 +1,10 @@
 {% extends "email_layout.html" %}
 {% block content %}
-	{% if heading %}
-		{{heading|safe}}
-	{% else %}
-		<h1>You're in!</h1>
-	{% endif %}
+	<h1>{{heading}}</h1>
 
-	{% if intro %}
-		{{intro|safe}}
-	{% else %}
-		<p>Thank you for registering for {{event_name}}.</p>
-	{% endif %}
+	{{intro|safe}}
 
-	{% if body %}
-		{{body|safe}}
-	{% else %}
-		<p>You will be sent a reminder email before the event with instructions on how to join the online meeting.</p>
-	{% endif %}
+	{{body|safe}}
 	
 
 	<div class="card">
@@ -37,11 +25,5 @@
 		</p>
 	{% endif %}
 
-	{% if footer %}
-		{{footer|safe}}
-	{% else %}
-		<p>We look forward to seeing you there!</p>
-
-		<p><strong>{{organization_name}}</strong></p>
-	{% endif %}
+	{{footer|safe}}
 {% endblock %}

--- a/api/src/email_templates/event_confirmation.html
+++ b/api/src/email_templates/event_confirmation.html
@@ -9,11 +9,13 @@
 	{% if intro %}
 		{{intro|safe}}
 	{% else %}
-		<p>Thank you for registering for {{event_name}}. You will be sent a reminder email before the event with instructions on how to join the online meeting.</p>
+		<p>Thank you for registering for {{event_name}}.</p>
 	{% endif %}
 
 	{% if body %}
 		{{body|safe}}
+	{% else %}
+		<p>You will be sent a reminder email before the event with instructions on how to join the online meeting.</p>
 	{% endif %}
 	
 
@@ -27,17 +29,17 @@
 
 	<p class="link">{{event_link}}</p>
 
+	{% if organization_email %}
+		<p>
+			For any questions, please contact us at
+			<br />
+			<a href="mailto:{{organization_email}}">{{organization_email}}</a>
+		</p>
+	{% endif %}
+
 	{% if footer %}
 		{{footer|safe}}
 	{% else %}
-		{% if organization_email %}
-			<p>
-				For any questions, please contact us at
-				<br />
-				<a href="mailto:{{organization_email}}">{{organization_email}}</a>
-			</p>
-		{% endif %}
-
 		<p>We look forward to seeing you there!</p>
 
 		<p><strong>{{organization_name}}</strong></p>

--- a/api/src/email_templates/event_confirmation.html
+++ b/api/src/email_templates/event_confirmation.html
@@ -39,7 +39,7 @@
 		{% endif %}
 
 		<p>We look forward to seeing you there!</p>
-	{% endif %}
 
-	<p><strong>{{organization_name}}</strong></p>
+		<p><strong>{{organization_name}}</strong></p>
+	{% endif %}
 {% endblock %}

--- a/api/src/email_templates/event_confirmation.html
+++ b/api/src/email_templates/event_confirmation.html
@@ -1,7 +1,21 @@
 {% extends "email_layout.html" %}
 {% block content %}
-	<h1>You're in!</h1>
-	<p>Thank you for registering for {{event_name}}. You will be sent a reminder email before the event with instructions on how to join the online meeting.</p>
+	{% if heading %}
+		{{heading|safe}}
+	{% else %}
+		<h1>You're in!</h1>
+	{% endif %}
+
+	{% if intro %}
+		{{intro|safe}}
+	{% else %}
+		<p>Thank you for registering for {{event_name}}. You will be sent a reminder email before the event with instructions on how to join the online meeting.</p>
+	{% endif %}
+
+	{% if body %}
+		{{body|safe}}
+	{% endif %}
+	
 
 	<div class="card">
 		<h2>{{event_name}}</h2>
@@ -13,15 +27,19 @@
 
 	<p class="link">{{event_link}}</p>
 
-	{% if organization_email %}
-		<p>
-			For any questions, please contact us at
-			<br />
-			<a href="mailto:{{organization_email}}">{{organization_email}}</a>
-		</p>
-	{% endif %}
+	{% if footer %}
+		{{footer|safe}}
+	{% else %}
+		{% if organization_email %}
+			<p>
+				For any questions, please contact us at
+				<br />
+				<a href="mailto:{{organization_email}}">{{organization_email}}</a>
+			</p>
+		{% endif %}
 
-	<p>We look forward to seeing you there!</p>
+		<p>We look forward to seeing you there!</p>
+	{% endif %}
 
 	<p><strong>{{organization_name}}</strong></p>
 {% endblock %}

--- a/api/src/email_templates/event_registration_invite.html
+++ b/api/src/email_templates/event_registration_invite.html
@@ -19,7 +19,7 @@ Required:
 
 {% extends "email_layout.html" %}
 {% block content %}
-	{{heading|safe}}
+	<h1>{{heading}}</h1>
 	
 	{{intro|safe}}
 

--- a/api/src/email_templates/event_registration_invite.html
+++ b/api/src/email_templates/event_registration_invite.html
@@ -19,23 +19,12 @@ Required:
 
 {% extends "email_layout.html" %}
 {% block content %}
-	{% if heading %}
-		{{heading|safe}}
-	{% else %}
-		<h1>Hello!</h1>
-	{% endif %}
-		
-	{% if intro %}
-		{{intro|safe}}
-	{% else %}
-		<p>You are invited to take part in {{event_name}} with {{organization_name}} to collaborate with them.</p>
-	{% endif %}
+	{{heading|safe}}
 	
-	{% if body %}
-		{{body|safe}}
-	{% endif %}
+	{{intro|safe}}
 
-	<p>Click the button below to register.</p>
+	{{body|safe}}
+
 
 	<div class="card">
 		<h2>{{event_name}}</h2>
@@ -47,19 +36,13 @@ Required:
 
 	<p class="link">{{invite_link}}</p>
 
-	{% if footer %}	
-		{{footer|safe}}
-	{% else %}
-		{% if organization_email %}
-			<p>
-				For any questions, please contact us at
-				<br />
-				<a href="mailto:{{organization_email}}">{{organization_email}}</a>
-			</p>
-		{% endif %}
-
-		<p>We look forward to your participation!</p>
-
-		<p><strong>{{organization_name}}</strong></p>
+	{% if organization_email %}
+		<p>
+			For any questions, please contact us at
+			<br />
+			<a href="mailto:{{organization_email}}">{{organization_email}}</a>
+		</p>
 	{% endif %}
+
+	{{footer|safe}}
 {% endblock %}

--- a/api/src/email_templates/event_registration_invite.html
+++ b/api/src/email_templates/event_registration_invite.html
@@ -1,7 +1,40 @@
+<!--
+
+Variables
+
+Optional:
+- heading
+- intro
+- body
+- footer
+- organization_email
+
+Required:
+- event_name
+- event_time
+- organization_name
+- invite_link
+
+-->
+
 {% extends "email_layout.html" %}
 {% block content %}
-	<h1>Hello!</h1>
-	<p>You are invited to take part in {{event_name}} with {{organization_name}} to collaborate with them.</p>
+	{% if heading %}
+		{{heading|safe}}
+	{% else %}
+		<h1>Hello!</h1>
+	{% endif %}
+		
+	{% if intro %}
+		{{intro|safe}}
+	{% else %}
+		<p>You are invited to take part in {{event_name}} with {{organization_name}} to collaborate with them.</p>
+	{% endif %}
+	
+	{% if body %}
+		{{body|safe}}
+	{% endif %}
+
 	<p>Click the button below to register.</p>
 
 	<div class="card">
@@ -14,15 +47,19 @@
 
 	<p class="link">{{invite_link}}</p>
 
-	{% if organization_email %}
-		<p>
-			For any questions, please contact us at
-			<br />
-			<a href="mailto:{{organization_email}}">{{organization_email}}</a>
-		</p>
+	{% if footer %}	
+		{{footer|safe}}
+	{% else %}
+		{% if organization_email %}
+			<p>
+				For any questions, please contact us at
+				<br />
+				<a href="mailto:{{organization_email}}">{{organization_email}}</a>
+			</p>
+		{% endif %}
+
+		<p>We look forward to your participation!</p>
+
+		<p><strong>{{organization_name}}</strong></p>
 	{% endif %}
-
-	<p>We look forward to your participation!</p>
-
-	<p><strong>{{organization_name}}</strong></p>
 {% endblock %}

--- a/api/src/email_templates/event_registration_invite.html
+++ b/api/src/email_templates/event_registration_invite.html
@@ -1,19 +1,16 @@
 <!--
 
-Variables
-
-Optional:
+Slots:
 - heading
 - intro
 - body
 - footer
-- organization_email
 
-Required:
+Variables:
 - event_name
 - event_time
-- organization_name
 - invite_link
+- organization_email
 
 -->
 

--- a/api/src/error.rs
+++ b/api/src/error.rs
@@ -313,6 +313,9 @@ pub enum ComhairleError {
     #[error("Missing email template schema")]
     MissingEmailTemplateSchema(String),
 
+    #[error("Missing email template")]
+    MissingEmailTemplate(String),
+
     #[error("CSV error: {0}")]
     CsvError(#[from] csv::Error),
 

--- a/api/src/error.rs
+++ b/api/src/error.rs
@@ -310,6 +310,9 @@ pub enum ComhairleError {
     #[error("Event missing video_meeting_id")]
     NoVideoMeetingId,
 
+    #[error("Missing email template schema")]
+    MissingEmailTemplateSchema(String),
+
     #[error("CSV error: {0}")]
     CsvError(#[from] csv::Error),
 

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -283,6 +283,10 @@ pub async fn setup_server(state: Arc<ComhairleState>) -> Result<Router<()>, Comh
         .nest_api_service("/jobs", routes::jobs::router(state.clone()))
         .nest_api_service("/services", routes::services::router(state.clone()))
         .nest_api_service("/api_keys", routes::api_keys::router(state.clone()))
+        .nest_api_service(
+            "/email_template_configs",
+            routes::email_template_configs::router(state.clone()),
+        )
         .nest_api_service("/docs", docs_routes(state.clone()))
         .finish_api_with(&mut api, api_docs)
         .layer(Extension(Arc::new(api.clone()))) // Arc is very important here or you will face massive memory and performance issues

--- a/api/src/mailer.rs
+++ b/api/src/mailer.rs
@@ -285,25 +285,22 @@ impl ComhairleMailer for Mailer {
         let conversation_context =
             context! { conversation_title => conversation.title, invite_link };
 
-        let (subject, slots_map) = match email_template_config::get_by_type_user(
+        let email_config = email_template_config::get_by_type_user(
             &state.db,
             user_id,
             &SCHEMA_CONVERSATION_INVITE.email_type,
         )
-        .await
-        {
-            Ok(email_config) => (
-                email_config
-                    .subject
-                    .unwrap_or(SCHEMA_CONVERSATION_INVITE.default_subject.to_string()),
-                email_config.slots.mailer_slots_map(),
-            ),
-            Err(ComhairleError::ResourceNotFound(_)) => (
-                SCHEMA_CONVERSATION_INVITE.default_subject.to_string(),
-                SCHEMA_CONVERSATION_INVITE.slots.mailer_context_map(),
-            ),
-            Err(e) => return Err(e),
-        };
+        .await?;
+
+        let subject = email_config
+            .as_ref()
+            .and_then(|ec| ec.subject.as_deref())
+            .unwrap_or(SCHEMA_CONVERSATION_INVITE.default_subject);
+
+        let slots_map = email_config
+            .as_ref()
+            .map(|ec| ec.slots.mailer_context_map())
+            .unwrap_or(SCHEMA_CONVERSATION_INVITE.slots.mailer_context_map());
 
         let rendered_map = self.resolve_slots_map(&conversation_context, &slots_map)?;
 
@@ -311,7 +308,7 @@ impl ComhairleMailer for Mailer {
 
         self.send_email(
             to,
-            &subject,
+            subject,
             SCHEMA_CONVERSATION_INVITE.template,
             context,
             None,
@@ -414,25 +411,22 @@ impl ComhairleMailer for Mailer {
             invite_link,
         };
 
-        let (subject, slots_map) = match email_template_config::get_by_type_user(
+        let email_config = email_template_config::get_by_type_user(
             &state.db,
             user_id,
             &SCHEMA_EVENT_REGISTRATION_INVITE.email_type,
         )
-        .await
-        {
-            Ok(email_config) => (
-                email_config
-                    .subject
-                    .unwrap_or(SCHEMA_EVENT_REGISTRATION_INVITE.default_subject.to_string()),
-                email_config.slots.mailer_slots_map(),
-            ),
-            Err(ComhairleError::ResourceNotFound(_)) => (
-                SCHEMA_EVENT_REGISTRATION_INVITE.default_subject.to_string(),
-                SCHEMA_EVENT_REGISTRATION_INVITE.slots.mailer_context_map(),
-            ),
-            Err(e) => return Err(e),
-        };
+        .await?;
+
+        let subject = email_config
+            .as_ref()
+            .and_then(|ec| ec.subject.as_deref())
+            .unwrap_or(SCHEMA_EVENT_REGISTRATION_INVITE.default_subject);
+
+        let slots_map = email_config
+            .as_ref()
+            .map(|ec| ec.slots.mailer_context_map())
+            .unwrap_or(SCHEMA_EVENT_REGISTRATION_INVITE.slots.mailer_context_map());
 
         let rendered_map = self.resolve_slots_map(&event_context, &slots_map)?;
 
@@ -445,7 +439,7 @@ impl ComhairleMailer for Mailer {
 
         self.send_email(
             email,
-            &subject,
+            subject,
             "event_registration_invite.html",
             context,
             None,
@@ -479,31 +473,26 @@ impl ComhairleMailer for Mailer {
             event_link,
         };
 
-        let (subject, slots_map) = match email_template_config::get_by_type_user(
+        let email_config = email_template_config::get_by_type_user(
             &state.db,
             user_id,
             &SCHEMA_EVENT_REGISTRATION_CONFIRMATION.email_type,
         )
-        .await
-        {
-            Ok(email_config) => (
-                email_config.subject.unwrap_or(
-                    SCHEMA_EVENT_REGISTRATION_CONFIRMATION
-                        .default_subject
-                        .to_string(),
-                ),
-                email_config.slots.mailer_slots_map(),
-            ),
-            Err(ComhairleError::ResourceNotFound(_)) => (
-                SCHEMA_EVENT_REGISTRATION_CONFIRMATION
-                    .default_subject
-                    .to_string(),
+        .await?;
+
+        let subject = email_config
+            .as_ref()
+            .and_then(|ec| ec.subject.as_deref())
+            .unwrap_or(SCHEMA_EVENT_REGISTRATION_CONFIRMATION.default_subject);
+
+        let slots_map = email_config
+            .as_ref()
+            .map(|ec| ec.slots.mailer_context_map())
+            .unwrap_or(
                 SCHEMA_EVENT_REGISTRATION_CONFIRMATION
                     .slots
                     .mailer_context_map(),
-            ),
-            Err(e) => return Err(e),
-        };
+            );
 
         let rendered_map = self.resolve_slots_map(&event_context, &slots_map)?;
 
@@ -516,7 +505,7 @@ impl ComhairleMailer for Mailer {
 
         self.send_email(
             email,
-            &subject,
+            subject,
             "event_confirmation.html",
             context,
             Some(calendar_invite),

--- a/api/src/mailer.rs
+++ b/api/src/mailer.rs
@@ -193,7 +193,7 @@ impl Mailer {
     ///
     /// Returns an error if any slot value fails to render (e.g. invalid
     /// minijinja syntax).
-    fn resolve_slots_map<'a>(
+    fn resolve_slots_map(
         &self,
         context: &minijinja::Value,
         slots_map: &HashMap<String, String>,
@@ -296,6 +296,9 @@ impl ComhairleMailer for Mailer {
             .as_ref()
             .and_then(|ec| ec.subject.as_deref())
             .unwrap_or(SCHEMA_CONVERSATION_INVITE.default_subject);
+        let subject = self
+            .template_engine
+            .render_str(subject, &conversation_context)?;
 
         let slots_map = email_config
             .as_ref()
@@ -308,7 +311,7 @@ impl ComhairleMailer for Mailer {
 
         self.send_email(
             to,
-            subject,
+            &subject,
             SCHEMA_CONVERSATION_INVITE.template,
             context,
             None,
@@ -422,6 +425,7 @@ impl ComhairleMailer for Mailer {
             .as_ref()
             .and_then(|ec| ec.subject.as_deref())
             .unwrap_or(SCHEMA_EVENT_REGISTRATION_INVITE.default_subject);
+        let subject = self.template_engine.render_str(subject, &event_context)?;
 
         let slots_map = email_config
             .as_ref()
@@ -439,7 +443,7 @@ impl ComhairleMailer for Mailer {
 
         self.send_email(
             email,
-            subject,
+            &subject,
             "event_registration_invite.html",
             context,
             None,
@@ -484,6 +488,7 @@ impl ComhairleMailer for Mailer {
             .as_ref()
             .and_then(|ec| ec.subject.as_deref())
             .unwrap_or(SCHEMA_EVENT_REGISTRATION_CONFIRMATION.default_subject);
+        let subject = self.template_engine.render_str(subject, &event_context)?;
 
         let slots_map = email_config
             .as_ref()
@@ -505,7 +510,7 @@ impl ComhairleMailer for Mailer {
 
         self.send_email(
             email,
-            subject,
+            &subject,
             "event_confirmation.html",
             context,
             Some(calendar_invite),

--- a/api/src/mailer.rs
+++ b/api/src/mailer.rs
@@ -1,10 +1,12 @@
+use crate::models::conversation;
 use crate::models::email_template_config::{
+    self, IntoSlotMap, SLOTS_SCHEMA_CONVERSATION_INVITE,
+    SLOTS_SCHEMA_EVENT_REGISTRATION_CONFIRMATION, SLOTS_SCHEMA_EVENT_REGISTRATION_INVITE,
     TYPE_CONVERSATION_INVITE, TYPE_EVENT_REGISTRATION_CONFIRMATION, TYPE_EVENT_REGISTRATION_INVITE,
 };
 use crate::models::event::{self, LocalizedEvent, ResolveTimeZone};
 use crate::models::organization::Organization;
 use crate::models::users::User;
-use crate::models::{conversation, email_template_config};
 use crate::{error::ComhairleError, ComhairleState};
 
 use async_trait::async_trait;
@@ -108,8 +110,8 @@ pub trait ComhairleMailer: Send + Sync {
     fn preview_email(
         &self,
         template: &str,
-        slots_map: HashMap<&str, String>,
-        variables_map: Option<HashMap<&str, String>>,
+        slots_map: HashMap<String, String>,
+        variables_map: Option<HashMap<String, String>>,
     ) -> Result<String, ComhairleError>;
 }
 
@@ -153,7 +155,7 @@ impl MockComhairleMailer {
             .returning(|_, _, _| Ok(()));
         mailer
             .expect_preview_email()
-            .returning(|_, _| Ok(String::new()));
+            .returning(|_, _, _| Ok(String::new()));
 
         mailer
     }
@@ -195,13 +197,13 @@ impl Mailer {
     fn resolve_slots_map<'a>(
         &self,
         context: &minijinja::Value,
-        slots_map: &HashMap<&'a str, String>,
-    ) -> Result<HashMap<&'a str, String>, ComhairleError> {
-        let mut rendered_map: HashMap<&str, String> = HashMap::new();
+        slots_map: &HashMap<String, String>,
+    ) -> Result<HashMap<String, String>, ComhairleError> {
+        let mut rendered_map: HashMap<String, String> = HashMap::new();
 
         for (key, value) in slots_map {
             let rendered = self.template_engine.render_str(value, context)?;
-            rendered_map.insert(key, rendered);
+            rendered_map.insert(key.to_string(), rendered);
         }
 
         Ok(rendered_map)
@@ -272,7 +274,6 @@ impl ComhairleMailer for Mailer {
         let conversation =
             conversation::get_localised_by_id(&state.db, &conversation_id, locale).await?;
 
-        let default_subject = "Invitation to take part in a public consultation";
         let invite_link = format!(
             "{}/conversations/{}/invite/{}",
             state.config.domain,
@@ -285,30 +286,31 @@ impl ComhairleMailer for Mailer {
         let conversation_context =
             context! { conversation_title => conversation.title, invite_link };
 
-        if let Ok(email_config) =
-            email_template_config::get_by_type_user(&state.db, user_id, TYPE_CONVERSATION_INVITE)
-                .await
-        {
-            let rendered_map =
-                self.resolve_slots_map(&conversation_context, &email_config.slots.to_mailer_map())?;
+        let default_subject = "Invitation to take part in a public consultation";
 
-            let context = minijinja::context! { invite_link, ..rendered_map };
-            self.send_email(
-                to,
-                email_config.subject.as_deref().unwrap_or(default_subject),
-                "conversation_invite.html",
-                context,
-                None,
-            )?;
-        } else {
-            self.send_email(
-                to,
-                default_subject,
-                "conversation_invite.html",
-                conversation_context,
-                None,
-            )?;
-        }
+        let (subject, slots_map) = match email_template_config::get_by_type_user(
+            &state.db,
+            user_id,
+            TYPE_CONVERSATION_INVITE,
+        )
+        .await
+        {
+            Ok(email_config) => (
+                email_config.subject.unwrap_or(default_subject.to_string()),
+                email_config.slots.mailer_slots_map(),
+            ),
+            Err(ComhairleError::ResourceNotFound(_)) => (
+                default_subject.to_string(),
+                SLOTS_SCHEMA_CONVERSATION_INVITE.into_slots_map(),
+            ),
+            Err(e) => return Err(e),
+        };
+
+        let rendered_map = self.resolve_slots_map(&conversation_context, &slots_map)?;
+
+        let context = context! { invite_link, ..rendered_map };
+
+        self.send_email(to, &subject, "conversation_invite.html", context, None)?;
 
         Ok(())
     }
@@ -396,7 +398,6 @@ impl ComhairleMailer for Mailer {
     ) -> Result<(), ComhairleError> {
         let event = event::get_localized_by_id(&state.db, &event_id, locale).await?;
 
-        let default_subject = "Invitation to take part in an event";
         let invite_link = format!(
             "{}/conversations/{}/events/{}/invite/{}",
             state.config.domain, event.conversation_id, event.id, invite_id
@@ -409,35 +410,43 @@ impl ComhairleMailer for Mailer {
             invite_link,
         };
 
-        if let Ok(email_config) = email_template_config::get_by_type_user(
+        let default_subject = "Invitation to take part in an event";
+
+        let (subject, slots_map) = match email_template_config::get_by_type_user(
             &state.db,
             user_id,
             TYPE_EVENT_REGISTRATION_INVITE,
         )
         .await
         {
-            let rendered_map =
-                self.resolve_slots_map(&event_context, &email_config.slots.to_mailer_map())?;
+            Ok(email_config) => (
+                email_config.subject.unwrap_or(default_subject.to_string()),
+                email_config.slots.mailer_slots_map(),
+            ),
+            Err(ComhairleError::ResourceNotFound(_)) => (
+                default_subject.to_string(),
+                SLOTS_SCHEMA_EVENT_REGISTRATION_INVITE.into_slots_map(),
+            ),
+            Err(e) => return Err(e),
+        };
 
-            let context = context! { invite_link, ..rendered_map }; // TODO: find a better way of
-                                                                    // handling this
+        let rendered_map = self.resolve_slots_map(&event_context, &slots_map)?;
 
-            self.send_email(
-                email,
-                email_config.subject.as_deref().unwrap_or(default_subject),
-                "event_registration_invite.html",
-                context,
-                None,
-            )
-        } else {
-            self.send_email(
-                email,
-                default_subject,
-                "event_registration_invite.html",
-                event_context,
-                None,
-            )
-        }
+        let context = context! {
+            event_name => event.name,
+            event_time => event.format_date_with_time_zone(event.start_time, None),
+            organization_name => "Bloom", // TODO:
+            invite_link,
+            ..rendered_map
+        };
+
+        self.send_email(
+            email,
+            &subject,
+            "event_registration_invite.html",
+            context,
+            None,
+        )
     }
 
     async fn send_event_confirmation_email(
@@ -470,34 +479,42 @@ impl ComhairleMailer for Mailer {
             event_link,
         };
 
-        if let Ok(email_config) = email_template_config::get_by_type_user(
+        let (subject, slots_map) = match email_template_config::get_by_type_user(
             &state.db,
             user_id,
             TYPE_EVENT_REGISTRATION_CONFIRMATION,
         )
         .await
         {
-            let rendered_map =
-                self.resolve_slots_map(&event_context, &email_config.slots.to_mailer_map())?;
+            Ok(email_config) => (
+                email_config.subject.unwrap_or(default_subject.to_string()),
+                email_config.slots.mailer_slots_map(),
+            ),
+            Err(ComhairleError::ResourceNotFound(_)) => (
+                default_subject.to_string(),
+                SLOTS_SCHEMA_EVENT_REGISTRATION_CONFIRMATION.into_slots_map(),
+            ),
+            Err(e) => return Err(e),
+        };
 
-            let context = context! { event_link, ..rendered_map }; // TODO: find a better way of
+        let rendered_map = self.resolve_slots_map(&event_context, &slots_map)?;
 
-            self.send_email(
-                email,
-                email_config.subject.as_deref().unwrap_or(default_subject),
-                "event_confirmation.html",
-                context,
-                Some(calendar_invite),
-            )
-        } else {
-            self.send_email(
-                email,
-                default_subject,
-                "event_confirmation.html",
-                event_context,
-                Some(calendar_invite),
-            )
-        }
+        let context = context! {
+            event_name => event.name,
+            event_time => event.format_date_with_time_zone(event.start_time, None),
+            organization_name => "Bloom", // TODO:
+            // organization_email => organization_email,
+            event_link,
+            ..rendered_map
+        }; // TODO: find a better way of
+
+        self.send_email(
+            email,
+            &subject,
+            "event_confirmation.html",
+            context,
+            Some(calendar_invite),
+        )
     }
 
     fn send_event_reminder(
@@ -559,8 +576,8 @@ impl ComhairleMailer for Mailer {
     fn preview_email(
         &self,
         template: &str,
-        slots_map: HashMap<&str, String>,
-        variables_map: Option<HashMap<&str, String>>,
+        slots_map: HashMap<String, String>,
+        variables_map: Option<HashMap<String, String>>,
     ) -> Result<String, ComhairleError> {
         let context = match variables_map {
             Some(var_map) => {

--- a/api/src/mailer.rs
+++ b/api/src/mailer.rs
@@ -105,7 +105,12 @@ pub trait ComhairleMailer: Send + Sync {
         html_body: &str,
     ) -> Result<(), ComhairleError>;
 
-    fn preview_email(&self, template: &str, context: Value) -> Result<String, ComhairleError>;
+    fn preview_email(
+        &self,
+        template: &str,
+        slots_map: HashMap<&str, String>,
+        variables_map: Option<HashMap<&str, String>>,
+    ) -> Result<String, ComhairleError>;
 }
 
 #[derive(Debug)]
@@ -551,7 +556,22 @@ impl ComhairleMailer for Mailer {
     /// - The named template does not exist ([`ComhairleError::MissingEmailTemplate`])
     /// - The template fails to render (e.g. missing required variables or invalid syntax)
     /// - CSS inlining fails
-    fn preview_email(&self, template: &str, context: Value) -> Result<String, ComhairleError> {
+    fn preview_email(
+        &self,
+        template: &str,
+        slots_map: HashMap<&str, String>,
+        variables_map: Option<HashMap<&str, String>>,
+    ) -> Result<String, ComhairleError> {
+        let context = match variables_map {
+            Some(var_map) => {
+                let local_context = context! { ..var_map };
+                let rendered_map = self.resolve_slots_map(&local_context, &slots_map)?;
+
+                context! { ..rendered_map }
+            }
+            None => context! { ..slots_map },
+        };
+
         let template = self
             .template_engine
             .get_template(template)

--- a/api/src/mailer.rs
+++ b/api/src/mailer.rs
@@ -1,5 +1,7 @@
-use crate::models::email_template_config::TYPE_CONVERSATION_INVITE;
-use crate::models::event::{LocalizedEvent, ResolveTimeZone};
+use crate::models::email_template_config::{
+    TYPE_CONVERSATION_INVITE, TYPE_EVENT_REGISTRATION_INVITE,
+};
+use crate::models::event::{self, LocalizedEvent, ResolveTimeZone};
 use crate::models::organization::Organization;
 use crate::models::users::User;
 use crate::models::{conversation, email_template_config};
@@ -38,7 +40,7 @@ pub trait ComhairleMailer: Send + Sync {
     async fn send_conversation_invite_email(
         &self,
         state: &Arc<ComhairleState>,
-        to: &str,
+        email: &str,
         conversation_id: Uuid,
         user_id: Uuid,
         invite_id: Uuid,
@@ -69,12 +71,14 @@ pub trait ComhairleMailer: Send + Sync {
         passcode_link: Option<String>,
     ) -> Result<(), ComhairleError>;
 
-    fn send_event_registration_email(
+    async fn send_event_registration_email(
         &self,
-        email: String,
-        event: &LocalizedEvent,
-        organization: &Option<Organization>,
-        invite_link: String,
+        state: &Arc<ComhairleState>,
+        email: &str,
+        event_id: Uuid,
+        user_id: Uuid,
+        invite_id: Uuid,
+        locale: &str,
     ) -> Result<(), ComhairleError>;
 
     fn send_event_confirmation_email(
@@ -129,7 +133,7 @@ impl MockComhairleMailer {
             .returning(|_, _, _| Ok(()));
         mailer
             .expect_send_event_registration_email()
-            .returning(|_, _, _, _| Ok(()));
+            .returning(|_, _, _, _, _, _| Box::pin(async move { Ok(()) }));
         mailer
             .expect_send_event_confirmation_email()
             .returning(|_, _, _, _| Ok(()));
@@ -266,7 +270,8 @@ impl ComhairleMailer for Mailer {
             invite_id
         );
 
-        let conversation_context = context! { conversation_title => conversation.title };
+        let conversation_context =
+            context! { conversation_title => conversation.title, invite_link };
 
         if let Ok(email_config) =
             email_template_config::get_by_type_user(&state.db, user_id, TYPE_CONVERSATION_INVITE)
@@ -368,26 +373,58 @@ impl ComhairleMailer for Mailer {
         }
     }
 
-    fn send_event_registration_email(
+    async fn send_event_registration_email(
         &self,
-        email: String,
-        event: &LocalizedEvent,
-        _organization: &Option<Organization>,
-        invite_link: String,
+        state: &Arc<ComhairleState>,
+        email: &str,
+        event_id: Uuid,
+        user_id: Uuid,
+        invite_id: Uuid,
+        locale: &str,
     ) -> Result<(), ComhairleError> {
-        self.send_email(
-            &email,
-            "Invitation to take part in an event",
-            "event_registration_invite.html",
-            context! {
-                event_name => event.name,
-                event_time => event.format_date_with_time_zone(event.start_time, None),
-                organization_name => "Bloom", //
-                // organization_email => organization_email,
-                invite_link => invite_link,
-            },
-            None,
+        let event = event::get_localized_by_id(&state.db, &event_id, locale).await?;
+
+        let invite_link = format!(
+            "{}/conversations/{}/events/{}/invite/{}",
+            state.config.domain, event.conversation_id, event.id, invite_id
+        );
+
+        let event_context = context! {
+            event_name => event.name,
+            event_time => event.format_date_with_time_zone(event.start_time, None),
+            organization_name => "Bloom", // TODO:
+            invite_link,
+        };
+
+        if let Ok(email_config) = email_template_config::get_by_type_user(
+            &state.db,
+            user_id,
+            TYPE_EVENT_REGISTRATION_INVITE,
         )
+        .await
+        {
+            let rendered_map =
+                self.resolve_slots_map(&event_context, &email_config.slots.to_mailer_map())?;
+
+            let context = context! { invite_link, ..rendered_map }; // TODO: find a better way of
+            // handling this
+
+            self.send_email(
+                email,
+                "Invitation to take part in an event",
+                "event_registration_invite.html",
+                context,
+                None,
+            )
+        } else {
+            self.send_email(
+                email,
+                "Invitation to take part in an event",
+                "event_registration_invite.html",
+                event_context,
+                None,
+            )
+        }
     }
 
     fn send_event_confirmation_email(

--- a/api/src/mailer.rs
+++ b/api/src/mailer.rs
@@ -1,8 +1,7 @@
 use crate::models::conversation;
 use crate::models::email_template_config::{
-    self, MailerContextMap, SLOTS_SCHEMA_CONVERSATION_INVITE,
-    SLOTS_SCHEMA_EVENT_REGISTRATION_CONFIRMATION, SLOTS_SCHEMA_EVENT_REGISTRATION_INVITE,
-    TYPE_CONVERSATION_INVITE, TYPE_EVENT_REGISTRATION_CONFIRMATION, TYPE_EVENT_REGISTRATION_INVITE,
+    self, MailerContextMap, SCHEMA_CONVERSATION_INVITE, SCHEMA_EVENT_REGISTRATION_CONFIRMATION,
+    SCHEMA_EVENT_REGISTRATION_INVITE,
 };
 use crate::models::event::{self, LocalizedEvent, ResolveTimeZone};
 use crate::models::organization::Organization;
@@ -286,22 +285,22 @@ impl ComhairleMailer for Mailer {
         let conversation_context =
             context! { conversation_title => conversation.title, invite_link };
 
-        let default_subject = "Invitation to take part in a public consultation";
-
         let (subject, slots_map) = match email_template_config::get_by_type_user(
             &state.db,
             user_id,
-            TYPE_CONVERSATION_INVITE,
+            &SCHEMA_CONVERSATION_INVITE.email_type,
         )
         .await
         {
             Ok(email_config) => (
-                email_config.subject.unwrap_or(default_subject.to_string()),
+                email_config
+                    .subject
+                    .unwrap_or(SCHEMA_CONVERSATION_INVITE.default_subject.to_string()),
                 email_config.slots.mailer_slots_map(),
             ),
             Err(ComhairleError::ResourceNotFound(_)) => (
-                default_subject.to_string(),
-                SLOTS_SCHEMA_CONVERSATION_INVITE.mailer_context_map(),
+                SCHEMA_CONVERSATION_INVITE.default_subject.to_string(),
+                SCHEMA_CONVERSATION_INVITE.slots.mailer_context_map(),
             ),
             Err(e) => return Err(e),
         };
@@ -310,7 +309,13 @@ impl ComhairleMailer for Mailer {
 
         let context = context! { invite_link, domain => state.config.domain, ..rendered_map };
 
-        self.send_email(to, &subject, "conversation_invite.html", context, None)?;
+        self.send_email(
+            to,
+            &subject,
+            SCHEMA_CONVERSATION_INVITE.template,
+            context,
+            None,
+        )?;
 
         Ok(())
     }
@@ -409,22 +414,22 @@ impl ComhairleMailer for Mailer {
             invite_link,
         };
 
-        let default_subject = "Invitation to take part in an event";
-
         let (subject, slots_map) = match email_template_config::get_by_type_user(
             &state.db,
             user_id,
-            TYPE_EVENT_REGISTRATION_INVITE,
+            &SCHEMA_EVENT_REGISTRATION_INVITE.email_type,
         )
         .await
         {
             Ok(email_config) => (
-                email_config.subject.unwrap_or(default_subject.to_string()),
+                email_config
+                    .subject
+                    .unwrap_or(SCHEMA_EVENT_REGISTRATION_INVITE.default_subject.to_string()),
                 email_config.slots.mailer_slots_map(),
             ),
             Err(ComhairleError::ResourceNotFound(_)) => (
-                default_subject.to_string(),
-                SLOTS_SCHEMA_EVENT_REGISTRATION_INVITE.mailer_context_map(),
+                SCHEMA_EVENT_REGISTRATION_INVITE.default_subject.to_string(),
+                SCHEMA_EVENT_REGISTRATION_INVITE.slots.mailer_context_map(),
             ),
             Err(e) => return Err(e),
         };
@@ -457,7 +462,6 @@ impl ComhairleMailer for Mailer {
     ) -> Result<(), ComhairleError> {
         let event = event::get_localized_by_id(&state.db, &event_id, locale).await?;
 
-        let default_subject = "Event registration confirmation";
         let event_link = format!(
             "{}/conversations/{}/events/{}",
             state.config.domain, event.conversation_id, event.id
@@ -478,17 +482,25 @@ impl ComhairleMailer for Mailer {
         let (subject, slots_map) = match email_template_config::get_by_type_user(
             &state.db,
             user_id,
-            TYPE_EVENT_REGISTRATION_CONFIRMATION,
+            &SCHEMA_EVENT_REGISTRATION_CONFIRMATION.email_type,
         )
         .await
         {
             Ok(email_config) => (
-                email_config.subject.unwrap_or(default_subject.to_string()),
+                email_config.subject.unwrap_or(
+                    SCHEMA_EVENT_REGISTRATION_CONFIRMATION
+                        .default_subject
+                        .to_string(),
+                ),
                 email_config.slots.mailer_slots_map(),
             ),
             Err(ComhairleError::ResourceNotFound(_)) => (
-                default_subject.to_string(),
-                SLOTS_SCHEMA_EVENT_REGISTRATION_CONFIRMATION.mailer_context_map(),
+                SCHEMA_EVENT_REGISTRATION_CONFIRMATION
+                    .default_subject
+                    .to_string(),
+                SCHEMA_EVENT_REGISTRATION_CONFIRMATION
+                    .slots
+                    .mailer_context_map(),
             ),
             Err(e) => return Err(e),
         };
@@ -500,7 +512,7 @@ impl ComhairleMailer for Mailer {
             event_time => event.format_date_with_time_zone(event.start_time, None),
             event_link,
             ..rendered_map
-        }; // TODO: find a better way of
+        };
 
         self.send_email(
             email,

--- a/api/src/mailer.rs
+++ b/api/src/mailer.rs
@@ -1,5 +1,5 @@
 use crate::models::email_template_config::{
-    TYPE_CONVERSATION_INVITE, TYPE_EVENT_REGISTRATION_INVITE,
+    TYPE_CONVERSATION_INVITE, TYPE_EVENT_REGISTRATION_CONFIRMATION, TYPE_EVENT_REGISTRATION_INVITE,
 };
 use crate::models::event::{self, LocalizedEvent, ResolveTimeZone};
 use crate::models::organization::Organization;
@@ -81,12 +81,13 @@ pub trait ComhairleMailer: Send + Sync {
         locale: &str,
     ) -> Result<(), ComhairleError>;
 
-    fn send_event_confirmation_email(
+    async fn send_event_confirmation_email(
         &self,
-        email: String,
-        event: &LocalizedEvent,
-        organization: &Option<Organization>,
-        link_href: String,
+        state: &Arc<ComhairleState>,
+        email: &str,
+        event_id: Uuid,
+        user_id: Uuid,
+        locale: &str,
     ) -> Result<(), ComhairleError>;
 
     fn send_event_reminder(
@@ -136,7 +137,7 @@ impl MockComhairleMailer {
             .returning(|_, _, _, _, _, _| Box::pin(async move { Ok(()) }));
         mailer
             .expect_send_event_confirmation_email()
-            .returning(|_, _, _, _| Ok(()));
+            .returning(|_, _, _, _, _| Box::pin(async move { Ok(()) }));
         mailer
             .expect_send_event_reminder()
             .returning(|_, _, _, _| Ok(()));
@@ -429,13 +430,21 @@ impl ComhairleMailer for Mailer {
         }
     }
 
-    fn send_event_confirmation_email(
+    async fn send_event_confirmation_email(
         &self,
-        email: String,
-        event: &LocalizedEvent,
-        _organization: &Option<Organization>,
-        link_href: String,
+        state: &Arc<ComhairleState>,
+        email: &str,
+        event_id: Uuid,
+        user_id: Uuid,
+        locale: &str,
     ) -> Result<(), ComhairleError> {
+        let event = event::get_localized_by_id(&state.db, &event_id, locale).await?;
+
+        let default_subject = "Event registration confirmation";
+        let event_link = format!(
+            "{}/conversations/{}/events/{}",
+            state.config.domain, event.conversation_id, event.id
+        );
         let calendar_invite = create_calendar_invite_attachment(
             &event.name,
             &event.description,
@@ -443,19 +452,42 @@ impl ComhairleMailer for Mailer {
             event.end_time,
         )?;
 
-        self.send_email(
-            &email,
-            "Event registration confirmation",
-            "event_confirmation.html",
-            context! {
-                event_name => event.name,
-                event_time => event.format_date_with_time_zone(event.start_time, None),
-                organization_name => "Bloom", // TODO:
-                // organization_email => organization_email,
-                event_link => link_href,
-            },
-            Some(calendar_invite),
+        let event_context = context! {
+            event_name => event.name,
+            event_time => event.format_date_with_time_zone(event.start_time, None),
+            organization_name => "Bloom", // TODO:
+            // organization_email => organization_email,
+            event_link,
+        };
+
+        if let Ok(email_config) = email_template_config::get_by_type_user(
+            &state.db,
+            user_id,
+            TYPE_EVENT_REGISTRATION_CONFIRMATION,
         )
+        .await
+        {
+            let rendered_map =
+                self.resolve_slots_map(&event_context, &email_config.slots.to_mailer_map())?;
+
+            let context = context! { event_link, ..rendered_map }; // TODO: find a better way of
+
+            self.send_email(
+                email,
+                email_config.subject.as_deref().unwrap_or(default_subject),
+                "event_confirmation.html",
+                context,
+                Some(calendar_invite),
+            )
+        } else {
+            self.send_email(
+                email,
+                default_subject,
+                "event_confirmation.html",
+                event_context,
+                Some(calendar_invite),
+            )
+        }
     }
 
     fn send_event_reminder(

--- a/api/src/mailer.rs
+++ b/api/src/mailer.rs
@@ -1,6 +1,6 @@
 use crate::models::conversation;
 use crate::models::email_template_config::{
-    self, IntoSlotMap, SLOTS_SCHEMA_CONVERSATION_INVITE,
+    self, MailerContextMap, SLOTS_SCHEMA_CONVERSATION_INVITE,
     SLOTS_SCHEMA_EVENT_REGISTRATION_CONFIRMATION, SLOTS_SCHEMA_EVENT_REGISTRATION_INVITE,
     TYPE_CONVERSATION_INVITE, TYPE_EVENT_REGISTRATION_CONFIRMATION, TYPE_EVENT_REGISTRATION_INVITE,
 };
@@ -301,7 +301,7 @@ impl ComhairleMailer for Mailer {
             ),
             Err(ComhairleError::ResourceNotFound(_)) => (
                 default_subject.to_string(),
-                SLOTS_SCHEMA_CONVERSATION_INVITE.into_slots_map(),
+                SLOTS_SCHEMA_CONVERSATION_INVITE.mailer_context_map(),
             ),
             Err(e) => return Err(e),
         };
@@ -425,7 +425,7 @@ impl ComhairleMailer for Mailer {
             ),
             Err(ComhairleError::ResourceNotFound(_)) => (
                 default_subject.to_string(),
-                SLOTS_SCHEMA_EVENT_REGISTRATION_INVITE.into_slots_map(),
+                SLOTS_SCHEMA_EVENT_REGISTRATION_INVITE.mailer_context_map(),
             ),
             Err(e) => return Err(e),
         };
@@ -492,7 +492,7 @@ impl ComhairleMailer for Mailer {
             ),
             Err(ComhairleError::ResourceNotFound(_)) => (
                 default_subject.to_string(),
-                SLOTS_SCHEMA_EVENT_REGISTRATION_CONFIRMATION.into_slots_map(),
+                SLOTS_SCHEMA_EVENT_REGISTRATION_CONFIRMATION.mailer_context_map(),
             ),
             Err(e) => return Err(e),
         };

--- a/api/src/mailer.rs
+++ b/api/src/mailer.rs
@@ -261,6 +261,7 @@ impl ComhairleMailer for Mailer {
         let conversation =
             conversation::get_localised_by_id(&state.db, &conversation_id, locale).await?;
 
+        let default_subject = "Invitation to take part in a public consultation";
         let invite_link = format!(
             "{}/conversations/{}/invite/{}",
             state.config.domain,
@@ -283,7 +284,7 @@ impl ComhairleMailer for Mailer {
             let context = minijinja::context! { invite_link, ..rendered_map };
             self.send_email(
                 to,
-                "Invitation to take part in a public consultation",
+                email_config.subject.as_deref().unwrap_or(default_subject),
                 "conversation_invite.html",
                 context,
                 None,
@@ -291,7 +292,7 @@ impl ComhairleMailer for Mailer {
         } else {
             self.send_email(
                 to,
-                "Invitation to take part in a public consultation",
+                default_subject,
                 "conversation_invite.html",
                 conversation_context,
                 None,
@@ -384,6 +385,7 @@ impl ComhairleMailer for Mailer {
     ) -> Result<(), ComhairleError> {
         let event = event::get_localized_by_id(&state.db, &event_id, locale).await?;
 
+        let default_subject = "Invitation to take part in an event";
         let invite_link = format!(
             "{}/conversations/{}/events/{}/invite/{}",
             state.config.domain, event.conversation_id, event.id, invite_id
@@ -407,11 +409,11 @@ impl ComhairleMailer for Mailer {
                 self.resolve_slots_map(&event_context, &email_config.slots.to_mailer_map())?;
 
             let context = context! { invite_link, ..rendered_map }; // TODO: find a better way of
-            // handling this
+                                                                    // handling this
 
             self.send_email(
                 email,
-                "Invitation to take part in an event",
+                email_config.subject.as_deref().unwrap_or(default_subject),
                 "event_registration_invite.html",
                 context,
                 None,
@@ -419,7 +421,7 @@ impl ComhairleMailer for Mailer {
         } else {
             self.send_email(
                 email,
-                "Invitation to take part in an event",
+                default_subject,
                 "event_registration_invite.html",
                 event_context,
                 None,

--- a/api/src/mailer.rs
+++ b/api/src/mailer.rs
@@ -104,6 +104,8 @@ pub trait ComhairleMailer: Send + Sync {
         subject: &str,
         html_body: &str,
     ) -> Result<(), ComhairleError>;
+
+    fn preview_email(&self, template: &str, context: Value) -> Result<String, ComhairleError>;
 }
 
 #[derive(Debug)]
@@ -144,6 +146,9 @@ impl MockComhairleMailer {
         mailer
             .expect_send_conversation_broadcast_email()
             .returning(|_, _, _| Ok(()));
+        mailer
+            .expect_preview_email()
+            .returning(|_, _| Ok(String::new()));
 
         mailer
     }
@@ -532,6 +537,30 @@ impl ComhairleMailer for Mailer {
             context! { subject, body => html_body },
             None,
         )
+    }
+
+    /// Renders an email template to HTML for preview purposes.
+    ///
+    /// Intended to be called from the frontend to allow users to preview how a
+    /// customised [`EmailTemplateConfig`] will appear as they are editing it,
+    /// before any emails are actually sent.
+    ///
+    /// # Errors
+    ///
+    /// Returns a [`ComhairleError`] if:
+    /// - The named template does not exist ([`ComhairleError::MissingEmailTemplate`])
+    /// - The template fails to render (e.g. missing required variables or invalid syntax)
+    /// - CSS inlining fails
+    fn preview_email(&self, template: &str, context: Value) -> Result<String, ComhairleError> {
+        let template = self
+            .template_engine
+            .get_template(template)
+            .map_err(|_| ComhairleError::MissingEmailTemplate(template.to_string()))?;
+
+        let html = template.render(context)?;
+        let html_inline_styles = css_inline::inline(&html)?;
+
+        Ok(html_inline_styles)
     }
 }
 

--- a/api/src/mailer.rs
+++ b/api/src/mailer.rs
@@ -1,8 +1,11 @@
-use crate::error::ComhairleError;
+use crate::models::email_template_config::TYPE_CONVERSATION_INVITE;
 use crate::models::event::{LocalizedEvent, ResolveTimeZone};
 use crate::models::organization::Organization;
 use crate::models::users::User;
+use crate::models::{conversation, email_template_config};
+use crate::{error::ComhairleError, ComhairleState};
 
+use async_trait::async_trait;
 use chrono::{DateTime, Utc};
 use icalendar::{self as ical, Component, EventLike};
 use lettre::message::Mailbox;
@@ -12,12 +15,15 @@ use lettre::{
     Message, SmtpTransport, Transport,
 };
 use minijinja::{context, Environment, Value};
-use std::str::FromStr;
+use std::collections::HashMap;
+use std::{str::FromStr, sync::Arc};
 use tracing::{instrument, warn};
+use uuid::Uuid;
 
 #[cfg(test)]
 use mockall::{automock, predicate::*};
 
+#[async_trait]
 #[cfg_attr(test, automock)]
 pub trait ComhairleMailer: Send + Sync {
     fn send_email(
@@ -27,6 +33,16 @@ pub trait ComhairleMailer: Send + Sync {
         template: &str,
         context: Value,
         attachment: Option<SinglePart>,
+    ) -> Result<(), ComhairleError>;
+
+    async fn send_conversation_invite_email(
+        &self,
+        state: &Arc<ComhairleState>,
+        to: &str,
+        conversation_id: Uuid,
+        user_id: Uuid,
+        invite_id: Uuid,
+        locale: &str,
     ) -> Result<(), ComhairleError>;
 
     fn send_welcome_email(&self, user: &User, verify_link: String) -> Result<(), ComhairleError>;
@@ -103,6 +119,9 @@ impl MockComhairleMailer {
             .returning(|_, _, _| Ok(()));
         mailer.expect_send_email().returning(|_, _, _, _, _| Ok(()));
         mailer
+            .expect_send_conversation_invite_email()
+            .returning(|_, _, _, _, _, _| Box::pin(async move { Ok(()) }));
+        mailer
             .expect_send_otp_email()
             .returning(|_, _, _, _| Ok(()));
         mailer
@@ -136,8 +155,45 @@ impl Mailer {
             template_engine: env,
         }
     }
+
+    /// Resolves dynamic placeholders within email template slot values.
+    ///
+    /// Each value in `slots_map` (e.g. `heading`, `intro`, `body`, `footer`)
+    /// may itself contain minijinja syntax such as `{{ conversation_title }}`,
+    /// allowing users to embed dynamic, runtime-provided data within the
+    /// content they configure for an email template.
+    ///
+    /// This method renders each slot value as its own minijinja template using
+    /// the supplied `context`, returning a new map with the resolved values.
+    /// The result can then be merged into the final context used to render the
+    /// outer email template, e.g.:
+    ///
+    /// ```ignore
+    /// let resolved = self.resolve_slots_map(&context, &slots_map)?;
+    /// let final_context = minijinja::context! { ..resolved };
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if any slot value fails to render (e.g. invalid
+    /// minijinja syntax).
+    fn resolve_slots_map<'a>(
+        &self,
+        context: &minijinja::Value,
+        slots_map: &HashMap<&'a str, String>,
+    ) -> Result<HashMap<&'a str, String>, ComhairleError> {
+        let mut rendered_map: HashMap<&str, String> = HashMap::new();
+
+        for (key, value) in slots_map {
+            let rendered = self.template_engine.render_str(value, context)?;
+            rendered_map.insert(key, rendered);
+        }
+
+        Ok(rendered_map)
+    }
 }
 
+#[async_trait]
 impl ComhairleMailer for Mailer {
     #[instrument(err(Debug), skip(attachment))]
     fn send_email(
@@ -185,6 +241,57 @@ impl ComhairleMailer for Mailer {
             warn!("Mailer error: {e}");
             e
         })?;
+
+        Ok(())
+    }
+
+    async fn send_conversation_invite_email(
+        &self,
+        state: &Arc<ComhairleState>,
+        to: &str,
+        conversation_id: Uuid,
+        user_id: Uuid,
+        invite_id: Uuid,
+        locale: &str,
+    ) -> Result<(), ComhairleError> {
+        let conversation =
+            conversation::get_localised_by_id(&state.db, &conversation_id, locale).await?;
+
+        let invite_link = format!(
+            "{}/conversations/{}/invite/{}",
+            state.config.domain,
+            conversation
+                .slug
+                .unwrap_or_else(|| conversation.id.to_string()),
+            invite_id
+        );
+
+        let conversation_context = context! { conversation_title => conversation.title };
+
+        if let Ok(email_config) =
+            email_template_config::get_by_type_user(&state.db, user_id, TYPE_CONVERSATION_INVITE)
+                .await
+        {
+            let rendered_map =
+                self.resolve_slots_map(&conversation_context, &email_config.slots.to_mailer_map())?;
+
+            let context = minijinja::context! { invite_link, ..rendered_map };
+            self.send_email(
+                to,
+                "Invitation to take part in a public consultation",
+                "conversation_invite.html",
+                context,
+                None,
+            )?;
+        } else {
+            self.send_email(
+                to,
+                "Invitation to take part in a public consultation",
+                "conversation_invite.html",
+                conversation_context,
+                None,
+            )?;
+        }
 
         Ok(())
     }

--- a/api/src/mailer.rs
+++ b/api/src/mailer.rs
@@ -308,7 +308,7 @@ impl ComhairleMailer for Mailer {
 
         let rendered_map = self.resolve_slots_map(&conversation_context, &slots_map)?;
 
-        let context = context! { invite_link, ..rendered_map };
+        let context = context! { invite_link, domain => state.config.domain, ..rendered_map };
 
         self.send_email(to, &subject, "conversation_invite.html", context, None)?;
 
@@ -406,7 +406,6 @@ impl ComhairleMailer for Mailer {
         let event_context = context! {
             event_name => event.name,
             event_time => event.format_date_with_time_zone(event.start_time, None),
-            organization_name => "Bloom", // TODO:
             invite_link,
         };
 
@@ -435,7 +434,6 @@ impl ComhairleMailer for Mailer {
         let context = context! {
             event_name => event.name,
             event_time => event.format_date_with_time_zone(event.start_time, None),
-            organization_name => "Bloom", // TODO:
             invite_link,
             ..rendered_map
         };
@@ -474,8 +472,6 @@ impl ComhairleMailer for Mailer {
         let event_context = context! {
             event_name => event.name,
             event_time => event.format_date_with_time_zone(event.start_time, None),
-            organization_name => "Bloom", // TODO:
-            // organization_email => organization_email,
             event_link,
         };
 
@@ -502,8 +498,6 @@ impl ComhairleMailer for Mailer {
         let context = context! {
             event_name => event.name,
             event_time => event.format_date_with_time_zone(event.start_time, None),
-            organization_name => "Bloom", // TODO:
-            // organization_email => organization_email,
             event_link,
             ..rendered_map
         }; // TODO: find a better way of

--- a/api/src/models.rs
+++ b/api/src/models.rs
@@ -2,6 +2,7 @@ pub mod api_key;
 pub mod bot_service_user_session;
 pub mod conversation;
 pub mod conversation_email_notification_recipients;
+pub mod email_template_config;
 pub mod event;
 pub mod event_attendance;
 pub mod feedback;

--- a/api/src/models.rs
+++ b/api/src/models.rs
@@ -1,3 +1,5 @@
+use crate::error::ComhairleError;
+
 pub mod api_key;
 pub mod bot_service_user_session;
 pub mod conversation;
@@ -37,3 +39,16 @@ pub mod workflow_step;
 
 #[cfg(test)]
 pub mod model_test_helpers;
+
+pub trait SqlxResultExt<T> {
+    fn not_found_as(self, resource: &str) -> Result<T, ComhairleError>;
+}
+
+impl<T> SqlxResultExt<T> for Result<T, sqlx::Error> {
+    fn not_found_as(self, resource: &str) -> Result<T, ComhairleError> {
+        self.map_err(|e| match e {
+            sqlx::Error::RowNotFound => ComhairleError::ResourceNotFound(resource.into()),
+            other => ComhairleError::DatabaseError(other),
+        })
+    }
+}

--- a/api/src/models/email_template_config.rs
+++ b/api/src/models/email_template_config.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use chrono::{DateTime, Utc};
 use schemars::JsonSchema;
 use sea_query::{enum_def, Expr, PostgresQueryBuilder, Query, SelectStatement, SimpleExpr};
@@ -12,7 +14,10 @@ use sqlx_postgres::{PgArgumentBuffer, PgTypeInfo, PgValueRef};
 use tracing::instrument;
 use uuid::Uuid;
 
-use crate::{error::ComhairleError, models::users};
+use crate::{
+    error::ComhairleError,
+    models::{users, SqlxResultExt},
+};
 
 /// A client-configured email template, persisted to the `email_template_config` table.
 ///
@@ -52,8 +57,8 @@ pub enum EmailTemplateSlots {
     EventRegistrationConfirmation(DefaultEmailSlots),
 }
 
-const TYPE_CONVERSATION_INVITE: &str = "conversation_invite";
-const TYPE_EVENT_REGISTRATION_CONFIRMATION: &str = "event_registration_confirmation";
+pub const TYPE_CONVERSATION_INVITE: &str = "conversation_invite";
+pub const TYPE_EVENT_REGISTRATION_CONFIRMATION: &str = "event_registration_confirmation";
 
 impl EmailTemplateSlots {
     /// Returns the schema for every email template type.
@@ -95,6 +100,29 @@ impl EmailTemplateSlots {
             EmailTemplateSlots::EventRegistrationConfirmation(_) => DEFAULT_SLOTS_SCHEMA,
         }
     }
+
+    /// Converts the email template slots into a `HashMap` of key/value pairs
+    /// suitable for use as a minijinja template context.
+    ///
+    /// The returned map contains the slot field names (e.g. `heading`, `intro`,
+    /// `body`, `footer`) and their corresponding values, which are used to
+    /// populate the variables referenced in the email's minijinja template.
+    ///
+    /// Because `minijinja::context!` supports spreading a `HashMap` with `..`,
+    /// the map returned here can be combined with additional ad-hoc context
+    /// variables that aren't stored as part of the email config (e.g. dynamic
+    /// links or IDs generated at send time). For example:
+    ///
+    /// ```ignore
+    /// let base = email_config.slots.to_mailer_map();
+    /// let context = minijinja::context! { invite_link => "foo@bar.com", ..base };
+    /// ```
+    pub fn to_mailer_map(&self) -> HashMap<&str, String> {
+        match self {
+            EmailTemplateSlots::ConversationInvite(slots) => slots.to_mailer_map(),
+            EmailTemplateSlots::EventRegistrationConfirmation(slots) => slots.to_mailer_map(),
+        }
+    }
 }
 
 impl std::fmt::Display for EmailTemplateSlots {
@@ -115,6 +143,17 @@ pub struct DefaultEmailSlots {
     pub intro: String,
     pub body: String,
     pub footer: String,
+}
+
+impl DefaultEmailSlots {
+    fn to_mailer_map(&self) -> HashMap<&str, String> {
+        HashMap::from([
+            ("heading", self.heading.clone()),
+            ("intro", self.intro.clone()),
+            ("body", self.body.clone()),
+            ("footer", self.footer.clone()),
+        ])
+    }
 }
 
 impl Type<Postgres> for EmailTemplateSlots {
@@ -304,12 +343,28 @@ pub async fn get_by_id(db: &PgPool, id: Uuid) -> Result<EmailTemplateConfig, Com
     let email_config = sqlx::query_as_with(&sql, values)
         .fetch_one(db)
         .await
-        .map_err(|e| match e {
-            sqlx::Error::RowNotFound => {
-                ComhairleError::ResourceNotFound("Email template config".into())
-            }
-            other => ComhairleError::DatabaseError(other),
-        })?;
+        .not_found_as("Email template config")?;
+
+    Ok(email_config)
+}
+
+#[instrument(err(Debug))]
+pub async fn get_by_type_user(
+    db: &PgPool,
+    user_id: Uuid,
+    email_type: &str,
+) -> Result<EmailTemplateConfig, ComhairleError> {
+    let (sql, values) = Query::select()
+        .columns(DEFAULT_COLUMNS)
+        .from(EmailTemplateConfigIden::Table)
+        .and_where(Expr::col(EmailTemplateConfigIden::OwnerId).eq(user_id))
+        .and_where(Expr::col(EmailTemplateConfigIden::EmailType).eq(email_type.to_owned()))
+        .build_sqlx(PostgresQueryBuilder);
+
+    let email_config = query_as_with(&sql, values)
+        .fetch_one(db)
+        .await
+        .not_found_as("Email template config")?;
 
     Ok(email_config)
 }
@@ -468,6 +523,33 @@ mod tests {
         let new_email_config = create(&pool, current_user.id, &params).await?;
 
         let email_config = get_by_id(&pool, new_email_config.id).await?;
+
+        assert_eq!(new_email_config.id, email_config.id, "ids don't match");
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn should_get_email_config_user_and_email_type(
+        pool: PgPool,
+    ) -> Result<(), Box<dyn Error>> {
+        let (app, mut session) = setup_default_app_and_session(&pool).await?;
+        let (_, current_user, _) = session.current_user(&app).await?;
+
+        let params = CreateEmailTemplateConfig {
+            slots: EmailTemplateSlots::ConversationInvite(DefaultEmailSlots {
+                heading: "<h1>You're invite to a conversation</h1>".to_string(),
+                intro: "<p>You have been selected to take part in a public engagement</p>"
+                    .to_string(),
+                body: "<p>Test body content</p>".to_string(),
+                footer: "<p>Thank you for your time</p>".to_string(),
+            }),
+        };
+
+        let new_email_config = create(&pool, current_user.id, &params).await?;
+
+        let email_config =
+            get_by_type_user(&pool, current_user.id, TYPE_CONVERSATION_INVITE).await?;
 
         assert_eq!(new_email_config.id, email_config.id, "ids don't match");
 

--- a/api/src/models/email_template_config.rs
+++ b/api/src/models/email_template_config.rs
@@ -33,16 +33,90 @@ pub struct EmailTemplateConfig {
     pub id: Uuid,
     pub owner_id: Uuid,
     pub organization_id: Option<Uuid>,
-    pub email_type: String,
+    pub email_type: EmailType,
     pub slots: EmailTemplateSlots,
     pub subject: Option<String>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
 
-pub const TYPE_CONVERSATION_INVITE: &str = "conversation_invite";
-pub const TYPE_EVENT_REGISTRATION_INVITE: &str = "event_registration_invite";
-pub const TYPE_EVENT_REGISTRATION_CONFIRMATION: &str = "event_registration_confirmation";
+#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone, PartialEq, PartialOrd, sqlx::Type)]
+#[sqlx(type_name = "TEXT")]
+#[serde(rename_all = "snake_case")]
+pub enum EmailType {
+    #[sqlx(rename = "conversation_invite")]
+    ConversationInvite,
+    #[sqlx(rename = "event_registration_invite")]
+    EventRegistrationInvite,
+    #[sqlx(rename = "event_registration_invite")]
+    EventRegistrationConfirmation,
+}
+
+impl From<EmailType> for sea_query::Value {
+    fn from(val: EmailType) -> Self {
+        sea_query::Value::String(Some(Box::new(val.to_string())))
+    }
+}
+
+impl std::fmt::Display for EmailType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let value = match self {
+            EmailType::ConversationInvite => "conversation_invite",
+            EmailType::EventRegistrationInvite => "event_registration_invite",
+            EmailType::EventRegistrationConfirmation => "event_registration_invite",
+        };
+        write!(f, "{}", value)
+    }
+}
+
+impl Type<Postgres> for EmailTemplateSlots {
+    fn type_info() -> PgTypeInfo {
+        <serde_json::Value as Type<Postgres>>::type_info()
+    }
+}
+
+impl<'q> Encode<'q, Postgres> for EmailTemplateSlots {
+    fn encode_by_ref(
+        &self,
+        buf: &mut PgArgumentBuffer,
+    ) -> Result<IsNull, sqlx::error::BoxDynError> {
+        let json = serde_json::to_value(self)?;
+        <serde_json::Value as Encode<Postgres>>::encode(json, buf)
+    }
+}
+
+impl<'r> Decode<'r, Postgres> for EmailTemplateSlots {
+    fn decode(value: PgValueRef<'r>) -> Result<Self, sqlx::error::BoxDynError> {
+        let json: serde_json::Value = Decode::<Postgres>::decode(value)?;
+        Ok(serde_json::from_value(json)?)
+    }
+}
+
+const DEFAULT_COLUMNS: [EmailTemplateConfigIden; 8] = [
+    EmailTemplateConfigIden::Id,
+    EmailTemplateConfigIden::OwnerId,
+    EmailTemplateConfigIden::OrganizationId,
+    EmailTemplateConfigIden::EmailType,
+    EmailTemplateConfigIden::Slots,
+    EmailTemplateConfigIden::Subject,
+    EmailTemplateConfigIden::CreatedAt,
+    EmailTemplateConfigIden::UpdatedAt,
+];
+
+// ===
+//
+// Schemas
+//
+// ===
+
+#[derive(Serialize, JsonSchema, Debug, Clone)]
+pub struct EmailTypeSchema {
+    pub email_type: EmailType,
+    pub template: &'static str,
+    pub default_subject: &'static str,
+    pub variables: &'static [&'static str],
+    pub slots: &'static [SlotSchemaDefinition],
+}
 
 /// Metadata describing a single configurable slot in an email template.
 ///
@@ -76,111 +150,116 @@ enum ContentType {
     RichText,
 }
 
-#[derive(Serialize, JsonSchema, Debug, Clone)]
-pub struct EmailTypeSchema {
-    pub email_type: &'static str,
-    pub variables: &'static [&'static str],
-    pub slots: &'static [SlotSchemaDefinition],
-}
+pub const SCHEMA_CONVERSATION_INVITE: EmailTypeSchema = EmailTypeSchema {
+    email_type: EmailType::ConversationInvite,
+    template: "conversation_invite.html",
+    default_subject: "Invitation to take part in a public consultation",
+    variables: &["conversation_title"],
+    slots: &[
+        SlotSchemaDefinition {
+            key: "heading",
+            label: "Heading",
+            hint: "The email heading",
+            default_content: "Dear Invited Participant,",
+            content_type: ContentType::PlainText,
+        },
+        SlotSchemaDefinition {
+            key: "intro",
+            label: "Intro",
+            hint: "Opening paragraph",
+            default_content: "<p>You have been selected to take part in a public engagement, <strong>{{conversation_title}}</strong>, hosted on the <strong>Comhairle</strong> platform by <strong>CrownShy</strong>.<p />",
+            content_type: ContentType::RichText,
+        },
+        SlotSchemaDefinition {
+            key: "body",
+            label: "Body",
+            hint: "Main email content",
+            default_content: "<p>We’re inviting you to complete the online engagement.</p><p>We’re keen to hear your real views and reflections. If you choose to take part, we ask that you:</p><ul><li>Read and consider each question carefully.</li><li>Provide your own honest opinions, not blank or repetitive answers.</li><li>Complete <strong>all sections</strong> of the engagement.</li></ul>",
+            content_type: ContentType::RichText,
+        },
+        SlotSchemaDefinition {
+            key: "footer",
+            label: "Footer",
+            hint: "Closing line",
+            default_content: "<p>Thank you very much for your time and contribution to this important process.</p><p>Warm regards, <br /><strong>The CrownShy Team.</strong></p>",
+            content_type: ContentType::RichText,
+        },
+    ]
+};
 
-// ===
-//
-// Schemas
-//
-// ===
+pub const SCHEMA_EVENT_REGISTRATION_INVITE: EmailTypeSchema = EmailTypeSchema {
+    email_type: EmailType::EventRegistrationInvite,
+    template: "event_registration_invite.html",
+    default_subject: "Invitation to take part in an event",
+    variables: &["event_name", "event_time", "invite_link"],
+    slots: &[
+        SlotSchemaDefinition {
+            key: "heading",
+            label: "Heading",
+            hint: "The email heading",
+            default_content: "Hello!",
+            content_type: ContentType::PlainText,
+        },
+        SlotSchemaDefinition {
+            key: "intro",
+            label: "Intro",
+            hint: "Opening paragraph",
+            default_content: "<p>You are invited to take part in <strong>{{event_name}}</strong> with <strong>CrownShy</strong> to collaborate with them.</p>",
+            content_type: ContentType::RichText,
+        },
+        SlotSchemaDefinition {
+            key: "body",
+            label: "Body",
+            hint: "Main email content",
+            default_content: "<p>Click the button below to register.</p>",
+            content_type: ContentType::RichText,
+        },
+        SlotSchemaDefinition {
+            key: "footer",
+            label: "Footer",
+            hint: "Closing line",
+            default_content: "<p>We look forward to your participation!</p><p><strong>CrownShy</strong></p>",
+            content_type: ContentType::RichText,
+        },
+    ]
+};
 
-pub const SLOTS_SCHEMA_CONVERSATION_INVITE: &[SlotSchemaDefinition] = &[
-    SlotSchemaDefinition {
-        key: "heading",
-        label: "Heading",
-        hint: "The email heading",
-        default_content: "Dear Invited Participant,",
-        content_type: ContentType::PlainText,
-    },
-    SlotSchemaDefinition {
-        key: "intro",
-        label: "Intro",
-        hint: "Opening paragraph",
-        default_content: "<p>You have been selected to take part in a public engagement, <strong>{{conversation_title}}</strong>, hosted on the <strong>Comhairle</strong> platform by <strong>CrownShy</strong>.<p />",
-        content_type: ContentType::RichText,
-    },
-    SlotSchemaDefinition {
-        key: "body",
-        label: "Body",
-        hint: "Main email content",
-        default_content: "<p>We’re inviting you to complete the online engagement.</p><p>We’re keen to hear your real views and reflections. If you choose to take part, we ask that you:</p><ul><li>Read and consider each question carefully.</li><li>Provide your own honest opinions, not blank or repetitive answers.</li><li>Complete <strong>all sections</strong> of the engagement.</li></ul>",
-        content_type: ContentType::RichText,
-    },
-    SlotSchemaDefinition {
-        key: "footer",
-        label: "Footer",
-        hint: "Closing line",
-        default_content: "<p>Thank you very much for your time and contribution to this important process.</p><p>Warm regards, <br /><strong>The CrownShy Team.</strong></p>",
-        content_type: ContentType::RichText,
-    },
-];
-
-pub const SLOTS_SCHEMA_EVENT_REGISTRATION_INVITE: &[SlotSchemaDefinition] = &[
-    SlotSchemaDefinition {
-        key: "heading",
-        label: "Heading",
-        hint: "The email heading",
-        default_content: "Hello!",
-        content_type: ContentType::PlainText,
-    },
-    SlotSchemaDefinition {
-        key: "intro",
-        label: "Intro",
-        hint: "Opening paragraph",
-        default_content: "<p>You are invited to take part in <strong>{{event_name}}</strong> with <strong>CrownShy</strong> to collaborate with them.</p>",
-        content_type: ContentType::RichText,
-    },
-    SlotSchemaDefinition {
-        key: "body",
-        label: "Body",
-        hint: "Main email content",
-        default_content: "<p>Click the button below to register.</p>",
-        content_type: ContentType::RichText,
-    },
-    SlotSchemaDefinition {
-        key: "footer",
-        label: "Footer",
-        hint: "Closing line",
-        default_content: "<p>We look forward to your participation!</p><p><strong>CrownShy</strong></p>",
-        content_type: ContentType::RichText,
-    },
-];
-
-pub const SLOTS_SCHEMA_EVENT_REGISTRATION_CONFIRMATION: &[SlotSchemaDefinition] = &[
-    SlotSchemaDefinition {
-        key: "heading",
-        label: "Heading",
-        hint: "The email heading",
-        default_content: "You're in!",
-        content_type: ContentType::PlainText,
-    },
-    SlotSchemaDefinition {
-        key: "intro",
-        label: "Intro",
-        hint: "Opening paragraph",
-        default_content: "<p>Thank you for registering for <strong>{{event_name}}</strong>.",
-        content_type: ContentType::RichText,
-    },
-    SlotSchemaDefinition {
-        key: "body",
-        label: "Body",
-        hint: "Main email content",
-        default_content: "<p>You will be sent a reminder email before the event with instructions on how to join the online meeting.</p>",
-        content_type: ContentType::RichText,
-    },
-    SlotSchemaDefinition {
-        key: "footer",
-        label: "Footer",
-        hint: "Closing line",
-        default_content: "<p>We look forward to seeing you there!</p><p><strong>CrownShy</strong></p>",
-        content_type: ContentType::RichText,
-    },
-];
+pub const SCHEMA_EVENT_REGISTRATION_CONFIRMATION: EmailTypeSchema = EmailTypeSchema {
+    email_type: EmailType::EventRegistrationConfirmation,
+    template: "event_confirmation.html",
+    default_subject: "Event registration confirmation",
+    variables: &["event_name", "event_time", "event_link"],
+    slots: &[
+        SlotSchemaDefinition {
+            key: "heading",
+            label: "Heading",
+            hint: "The email heading",
+            default_content: "You're in!",
+            content_type: ContentType::PlainText,
+        },
+        SlotSchemaDefinition {
+            key: "intro",
+            label: "Intro",
+            hint: "Opening paragraph",
+            default_content: "<p>Thank you for registering for <strong>{{event_name}}</strong>.",
+            content_type: ContentType::RichText,
+        },
+        SlotSchemaDefinition {
+            key: "body",
+            label: "Body",
+            hint: "Main email content",
+            default_content: "<p>You will be sent a reminder email before the event with instructions on how to join the online meeting.</p>",
+            content_type: ContentType::RichText,
+        },
+        SlotSchemaDefinition {
+            key: "footer",
+            label: "Footer",
+            hint: "Closing line",
+            default_content: "<p>We look forward to seeing you there!</p><p><strong>CrownShy</strong></p>",
+            content_type: ContentType::RichText,
+        },
+    ]
+};
 
 /// Converts `self` to [`HashMap`] mapping email template variable keys to their content.
 pub trait MailerContextMap {
@@ -254,60 +333,13 @@ impl EmailTemplateSlots {
         ]
     }
 
+    /// Returns the schema for the associated email template type.
     pub fn schema(&self) -> EmailTypeSchema {
         match self {
-            EmailTemplateSlots::ConversationInvite(_) => EmailTypeSchema {
-                email_type: self.type_str(),
-                variables: self.template_variables(),
-                slots: SLOTS_SCHEMA_CONVERSATION_INVITE,
-            },
-            EmailTemplateSlots::EventRegistrationInvite(_) => EmailTypeSchema {
-                email_type: self.type_str(),
-                variables: self.template_variables(),
-                slots: SLOTS_SCHEMA_EVENT_REGISTRATION_INVITE,
-            },
-            EmailTemplateSlots::EventRegistrationConfirmation(_) => EmailTypeSchema {
-                email_type: self.type_str(),
-                variables: self.template_variables(),
-                slots: SLOTS_SCHEMA_EVENT_REGISTRATION_CONFIRMATION,
-            },
-        }
-    }
-
-    /// Helper method returning associated template HTML file
-    pub fn email_template(&self) -> &str {
-        match self {
-            EmailTemplateSlots::ConversationInvite(_) => "conversation_invite.html",
-            EmailTemplateSlots::EventRegistrationInvite(_) => "event_registration_invite.html",
-            EmailTemplateSlots::EventRegistrationConfirmation(_) => "event_confirmation.html",
-        }
-    }
-
-    fn template_variables(&self) -> &'static [&'static str] {
-        match self {
-            EmailTemplateSlots::ConversationInvite(_) => &["conversation_title"],
-            EmailTemplateSlots::EventRegistrationInvite(_) => {
-                &["event_name", "event_time", "invite_link"]
-            }
+            EmailTemplateSlots::ConversationInvite(_) => SCHEMA_CONVERSATION_INVITE,
+            EmailTemplateSlots::EventRegistrationInvite(_) => SCHEMA_EVENT_REGISTRATION_INVITE,
             EmailTemplateSlots::EventRegistrationConfirmation(_) => {
-                &["event_name", "event_time", "event_link"]
-            }
-        }
-    }
-
-    /// Returns the canonical string identifier for this email template variant.
-    ///
-    /// This is the single source of truth for the string representation of each
-    /// variant, and is used by both [`Display`] and [`schema`] to avoid
-    /// duplicating the mapping. The returned string is always a `&'static str`
-    /// drawn from the `TYPE_*` constants, which allows it to be embedded in
-    /// [`EmailTypeSchema`] without lifetime annotation.
-    fn type_str(&self) -> &'static str {
-        match self {
-            EmailTemplateSlots::ConversationInvite(_) => TYPE_CONVERSATION_INVITE,
-            EmailTemplateSlots::EventRegistrationInvite(_) => TYPE_EVENT_REGISTRATION_INVITE,
-            EmailTemplateSlots::EventRegistrationConfirmation(_) => {
-                TYPE_EVENT_REGISTRATION_CONFIRMATION
+                SCHEMA_EVENT_REGISTRATION_CONFIRMATION
             }
         }
     }
@@ -378,47 +410,18 @@ impl EmailTemplateSlots {
             ]),
         }
     }
+
+    /// Helper method to return HTML template file name for associated email type
+    pub fn email_template(&self) -> &str {
+        self.schema().template
+    }
 }
 
 impl std::fmt::Display for EmailTemplateSlots {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.type_str())
+        write!(f, "{}", self.schema().email_type)
     }
 }
-
-impl Type<Postgres> for EmailTemplateSlots {
-    fn type_info() -> PgTypeInfo {
-        <serde_json::Value as Type<Postgres>>::type_info()
-    }
-}
-
-impl<'q> Encode<'q, Postgres> for EmailTemplateSlots {
-    fn encode_by_ref(
-        &self,
-        buf: &mut PgArgumentBuffer,
-    ) -> Result<IsNull, sqlx::error::BoxDynError> {
-        let json = serde_json::to_value(self)?;
-        <serde_json::Value as Encode<Postgres>>::encode(json, buf)
-    }
-}
-
-impl<'r> Decode<'r, Postgres> for EmailTemplateSlots {
-    fn decode(value: PgValueRef<'r>) -> Result<Self, sqlx::error::BoxDynError> {
-        let json: serde_json::Value = Decode::<Postgres>::decode(value)?;
-        Ok(serde_json::from_value(json)?)
-    }
-}
-
-const DEFAULT_COLUMNS: [EmailTemplateConfigIden; 8] = [
-    EmailTemplateConfigIden::Id,
-    EmailTemplateConfigIden::OwnerId,
-    EmailTemplateConfigIden::OrganizationId,
-    EmailTemplateConfigIden::EmailType,
-    EmailTemplateConfigIden::Slots,
-    EmailTemplateConfigIden::Subject,
-    EmailTemplateConfigIden::CreatedAt,
-    EmailTemplateConfigIden::UpdatedAt,
-];
 
 #[derive(Deserialize, JsonSchema, Debug)]
 pub struct CreateEmailTemplateConfig {
@@ -533,7 +536,7 @@ pub async fn get_by_id(db: &PgPool, id: Uuid) -> Result<EmailTemplateConfig, Com
 pub async fn get_by_type_user(
     db: &PgPool,
     user_id: Uuid,
-    email_type: &str,
+    email_type: &EmailType,
 ) -> Result<EmailTemplateConfig, ComhairleError> {
     let (sql, values) = Query::select()
         .columns(DEFAULT_COLUMNS)
@@ -734,8 +737,12 @@ mod tests {
 
         let new_email_config = create(&pool, current_user.id, &params).await?;
 
-        let email_config =
-            get_by_type_user(&pool, current_user.id, TYPE_CONVERSATION_INVITE).await?;
+        let email_config = get_by_type_user(
+            &pool,
+            current_user.id,
+            &SCHEMA_CONVERSATION_INVITE.email_type,
+        )
+        .await?;
 
         assert_eq!(new_email_config.id, email_config.id, "ids don't match");
 

--- a/api/src/models/email_template_config.rs
+++ b/api/src/models/email_template_config.rs
@@ -154,6 +154,41 @@ impl EmailTemplateSlots {
             EmailTemplateSlots::EventRegistrationConfirmation(slots) => slots.to_mailer_map(),
         }
     }
+
+    /// Returns a map of placeholder values for runtime template variables,
+    /// used when previewing a customised [`EmailTemplateConfig`] in the frontend.
+    ///
+    /// When users compose email content they can embed dynamic variables (e.g.
+    /// `{{ conversation_title }}`) that are only available at the point an email
+    /// is actually sent. This method provides realistic example values for those
+    /// variables so that previews render meaningfully rather than showing empty
+    /// or broken output.
+    ///
+    /// The returned map is specific to each [`EmailTemplateSlots`] variant, as
+    /// different email types expose different runtime variables. The values are
+    /// illustrative only and are never used in real email sends.
+    pub fn preview_variables_map(&self) -> HashMap<&str, String> {
+        match self {
+            EmailTemplateSlots::ConversationInvite(_) => HashMap::from([(
+                "conversation_title",
+                "Renewable energy in rural areas".to_string(),
+            )]),
+            EmailTemplateSlots::EventRegistrationConfirmation(_) => HashMap::from([
+                (
+                    "event_name",
+                    "Prioritising accessibility in websites".to_string(),
+                ),
+                ("event_time", "24 May, 2026".to_string()),
+            ]),
+            EmailTemplateSlots::EventRegistrationInvite(_) => HashMap::from([
+                (
+                    "event_name",
+                    "Prioritising accessibility in websites".to_string(),
+                ),
+                ("event_time", "24 May, 2026".to_string()),
+            ]),
+        }
+    }
 }
 
 impl std::fmt::Display for EmailTemplateSlots {

--- a/api/src/models/email_template_config.rs
+++ b/api/src/models/email_template_config.rs
@@ -14,6 +14,12 @@ use uuid::Uuid;
 
 use crate::{error::ComhairleError, models::users};
 
+/// A client-configured email template, persisted to the `email_template_config` table.
+///
+/// Each record belongs to an owner and optionally an organization, and holds
+/// the configured slot content for a particular email type via [`EmailTemplateSlots`].
+/// The `slots` field determines which email template will be rendered and what
+/// content will be injected into it.
 #[derive(Serialize, Deserialize, Debug, FromRow, Clone, JsonSchema)]
 #[enum_def(table_name = "email_template_config")]
 pub struct EmailTemplateConfig {
@@ -26,6 +32,19 @@ pub struct EmailTemplateConfig {
     pub updated_at: DateTime<Utc>,
 }
 
+/// The configurable slot content for a particular email template type.
+///
+/// Each variant corresponds to a distinct email template and carries the slot
+/// content that will be injected into it at send time. Serialised as a tagged
+/// JSON object (e.g. `{ "type": "conversation_invite", "heading": "...", ... }`)
+/// for storage in the `slots` JSONB column on [`EmailTemplateConfig`].
+///
+/// # Adding a new email type
+///
+/// 1. Add a variant here with its slot struct.
+/// 2. Add the corresponding HTML template.
+/// 3. Update [`EmailTemplateSlots::schemas`] with the new variant's schema.
+/// 4. Update [`EmailTemplateSlots::to_template`] to return the template filename.
 #[derive(Serialize, Deserialize, JsonSchema, Debug, Clone, PartialEq)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum EmailTemplateSlots {
@@ -33,11 +52,47 @@ pub enum EmailTemplateSlots {
     EventRegistrationConfirmation(DefaultEmailSlots),
 }
 
+const TYPE_CONVERSATION_INVITE: &str = "conversation_invite";
+const TYPE_EVENT_REGISTRATION_CONFIRMATION: &str = "event_registration_confirmation";
+
 impl EmailTemplateSlots {
-    fn to_template(&self) -> &str {
+    /// Returns the schema for every email template type.
+    ///
+    /// Each entry describes a variant of [`EmailTemplateSlots`], pairing the
+    /// variant's string identifier with the [`SlotDefinition`]s that define its
+    /// configurable slots. This is intended to be served to the frontend so it
+    /// can render the correct form fields when a user selects an email type to
+    /// configure.
+    ///
+    /// # Adding a new email type
+    ///
+    /// When a new variant is added to [`EmailTemplateSlots`], a corresponding
+    /// [`EmailTypeSchema`] must be added here manually. There is no compiler
+    /// enforcement for this.
+    pub fn schemas() -> &'static [EmailTypeSchema] {
+        &[
+            EmailTypeSchema {
+                email_type: TYPE_CONVERSATION_INVITE,
+                slots: DEFAULT_SLOTS_SCHEMA,
+            },
+            EmailTypeSchema {
+                email_type: TYPE_EVENT_REGISTRATION_CONFIRMATION,
+                slots: DEFAULT_SLOTS_SCHEMA,
+            },
+        ]
+    }
+
+    pub fn to_template(&self) -> &str {
         match self {
             EmailTemplateSlots::ConversationInvite(_) => "conversation_invite.html",
             EmailTemplateSlots::EventRegistrationConfirmation(_) => "event_confirmation.html",
+        }
+    }
+
+    pub fn schema(&self) -> &'static [SlotSchemaDefinition] {
+        match self {
+            EmailTemplateSlots::ConversationInvite(_) => DEFAULT_SLOTS_SCHEMA,
+            EmailTemplateSlots::EventRegistrationConfirmation(_) => DEFAULT_SLOTS_SCHEMA,
         }
     }
 }
@@ -45,16 +100,16 @@ impl EmailTemplateSlots {
 impl std::fmt::Display for EmailTemplateSlots {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let value = match self {
-            EmailTemplateSlots::ConversationInvite(_) => "conversation_invite",
+            EmailTemplateSlots::ConversationInvite(_) => TYPE_CONVERSATION_INVITE,
             EmailTemplateSlots::EventRegistrationConfirmation(_) => {
-                "event_registration_confirmation"
+                TYPE_EVENT_REGISTRATION_CONFIRMATION
             }
         };
         write!(f, "{}", value)
     }
 }
 
-#[derive(Serialize, Deserialize, JsonSchema, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, JsonSchema, Debug, Clone, PartialEq, Default)]
 pub struct DefaultEmailSlots {
     pub heading: String,
     pub intro: String,
@@ -84,6 +139,67 @@ impl<'r> Decode<'r, Postgres> for EmailTemplateSlots {
         Ok(serde_json::from_value(json)?)
     }
 }
+
+/// Metadata describing a single configurable slot in an email template.
+///
+/// `SlotSchemaDefinition` is used to communicate the structure of an email template
+/// to the frontend, allowing it to render the correct form fields when a user
+/// is configuring a particular email type. It is the UI-facing counterpart to
+/// the typed fields on structs like [`DefaultEmailSlots`].
+#[derive(Serialize, JsonSchema, Debug, Clone)]
+pub struct SlotSchemaDefinition {
+    /// The key used to identify this slot, matching the field name on the
+    /// corresponding slots struct (e.g. `"heading"`, `"body"`).
+    pub key: &'static str,
+    /// A human-readable label for display in the configuration UI.
+    pub label: &'static str,
+    /// A short description shown to the user explaining what this slot
+    /// controls and any guidance on what to write.
+    pub hint: &'static str,
+    /// Whether this slot must be populated before the config can be saved.
+    pub required: bool,
+    /// An optional upper bound on the number of characters allowed in this
+    /// slot. Used for both frontend validation and server-side validation
+    /// before persisting. `None` means no limit is enforced.
+    pub max_chars: Option<usize>,
+}
+
+#[derive(Serialize, JsonSchema, Debug, Clone)]
+pub struct EmailTypeSchema {
+    pub email_type: &'static str,
+    pub slots: &'static [SlotSchemaDefinition],
+}
+
+const DEFAULT_SLOTS_SCHEMA: &[SlotSchemaDefinition] = &[
+    SlotSchemaDefinition {
+        key: "heading",
+        label: "Heading",
+        hint: "The email heading",
+        required: true,
+        max_chars: Some(100),
+    },
+    SlotSchemaDefinition {
+        key: "intro",
+        label: "Intro",
+        hint: "Opening paragraph",
+        required: true,
+        max_chars: Some(100),
+    },
+    SlotSchemaDefinition {
+        key: "body",
+        label: "Body",
+        hint: "Main email content",
+        required: true,
+        max_chars: None,
+    },
+    SlotSchemaDefinition {
+        key: "footer",
+        label: "Footer",
+        hint: "Closing line",
+        required: false,
+        max_chars: Some(100),
+    },
+];
 
 const DEFAULT_COLUMNS: [EmailTemplateConfigIden; 7] = [
     EmailTemplateConfigIden::Id,

--- a/api/src/models/email_template_config.rs
+++ b/api/src/models/email_template_config.rs
@@ -38,6 +38,146 @@ pub struct EmailTemplateConfig {
     pub updated_at: DateTime<Utc>,
 }
 
+pub const TYPE_CONVERSATION_INVITE: &str = "conversation_invite";
+pub const TYPE_EVENT_REGISTRATION_INVITE: &str = "event_registration_invite";
+pub const TYPE_EVENT_REGISTRATION_CONFIRMATION: &str = "event_registration_confirmation";
+
+/// Metadata describing a single configurable slot in an email template.
+///
+/// `SlotSchemaDefinition` is used to communicate the structure of an email template
+/// to the frontend, allowing it to render the correct form fields when a user
+/// is configuring a particular email type. It is the UI-facing counterpart to
+/// the typed fields on structs like [`DefaultEmailSlots`].
+#[derive(Serialize, JsonSchema, Debug, Clone)]
+pub struct SlotSchemaDefinition {
+    /// The key used to identify this slot, matching the field name on the
+    /// corresponding slots struct (e.g. `"heading"`, `"body"`).
+    pub key: &'static str,
+    /// A human-readable label for display in the configuration UI.
+    pub label: &'static str,
+    /// A short description shown to the user explaining what this slot
+    /// controls and any guidance on what to write.
+    pub hint: &'static str,
+    /// Default html used as a starting point for a slot as well as a fallback
+    /// if an [`EmailTemplateConfig`] does not exist for this user / email_type.
+    pub default_content: &'static str,
+}
+
+#[derive(Serialize, JsonSchema, Debug, Clone)]
+pub struct EmailTypeSchema {
+    pub email_type: &'static str,
+    pub variables: &'static [&'static str],
+    pub slots: &'static [SlotSchemaDefinition],
+}
+
+// ===
+//
+// Schemas
+//
+// ===
+
+pub const SLOTS_SCHEMA_CONVERSATION_INVITE: &[SlotSchemaDefinition] = &[
+    SlotSchemaDefinition {
+        key: "heading",
+        label: "Heading",
+        hint: "The email heading",
+        default_content: "Dear Invited Participant,"
+    },
+    SlotSchemaDefinition {
+        key: "intro",
+        label: "Intro",
+        hint: "Opening paragraph",
+        default_content: "<p>You have been selected to take part in a public engagement, <strong>{{conversation_title}}</strong>, hosted on the <strong>Comhairle</strong> platform by <strong>CrownShy</strong>.<p />"
+    },
+    SlotSchemaDefinition {
+        key: "body",
+        label: "Body",
+        hint: "Main email content",
+        default_content: "<p>We’re inviting you to complete the online engagement.</p><p>We’re keen to hear your real views and reflections. If you choose to take part, we ask that you:</p><ul><li>Read and consider each question carefully.</li><li>Provide your own honest opinions, not blank or repetitive answers.</li><li>Complete <strong>all sections</strong> of the engagement.</li></ul>"
+    },
+    SlotSchemaDefinition {
+        key: "footer",
+        label: "Footer",
+        hint: "Closing line",
+        default_content: "<p>Thank you very much for your time and contribution to this important process.</p><p>Warm regards, <br /><strong>The CrownShy Team.</strong></p>"
+    },
+];
+
+pub const SLOTS_SCHEMA_EVENT_REGISTRATION_INVITE: &[SlotSchemaDefinition] = &[
+    SlotSchemaDefinition {
+        key: "heading",
+        label: "Heading",
+        hint: "The email heading",
+        default_content: "Hello!"
+    },
+    SlotSchemaDefinition {
+        key: "intro",
+        label: "Intro",
+        hint: "Opening paragraph",
+        default_content: "<p>You are invited to take part in <strong>{{event_name}}</strong> with <strong>{{organization_name}}</strong> to collaborate with them.</p>"
+    },
+    SlotSchemaDefinition {
+        key: "body",
+        label: "Body",
+        hint: "Main email content",
+        default_content: "<p>Click the button below to register.</p>"
+    },
+    SlotSchemaDefinition {
+        key: "footer",
+        label: "Footer",
+        hint: "Closing line",
+        default_content: "<p>We look forward to your participation!</p><p><strong>{{organization_name}}</strong></p>"
+    },
+];
+
+pub const SLOTS_SCHEMA_EVENT_REGISTRATION_CONFIRMATION: &[SlotSchemaDefinition] = &[
+    SlotSchemaDefinition {
+        key: "heading",
+        label: "Heading",
+        hint: "The email heading",
+        default_content: "You're in!",
+    },
+    SlotSchemaDefinition {
+        key: "intro",
+        label: "Intro",
+        hint: "Opening paragraph",
+        default_content: "<p>Thank you for registering for <strong>{{event_name}}</strong>.",
+    },
+    SlotSchemaDefinition {
+        key: "body",
+        label: "Body",
+        hint: "Main email content",
+        default_content: "<p>You will be sent a reminder email before the event with instructions on how to join the online meeting.</p>",
+    },
+    SlotSchemaDefinition {
+        key: "footer",
+        label: "Footer",
+        hint: "Closing line",
+        default_content: "<p>We look forward to seeing you there!</p><p><strong>{{organization_name}}</strong></p>",
+    },
+];
+
+/// Provides conversion of a [`SlotSchemaDefinition`] slice into a [`HashMap`] of
+/// slot keys to their default content.
+///
+/// This trait exists as a workaround for Rust's orphan rules, which prevent
+/// implementing foreign traits (such as [`From`]) for foreign types (such as
+/// [`HashMap`]). Since both [`From`] and [`HashMap`] are defined outside of this
+/// crate, a direct `impl From<&[SlotSchemaDefinition]> for HashMap<String, String>`
+/// is not permitted. Defining our own trait here gives us a local trait that we
+/// are free to implement for any type.
+pub trait IntoSlotMap {
+    fn into_slots_map(&self) -> HashMap<String, String>;
+}
+
+impl IntoSlotMap for [SlotSchemaDefinition] {
+    fn into_slots_map(&self) -> HashMap<String, String> {
+        self.iter()
+            .map(|slot| (slot.key.to_string(), slot.default_content.to_string()))
+            .collect()
+    }
+}
+
 /// The configurable slot content for a particular email template type.
 ///
 /// Each variant corresponds to a distinct email template and carries the slot
@@ -50,7 +190,7 @@ pub struct EmailTemplateConfig {
 /// 1. Add a variant here with its slot struct.
 /// 2. Add the corresponding HTML template.
 /// 3. Update [`EmailTemplateSlots::schemas`] with the new variant's schema.
-/// 4. Update [`EmailTemplateSlots::to_template`] to return the template filename.
+/// 4. Update [`EmailTemplateSlots::email_template`] to return the template filename.
 #[derive(Serialize, Deserialize, JsonSchema, Debug, Clone, PartialEq)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum EmailTemplateSlots {
@@ -58,10 +198,6 @@ pub enum EmailTemplateSlots {
     EventRegistrationInvite(DefaultEmailSlots),
     EventRegistrationConfirmation(DefaultEmailSlots),
 }
-
-pub const TYPE_CONVERSATION_INVITE: &str = "conversation_invite";
-pub const TYPE_EVENT_REGISTRATION_INVITE: &str = "event_registration_invite";
-pub const TYPE_EVENT_REGISTRATION_CONFIRMATION: &str = "event_registration_confirmation";
 
 impl EmailTemplateSlots {
     /// Returns the schema for every email template type.
@@ -89,28 +225,40 @@ impl EmailTemplateSlots {
     pub fn schema(&self) -> EmailTypeSchema {
         match self {
             EmailTemplateSlots::ConversationInvite(_) => EmailTypeSchema {
-                email_type: self.to_type_str(),
-                variables: &["conversation_title"],
-                slots: DEFAULT_SLOTS_SCHEMA,
+                email_type: self.type_str(),
+                variables: self.template_variables(),
+                slots: SLOTS_SCHEMA_CONVERSATION_INVITE,
             },
             EmailTemplateSlots::EventRegistrationInvite(_) => EmailTypeSchema {
-                email_type: self.to_type_str(),
-                variables: &["event_name", "event_time"],
-                slots: DEFAULT_SLOTS_SCHEMA,
+                email_type: self.type_str(),
+                variables: self.template_variables(),
+                slots: SLOTS_SCHEMA_EVENT_REGISTRATION_INVITE,
             },
             EmailTemplateSlots::EventRegistrationConfirmation(_) => EmailTypeSchema {
-                email_type: self.to_type_str(),
-                variables: &["event_name", "event_time"],
-                slots: DEFAULT_SLOTS_SCHEMA,
+                email_type: self.type_str(),
+                variables: self.template_variables(),
+                slots: SLOTS_SCHEMA_EVENT_REGISTRATION_CONFIRMATION,
             },
         }
     }
 
-    pub fn to_template(&self) -> &str {
+    pub fn email_template(&self) -> &str {
         match self {
             EmailTemplateSlots::ConversationInvite(_) => "conversation_invite.html",
             EmailTemplateSlots::EventRegistrationInvite(_) => "event_registration_invite.html",
             EmailTemplateSlots::EventRegistrationConfirmation(_) => "event_confirmation.html",
+        }
+    }
+
+    fn template_variables(&self) -> &'static [&'static str] {
+        match self {
+            EmailTemplateSlots::ConversationInvite(_) => &["conversation_title"],
+            EmailTemplateSlots::EventRegistrationInvite(_) => {
+                &["event_name", "event_time", "organization_name"]
+            }
+            EmailTemplateSlots::EventRegistrationConfirmation(_) => {
+                &["event_name", "event_time", "organization_name"]
+            }
         }
     }
 
@@ -121,7 +269,7 @@ impl EmailTemplateSlots {
     /// duplicating the mapping. The returned string is always a `&'static str`
     /// drawn from the `TYPE_*` constants, which allows it to be embedded in
     /// [`EmailTypeSchema`] without lifetime annotation.
-    fn to_type_str(&self) -> &'static str {
+    fn type_str(&self) -> &'static str {
         match self {
             EmailTemplateSlots::ConversationInvite(_) => TYPE_CONVERSATION_INVITE,
             EmailTemplateSlots::EventRegistrationInvite(_) => TYPE_EVENT_REGISTRATION_INVITE,
@@ -147,7 +295,7 @@ impl EmailTemplateSlots {
     /// let base = email_config.slots.to_mailer_map();
     /// let context = minijinja::context! { invite_link => "foo@bar.com", ..base };
     /// ```
-    pub fn to_mailer_map(&self) -> HashMap<&str, String> {
+    pub fn mailer_slots_map(&self) -> HashMap<String, String> {
         match self {
             EmailTemplateSlots::ConversationInvite(slots) => slots.to_mailer_map(),
             EmailTemplateSlots::EventRegistrationInvite(slots) => slots.to_mailer_map(),
@@ -167,33 +315,49 @@ impl EmailTemplateSlots {
     /// The returned map is specific to each [`EmailTemplateSlots`] variant, as
     /// different email types expose different runtime variables. The values are
     /// illustrative only and are never used in real email sends.
-    pub fn preview_variables_map(&self) -> HashMap<&str, String> {
+    pub fn preview_variables_map(&self) -> HashMap<String, String> {
         match self {
             EmailTemplateSlots::ConversationInvite(_) => HashMap::from([(
-                "conversation_title",
+                "conversation_title".to_string(),
                 "Renewable energy in rural areas".to_string(),
             )]),
             EmailTemplateSlots::EventRegistrationConfirmation(_) => HashMap::from([
                 (
-                    "event_name",
+                    "event_name".to_string(),
                     "Prioritising accessibility in websites".to_string(),
                 ),
-                ("event_time", "24 May, 2026".to_string()),
+                ("event_time".to_string(), "24 May, 2026".to_string()),
+                ("organization_name".to_string(), "CrownShy".to_string()),
             ]),
             EmailTemplateSlots::EventRegistrationInvite(_) => HashMap::from([
                 (
-                    "event_name",
+                    "event_name".to_string(),
                     "Prioritising accessibility in websites".to_string(),
                 ),
-                ("event_time", "24 May, 2026".to_string()),
+                ("event_time".to_string(), "24 May, 2026".to_string()),
+                ("organization_name".to_string(), "CrownShy".to_string()),
             ]),
+        }
+    }
+
+    pub fn fallback_slots_map(&self) -> HashMap<String, String> {
+        match self {
+            EmailTemplateSlots::ConversationInvite(_) => {
+                SLOTS_SCHEMA_CONVERSATION_INVITE.into_slots_map()
+            }
+            EmailTemplateSlots::EventRegistrationConfirmation(_) => {
+                SLOTS_SCHEMA_EVENT_REGISTRATION_INVITE.into_slots_map()
+            }
+            EmailTemplateSlots::EventRegistrationInvite(_) => {
+                SLOTS_SCHEMA_EVENT_REGISTRATION_CONFIRMATION.into_slots_map()
+            }
         }
     }
 }
 
 impl std::fmt::Display for EmailTemplateSlots {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.to_type_str())
+        write!(f, "{}", self.type_str())
     }
 }
 
@@ -206,12 +370,12 @@ pub struct DefaultEmailSlots {
 }
 
 impl DefaultEmailSlots {
-    fn to_mailer_map(&self) -> HashMap<&str, String> {
+    fn to_mailer_map(&self) -> HashMap<String, String> {
         HashMap::from([
-            ("heading", self.heading.clone()),
-            ("intro", self.intro.clone()),
-            ("body", self.body.clone()),
-            ("footer", self.footer.clone()),
+            ("heading".to_string(), self.heading.clone()),
+            ("intro".to_string(), self.intro.clone()),
+            ("body".to_string(), self.body.clone()),
+            ("footer".to_string(), self.footer.clone()),
         ])
     }
 }
@@ -238,68 +402,6 @@ impl<'r> Decode<'r, Postgres> for EmailTemplateSlots {
         Ok(serde_json::from_value(json)?)
     }
 }
-
-/// Metadata describing a single configurable slot in an email template.
-///
-/// `SlotSchemaDefinition` is used to communicate the structure of an email template
-/// to the frontend, allowing it to render the correct form fields when a user
-/// is configuring a particular email type. It is the UI-facing counterpart to
-/// the typed fields on structs like [`DefaultEmailSlots`].
-#[derive(Serialize, JsonSchema, Debug, Clone)]
-pub struct SlotSchemaDefinition {
-    /// The key used to identify this slot, matching the field name on the
-    /// corresponding slots struct (e.g. `"heading"`, `"body"`).
-    pub key: &'static str,
-    /// A human-readable label for display in the configuration UI.
-    pub label: &'static str,
-    /// A short description shown to the user explaining what this slot
-    /// controls and any guidance on what to write.
-    pub hint: &'static str,
-    /// Whether this slot must be populated before the config can be saved.
-    pub required: bool,
-    /// An optional upper bound on the number of characters allowed in this
-    /// slot. Used for both frontend validation and server-side validation
-    /// before persisting. `None` means no limit is enforced.
-    pub max_chars: Option<usize>,
-}
-
-#[derive(Serialize, JsonSchema, Debug, Clone)]
-pub struct EmailTypeSchema {
-    pub email_type: &'static str,
-    pub variables: &'static [&'static str],
-    pub slots: &'static [SlotSchemaDefinition],
-}
-
-const DEFAULT_SLOTS_SCHEMA: &[SlotSchemaDefinition] = &[
-    SlotSchemaDefinition {
-        key: "heading",
-        label: "Heading",
-        hint: "The email heading",
-        required: true,
-        max_chars: Some(100),
-    },
-    SlotSchemaDefinition {
-        key: "intro",
-        label: "Intro",
-        hint: "Opening paragraph",
-        required: true,
-        max_chars: Some(100),
-    },
-    SlotSchemaDefinition {
-        key: "body",
-        label: "Body",
-        hint: "Main email content",
-        required: true,
-        max_chars: None,
-    },
-    SlotSchemaDefinition {
-        key: "footer",
-        label: "Footer",
-        hint: "Closing line",
-        required: false,
-        max_chars: Some(100),
-    },
-];
 
 const DEFAULT_COLUMNS: [EmailTemplateConfigIden; 8] = [
     EmailTemplateConfigIden::Id,

--- a/api/src/models/email_template_config.rs
+++ b/api/src/models/email_template_config.rs
@@ -132,7 +132,7 @@ pub const SLOTS_SCHEMA_EVENT_REGISTRATION_INVITE: &[SlotSchemaDefinition] = &[
         key: "intro",
         label: "Intro",
         hint: "Opening paragraph",
-        default_content: "<p>You are invited to take part in <strong>{{event_name}}</strong> with <strong>{{organization_name}}</strong> to collaborate with them.</p>",
+        default_content: "<p>You are invited to take part in <strong>{{event_name}}</strong> with <strong>CrownShy</strong> to collaborate with them.</p>",
         content_type: ContentType::RichText,
     },
     SlotSchemaDefinition {
@@ -146,7 +146,7 @@ pub const SLOTS_SCHEMA_EVENT_REGISTRATION_INVITE: &[SlotSchemaDefinition] = &[
         key: "footer",
         label: "Footer",
         hint: "Closing line",
-        default_content: "<p>We look forward to your participation!</p><p><strong>{{organization_name}}</strong></p>",
+        default_content: "<p>We look forward to your participation!</p><p><strong>CrownShy</strong></p>",
         content_type: ContentType::RichText,
     },
 ];
@@ -177,7 +177,7 @@ pub const SLOTS_SCHEMA_EVENT_REGISTRATION_CONFIRMATION: &[SlotSchemaDefinition] 
         key: "footer",
         label: "Footer",
         hint: "Closing line",
-        default_content: "<p>We look forward to seeing you there!</p><p><strong>{{organization_name}}</strong></p>",
+        default_content: "<p>We look forward to seeing you there!</p><p><strong>CrownShy</strong></p>",
         content_type: ContentType::RichText,
     },
 ];
@@ -287,10 +287,10 @@ impl EmailTemplateSlots {
         match self {
             EmailTemplateSlots::ConversationInvite(_) => &["conversation_title"],
             EmailTemplateSlots::EventRegistrationInvite(_) => {
-                &["event_name", "event_time", "organization_name"]
+                &["event_name", "event_time", "invite_link"]
             }
             EmailTemplateSlots::EventRegistrationConfirmation(_) => {
-                &["event_name", "event_time", "organization_name"]
+                &["event_name", "event_time", "event_link"]
             }
         }
     }
@@ -360,7 +360,10 @@ impl EmailTemplateSlots {
                     "Prioritising accessibility in websites".to_string(),
                 ),
                 ("event_time".to_string(), "24 May, 2026".to_string()),
-                ("organization_name".to_string(), "CrownShy".to_string()),
+                (
+                    "invite_link".to_string(),
+                    "https://crown-shy.com/invite".to_string(),
+                ),
             ]),
             EmailTemplateSlots::EventRegistrationInvite(_) => HashMap::from([
                 (
@@ -368,7 +371,10 @@ impl EmailTemplateSlots {
                     "Prioritising accessibility in websites".to_string(),
                 ),
                 ("event_time".to_string(), "24 May, 2026".to_string()),
-                ("organization_name".to_string(), "CrownShy".to_string()),
+                (
+                    "event_link".to_string(),
+                    "https://crown-shy.com/event".to_string(),
+                ),
             ]),
         }
     }

--- a/api/src/models/email_template_config.rs
+++ b/api/src/models/email_template_config.rs
@@ -103,7 +103,7 @@ pub struct CreateEmailTemplateConfig {
 #[instrument(err(Debug))]
 pub async fn create(
     db: &PgPool,
-    user_id: &Uuid,
+    user_id: Uuid,
     params: &CreateEmailTemplateConfig,
 ) -> Result<EmailTemplateConfig, ComhairleError> {
     let slots_json = serde_json::to_value(&params.slots)?;
@@ -112,12 +112,12 @@ pub async fn create(
         EmailTemplateConfigIden::Slots,
         EmailTemplateConfigIden::OwnerId,
     ];
-    let mut values = vec![slots_json.into(), (*user_id).into()];
+    let mut values = vec![slots_json.into(), user_id.into()];
 
     columns.push(EmailTemplateConfigIden::EmailType);
     values.push(params.slots.to_string().into());
 
-    let user = users::get_user_by_id(user_id, db).await?;
+    let user = users::get_user_by_id(&user_id, db).await?;
 
     if let Some(organization_id) = user.organization_id {
         columns.push(EmailTemplateConfigIden::OrganizationId);
@@ -276,7 +276,7 @@ mod tests {
             }),
         };
 
-        let email_config = create(&pool, &current_user.id, &params).await?;
+        let email_config = create(&pool, current_user.id, &params).await?;
 
         assert_eq!(
             email_config.owner_id, current_user.id,
@@ -302,7 +302,7 @@ mod tests {
             slots: create_slots.clone(),
         };
 
-        let new_email_config = create(&pool, &current_user.id, &params).await?;
+        let new_email_config = create(&pool, current_user.id, &params).await?;
 
         assert_eq!(
             new_email_config.slots, create_slots,
@@ -349,7 +349,7 @@ mod tests {
             }),
         };
 
-        let new_email_config = create(&pool, &current_user.id, &params).await?;
+        let new_email_config = create(&pool, current_user.id, &params).await?;
 
         let email_config = get_by_id(&pool, new_email_config.id).await?;
 
@@ -375,11 +375,11 @@ mod tests {
         let params_a = CreateEmailTemplateConfig {
             slots: EmailTemplateSlots::EventRegistrationConfirmation(default_slots.clone()),
         };
-        create(&pool, &user_a.id, &params_a).await?;
+        create(&pool, user_a.id, &params_a).await?;
         let params_b = CreateEmailTemplateConfig {
             slots: EmailTemplateSlots::ConversationInvite(default_slots.clone()),
         };
-        create(&pool, &user_b.id, &params_b).await?;
+        create(&pool, user_b.id, &params_b).await?;
 
         let filter_options = EmailTemplateConfigFilterOptions {
             owner_id: Some(user_b.id),
@@ -411,7 +411,7 @@ mod tests {
             }),
         };
 
-        let email_config = create(&pool, &current_user.id, &params).await?;
+        let email_config = create(&pool, current_user.id, &params).await?;
 
         delete(&pool, email_config.id).await?;
 

--- a/api/src/models/email_template_config.rs
+++ b/api/src/models/email_template_config.rs
@@ -100,7 +100,7 @@ impl EmailTemplateSlots {
             },
             EmailTemplateSlots::EventRegistrationConfirmation(_) => EmailTypeSchema {
                 email_type: self.to_type_str(),
-                variables: &[],
+                variables: &["event_name", "event_time"],
                 slots: DEFAULT_SLOTS_SCHEMA,
             },
         }

--- a/api/src/models/email_template_config.rs
+++ b/api/src/models/email_template_config.rs
@@ -33,6 +33,7 @@ pub struct EmailTemplateConfig {
     pub organization_id: Option<Uuid>,
     pub email_type: String,
     pub slots: EmailTemplateSlots,
+    pub subject: Option<String>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -265,12 +266,13 @@ const DEFAULT_SLOTS_SCHEMA: &[SlotSchemaDefinition] = &[
     },
 ];
 
-const DEFAULT_COLUMNS: [EmailTemplateConfigIden; 7] = [
+const DEFAULT_COLUMNS: [EmailTemplateConfigIden; 8] = [
     EmailTemplateConfigIden::Id,
     EmailTemplateConfigIden::OwnerId,
     EmailTemplateConfigIden::OrganizationId,
     EmailTemplateConfigIden::EmailType,
     EmailTemplateConfigIden::Slots,
+    EmailTemplateConfigIden::Subject,
     EmailTemplateConfigIden::CreatedAt,
     EmailTemplateConfigIden::UpdatedAt,
 ];
@@ -278,6 +280,7 @@ const DEFAULT_COLUMNS: [EmailTemplateConfigIden; 7] = [
 #[derive(Deserialize, JsonSchema, Debug)]
 pub struct CreateEmailTemplateConfig {
     pub slots: EmailTemplateSlots,
+    pub subject: Option<String>,
 }
 
 #[instrument(err(Debug))]
@@ -296,6 +299,11 @@ pub async fn create(
 
     columns.push(EmailTemplateConfigIden::EmailType);
     values.push(params.slots.to_string().into());
+
+    if let Some(subject) = &params.subject {
+        columns.push(EmailTemplateConfigIden::Subject);
+        values.push(subject.into());
+    }
 
     let user = users::get_user_by_id(&user_id, db).await?;
 
@@ -316,9 +324,10 @@ pub async fn create(
     Ok(email_config)
 }
 
-#[derive(Deserialize, JsonSchema, Debug)]
+#[derive(Deserialize, JsonSchema, Debug, Default)]
 pub struct UpdateEmailTemplateConfig {
     slots: Option<EmailTemplateSlots>,
+    subject: Option<String>,
 }
 
 impl UpdateEmailTemplateConfig {
@@ -327,6 +336,10 @@ impl UpdateEmailTemplateConfig {
         if let Some(value) = &self.slots {
             let slots_json = serde_json::to_value(value)?;
             values.push((EmailTemplateConfigIden::Slots, slots_json.into()));
+        }
+
+        if let Some(value) = &self.subject {
+            values.push((EmailTemplateConfigIden::Subject, value.into()))
         }
 
         Ok(values)
@@ -470,6 +483,7 @@ mod tests {
                 body: "<p>Test body content</p>".to_string(),
                 footer: "<p>Thank you for your time</p>".to_string(),
             }),
+            subject: None,
         };
 
         let email_config = create(&pool, current_user.id, &params).await?;
@@ -496,6 +510,7 @@ mod tests {
 
         let params = CreateEmailTemplateConfig {
             slots: create_slots.clone(),
+            subject: None,
         };
 
         let new_email_config = create(&pool, current_user.id, &params).await?;
@@ -518,6 +533,7 @@ mod tests {
             new_email_config.id,
             &UpdateEmailTemplateConfig {
                 slots: Some(update_slots.clone()),
+                ..Default::default()
             },
         )
         .await?;
@@ -543,6 +559,7 @@ mod tests {
                 body: "<p>Test body content</p>".to_string(),
                 footer: "<p>Thank you for your time</p>".to_string(),
             }),
+            subject: None,
         };
 
         let new_email_config = create(&pool, current_user.id, &params).await?;
@@ -569,6 +586,7 @@ mod tests {
                 body: "<p>Test body content</p>".to_string(),
                 footer: "<p>Thank you for your time</p>".to_string(),
             }),
+            subject: None,
         };
 
         let new_email_config = create(&pool, current_user.id, &params).await?;
@@ -597,10 +615,12 @@ mod tests {
 
         let params_a = CreateEmailTemplateConfig {
             slots: EmailTemplateSlots::EventRegistrationConfirmation(default_slots.clone()),
+            subject: None,
         };
         create(&pool, user_a.id, &params_a).await?;
         let params_b = CreateEmailTemplateConfig {
             slots: EmailTemplateSlots::ConversationInvite(default_slots.clone()),
+            subject: None,
         };
         create(&pool, user_b.id, &params_b).await?;
 
@@ -632,6 +652,7 @@ mod tests {
                 body: "<p>Test body content</p>".to_string(),
                 footer: "<p>Thank you for your time</p>".to_string(),
             }),
+            subject: None,
         };
 
         let email_config = create(&pool, current_user.id, &params).await?;

--- a/api/src/models/email_template_config.rs
+++ b/api/src/models/email_template_config.rs
@@ -11,6 +11,8 @@ use sqlx::{
     query_as_with, Decode, Encode, PgPool, Postgres,
 };
 use sqlx_postgres::{PgArgumentBuffer, PgTypeInfo, PgValueRef};
+use strum::EnumCount as _;
+use strum_macros::EnumCount;
 use tracing::instrument;
 use uuid::Uuid;
 
@@ -64,7 +66,7 @@ pub struct SlotSchemaDefinition {
     /// Defines whether a slot requires rich text HTML editing or plain text
     /// inserted into an existing HTML tag and is used on the frontend to render
     /// the appropriate input type.
-    pub content_type: ContentType,
+    content_type: ContentType,
 }
 
 #[derive(Serialize, JsonSchema, Debug, Clone)]
@@ -214,7 +216,7 @@ impl IntoSlotMap for [SlotSchemaDefinition] {
 /// 2. Add the corresponding HTML template.
 /// 3. Update [`EmailTemplateSlots::schemas`] with the new variant's schema.
 /// 4. Update [`EmailTemplateSlots::email_template`] to return the template filename.
-#[derive(Serialize, Deserialize, JsonSchema, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, JsonSchema, Debug, Clone, PartialEq, EnumCount)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum EmailTemplateSlots {
     ConversationInvite(DefaultEmailSlots),
@@ -228,15 +230,9 @@ impl EmailTemplateSlots {
     /// Each entry describes a variant of [`EmailTemplateSlots`], pairing the
     /// variant's string identifier with the [`SlotDefinition`]s that define its
     /// configurable slots. This is intended to be served to the frontend so it
-    /// can render the correct form fields when a user selects an email type to
-    /// configure.
-    ///
-    /// # Adding a new email type
-    ///
-    /// When a new variant is added to [`EmailTemplateSlots`], a corresponding
-    /// [`EmailTypeSchema`] must be added here manually. There is no compiler
-    /// enforcement for this.
-    pub fn schemas() -> [EmailTypeSchema; 3] {
+    /// can render the correct form fields and default content when a user
+    /// selects an email type to configure.
+    pub fn schemas() -> [EmailTypeSchema; EmailTemplateSlots::COUNT] {
         [
             EmailTemplateSlots::ConversationInvite(DefaultEmailSlots::default()).schema(),
             EmailTemplateSlots::EventRegistrationInvite(DefaultEmailSlots::default()).schema(),
@@ -265,6 +261,7 @@ impl EmailTemplateSlots {
         }
     }
 
+    /// Helper method returning associated template HTML file
     pub fn email_template(&self) -> &str {
         match self {
             EmailTemplateSlots::ConversationInvite(_) => "conversation_invite.html",
@@ -360,20 +357,6 @@ impl EmailTemplateSlots {
                 ("event_time".to_string(), "24 May, 2026".to_string()),
                 ("organization_name".to_string(), "CrownShy".to_string()),
             ]),
-        }
-    }
-
-    pub fn fallback_slots_map(&self) -> HashMap<String, String> {
-        match self {
-            EmailTemplateSlots::ConversationInvite(_) => {
-                SLOTS_SCHEMA_CONVERSATION_INVITE.into_slots_map()
-            }
-            EmailTemplateSlots::EventRegistrationConfirmation(_) => {
-                SLOTS_SCHEMA_EVENT_REGISTRATION_INVITE.into_slots_map()
-            }
-            EmailTemplateSlots::EventRegistrationInvite(_) => {
-                SLOTS_SCHEMA_EVENT_REGISTRATION_CONFIRMATION.into_slots_map()
-            }
         }
     }
 }

--- a/api/src/models/email_template_config.rs
+++ b/api/src/models/email_template_config.rs
@@ -103,6 +103,133 @@ const DEFAULT_COLUMNS: [EmailTemplateConfigIden; 8] = [
     EmailTemplateConfigIden::UpdatedAt,
 ];
 
+/// The configurable slot content for a particular email template type.
+///
+/// Each variant corresponds to a distinct email template and carries the slot
+/// content that will be injected into it at send time. Serialised as a tagged
+/// JSON object (e.g. `{ "type": "conversation_invite", "heading": "...", ... }`)
+/// for storage in the `slots` JSONB column on [`EmailTemplateConfig`].
+///
+/// # Adding a new email type
+///
+/// 1. Add a variant here with its slot struct.
+/// 2. Add the corresponding HTML template.
+/// 3. Update [`EmailTemplateSlots::schemas`] with the new variant's schema.
+#[derive(Serialize, Deserialize, JsonSchema, Debug, Clone, PartialEq, EnumCount)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum EmailTemplateSlots {
+    ConversationInvite(DefaultEmailSlots),
+    EventRegistrationInvite(DefaultEmailSlots),
+    EventRegistrationConfirmation(DefaultEmailSlots),
+}
+
+impl EmailTemplateSlots {
+    /// Returns the schema for every email template type.
+    ///
+    /// Each entry describes a variant of [`EmailTemplateSlots`], pairing the
+    /// variant's string identifier with the [`SlotDefinition`]s that define its
+    /// configurable slots. This is intended to be served to the frontend so it
+    /// can render the correct form fields and default content when a user
+    /// selects an email type to configure.
+    pub fn schemas() -> [EmailTypeSchema; EmailTemplateSlots::COUNT] {
+        [
+            EmailTemplateSlots::ConversationInvite(DefaultEmailSlots::default()).schema(),
+            EmailTemplateSlots::EventRegistrationInvite(DefaultEmailSlots::default()).schema(),
+            EmailTemplateSlots::EventRegistrationConfirmation(DefaultEmailSlots::default())
+                .schema(),
+        ]
+    }
+
+    /// Returns the schema for the associated email template type.
+    pub fn schema(&self) -> EmailTypeSchema {
+        match self {
+            EmailTemplateSlots::ConversationInvite(_) => SCHEMA_CONVERSATION_INVITE,
+            EmailTemplateSlots::EventRegistrationInvite(_) => SCHEMA_EVENT_REGISTRATION_INVITE,
+            EmailTemplateSlots::EventRegistrationConfirmation(_) => {
+                SCHEMA_EVENT_REGISTRATION_CONFIRMATION
+            }
+        }
+    }
+
+    /// Converts the email template slots into a `HashMap` of key/value pairs
+    /// suitable for use as a minijinja template context.
+    ///
+    /// The returned map contains the slot field names (e.g. `heading`, `intro`,
+    /// `body`, `footer`) and their corresponding values, which are used to
+    /// populate the variables referenced in the email's minijinja template.
+    ///
+    /// Because `minijinja::context!` supports spreading a `HashMap` with `..`,
+    /// the map returned here can be combined with additional ad-hoc context
+    /// variables that aren't stored as part of the email config (e.g. dynamic
+    /// links or IDs generated at send time). For example:
+    ///
+    /// ```ignore
+    /// let base = email_config.slots.mailer_context_map();
+    /// let context = minijinja::context! { invite_link => "foo@bar.com", ..base };
+    /// ```
+    pub fn mailer_context_map(&self) -> HashMap<String, String> {
+        match self {
+            EmailTemplateSlots::ConversationInvite(slots) => slots.mailer_context_map(),
+            EmailTemplateSlots::EventRegistrationInvite(slots) => slots.mailer_context_map(),
+            EmailTemplateSlots::EventRegistrationConfirmation(slots) => slots.mailer_context_map(),
+        }
+    }
+
+    /// Returns a map of placeholder values for runtime template variables,
+    /// used when previewing a customised [`EmailTemplateConfig`] in the frontend.
+    ///
+    /// When users compose email content they can embed dynamic variables (e.g.
+    /// `{{ conversation_title }}`) that are only available at the point an email
+    /// is actually sent. This method provides realistic example values for those
+    /// variables so that previews render meaningfully rather than showing empty
+    /// or broken output.
+    ///
+    /// The returned map is specific to each [`EmailTemplateSlots`] variant, as
+    /// different email types expose different runtime variables. The values are
+    /// illustrative only and are never used in real email sends.
+    pub fn preview_variables_map(&self) -> HashMap<String, String> {
+        match self {
+            EmailTemplateSlots::ConversationInvite(_) => HashMap::from([(
+                "conversation_title".to_string(),
+                "Renewable energy in rural areas".to_string(),
+            )]),
+            EmailTemplateSlots::EventRegistrationConfirmation(_) => HashMap::from([
+                (
+                    "event_name".to_string(),
+                    "Prioritising accessibility in websites".to_string(),
+                ),
+                ("event_time".to_string(), "24 May, 2026".to_string()),
+                (
+                    "invite_link".to_string(),
+                    "https://crown-shy.com/invite".to_string(),
+                ),
+            ]),
+            EmailTemplateSlots::EventRegistrationInvite(_) => HashMap::from([
+                (
+                    "event_name".to_string(),
+                    "Prioritising accessibility in websites".to_string(),
+                ),
+                ("event_time".to_string(), "24 May, 2026".to_string()),
+                (
+                    "event_link".to_string(),
+                    "https://crown-shy.com/event".to_string(),
+                ),
+            ]),
+        }
+    }
+
+    /// Helper method to return HTML template file name for associated email type
+    pub fn email_template(&self) -> &str {
+        self.schema().template
+    }
+}
+
+impl std::fmt::Display for EmailTemplateSlots {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.schema().email_type)
+    }
+}
+
 // ===
 //
 // Schemas
@@ -295,134 +422,7 @@ impl MailerContextMap for DefaultEmailSlots {
     }
 }
 
-/// The configurable slot content for a particular email template type.
-///
-/// Each variant corresponds to a distinct email template and carries the slot
-/// content that will be injected into it at send time. Serialised as a tagged
-/// JSON object (e.g. `{ "type": "conversation_invite", "heading": "...", ... }`)
-/// for storage in the `slots` JSONB column on [`EmailTemplateConfig`].
-///
-/// # Adding a new email type
-///
-/// 1. Add a variant here with its slot struct.
-/// 2. Add the corresponding HTML template.
-/// 3. Update [`EmailTemplateSlots::schemas`] with the new variant's schema.
-#[derive(Serialize, Deserialize, JsonSchema, Debug, Clone, PartialEq, EnumCount)]
-#[serde(tag = "type", rename_all = "snake_case")]
-pub enum EmailTemplateSlots {
-    ConversationInvite(DefaultEmailSlots),
-    EventRegistrationInvite(DefaultEmailSlots),
-    EventRegistrationConfirmation(DefaultEmailSlots),
-}
-
-impl EmailTemplateSlots {
-    /// Returns the schema for every email template type.
-    ///
-    /// Each entry describes a variant of [`EmailTemplateSlots`], pairing the
-    /// variant's string identifier with the [`SlotDefinition`]s that define its
-    /// configurable slots. This is intended to be served to the frontend so it
-    /// can render the correct form fields and default content when a user
-    /// selects an email type to configure.
-    pub fn schemas() -> [EmailTypeSchema; EmailTemplateSlots::COUNT] {
-        [
-            EmailTemplateSlots::ConversationInvite(DefaultEmailSlots::default()).schema(),
-            EmailTemplateSlots::EventRegistrationInvite(DefaultEmailSlots::default()).schema(),
-            EmailTemplateSlots::EventRegistrationConfirmation(DefaultEmailSlots::default())
-                .schema(),
-        ]
-    }
-
-    /// Returns the schema for the associated email template type.
-    pub fn schema(&self) -> EmailTypeSchema {
-        match self {
-            EmailTemplateSlots::ConversationInvite(_) => SCHEMA_CONVERSATION_INVITE,
-            EmailTemplateSlots::EventRegistrationInvite(_) => SCHEMA_EVENT_REGISTRATION_INVITE,
-            EmailTemplateSlots::EventRegistrationConfirmation(_) => {
-                SCHEMA_EVENT_REGISTRATION_CONFIRMATION
-            }
-        }
-    }
-
-    /// Converts the email template slots into a `HashMap` of key/value pairs
-    /// suitable for use as a minijinja template context.
-    ///
-    /// The returned map contains the slot field names (e.g. `heading`, `intro`,
-    /// `body`, `footer`) and their corresponding values, which are used to
-    /// populate the variables referenced in the email's minijinja template.
-    ///
-    /// Because `minijinja::context!` supports spreading a `HashMap` with `..`,
-    /// the map returned here can be combined with additional ad-hoc context
-    /// variables that aren't stored as part of the email config (e.g. dynamic
-    /// links or IDs generated at send time). For example:
-    ///
-    /// ```ignore
-    /// let base = email_config.slots.mailer_context_map();
-    /// let context = minijinja::context! { invite_link => "foo@bar.com", ..base };
-    /// ```
-    pub fn mailer_context_map(&self) -> HashMap<String, String> {
-        match self {
-            EmailTemplateSlots::ConversationInvite(slots) => slots.mailer_context_map(),
-            EmailTemplateSlots::EventRegistrationInvite(slots) => slots.mailer_context_map(),
-            EmailTemplateSlots::EventRegistrationConfirmation(slots) => slots.mailer_context_map(),
-        }
-    }
-
-    /// Returns a map of placeholder values for runtime template variables,
-    /// used when previewing a customised [`EmailTemplateConfig`] in the frontend.
-    ///
-    /// When users compose email content they can embed dynamic variables (e.g.
-    /// `{{ conversation_title }}`) that are only available at the point an email
-    /// is actually sent. This method provides realistic example values for those
-    /// variables so that previews render meaningfully rather than showing empty
-    /// or broken output.
-    ///
-    /// The returned map is specific to each [`EmailTemplateSlots`] variant, as
-    /// different email types expose different runtime variables. The values are
-    /// illustrative only and are never used in real email sends.
-    pub fn preview_variables_map(&self) -> HashMap<String, String> {
-        match self {
-            EmailTemplateSlots::ConversationInvite(_) => HashMap::from([(
-                "conversation_title".to_string(),
-                "Renewable energy in rural areas".to_string(),
-            )]),
-            EmailTemplateSlots::EventRegistrationConfirmation(_) => HashMap::from([
-                (
-                    "event_name".to_string(),
-                    "Prioritising accessibility in websites".to_string(),
-                ),
-                ("event_time".to_string(), "24 May, 2026".to_string()),
-                (
-                    "invite_link".to_string(),
-                    "https://crown-shy.com/invite".to_string(),
-                ),
-            ]),
-            EmailTemplateSlots::EventRegistrationInvite(_) => HashMap::from([
-                (
-                    "event_name".to_string(),
-                    "Prioritising accessibility in websites".to_string(),
-                ),
-                ("event_time".to_string(), "24 May, 2026".to_string()),
-                (
-                    "event_link".to_string(),
-                    "https://crown-shy.com/event".to_string(),
-                ),
-            ]),
-        }
-    }
-
-    /// Helper method to return HTML template file name for associated email type
-    pub fn email_template(&self) -> &str {
-        self.schema().template
-    }
-}
-
-impl std::fmt::Display for EmailTemplateSlots {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.schema().email_type)
-    }
-}
-
-#[derive(Deserialize, JsonSchema, Debug)]
+#[derive(Serialize, Deserialize, JsonSchema, Debug)]
 pub struct CreateEmailTemplateConfig {
     pub slots: EmailTemplateSlots,
     pub subject: Option<String>,
@@ -469,10 +469,10 @@ pub async fn create(
     Ok(email_config)
 }
 
-#[derive(Deserialize, JsonSchema, Debug, Default)]
+#[derive(Serialize, Deserialize, JsonSchema, Debug, Default)]
 pub struct UpdateEmailTemplateConfig {
-    slots: Option<EmailTemplateSlots>,
-    subject: Option<String>,
+    pub slots: Option<EmailTemplateSlots>,
+    pub subject: Option<String>,
 }
 
 impl UpdateEmailTemplateConfig {
@@ -551,20 +551,14 @@ pub async fn get_by_type_user(
 
 #[derive(Deserialize, Debug, JsonSchema, Default)]
 pub struct EmailTemplateConfigFilterOptions {
-    pub owner_id: Option<Uuid>,
-    pub organization_id: Option<Uuid>,
+    pub email_type: Option<EmailType>,
 }
 
 impl EmailTemplateConfigFilterOptions {
     fn apply(&self, mut query: SelectStatement) -> SelectStatement {
-        if let Some(owner_id) = self.owner_id {
+        if let Some(email_type) = &self.email_type {
             query = query
-                .and_where(Expr::col(EmailTemplateConfigIden::OwnerId).eq(owner_id))
-                .to_owned();
-        }
-        if let Some(organization_id) = self.organization_id {
-            query = query
-                .and_where(Expr::col(EmailTemplateConfigIden::OrganizationId).eq(organization_id))
+                .and_where(Expr::col(EmailTemplateConfigIden::EmailType).eq(email_type.to_owned()))
                 .to_owned();
         }
 
@@ -575,11 +569,13 @@ impl EmailTemplateConfigFilterOptions {
 #[instrument(err(Debug))]
 pub async fn list(
     db: &PgPool,
+    user_id: &Uuid,
     filter_options: EmailTemplateConfigFilterOptions,
 ) -> Result<Vec<EmailTemplateConfig>, ComhairleError> {
     let query = Query::select()
         .from(EmailTemplateConfigIden::Table)
         .columns(DEFAULT_COLUMNS)
+        .and_where(Expr::col(EmailTemplateConfigIden::OwnerId).eq(user_id.to_owned()))
         .to_owned();
 
     let query = filter_options.apply(query);
@@ -714,7 +710,7 @@ mod tests {
     }
 
     #[sqlx::test]
-    async fn should_get_email_config_user_and_email_type(
+    async fn should_optionally_get_email_config_user_and_email_type(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
@@ -731,7 +727,7 @@ mod tests {
             subject: None,
         };
 
-        let new_email_config = create(&pool, current_user.id, &params).await?;
+        create(&pool, current_user.id, &params).await?;
 
         let email_config = get_by_type_user(
             &pool,
@@ -740,11 +736,16 @@ mod tests {
         )
         .await?;
 
-        assert_eq!(
-            new_email_config.id,
-            email_config.unwrap().id,
-            "ids don't match"
-        );
+        assert!(email_config.is_some(), "existing config not found");
+
+        let email_config = get_by_type_user(
+            &pool,
+            Uuid::new_v4(),
+            &SCHEMA_CONVERSATION_INVITE.email_type,
+        )
+        .await?;
+
+        assert!(email_config.is_none(), "random user config found");
 
         Ok(())
     }
@@ -752,9 +753,7 @@ mod tests {
     #[sqlx::test]
     async fn should_list_email_configs(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
-        let (_, user_a, _) = session.current_user(&app).await?;
-
-        let user_b = users::create_annon_user(&pool).await?;
+        let (_, user, _) = session.current_user(&app).await?;
 
         let default_slots = DefaultEmailSlots {
             heading: "<h1>Test heading</h1>".to_string(),
@@ -767,23 +766,24 @@ mod tests {
             slots: EmailTemplateSlots::EventRegistrationConfirmation(default_slots.clone()),
             subject: None,
         };
-        create(&pool, user_a.id, &params_a).await?;
+        create(&pool, user.id, &params_a).await?;
         let params_b = CreateEmailTemplateConfig {
             slots: EmailTemplateSlots::ConversationInvite(default_slots.clone()),
             subject: None,
         };
-        create(&pool, user_b.id, &params_b).await?;
+        create(&pool, user.id, &params_b).await?;
 
         let filter_options = EmailTemplateConfigFilterOptions {
-            owner_id: Some(user_b.id),
-            ..Default::default()
+            email_type: Some(EmailType::EventRegistrationConfirmation),
         };
-        let email_configs = list(&pool, filter_options).await?;
+        let email_configs = list(&pool, &user.id, filter_options).await?;
 
         assert_eq!(email_configs.len(), 1, "incorrect total");
         assert!(
-            !email_configs.iter().any(|c| c.owner_id == user_a.id),
-            "user_a incorrectly included"
+            !email_configs
+                .iter()
+                .any(|c| c.email_type == EmailType::ConversationInvite),
+            "incorrectly email_type included"
         );
 
         Ok(())

--- a/api/src/models/email_template_config.rs
+++ b/api/src/models/email_template_config.rs
@@ -41,14 +41,11 @@ pub struct EmailTemplateConfig {
 }
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema, Clone, PartialEq, PartialOrd, sqlx::Type)]
-#[sqlx(type_name = "TEXT")]
+#[sqlx(type_name = "TEXT", rename_all = "snake_case")]
 #[serde(rename_all = "snake_case")]
 pub enum EmailType {
-    #[sqlx(rename = "conversation_invite")]
     ConversationInvite,
-    #[sqlx(rename = "event_registration_invite")]
     EventRegistrationInvite,
-    #[sqlx(rename = "event_registration_invite")]
     EventRegistrationConfirmation,
 }
 
@@ -63,7 +60,7 @@ impl std::fmt::Display for EmailType {
         let value = match self {
             EmailType::ConversationInvite => "conversation_invite",
             EmailType::EventRegistrationInvite => "event_registration_invite",
-            EmailType::EventRegistrationConfirmation => "event_registration_invite",
+            EmailType::EventRegistrationConfirmation => "event_registration_confirmation",
         };
         write!(f, "{}", value)
     }

--- a/api/src/models/email_template_config.rs
+++ b/api/src/models/email_template_config.rs
@@ -63,33 +63,6 @@ pub const TYPE_EVENT_REGISTRATION_INVITE: &str = "event_registration_invite";
 pub const TYPE_EVENT_REGISTRATION_CONFIRMATION: &str = "event_registration_confirmation";
 
 impl EmailTemplateSlots {
-    fn try_schema_for_type(email_type: &str) -> Result<EmailTypeSchema, ComhairleError> {
-        let schema = match email_type {
-            TYPE_CONVERSATION_INVITE => EmailTypeSchema {
-                email_type: TYPE_CONVERSATION_INVITE,
-                variables: &["conversation_title"],
-                slots: DEFAULT_SLOTS_SCHEMA,
-            },
-            TYPE_EVENT_REGISTRATION_INVITE => EmailTypeSchema {
-                email_type: TYPE_EVENT_REGISTRATION_INVITE,
-                variables: &["event_name", "event_time"],
-                slots: DEFAULT_SLOTS_SCHEMA,
-            },
-            TYPE_EVENT_REGISTRATION_CONFIRMATION => EmailTypeSchema {
-                email_type: TYPE_EVENT_REGISTRATION_CONFIRMATION,
-                variables: &[],
-                slots: DEFAULT_SLOTS_SCHEMA,
-            },
-            _ => {
-                return Err(ComhairleError::MissingEmailTemplateSchema(
-                    email_type.to_string(),
-                ))
-            }
-        };
-
-        Ok(schema)
-    }
-
     /// Returns the schema for every email template type.
     ///
     /// Each entry describes a variant of [`EmailTemplateSlots`], pairing the
@@ -103,16 +76,33 @@ impl EmailTemplateSlots {
     /// When a new variant is added to [`EmailTemplateSlots`], a corresponding
     /// [`EmailTypeSchema`] must be added here manually. There is no compiler
     /// enforcement for this.
-    pub fn schemas() -> Result<[EmailTypeSchema; 3], ComhairleError> {
-        Ok([
-            Self::try_schema_for_type(TYPE_CONVERSATION_INVITE)?,
-            Self::try_schema_for_type(TYPE_EVENT_REGISTRATION_INVITE)?,
-            Self::try_schema_for_type(TYPE_EVENT_REGISTRATION_CONFIRMATION)?,
-        ])
+    pub fn schemas() -> [EmailTypeSchema; 3] {
+        [
+            EmailTemplateSlots::ConversationInvite(DefaultEmailSlots::default()).schema(),
+            EmailTemplateSlots::EventRegistrationInvite(DefaultEmailSlots::default()).schema(),
+            EmailTemplateSlots::EventRegistrationConfirmation(DefaultEmailSlots::default())
+                .schema(),
+        ]
     }
 
-    pub fn schema(&self) -> Result<EmailTypeSchema, ComhairleError> {
-        Self::try_schema_for_type(&self.to_string())
+    pub fn schema(&self) -> EmailTypeSchema {
+        match self {
+            EmailTemplateSlots::ConversationInvite(_) => EmailTypeSchema {
+                email_type: self.to_type_str(),
+                variables: &["conversation_title"],
+                slots: DEFAULT_SLOTS_SCHEMA,
+            },
+            EmailTemplateSlots::EventRegistrationInvite(_) => EmailTypeSchema {
+                email_type: self.to_type_str(),
+                variables: &["event_name", "event_time"],
+                slots: DEFAULT_SLOTS_SCHEMA,
+            },
+            EmailTemplateSlots::EventRegistrationConfirmation(_) => EmailTypeSchema {
+                email_type: self.to_type_str(),
+                variables: &[],
+                slots: DEFAULT_SLOTS_SCHEMA,
+            },
+        }
     }
 
     pub fn to_template(&self) -> &str {
@@ -120,6 +110,23 @@ impl EmailTemplateSlots {
             EmailTemplateSlots::ConversationInvite(_) => "conversation_invite.html",
             EmailTemplateSlots::EventRegistrationInvite(_) => "event_registration_invite.html",
             EmailTemplateSlots::EventRegistrationConfirmation(_) => "event_confirmation.html",
+        }
+    }
+
+    /// Returns the canonical string identifier for this email template variant.
+    ///
+    /// This is the single source of truth for the string representation of each
+    /// variant, and is used by both [`Display`] and [`schema`] to avoid
+    /// duplicating the mapping. The returned string is always a `&'static str`
+    /// drawn from the `TYPE_*` constants, which allows it to be embedded in
+    /// [`EmailTypeSchema`] without lifetime annotation.
+    fn to_type_str(&self) -> &'static str {
+        match self {
+            EmailTemplateSlots::ConversationInvite(_) => TYPE_CONVERSATION_INVITE,
+            EmailTemplateSlots::EventRegistrationInvite(_) => TYPE_EVENT_REGISTRATION_INVITE,
+            EmailTemplateSlots::EventRegistrationConfirmation(_) => {
+                TYPE_EVENT_REGISTRATION_CONFIRMATION
+            }
         }
     }
 
@@ -150,14 +157,7 @@ impl EmailTemplateSlots {
 
 impl std::fmt::Display for EmailTemplateSlots {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let value = match self {
-            EmailTemplateSlots::ConversationInvite(_) => TYPE_CONVERSATION_INVITE,
-            EmailTemplateSlots::EventRegistrationInvite(_) => TYPE_EVENT_REGISTRATION_INVITE,
-            EmailTemplateSlots::EventRegistrationConfirmation(_) => {
-                TYPE_EVENT_REGISTRATION_CONFIRMATION
-            }
-        };
-        write!(f, "{}", value)
+        write!(f, "{}", self.to_type_str())
     }
 }
 

--- a/api/src/models/email_template_config.rs
+++ b/api/src/models/email_template_config.rs
@@ -182,24 +182,37 @@ pub const SLOTS_SCHEMA_EVENT_REGISTRATION_CONFIRMATION: &[SlotSchemaDefinition] 
     },
 ];
 
-/// Provides conversion of a [`SlotSchemaDefinition`] slice into a [`HashMap`] of
-/// slot keys to their default content.
-///
-/// This trait exists as a workaround for Rust's orphan rules, which prevent
-/// implementing foreign traits (such as [`From`]) for foreign types (such as
-/// [`HashMap`]). Since both [`From`] and [`HashMap`] are defined outside of this
-/// crate, a direct `impl From<&[SlotSchemaDefinition]> for HashMap<String, String>`
-/// is not permitted. Defining our own trait here gives us a local trait that we
-/// are free to implement for any type.
-pub trait IntoSlotMap {
-    fn into_slots_map(&self) -> HashMap<String, String>;
+/// Converts `self` to [`HashMap`] mapping email template variable keys to their content.
+pub trait MailerContextMap {
+    fn mailer_context_map(&self) -> HashMap<String, String>;
 }
 
-impl IntoSlotMap for [SlotSchemaDefinition] {
-    fn into_slots_map(&self) -> HashMap<String, String> {
+/// Builds the map from each slot's key to its default content.
+impl MailerContextMap for [SlotSchemaDefinition] {
+    fn mailer_context_map(&self) -> HashMap<String, String> {
         self.iter()
             .map(|slot| (slot.key.to_string(), slot.default_content.to_string()))
             .collect()
+    }
+}
+
+#[derive(Serialize, Deserialize, JsonSchema, Debug, Clone, PartialEq, Default)]
+pub struct DefaultEmailSlots {
+    pub heading: String,
+    pub intro: String,
+    pub body: String,
+    pub footer: String,
+}
+
+/// Builds the map from the fixed email slot field names to their current values.
+impl MailerContextMap for DefaultEmailSlots {
+    fn mailer_context_map(&self) -> HashMap<String, String> {
+        HashMap::from([
+            ("heading".to_string(), self.heading.clone()),
+            ("intro".to_string(), self.intro.clone()),
+            ("body".to_string(), self.body.clone()),
+            ("footer".to_string(), self.footer.clone()),
+        ])
     }
 }
 
@@ -317,9 +330,9 @@ impl EmailTemplateSlots {
     /// ```
     pub fn mailer_slots_map(&self) -> HashMap<String, String> {
         match self {
-            EmailTemplateSlots::ConversationInvite(slots) => slots.to_mailer_map(),
-            EmailTemplateSlots::EventRegistrationInvite(slots) => slots.to_mailer_map(),
-            EmailTemplateSlots::EventRegistrationConfirmation(slots) => slots.to_mailer_map(),
+            EmailTemplateSlots::ConversationInvite(slots) => slots.mailer_context_map(),
+            EmailTemplateSlots::EventRegistrationInvite(slots) => slots.mailer_context_map(),
+            EmailTemplateSlots::EventRegistrationConfirmation(slots) => slots.mailer_context_map(),
         }
     }
 
@@ -364,25 +377,6 @@ impl EmailTemplateSlots {
 impl std::fmt::Display for EmailTemplateSlots {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.type_str())
-    }
-}
-
-#[derive(Serialize, Deserialize, JsonSchema, Debug, Clone, PartialEq, Default)]
-pub struct DefaultEmailSlots {
-    pub heading: String,
-    pub intro: String,
-    pub body: String,
-    pub footer: String,
-}
-
-impl DefaultEmailSlots {
-    fn to_mailer_map(&self) -> HashMap<String, String> {
-        HashMap::from([
-            ("heading".to_string(), self.heading.clone()),
-            ("intro".to_string(), self.intro.clone()),
-            ("body".to_string(), self.body.clone()),
-            ("footer".to_string(), self.footer.clone()),
-        ])
     }
 }
 

--- a/api/src/models/email_template_config.rs
+++ b/api/src/models/email_template_config.rs
@@ -61,6 +61,17 @@ pub struct SlotSchemaDefinition {
     /// Default html used as a starting point for a slot as well as a fallback
     /// if an [`EmailTemplateConfig`] does not exist for this user / email_type.
     pub default_content: &'static str,
+    /// Defines whether a slot requires rich text HTML editing or plain text
+    /// inserted into an existing HTML tag and is used on the frontend to render
+    /// the appropriate input type.
+    pub content_type: ContentType,
+}
+
+#[derive(Serialize, JsonSchema, Debug, Clone)]
+#[serde(rename_all = "snake_case")]
+enum ContentType {
+    PlainText,
+    RichText,
 }
 
 #[derive(Serialize, JsonSchema, Debug, Clone)]
@@ -81,25 +92,29 @@ pub const SLOTS_SCHEMA_CONVERSATION_INVITE: &[SlotSchemaDefinition] = &[
         key: "heading",
         label: "Heading",
         hint: "The email heading",
-        default_content: "Dear Invited Participant,"
+        default_content: "Dear Invited Participant,",
+        content_type: ContentType::PlainText,
     },
     SlotSchemaDefinition {
         key: "intro",
         label: "Intro",
         hint: "Opening paragraph",
-        default_content: "<p>You have been selected to take part in a public engagement, <strong>{{conversation_title}}</strong>, hosted on the <strong>Comhairle</strong> platform by <strong>CrownShy</strong>.<p />"
+        default_content: "<p>You have been selected to take part in a public engagement, <strong>{{conversation_title}}</strong>, hosted on the <strong>Comhairle</strong> platform by <strong>CrownShy</strong>.<p />",
+        content_type: ContentType::RichText,
     },
     SlotSchemaDefinition {
         key: "body",
         label: "Body",
         hint: "Main email content",
-        default_content: "<p>We’re inviting you to complete the online engagement.</p><p>We’re keen to hear your real views and reflections. If you choose to take part, we ask that you:</p><ul><li>Read and consider each question carefully.</li><li>Provide your own honest opinions, not blank or repetitive answers.</li><li>Complete <strong>all sections</strong> of the engagement.</li></ul>"
+        default_content: "<p>We’re inviting you to complete the online engagement.</p><p>We’re keen to hear your real views and reflections. If you choose to take part, we ask that you:</p><ul><li>Read and consider each question carefully.</li><li>Provide your own honest opinions, not blank or repetitive answers.</li><li>Complete <strong>all sections</strong> of the engagement.</li></ul>",
+        content_type: ContentType::RichText,
     },
     SlotSchemaDefinition {
         key: "footer",
         label: "Footer",
         hint: "Closing line",
-        default_content: "<p>Thank you very much for your time and contribution to this important process.</p><p>Warm regards, <br /><strong>The CrownShy Team.</strong></p>"
+        default_content: "<p>Thank you very much for your time and contribution to this important process.</p><p>Warm regards, <br /><strong>The CrownShy Team.</strong></p>",
+        content_type: ContentType::RichText,
     },
 ];
 
@@ -108,25 +123,29 @@ pub const SLOTS_SCHEMA_EVENT_REGISTRATION_INVITE: &[SlotSchemaDefinition] = &[
         key: "heading",
         label: "Heading",
         hint: "The email heading",
-        default_content: "Hello!"
+        default_content: "Hello!",
+        content_type: ContentType::PlainText,
     },
     SlotSchemaDefinition {
         key: "intro",
         label: "Intro",
         hint: "Opening paragraph",
-        default_content: "<p>You are invited to take part in <strong>{{event_name}}</strong> with <strong>{{organization_name}}</strong> to collaborate with them.</p>"
+        default_content: "<p>You are invited to take part in <strong>{{event_name}}</strong> with <strong>{{organization_name}}</strong> to collaborate with them.</p>",
+        content_type: ContentType::RichText,
     },
     SlotSchemaDefinition {
         key: "body",
         label: "Body",
         hint: "Main email content",
-        default_content: "<p>Click the button below to register.</p>"
+        default_content: "<p>Click the button below to register.</p>",
+        content_type: ContentType::RichText,
     },
     SlotSchemaDefinition {
         key: "footer",
         label: "Footer",
         hint: "Closing line",
-        default_content: "<p>We look forward to your participation!</p><p><strong>{{organization_name}}</strong></p>"
+        default_content: "<p>We look forward to your participation!</p><p><strong>{{organization_name}}</strong></p>",
+        content_type: ContentType::RichText,
     },
 ];
 
@@ -136,24 +155,28 @@ pub const SLOTS_SCHEMA_EVENT_REGISTRATION_CONFIRMATION: &[SlotSchemaDefinition] 
         label: "Heading",
         hint: "The email heading",
         default_content: "You're in!",
+        content_type: ContentType::PlainText,
     },
     SlotSchemaDefinition {
         key: "intro",
         label: "Intro",
         hint: "Opening paragraph",
         default_content: "<p>Thank you for registering for <strong>{{event_name}}</strong>.",
+        content_type: ContentType::RichText,
     },
     SlotSchemaDefinition {
         key: "body",
         label: "Body",
         hint: "Main email content",
         default_content: "<p>You will be sent a reminder email before the event with instructions on how to join the online meeting.</p>",
+        content_type: ContentType::RichText,
     },
     SlotSchemaDefinition {
         key: "footer",
         label: "Footer",
         hint: "Closing line",
         default_content: "<p>We look forward to seeing you there!</p><p><strong>{{organization_name}}</strong></p>",
+        content_type: ContentType::RichText,
     },
 ];
 

--- a/api/src/models/email_template_config.rs
+++ b/api/src/models/email_template_config.rs
@@ -54,10 +54,12 @@ pub struct EmailTemplateConfig {
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum EmailTemplateSlots {
     ConversationInvite(DefaultEmailSlots),
+    EventRegistrationInvite(DefaultEmailSlots),
     EventRegistrationConfirmation(DefaultEmailSlots),
 }
 
 pub const TYPE_CONVERSATION_INVITE: &str = "conversation_invite";
+pub const TYPE_EVENT_REGISTRATION_INVITE: &str = "event_registration_invite";
 pub const TYPE_EVENT_REGISTRATION_CONFIRMATION: &str = "event_registration_confirmation";
 
 impl EmailTemplateSlots {
@@ -81,6 +83,10 @@ impl EmailTemplateSlots {
                 slots: DEFAULT_SLOTS_SCHEMA,
             },
             EmailTypeSchema {
+                email_type: TYPE_EVENT_REGISTRATION_INVITE,
+                slots: DEFAULT_SLOTS_SCHEMA,
+            },
+            EmailTypeSchema {
                 email_type: TYPE_EVENT_REGISTRATION_CONFIRMATION,
                 slots: DEFAULT_SLOTS_SCHEMA,
             },
@@ -90,6 +96,7 @@ impl EmailTemplateSlots {
     pub fn to_template(&self) -> &str {
         match self {
             EmailTemplateSlots::ConversationInvite(_) => "conversation_invite.html",
+            EmailTemplateSlots::EventRegistrationInvite(_) => "event_registration_invite.html",
             EmailTemplateSlots::EventRegistrationConfirmation(_) => "event_confirmation.html",
         }
     }
@@ -97,6 +104,7 @@ impl EmailTemplateSlots {
     pub fn schema(&self) -> &'static [SlotSchemaDefinition] {
         match self {
             EmailTemplateSlots::ConversationInvite(_) => DEFAULT_SLOTS_SCHEMA,
+            EmailTemplateSlots::EventRegistrationInvite(_) => DEFAULT_SLOTS_SCHEMA,
             EmailTemplateSlots::EventRegistrationConfirmation(_) => DEFAULT_SLOTS_SCHEMA,
         }
     }
@@ -120,6 +128,7 @@ impl EmailTemplateSlots {
     pub fn to_mailer_map(&self) -> HashMap<&str, String> {
         match self {
             EmailTemplateSlots::ConversationInvite(slots) => slots.to_mailer_map(),
+            EmailTemplateSlots::EventRegistrationInvite(slots) => slots.to_mailer_map(),
             EmailTemplateSlots::EventRegistrationConfirmation(slots) => slots.to_mailer_map(),
         }
     }
@@ -129,6 +138,7 @@ impl std::fmt::Display for EmailTemplateSlots {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let value = match self {
             EmailTemplateSlots::ConversationInvite(_) => TYPE_CONVERSATION_INVITE,
+            EmailTemplateSlots::EventRegistrationInvite(_) => TYPE_EVENT_REGISTRATION_INVITE,
             EmailTemplateSlots::EventRegistrationConfirmation(_) => {
                 TYPE_EVENT_REGISTRATION_CONFIRMATION
             }

--- a/api/src/models/email_template_config.rs
+++ b/api/src/models/email_template_config.rs
@@ -63,6 +63,33 @@ pub const TYPE_EVENT_REGISTRATION_INVITE: &str = "event_registration_invite";
 pub const TYPE_EVENT_REGISTRATION_CONFIRMATION: &str = "event_registration_confirmation";
 
 impl EmailTemplateSlots {
+    fn try_schema_for_type(email_type: &str) -> Result<EmailTypeSchema, ComhairleError> {
+        let schema = match email_type {
+            TYPE_CONVERSATION_INVITE => EmailTypeSchema {
+                email_type: TYPE_CONVERSATION_INVITE,
+                variables: &["conversation_title"],
+                slots: DEFAULT_SLOTS_SCHEMA,
+            },
+            TYPE_EVENT_REGISTRATION_INVITE => EmailTypeSchema {
+                email_type: TYPE_EVENT_REGISTRATION_INVITE,
+                variables: &["event_name", "event_time"],
+                slots: DEFAULT_SLOTS_SCHEMA,
+            },
+            TYPE_EVENT_REGISTRATION_CONFIRMATION => EmailTypeSchema {
+                email_type: TYPE_EVENT_REGISTRATION_CONFIRMATION,
+                variables: &[],
+                slots: DEFAULT_SLOTS_SCHEMA,
+            },
+            _ => {
+                return Err(ComhairleError::MissingEmailTemplateSchema(
+                    email_type.to_string(),
+                ))
+            }
+        };
+
+        Ok(schema)
+    }
+
     /// Returns the schema for every email template type.
     ///
     /// Each entry describes a variant of [`EmailTemplateSlots`], pairing the
@@ -76,21 +103,16 @@ impl EmailTemplateSlots {
     /// When a new variant is added to [`EmailTemplateSlots`], a corresponding
     /// [`EmailTypeSchema`] must be added here manually. There is no compiler
     /// enforcement for this.
-    pub fn schemas() -> &'static [EmailTypeSchema] {
-        &[
-            EmailTypeSchema {
-                email_type: TYPE_CONVERSATION_INVITE,
-                slots: DEFAULT_SLOTS_SCHEMA,
-            },
-            EmailTypeSchema {
-                email_type: TYPE_EVENT_REGISTRATION_INVITE,
-                slots: DEFAULT_SLOTS_SCHEMA,
-            },
-            EmailTypeSchema {
-                email_type: TYPE_EVENT_REGISTRATION_CONFIRMATION,
-                slots: DEFAULT_SLOTS_SCHEMA,
-            },
-        ]
+    pub fn schemas() -> Result<[EmailTypeSchema; 3], ComhairleError> {
+        Ok([
+            Self::try_schema_for_type(TYPE_CONVERSATION_INVITE)?,
+            Self::try_schema_for_type(TYPE_EVENT_REGISTRATION_INVITE)?,
+            Self::try_schema_for_type(TYPE_EVENT_REGISTRATION_CONFIRMATION)?,
+        ])
+    }
+
+    pub fn schema(&self) -> Result<EmailTypeSchema, ComhairleError> {
+        Self::try_schema_for_type(&self.to_string())
     }
 
     pub fn to_template(&self) -> &str {
@@ -98,14 +120,6 @@ impl EmailTemplateSlots {
             EmailTemplateSlots::ConversationInvite(_) => "conversation_invite.html",
             EmailTemplateSlots::EventRegistrationInvite(_) => "event_registration_invite.html",
             EmailTemplateSlots::EventRegistrationConfirmation(_) => "event_confirmation.html",
-        }
-    }
-
-    pub fn schema(&self) -> &'static [SlotSchemaDefinition] {
-        match self {
-            EmailTemplateSlots::ConversationInvite(_) => DEFAULT_SLOTS_SCHEMA,
-            EmailTemplateSlots::EventRegistrationInvite(_) => DEFAULT_SLOTS_SCHEMA,
-            EmailTemplateSlots::EventRegistrationConfirmation(_) => DEFAULT_SLOTS_SCHEMA,
         }
     }
 
@@ -216,6 +230,7 @@ pub struct SlotSchemaDefinition {
 #[derive(Serialize, JsonSchema, Debug, Clone)]
 pub struct EmailTypeSchema {
     pub email_type: &'static str,
+    pub variables: &'static [&'static str],
     pub slots: &'static [SlotSchemaDefinition],
 }
 

--- a/api/src/models/email_template_config.rs
+++ b/api/src/models/email_template_config.rs
@@ -307,7 +307,6 @@ impl MailerContextMap for DefaultEmailSlots {
 /// 1. Add a variant here with its slot struct.
 /// 2. Add the corresponding HTML template.
 /// 3. Update [`EmailTemplateSlots::schemas`] with the new variant's schema.
-/// 4. Update [`EmailTemplateSlots::email_template`] to return the template filename.
 #[derive(Serialize, Deserialize, JsonSchema, Debug, Clone, PartialEq, EnumCount)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum EmailTemplateSlots {
@@ -357,10 +356,10 @@ impl EmailTemplateSlots {
     /// links or IDs generated at send time). For example:
     ///
     /// ```ignore
-    /// let base = email_config.slots.to_mailer_map();
+    /// let base = email_config.slots.mailer_context_map();
     /// let context = minijinja::context! { invite_link => "foo@bar.com", ..base };
     /// ```
-    pub fn mailer_slots_map(&self) -> HashMap<String, String> {
+    pub fn mailer_context_map(&self) -> HashMap<String, String> {
         match self {
             EmailTemplateSlots::ConversationInvite(slots) => slots.mailer_context_map(),
             EmailTemplateSlots::EventRegistrationInvite(slots) => slots.mailer_context_map(),
@@ -537,7 +536,7 @@ pub async fn get_by_type_user(
     db: &PgPool,
     user_id: Uuid,
     email_type: &EmailType,
-) -> Result<EmailTemplateConfig, ComhairleError> {
+) -> Result<Option<EmailTemplateConfig>, ComhairleError> {
     let (sql, values) = Query::select()
         .columns(DEFAULT_COLUMNS)
         .from(EmailTemplateConfigIden::Table)
@@ -545,10 +544,7 @@ pub async fn get_by_type_user(
         .and_where(Expr::col(EmailTemplateConfigIden::EmailType).eq(email_type.to_owned()))
         .build_sqlx(PostgresQueryBuilder);
 
-    let email_config = query_as_with(&sql, values)
-        .fetch_one(db)
-        .await
-        .not_found_as("Email template config")?;
+    let email_config = query_as_with(&sql, values).fetch_optional(db).await?;
 
     Ok(email_config)
 }
@@ -744,7 +740,11 @@ mod tests {
         )
         .await?;
 
-        assert_eq!(new_email_config.id, email_config.id, "ids don't match");
+        assert_eq!(
+            new_email_config.id,
+            email_config.unwrap().id,
+            "ids don't match"
+        );
 
         Ok(())
     }

--- a/api/src/models/email_template_config.rs
+++ b/api/src/models/email_template_config.rs
@@ -1,0 +1,433 @@
+use chrono::{DateTime, Utc};
+use schemars::JsonSchema;
+use sea_query::{enum_def, Expr, PostgresQueryBuilder, Query, SelectStatement, SimpleExpr};
+use sea_query_binder::SqlxBinder;
+use serde::{Deserialize, Serialize};
+use sqlx::{
+    encode::IsNull,
+    prelude::{FromRow, Type},
+    query_as_with, Decode, Encode, PgPool, Postgres,
+};
+use sqlx_postgres::{PgArgumentBuffer, PgTypeInfo, PgValueRef};
+use tracing::instrument;
+use uuid::Uuid;
+
+use crate::{error::ComhairleError, models::users};
+
+#[derive(Serialize, Deserialize, Debug, FromRow, Clone, JsonSchema)]
+#[enum_def(table_name = "email_template_config")]
+pub struct EmailTemplateConfig {
+    pub id: Uuid,
+    pub owner_id: Uuid,
+    pub organization_id: Option<Uuid>,
+    pub email_type: String,
+    pub slots: EmailTemplateSlots,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Serialize, Deserialize, JsonSchema, Debug, Clone, PartialEq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum EmailTemplateSlots {
+    ConversationInvite(DefaultEmailSlots),
+    EventRegistrationConfirmation(DefaultEmailSlots),
+}
+
+impl EmailTemplateSlots {
+    fn to_template(&self) -> &str {
+        match self {
+            EmailTemplateSlots::ConversationInvite(_) => "conversation_invite.html",
+            EmailTemplateSlots::EventRegistrationConfirmation(_) => "event_confirmation.html",
+        }
+    }
+}
+
+impl std::fmt::Display for EmailTemplateSlots {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let value = match self {
+            EmailTemplateSlots::ConversationInvite(_) => "conversation_invite",
+            EmailTemplateSlots::EventRegistrationConfirmation(_) => {
+                "event_registration_confirmation"
+            }
+        };
+        write!(f, "{}", value)
+    }
+}
+
+#[derive(Serialize, Deserialize, JsonSchema, Debug, Clone, PartialEq)]
+pub struct DefaultEmailSlots {
+    pub heading: String,
+    pub intro: String,
+    pub body: String,
+    pub footer: String,
+}
+
+impl Type<Postgres> for EmailTemplateSlots {
+    fn type_info() -> PgTypeInfo {
+        <serde_json::Value as Type<Postgres>>::type_info()
+    }
+}
+
+impl<'q> Encode<'q, Postgres> for EmailTemplateSlots {
+    fn encode_by_ref(
+        &self,
+        buf: &mut PgArgumentBuffer,
+    ) -> Result<IsNull, sqlx::error::BoxDynError> {
+        let json = serde_json::to_value(self)?;
+        <serde_json::Value as Encode<Postgres>>::encode(json, buf)
+    }
+}
+
+impl<'r> Decode<'r, Postgres> for EmailTemplateSlots {
+    fn decode(value: PgValueRef<'r>) -> Result<Self, sqlx::error::BoxDynError> {
+        let json: serde_json::Value = Decode::<Postgres>::decode(value)?;
+        Ok(serde_json::from_value(json)?)
+    }
+}
+
+const DEFAULT_COLUMNS: [EmailTemplateConfigIden; 7] = [
+    EmailTemplateConfigIden::Id,
+    EmailTemplateConfigIden::OwnerId,
+    EmailTemplateConfigIden::OrganizationId,
+    EmailTemplateConfigIden::EmailType,
+    EmailTemplateConfigIden::Slots,
+    EmailTemplateConfigIden::CreatedAt,
+    EmailTemplateConfigIden::UpdatedAt,
+];
+
+#[derive(Deserialize, JsonSchema, Debug)]
+pub struct CreateEmailTemplateConfig {
+    pub slots: EmailTemplateSlots,
+}
+
+#[instrument(err(Debug))]
+pub async fn create(
+    db: &PgPool,
+    user_id: &Uuid,
+    params: &CreateEmailTemplateConfig,
+) -> Result<EmailTemplateConfig, ComhairleError> {
+    let slots_json = serde_json::to_value(&params.slots)?;
+
+    let mut columns = vec![
+        EmailTemplateConfigIden::Slots,
+        EmailTemplateConfigIden::OwnerId,
+    ];
+    let mut values = vec![slots_json.into(), (*user_id).into()];
+
+    columns.push(EmailTemplateConfigIden::EmailType);
+    values.push(params.slots.to_string().into());
+
+    let user = users::get_user_by_id(user_id, db).await?;
+
+    if let Some(organization_id) = user.organization_id {
+        columns.push(EmailTemplateConfigIden::OrganizationId);
+        values.push(organization_id.into());
+    }
+
+    let (sql, values) = Query::insert()
+        .into_table(EmailTemplateConfigIden::Table)
+        .columns(columns)
+        .values(values)?
+        .returning(Query::returning().columns(DEFAULT_COLUMNS))
+        .build_sqlx(PostgresQueryBuilder);
+
+    let email_config = query_as_with(&sql, values).fetch_one(db).await?;
+
+    Ok(email_config)
+}
+
+#[derive(Deserialize, JsonSchema, Debug)]
+pub struct UpdateEmailTemplateConfig {
+    slots: Option<EmailTemplateSlots>,
+}
+
+impl UpdateEmailTemplateConfig {
+    fn try_to_values(&self) -> Result<Vec<(EmailTemplateConfigIden, SimpleExpr)>, ComhairleError> {
+        let mut values = vec![];
+        if let Some(value) = &self.slots {
+            let slots_json = serde_json::to_value(value)?;
+            values.push((EmailTemplateConfigIden::Slots, slots_json.into()));
+        }
+
+        Ok(values)
+    }
+}
+
+#[instrument(err(Debug))]
+pub async fn update(
+    db: &PgPool,
+    id: Uuid,
+    params: &UpdateEmailTemplateConfig,
+) -> Result<EmailTemplateConfig, ComhairleError> {
+    let values = params.try_to_values()?;
+
+    if values.is_empty() {
+        return Err(ComhairleError::NoValidUpdates);
+    }
+
+    let (sql, values) = Query::update()
+        .table(EmailTemplateConfigIden::Table)
+        .values(values)
+        .and_where(Expr::col(EmailTemplateConfigIden::Id).eq(id))
+        .returning(Query::returning().columns(DEFAULT_COLUMNS))
+        .build_sqlx(PostgresQueryBuilder);
+
+    let email_config = query_as_with(&sql, values).fetch_one(db).await?;
+
+    Ok(email_config)
+}
+
+#[instrument(err(Debug))]
+pub async fn get_by_id(db: &PgPool, id: Uuid) -> Result<EmailTemplateConfig, ComhairleError> {
+    let (sql, values) = Query::select()
+        .columns(DEFAULT_COLUMNS)
+        .from(EmailTemplateConfigIden::Table)
+        .and_where(Expr::col(EmailTemplateConfigIden::Id).eq(id.to_owned()))
+        .build_sqlx(PostgresQueryBuilder);
+
+    let email_config = sqlx::query_as_with(&sql, values)
+        .fetch_one(db)
+        .await
+        .map_err(|e| match e {
+            sqlx::Error::RowNotFound => {
+                ComhairleError::ResourceNotFound("Email template config".into())
+            }
+            other => ComhairleError::DatabaseError(other),
+        })?;
+
+    Ok(email_config)
+}
+
+#[derive(Deserialize, Debug, JsonSchema, Default)]
+pub struct EmailTemplateConfigFilterOptions {
+    pub owner_id: Option<Uuid>,
+    pub organization_id: Option<Uuid>,
+}
+
+impl EmailTemplateConfigFilterOptions {
+    fn apply(&self, mut query: SelectStatement) -> SelectStatement {
+        if let Some(owner_id) = self.owner_id {
+            query = query
+                .and_where(Expr::col(EmailTemplateConfigIden::OwnerId).eq(owner_id))
+                .to_owned();
+        }
+        if let Some(organization_id) = self.organization_id {
+            query = query
+                .and_where(Expr::col(EmailTemplateConfigIden::OrganizationId).eq(organization_id))
+                .to_owned();
+        }
+
+        query
+    }
+}
+
+#[instrument(err(Debug))]
+pub async fn list(
+    db: &PgPool,
+    filter_options: EmailTemplateConfigFilterOptions,
+) -> Result<Vec<EmailTemplateConfig>, ComhairleError> {
+    let query = Query::select()
+        .from(EmailTemplateConfigIden::Table)
+        .columns(DEFAULT_COLUMNS)
+        .to_owned();
+
+    let query = filter_options.apply(query);
+
+    let (sql, values) = query.build_sqlx(PostgresQueryBuilder);
+
+    let email_configs = query_as_with(&sql, values).fetch_all(db).await?;
+
+    Ok(email_configs)
+}
+
+#[instrument(err(Debug))]
+pub async fn delete(db: &PgPool, id: Uuid) -> Result<EmailTemplateConfig, ComhairleError> {
+    let (sql, values) = Query::delete()
+        .from_table(EmailTemplateConfigIden::Table)
+        .and_where(Expr::col(EmailTemplateConfigIden::Id).eq(id))
+        .returning(Query::returning().columns(DEFAULT_COLUMNS))
+        .build_sqlx(PostgresQueryBuilder);
+
+    let email_config = query_as_with(&sql, values).fetch_one(db).await?;
+
+    Ok(email_config)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::models::model_test_helpers::setup_default_app_and_session;
+
+    use super::*;
+
+    use std::error::Error;
+
+    #[sqlx::test]
+    async fn should_create_email_config(pool: PgPool) -> Result<(), Box<dyn Error>> {
+        let (app, mut session) = setup_default_app_and_session(&pool).await?;
+        let (_, current_user, _) = session.current_user(&app).await?;
+
+        let params = CreateEmailTemplateConfig {
+            slots: EmailTemplateSlots::ConversationInvite(DefaultEmailSlots {
+                heading: "<h1>You're invite to a conversation</h1>".to_string(),
+                intro: "<p>You have been selected to take part in a public engagement</p>"
+                    .to_string(),
+                body: "<p>Test body content</p>".to_string(),
+                footer: "<p>Thank you for your time</p>".to_string(),
+            }),
+        };
+
+        let email_config = create(&pool, &current_user.id, &params).await?;
+
+        assert_eq!(
+            email_config.owner_id, current_user.id,
+            "owner_id doesn't match"
+        );
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn should_update_email_config(pool: PgPool) -> Result<(), Box<dyn Error>> {
+        let (app, mut session) = setup_default_app_and_session(&pool).await?;
+        let (_, current_user, _) = session.current_user(&app).await?;
+
+        let create_slots = EmailTemplateSlots::ConversationInvite(DefaultEmailSlots {
+            heading: "<h1>You're invite to a conversation</h1>".to_string(),
+            intro: "<p>You have been selected to take part in a public engagement</p>".to_string(),
+            body: "<p>Test body content</p>".to_string(),
+            footer: "<p>Thank you for your time</p>".to_string(),
+        });
+
+        let params = CreateEmailTemplateConfig {
+            slots: create_slots.clone(),
+        };
+
+        let new_email_config = create(&pool, &current_user.id, &params).await?;
+
+        assert_eq!(
+            new_email_config.slots, create_slots,
+            "incorrect slots before update"
+        );
+
+        let update_slots = EmailTemplateSlots::ConversationInvite(DefaultEmailSlots {
+            heading: "<h1>You're not invite to a conversation</h1>".to_string(),
+            intro: "<p>You have not been selected to take part in a public engagement</p>"
+                .to_string(),
+            body: "<p>Test body content</p>".to_string(),
+            footer: "<p>Thank you for your time</p>".to_string(),
+        });
+
+        let email_config = update(
+            &pool,
+            new_email_config.id,
+            &UpdateEmailTemplateConfig {
+                slots: Some(update_slots.clone()),
+            },
+        )
+        .await?;
+
+        assert_eq!(
+            email_config.slots, update_slots,
+            "incorrect slots after update"
+        );
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn should_get_email_config_by_id(pool: PgPool) -> Result<(), Box<dyn Error>> {
+        let (app, mut session) = setup_default_app_and_session(&pool).await?;
+        let (_, current_user, _) = session.current_user(&app).await?;
+
+        let params = CreateEmailTemplateConfig {
+            slots: EmailTemplateSlots::ConversationInvite(DefaultEmailSlots {
+                heading: "<h1>You're invite to a conversation</h1>".to_string(),
+                intro: "<p>You have been selected to take part in a public engagement</p>"
+                    .to_string(),
+                body: "<p>Test body content</p>".to_string(),
+                footer: "<p>Thank you for your time</p>".to_string(),
+            }),
+        };
+
+        let new_email_config = create(&pool, &current_user.id, &params).await?;
+
+        let email_config = get_by_id(&pool, new_email_config.id).await?;
+
+        assert_eq!(new_email_config.id, email_config.id, "ids don't match");
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn should_list_email_configs(pool: PgPool) -> Result<(), Box<dyn Error>> {
+        let (app, mut session) = setup_default_app_and_session(&pool).await?;
+        let (_, user_a, _) = session.current_user(&app).await?;
+
+        let user_b = users::create_annon_user(&pool).await?;
+
+        let default_slots = DefaultEmailSlots {
+            heading: "<h1>Test heading</h1>".to_string(),
+            intro: "<p>Test intro</p>".to_string(),
+            body: "<p>Test body</p>".to_string(),
+            footer: "<p>Test footer</p>".to_string(),
+        };
+
+        let params_a = CreateEmailTemplateConfig {
+            slots: EmailTemplateSlots::EventRegistrationConfirmation(default_slots.clone()),
+        };
+        create(&pool, &user_a.id, &params_a).await?;
+        let params_b = CreateEmailTemplateConfig {
+            slots: EmailTemplateSlots::ConversationInvite(default_slots.clone()),
+        };
+        create(&pool, &user_b.id, &params_b).await?;
+
+        let filter_options = EmailTemplateConfigFilterOptions {
+            owner_id: Some(user_b.id),
+            ..Default::default()
+        };
+        let email_configs = list(&pool, filter_options).await?;
+
+        assert_eq!(email_configs.len(), 1, "incorrect total");
+        assert!(
+            !email_configs.iter().any(|c| c.owner_id == user_a.id),
+            "user_a incorrectly included"
+        );
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn should_delete_email_config(pool: PgPool) -> Result<(), Box<dyn Error>> {
+        let (app, mut session) = setup_default_app_and_session(&pool).await?;
+        let (_, current_user, _) = session.current_user(&app).await?;
+
+        let params = CreateEmailTemplateConfig {
+            slots: EmailTemplateSlots::ConversationInvite(DefaultEmailSlots {
+                heading: "<h1>You're invite to a conversation</h1>".to_string(),
+                intro: "<p>You have been selected to take part in a public engagement</p>"
+                    .to_string(),
+                body: "<p>Test body content</p>".to_string(),
+                footer: "<p>Thank you for your time</p>".to_string(),
+            }),
+        };
+
+        let email_config = create(&pool, &current_user.id, &params).await?;
+
+        delete(&pool, email_config.id).await?;
+
+        let err = get_by_id(&pool, email_config.id).await.unwrap_err();
+
+        match err {
+            ComhairleError::ResourceNotFound(e) => {
+                assert_eq!(
+                    e,
+                    "Email template config".to_string(),
+                    "incorrect error message"
+                );
+            }
+            _ => panic!("Expected ResourceNotFound error"),
+        }
+
+        Ok(())
+    }
+}

--- a/api/src/routes.rs
+++ b/api/src/routes.rs
@@ -3,6 +3,7 @@ pub mod auth;
 pub mod chat_sessions;
 pub mod conversations;
 pub mod documents;
+pub mod email_template_configs;
 pub mod event_attendances;
 pub mod events;
 pub mod feedback;

--- a/api/src/routes/conversations.rs
+++ b/api/src/routes/conversations.rs
@@ -1832,7 +1832,7 @@ mod tests {
             .returning(|_, _, _, _, _, _| Box::pin(async move { Ok(()) }));
         mailer
             .expect_send_event_confirmation_email()
-            .returning(|_, _, _, _| Ok(()));
+            .returning(|_, _, _, _, _| Box::pin(async move { Ok(()) }));
         mailer
             .expect_send_event_reminder()
             .returning(|_, _, _, _| Ok(()));

--- a/api/src/routes/conversations.rs
+++ b/api/src/routes/conversations.rs
@@ -331,7 +331,11 @@ async fn send_test_broadcast_email(
         .mailer
         .send_conversation_broadcast_email(&recipient, &request.title, &html_content)
         .map_err(|e| {
-            tracing::warn!("Failed to send test broadcast email to {}: {:?}", recipient, e);
+            tracing::warn!(
+                "Failed to send test broadcast email to {}: {:?}",
+                recipient,
+                e
+            );
             ComhairleError::BadRequest(format!("Failed to send test email: {}", e))
         })?;
 
@@ -481,7 +485,12 @@ async fn send_broadcast_email_to_opted_in(
             last_error.unwrap_or_else(|| "unknown error".into())
         ),
         (s, 0) => format!("Email sent to {} recipients", s),
-        (s, n) => format!("Email sent to {} of {} recipients ({} failed)", s, s + n as i32, n),
+        (s, n) => format!(
+            "Email sent to {} of {} recipients ({} failed)",
+            s,
+            s + n as i32,
+            n
+        ),
     };
 
     Ok((
@@ -1820,19 +1829,19 @@ mod tests {
             .returning(|_, _, _| Ok(()));
         mailer
             .expect_send_event_registration_email()
-            .returning(|_, _, _, _| Ok(()));
+            .returning(|_, _, _, _, _, _| Box::pin(async move { Ok(()) }));
         mailer
             .expect_send_event_confirmation_email()
             .returning(|_, _, _, _| Ok(()));
         mailer
             .expect_send_event_reminder()
             .returning(|_, _, _, _| Ok(()));
-        mailer
-            .expect_send_conversation_broadcast_email()
-            .returning(move |email, _subject, _html| {
+        mailer.expect_send_conversation_broadcast_email().returning(
+            move |email, _subject, _html| {
                 sent.lock().unwrap().push(email.to_string());
                 Ok(())
-            });
+            },
+        );
         mailer
     }
 
@@ -2218,7 +2227,10 @@ mod tests {
 
         assert_eq!(
             emails,
-            vec!["anon_in@test.com".to_string(), "authed_in@test.com".to_string()],
+            vec![
+                "anon_in@test.com".to_string(),
+                "authed_in@test.com".to_string()
+            ],
             "recipients endpoint must list only opted-in emails (auth + anon)"
         );
         assert_eq!(

--- a/api/src/routes/email_template_configs.rs
+++ b/api/src/routes/email_template_configs.rs
@@ -16,7 +16,7 @@ use uuid::Uuid;
 use crate::{
     models::email_template_config::{
         self, CreateEmailTemplateConfig, EmailTemplateConfigFilterOptions, EmailTemplateSlots,
-        EmailTypeSchema, UpdateEmailTemplateConfig,
+        EmailTypeSchema, SlotSchemaDefinition, UpdateEmailTemplateConfig,
     },
     routes::{auth::RequiredAdminUser, email_template_configs::dto::EmailTemplateConfigDto},
     ComhairleError, ComhairleState,
@@ -59,15 +59,6 @@ async fn list(
     Ok((StatusCode::OK, Json(email_configs)))
 }
 
-#[instrument(err(Debug))]
-async fn list_slot_schemas(
-    RequiredAdminUser(user): RequiredAdminUser,
-) -> Result<(StatusCode, Json<&'static [EmailTypeSchema]>), ComhairleError> {
-    let schemas = EmailTemplateSlots::schemas();
-
-    Ok((StatusCode::OK, Json(schemas)))
-}
-
 #[instrument(err(Debug), skip(state))]
 async fn update(
     State(state): State<Arc<ComhairleState>>,
@@ -89,6 +80,27 @@ async fn delete(
     let email_config = email_template_config::delete(&state.db, email_config_id).await?;
 
     Ok((StatusCode::OK, Json(email_config.into())))
+}
+
+#[instrument(err(Debug), skip(state))]
+async fn get_slot_schema(
+    State(state): State<Arc<ComhairleState>>,
+    Path(email_config_id): Path<Uuid>,
+    RequiredAdminUser(user): RequiredAdminUser,
+) -> Result<(StatusCode, Json<&'static [SlotSchemaDefinition]>), ComhairleError> {
+    let email_config = email_template_config::get_by_id(&state.db, email_config_id).await?;
+    let schema = email_config.slots.schema();
+
+    Ok((StatusCode::OK, Json(schema)))
+}
+
+#[instrument(err(Debug))]
+async fn list_slot_schemas(
+    RequiredAdminUser(user): RequiredAdminUser,
+) -> Result<(StatusCode, Json<&'static [EmailTypeSchema]>), ComhairleError> {
+    let schemas = EmailTemplateSlots::schemas();
+
+    Ok((StatusCode::OK, Json(schemas)))
 }
 
 pub fn router(state: Arc<ComhairleState>) -> ApiRouter {
@@ -146,6 +158,17 @@ pub fn router(state: Arc<ComhairleState>) -> ApiRouter {
                     .security_requirement("JWT")
                     .tag("EmailTemplateConfig")
                     .response::<200, Json<EmailTemplateConfigDto>>()
+            }),
+        )
+        .api_route(
+            "/{email_config_id}/schemas",
+            get_with(get_slot_schema, |op| {
+                op.id("GetEmailSlotSchema")
+                    .summary("Get email slot schema")
+                    .description("Get slot schemas for an email config")
+                    .security_requirement("JWT")
+                    .tag("EmailTemplateConfig")
+                    .response::<200, Json<&'static [SlotSchemaDefinition]>>()
             }),
         )
         .api_route(

--- a/api/src/routes/email_template_configs.rs
+++ b/api/src/routes/email_template_configs.rs
@@ -10,6 +10,8 @@ use axum::{
     extract::{Json, Path, Query, State},
     http::StatusCode,
 };
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 use tracing::instrument;
 use uuid::Uuid;
 
@@ -103,6 +105,34 @@ async fn list_schemas(
     Ok((StatusCode::OK, Json(schemas)))
 }
 
+#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+struct PreviewEmailTemplateConfigRequest {
+    slots: EmailTemplateSlots,
+}
+
+#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+struct PreviewEmailTemplateConfigResponse {
+    html: String,
+}
+
+#[instrument(err(Debug), skip(state))]
+async fn preview(
+    State(state): State<Arc<ComhairleState>>,
+    RequiredAdminUser(user): RequiredAdminUser,
+    Json(PreviewEmailTemplateConfigRequest { slots }): Json<PreviewEmailTemplateConfigRequest>,
+) -> Result<(StatusCode, Json<PreviewEmailTemplateConfigResponse>), ComhairleError> {
+    let template = slots.to_template();
+    let custom_slots_map = slots.to_mailer_map();
+    let context = minijinja::context! { ..custom_slots_map };
+
+    let html = state.mailer.preview_email(template, context)?;
+
+    Ok((
+        StatusCode::OK,
+        Json(PreviewEmailTemplateConfigResponse { html }),
+    ))
+}
+
 pub fn router(state: Arc<ComhairleState>) -> ApiRouter {
     ApiRouter::new()
         .api_route(
@@ -180,6 +210,17 @@ pub fn router(state: Arc<ComhairleState>) -> ApiRouter {
                     .security_requirement("JWT")
                     .tag("EmailTemplateConfig")
                     .response::<200, Json<[EmailTypeSchema; 3]>>()
+            }),
+        )
+        .api_route(
+            "/preview",
+            post_with(preview, |op| {
+                op.id("PreviewEmailTemplateConfig")
+                    .summary("Preview email template config")
+                    .description("Preview appearance of custom email before sending")
+                    .security_requirement("JWT")
+                    .tag("EmailTemplateConfig")
+                    .response::<200, Json<PreviewEmailTemplateConfigResponse>>()
             }),
         )
         .with_state(state)

--- a/api/src/routes/email_template_configs.rs
+++ b/api/src/routes/email_template_configs.rs
@@ -121,8 +121,8 @@ async fn preview(
     RequiredAdminUser(user): RequiredAdminUser,
     Json(PreviewEmailTemplateConfigRequest { slots }): Json<PreviewEmailTemplateConfigRequest>,
 ) -> Result<(StatusCode, Json<PreviewEmailTemplateConfigResponse>), ComhairleError> {
-    let template = slots.to_template();
-    let custom_slots_map = slots.to_mailer_map();
+    let template = slots.email_template();
+    let custom_slots_map = slots.mailer_slots_map();
     let preview_variables_map = slots.preview_variables_map();
 
     let html =

--- a/api/src/routes/email_template_configs.rs
+++ b/api/src/routes/email_template_configs.rs
@@ -413,7 +413,7 @@ mod tests {
         let (_, value, _) = session
             .get(
                 &app,
-                "/email_template_configs?email_type=event_registration_invite",
+                "/email_template_configs?email_type=event_registration_confirmation",
             )
             .await?;
         let email_configs: Vec<EmailTemplateConfigDto> = serde_json::from_value(value)?;

--- a/api/src/routes/email_template_configs.rs
+++ b/api/src/routes/email_template_configs.rs
@@ -89,7 +89,7 @@ async fn get_schema(
     RequiredAdminUser(user): RequiredAdminUser,
 ) -> Result<(StatusCode, Json<EmailTypeSchema>), ComhairleError> {
     let email_config = email_template_config::get_by_id(&state.db, email_config_id).await?;
-    let schema = email_config.slots.schema()?;
+    let schema = email_config.slots.schema();
 
     Ok((StatusCode::OK, Json(schema)))
 }
@@ -98,7 +98,7 @@ async fn get_schema(
 async fn list_schemas(
     RequiredAdminUser(user): RequiredAdminUser,
 ) -> Result<(StatusCode, Json<[EmailTypeSchema; 3]>), ComhairleError> {
-    let schemas = EmailTemplateSlots::schemas()?;
+    let schemas = EmailTemplateSlots::schemas();
 
     Ok((StatusCode::OK, Json(schemas)))
 }

--- a/api/src/routes/email_template_configs.rs
+++ b/api/src/routes/email_template_configs.rs
@@ -53,7 +53,7 @@ async fn list(
     RequiredAdminUser(user): RequiredAdminUser,
     Query(filter_options): Query<EmailTemplateConfigFilterOptions>,
 ) -> Result<(StatusCode, Json<Vec<EmailTemplateConfigDto>>), ComhairleError> {
-    let email_configs = email_template_config::list(&state.db, filter_options)
+    let email_configs = email_template_config::list(&state.db, &user.id, filter_options)
         .await?
         .into_iter()
         .map(Into::into)
@@ -219,7 +219,7 @@ pub fn router(state: Arc<ComhairleState>) -> ApiRouter {
                     .description("List all template schemas for each email template type")
                     .security_requirement("JWT")
                     .tag("EmailTemplateConfig")
-                    .response::<200, Json<[EmailTypeSchema; 3]>>()
+                    .response::<200, Json<[EmailTypeSchema; EmailTemplateSlots::COUNT]>>()
             }),
         )
         .api_route(
@@ -234,4 +234,352 @@ pub fn router(state: Arc<ComhairleState>) -> ApiRouter {
             }),
         )
         .with_state(state)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        mailer::MockComhairleMailer,
+        models::{
+            email_template_config::{DefaultEmailSlots, EmailType},
+            model_test_helpers::setup_default_app_and_session,
+        },
+        setup_server,
+        test_helpers::{test_state, UserSession},
+    };
+
+    use super::*;
+
+    use std::error::Error;
+
+    use sqlx::PgPool;
+
+    #[sqlx::test]
+    async fn should_create_email_template_config(pool: PgPool) -> Result<(), Box<dyn Error>> {
+        let (app, mut session) = setup_default_app_and_session(&pool).await?;
+        let (_, current_user, _) = session.current_user(&app).await?;
+
+        let params = CreateEmailTemplateConfig {
+            slots: EmailTemplateSlots::ConversationInvite(DefaultEmailSlots {
+                heading: "<h1>You're invite to a conversation</h1>".to_string(),
+                intro: "<p>You have been selected to take part in a public engagement</p>"
+                    .to_string(),
+                body: "<p>Test body content</p>".to_string(),
+                footer: "<p>Thank you for your time</p>".to_string(),
+            }),
+            subject: Some("A custom conversation template".to_string()),
+        };
+
+        let (_, value, _) = session
+            .post(
+                &app,
+                "/email_template_configs",
+                serde_json::to_string(&params)?.into(),
+            )
+            .await?;
+        let email_config: EmailTemplateConfigDto = serde_json::from_value(value)?;
+
+        assert_eq!(
+            email_config.subject.unwrap(),
+            "A custom conversation template".to_string(),
+            "incorrect subject",
+        );
+        assert_eq!(email_config.owner_id, current_user.id, "incorrect owner_id");
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn should_update_email_template_config(pool: PgPool) -> Result<(), Box<dyn Error>> {
+        let (app, mut session) = setup_default_app_and_session(&pool).await?;
+
+        let create_slots = EmailTemplateSlots::ConversationInvite(DefaultEmailSlots {
+            heading: "<h1>You're invite to a conversation</h1>".to_string(),
+            intro: "<p>You have been selected to take part in a public engagement</p>".to_string(),
+            body: "<p>Test body content</p>".to_string(),
+            footer: "<p>Thank you for your time</p>".to_string(),
+        });
+
+        let params = CreateEmailTemplateConfig {
+            slots: create_slots,
+            subject: Some("A custom conversation template".to_string()),
+        };
+
+        let (_, value, _) = session
+            .post(
+                &app,
+                "/email_template_configs",
+                serde_json::to_string(&params)?.into(),
+            )
+            .await?;
+        let created_email_config: EmailTemplateConfigDto = serde_json::from_value(value)?;
+
+        let update_slots = EmailTemplateSlots::ConversationInvite(DefaultEmailSlots {
+            heading: "<h1>Updated heading</h1>".to_string(),
+            intro: "<p>Updated intro</p>".to_string(),
+            body: "<p>Updated body</p>".to_string(),
+            footer: "<p>Updated footer</p>".to_string(),
+        });
+        let params = UpdateEmailTemplateConfig {
+            slots: Some(update_slots.clone()),
+            subject: None,
+        };
+        let (_, value, _) = session
+            .put(
+                &app,
+                &format!("/email_template_configs/{}", created_email_config.id),
+                serde_json::to_string(&params)?.into(),
+            )
+            .await?;
+        let email_config: EmailTemplateConfigDto = serde_json::from_value(value)?;
+
+        assert_eq!(email_config.slots, update_slots, "incorrect slots");
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn should_get_email_template_config_by_id(pool: PgPool) -> Result<(), Box<dyn Error>> {
+        let (app, mut session) = setup_default_app_and_session(&pool).await?;
+
+        let params = CreateEmailTemplateConfig {
+            slots: EmailTemplateSlots::ConversationInvite(DefaultEmailSlots {
+                heading: "<h1>You're invite to a conversation</h1>".to_string(),
+                intro: "<p>You have been selected to take part in a public engagement</p>"
+                    .to_string(),
+                body: "<p>Test body content</p>".to_string(),
+                footer: "<p>Thank you for your time</p>".to_string(),
+            }),
+            subject: Some("A custom conversation template".to_string()),
+        };
+
+        let (_, value, _) = session
+            .post(
+                &app,
+                "/email_template_configs",
+                serde_json::to_string(&params)?.into(),
+            )
+            .await?;
+        let create_email_config: EmailTemplateConfigDto = serde_json::from_value(value)?;
+
+        let (_, value, _) = session
+            .get(
+                &app,
+                &format!("/email_template_configs/{}", create_email_config.id),
+            )
+            .await?;
+        let email_config: EmailTemplateConfigDto = serde_json::from_value(value)?;
+
+        assert_eq!(email_config.id, create_email_config.id, "ids don't match");
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn should_list_email_template_configs(pool: PgPool) -> Result<(), Box<dyn Error>> {
+        let (app, mut session) = setup_default_app_and_session(&pool).await?;
+
+        let default_slots = DefaultEmailSlots {
+            heading: "<h1>Test heading</h1>".to_string(),
+            intro: "<p>Test intro</p>".to_string(),
+            body: "<p>Test body</p>".to_string(),
+            footer: "<p>Test footer</p>".to_string(),
+        };
+
+        let params_a = CreateEmailTemplateConfig {
+            slots: EmailTemplateSlots::EventRegistrationConfirmation(default_slots.clone()),
+            subject: None,
+        };
+        session
+            .post(
+                &app,
+                "/email_template_configs",
+                serde_json::to_string(&params_a)?.into(),
+            )
+            .await?;
+
+        let params_b = CreateEmailTemplateConfig {
+            slots: EmailTemplateSlots::ConversationInvite(default_slots.clone()),
+            subject: None,
+        };
+        session
+            .post(
+                &app,
+                "/email_template_configs",
+                serde_json::to_string(&params_b)?.into(),
+            )
+            .await?;
+
+        let (_, value, _) = session
+            .get(
+                &app,
+                "/email_template_configs?email_type=event_registration_invite",
+            )
+            .await?;
+        let email_configs: Vec<EmailTemplateConfigDto> = serde_json::from_value(value)?;
+
+        assert_eq!(email_configs.len(), 1, "incorrect total");
+        assert!(
+            !email_configs
+                .iter()
+                .any(|c| c.email_type == EmailType::ConversationInvite),
+            "incorrectly email_type included"
+        );
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn should_delete_email_template_config_by_id(pool: PgPool) -> Result<(), Box<dyn Error>> {
+        let (app, mut session) = setup_default_app_and_session(&pool).await?;
+
+        let params = CreateEmailTemplateConfig {
+            slots: EmailTemplateSlots::ConversationInvite(DefaultEmailSlots {
+                heading: "<h1>You're invite to a conversation</h1>".to_string(),
+                intro: "<p>You have been selected to take part in a public engagement</p>"
+                    .to_string(),
+                body: "<p>Test body content</p>".to_string(),
+                footer: "<p>Thank you for your time</p>".to_string(),
+            }),
+            subject: Some("A custom conversation template".to_string()),
+        };
+
+        let (_, value, _) = session
+            .post(
+                &app,
+                "/email_template_configs",
+                serde_json::to_string(&params)?.into(),
+            )
+            .await?;
+        let create_email_config: EmailTemplateConfigDto = serde_json::from_value(value)?;
+
+        session
+            .delete(
+                &app,
+                &format!("/email_template_configs/{}", create_email_config.id),
+            )
+            .await?;
+
+        let (_, response, _) = session
+            .get(
+                &app,
+                &format!("/email_template_configs/{}", create_email_config.id),
+            )
+            .await?;
+
+        assert_eq!(
+            response.get("err").and_then(|v| v.as_str()).unwrap(),
+            "Email template config not found",
+            "incorrect error message"
+        );
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn should_get_associated_schema_for_email_config_type(
+        pool: PgPool,
+    ) -> Result<(), Box<dyn Error>> {
+        let (app, mut session) = setup_default_app_and_session(&pool).await?;
+
+        let params = CreateEmailTemplateConfig {
+            slots: EmailTemplateSlots::ConversationInvite(DefaultEmailSlots {
+                heading: "<h1>You're invite to a conversation</h1>".to_string(),
+                intro: "<p>You have been selected to take part in a public engagement</p>"
+                    .to_string(),
+                body: "<p>Test body content</p>".to_string(),
+                footer: "<p>Thank you for your time</p>".to_string(),
+            }),
+            subject: Some("A custom conversation template".to_string()),
+        };
+
+        let (_, value, _) = session
+            .post(
+                &app,
+                "/email_template_configs",
+                serde_json::to_string(&params)?.into(),
+            )
+            .await?;
+        let email_config: EmailTemplateConfigDto = serde_json::from_value(value)?;
+
+        let (_, response, _) = session
+            .get(
+                &app,
+                &format!("/email_template_configs/{}/schemas", email_config.id),
+            )
+            .await?;
+
+        assert_eq!(
+            response.get("email_type").and_then(|v| v.as_str()).unwrap(),
+            "conversation_invite",
+            "incorrect email_type from schema"
+        );
+        assert_eq!(
+            response.get("template").and_then(|v| v.as_str()).unwrap(),
+            "conversation_invite.html",
+            "incorrect template from schema"
+        );
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn should_list_schemas_for_email_config_types(
+        pool: PgPool,
+    ) -> Result<(), Box<dyn Error>> {
+        let (app, mut session) = setup_default_app_and_session(&pool).await?;
+
+        let (_, value, _) = session.get(&app, "/email_template_configs/schemas").await?;
+
+        let arr = value.as_array().unwrap();
+        assert_eq!(
+            arr.len(),
+            EmailTemplateSlots::COUNT,
+            "incorrect number of schemas"
+        );
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn should_send_preview_html_of_email(pool: PgPool) -> Result<(), Box<dyn Error>> {
+        let html_str = "<html><h1>You're invite to a conversation</h1><p>You have been selected to take part in a public engagement</p><p>Test body content</p><p>Thank you for your time</p></html>";
+        let mut mailer = MockComhairleMailer::new();
+        mailer
+            .expect_preview_email()
+            .returning(|_, _, _| Ok(html_str.to_string()));
+        mailer.expect_send_welcome_email().returning(|_, _| Ok(()));
+
+        let state = test_state()
+            .db(pool.clone())
+            .mailer(Arc::new(mailer))
+            .call()?;
+        let app = setup_server(Arc::new(state)).await?;
+
+        let mut session = UserSession::new_admin();
+        session.signup(&app).await?;
+
+        let params = PreviewEmailTemplateConfigRequest {
+            slots: EmailTemplateSlots::ConversationInvite(DefaultEmailSlots {
+                heading: "<h1>You're invite to a conversation</h1>".to_string(),
+                intro: "<p>You have been selected to take part in a public engagement</p>"
+                    .to_string(),
+                body: "<p>Test body content</p>".to_string(),
+                footer: "<p>Thank you for your time</p>".to_string(),
+            }),
+        };
+
+        let (_, value, _) = session
+            .post(
+                &app,
+                "/email_template_configs/preview",
+                serde_json::to_string(&params)?.into(),
+            )
+            .await?;
+        let response: PreviewEmailTemplateConfigResponse = serde_json::from_value(value)?;
+
+        assert_eq!(response.html, html_str, "incorrect html response");
+
+        Ok(())
+    }
 }

--- a/api/src/routes/email_template_configs.rs
+++ b/api/src/routes/email_template_configs.rs
@@ -15,8 +15,8 @@ use uuid::Uuid;
 
 use crate::{
     models::email_template_config::{
-        self, CreateEmailTemplateConfig, EmailTemplateConfigFilterOptions,
-        UpdateEmailTemplateConfig,
+        self, CreateEmailTemplateConfig, EmailTemplateConfigFilterOptions, EmailTemplateSlots,
+        EmailTypeSchema, UpdateEmailTemplateConfig,
     },
     routes::{auth::RequiredAdminUser, email_template_configs::dto::EmailTemplateConfigDto},
     ComhairleError, ComhairleState,
@@ -57,6 +57,15 @@ async fn list(
         .collect();
 
     Ok((StatusCode::OK, Json(email_configs)))
+}
+
+#[instrument(err(Debug))]
+async fn list_slot_schemas(
+    RequiredAdminUser(user): RequiredAdminUser,
+) -> Result<(StatusCode, Json<&'static [EmailTypeSchema]>), ComhairleError> {
+    let schemas = EmailTemplateSlots::schemas();
+
+    Ok((StatusCode::OK, Json(schemas)))
 }
 
 #[instrument(err(Debug), skip(state))]
@@ -137,6 +146,17 @@ pub fn router(state: Arc<ComhairleState>) -> ApiRouter {
                     .security_requirement("JWT")
                     .tag("EmailTemplateConfig")
                     .response::<200, Json<EmailTemplateConfigDto>>()
+            }),
+        )
+        .api_route(
+            "/schemas",
+            get_with(list_slot_schemas, |op| {
+                op.id("ListEmailSlotSchemas")
+                    .summary("List email slot schemas")
+                    .description("List all slot schemas for each email template type")
+                    .security_requirement("JWT")
+                    .tag("EmailTemplateConfig")
+                    .response::<200, Json<&'static [EmailTypeSchema]>>()
             }),
         )
         .with_state(state)

--- a/api/src/routes/email_template_configs.rs
+++ b/api/src/routes/email_template_configs.rs
@@ -12,6 +12,7 @@ use axum::{
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use strum::EnumCount;
 use tracing::instrument;
 use uuid::Uuid;
 
@@ -99,7 +100,13 @@ async fn get_schema(
 #[instrument(err(Debug))]
 async fn list_schemas(
     RequiredAdminUser(user): RequiredAdminUser,
-) -> Result<(StatusCode, Json<[EmailTypeSchema; 3]>), ComhairleError> {
+) -> Result<
+    (
+        StatusCode,
+        Json<[EmailTypeSchema; EmailTemplateSlots::COUNT]>,
+    ),
+    ComhairleError,
+> {
     let schemas = EmailTemplateSlots::schemas();
 
     Ok((StatusCode::OK, Json(schemas)))

--- a/api/src/routes/email_template_configs.rs
+++ b/api/src/routes/email_template_configs.rs
@@ -1,0 +1,143 @@
+pub mod dto;
+
+use std::sync::Arc;
+
+use aide::axum::{
+    routing::{delete_with, get_with, post_with, put_with},
+    ApiRouter,
+};
+use axum::{
+    extract::{Json, Path, Query, State},
+    http::StatusCode,
+};
+use tracing::instrument;
+use uuid::Uuid;
+
+use crate::{
+    models::email_template_config::{
+        self, CreateEmailTemplateConfig, EmailTemplateConfigFilterOptions,
+        UpdateEmailTemplateConfig,
+    },
+    routes::{auth::RequiredAdminUser, email_template_configs::dto::EmailTemplateConfigDto},
+    ComhairleError, ComhairleState,
+};
+
+#[instrument(err(Debug), skip(state))]
+async fn create(
+    State(state): State<Arc<ComhairleState>>,
+    RequiredAdminUser(user): RequiredAdminUser,
+    Json(payload): Json<CreateEmailTemplateConfig>,
+) -> Result<(StatusCode, Json<EmailTemplateConfigDto>), ComhairleError> {
+    let email_config = email_template_config::create(&state.db, user.id, &payload).await?;
+
+    Ok((StatusCode::CREATED, Json(email_config.into())))
+}
+
+#[instrument(err(Debug), skip(state))]
+async fn get(
+    State(state): State<Arc<ComhairleState>>,
+    RequiredAdminUser(user): RequiredAdminUser,
+    Path(email_config_id): Path<Uuid>,
+) -> Result<(StatusCode, Json<EmailTemplateConfigDto>), ComhairleError> {
+    let email_config = email_template_config::get_by_id(&state.db, email_config_id).await?;
+
+    Ok((StatusCode::OK, Json(email_config.into())))
+}
+
+#[instrument(err(Debug), skip(state))]
+async fn list(
+    State(state): State<Arc<ComhairleState>>,
+    RequiredAdminUser(user): RequiredAdminUser,
+    Query(filter_options): Query<EmailTemplateConfigFilterOptions>,
+) -> Result<(StatusCode, Json<Vec<EmailTemplateConfigDto>>), ComhairleError> {
+    let email_configs = email_template_config::list(&state.db, filter_options)
+        .await?
+        .into_iter()
+        .map(Into::into)
+        .collect();
+
+    Ok((StatusCode::OK, Json(email_configs)))
+}
+
+#[instrument(err(Debug), skip(state))]
+async fn update(
+    State(state): State<Arc<ComhairleState>>,
+    RequiredAdminUser(user): RequiredAdminUser,
+    Path(email_config_id): Path<Uuid>,
+    Json(payload): Json<UpdateEmailTemplateConfig>,
+) -> Result<(StatusCode, Json<EmailTemplateConfigDto>), ComhairleError> {
+    let email_config = email_template_config::update(&state.db, email_config_id, &payload).await?;
+
+    Ok((StatusCode::OK, Json(email_config.into())))
+}
+
+#[instrument(err(Debug), skip(state))]
+async fn delete(
+    State(state): State<Arc<ComhairleState>>,
+    RequiredAdminUser(user): RequiredAdminUser,
+    Path(email_config_id): Path<Uuid>,
+) -> Result<(StatusCode, Json<EmailTemplateConfigDto>), ComhairleError> {
+    let email_config = email_template_config::delete(&state.db, email_config_id).await?;
+
+    Ok((StatusCode::OK, Json(email_config.into())))
+}
+
+pub fn router(state: Arc<ComhairleState>) -> ApiRouter {
+    ApiRouter::new()
+        .api_route(
+            "/",
+            post_with(create, |op| {
+                op.id("CreateEmailTemplateConfig")
+                    .summary("Create email template config")
+                    .description("Create custom content for specific email template")
+                    .security_requirement("JWT")
+                    .tag("EmailTemplateConfig")
+                    .response::<201, Json<EmailTemplateConfigDto>>()
+            }),
+        )
+        .api_route(
+            "/{email_config_id}",
+            get_with(get, |op| {
+                op.id("GetEmailTemplateConfig")
+                    .summary("Get email template config")
+                    .description("Get custom email template configuration")
+                    .security_requirement("JWT")
+                    .tag("EmailTemplateConfig")
+                    .response::<200, Json<EmailTemplateConfigDto>>()
+            }),
+        )
+        .api_route(
+            "/",
+            get_with(list, |op| {
+                op.id("ListEmailTemplateConfigs")
+                    .summary("List email template configs")
+                    .description("List custom email template configurations")
+                    .security_requirement("JWT")
+                    .tag("EmailTemplateConfig")
+                    .response::<200, Json<Vec<EmailTemplateConfigDto>>>()
+            }),
+        )
+        .api_route(
+            "/{email_config_id}",
+            put_with(update, |op| {
+                op.id("UpdateEmailTemplateConfig")
+                    .summary("Update email template config")
+                    .description("Update custom email template configuration")
+                    .security_requirement("JWT")
+                    .tag("EmailTemplateConfig")
+                    .response::<200, Json<EmailTemplateConfigDto>>()
+            }),
+        )
+        .api_route(
+            "/{email_config_id}",
+            delete_with(delete, |op| {
+                op.id("DeleteEmailTemplateConfig")
+                    .summary("Delete email template config")
+                    .description("Delete custom email template configuration")
+                    .security_requirement("JWT")
+                    .tag("EmailTemplateConfig")
+                    .response::<200, Json<EmailTemplateConfigDto>>()
+            }),
+        )
+        .with_state(state)
+}

--- a/api/src/routes/email_template_configs.rs
+++ b/api/src/routes/email_template_configs.rs
@@ -16,7 +16,7 @@ use uuid::Uuid;
 use crate::{
     models::email_template_config::{
         self, CreateEmailTemplateConfig, EmailTemplateConfigFilterOptions, EmailTemplateSlots,
-        EmailTypeSchema, SlotSchemaDefinition, UpdateEmailTemplateConfig,
+        EmailTypeSchema, UpdateEmailTemplateConfig,
     },
     routes::{auth::RequiredAdminUser, email_template_configs::dto::EmailTemplateConfigDto},
     ComhairleError, ComhairleState,
@@ -83,22 +83,22 @@ async fn delete(
 }
 
 #[instrument(err(Debug), skip(state))]
-async fn get_slot_schema(
+async fn get_schema(
     State(state): State<Arc<ComhairleState>>,
     Path(email_config_id): Path<Uuid>,
     RequiredAdminUser(user): RequiredAdminUser,
-) -> Result<(StatusCode, Json<&'static [SlotSchemaDefinition]>), ComhairleError> {
+) -> Result<(StatusCode, Json<EmailTypeSchema>), ComhairleError> {
     let email_config = email_template_config::get_by_id(&state.db, email_config_id).await?;
-    let schema = email_config.slots.schema();
+    let schema = email_config.slots.schema()?;
 
     Ok((StatusCode::OK, Json(schema)))
 }
 
 #[instrument(err(Debug))]
-async fn list_slot_schemas(
+async fn list_schemas(
     RequiredAdminUser(user): RequiredAdminUser,
-) -> Result<(StatusCode, Json<&'static [EmailTypeSchema]>), ComhairleError> {
-    let schemas = EmailTemplateSlots::schemas();
+) -> Result<(StatusCode, Json<[EmailTypeSchema; 3]>), ComhairleError> {
+    let schemas = EmailTemplateSlots::schemas()?;
 
     Ok((StatusCode::OK, Json(schemas)))
 }
@@ -162,24 +162,24 @@ pub fn router(state: Arc<ComhairleState>) -> ApiRouter {
         )
         .api_route(
             "/{email_config_id}/schemas",
-            get_with(get_slot_schema, |op| {
-                op.id("GetEmailSlotSchema")
-                    .summary("Get email slot schema")
-                    .description("Get slot schemas for an email config")
+            get_with(get_schema, |op| {
+                op.id("GetEmailTemplateSchema")
+                    .summary("Get email template schema")
+                    .description("Get template schemas for an email config")
                     .security_requirement("JWT")
                     .tag("EmailTemplateConfig")
-                    .response::<200, Json<&'static [SlotSchemaDefinition]>>()
+                    .response::<200, Json<EmailTypeSchema>>()
             }),
         )
         .api_route(
             "/schemas",
-            get_with(list_slot_schemas, |op| {
-                op.id("ListEmailSlotSchemas")
-                    .summary("List email slot schemas")
-                    .description("List all slot schemas for each email template type")
+            get_with(list_schemas, |op| {
+                op.id("ListEmailTemplateSchemas")
+                    .summary("List email template schemas")
+                    .description("List all template schemas for each email template type")
                     .security_requirement("JWT")
                     .tag("EmailTemplateConfig")
-                    .response::<200, Json<&'static [EmailTypeSchema]>>()
+                    .response::<200, Json<[EmailTypeSchema; 3]>>()
             }),
         )
         .with_state(state)

--- a/api/src/routes/email_template_configs.rs
+++ b/api/src/routes/email_template_configs.rs
@@ -123,9 +123,12 @@ async fn preview(
 ) -> Result<(StatusCode, Json<PreviewEmailTemplateConfigResponse>), ComhairleError> {
     let template = slots.to_template();
     let custom_slots_map = slots.to_mailer_map();
-    let context = minijinja::context! { ..custom_slots_map };
+    let preview_variables_map = slots.preview_variables_map();
 
-    let html = state.mailer.preview_email(template, context)?;
+    let html =
+        state
+            .mailer
+            .preview_email(template, custom_slots_map, Some(preview_variables_map))?;
 
     Ok((
         StatusCode::OK,

--- a/api/src/routes/email_template_configs.rs
+++ b/api/src/routes/email_template_configs.rs
@@ -129,7 +129,7 @@ async fn preview(
     Json(PreviewEmailTemplateConfigRequest { slots }): Json<PreviewEmailTemplateConfigRequest>,
 ) -> Result<(StatusCode, Json<PreviewEmailTemplateConfigResponse>), ComhairleError> {
     let template = slots.email_template();
-    let custom_slots_map = slots.mailer_slots_map();
+    let custom_slots_map = slots.mailer_context_map();
     let preview_variables_map = slots.preview_variables_map();
 
     let html =

--- a/api/src/routes/email_template_configs/dto.rs
+++ b/api/src/routes/email_template_configs/dto.rs
@@ -1,0 +1,38 @@
+use chrono::{DateTime, Utc};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::models::email_template_config::{EmailTemplateConfig, EmailTemplateSlots};
+
+/// Data transfer object (public API representation) for an EmailTemplateConfig.
+///
+/// This DTO is returned by email_template_config related endpoints and is safe to expose
+/// to clients. It intentionally omits fields such as:
+///
+/// * `updated_at`
+///
+/// Serialized to JSON using camelCase field names for frontend (JavaScript) compatibility.
+#[derive(Serialize, Deserialize, JsonSchema, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct EmailTemplateConfigDto {
+    pub id: Uuid,
+    pub email_type: String,
+    pub owner_id: Uuid,
+    pub organization_id: Option<Uuid>,
+    pub slots: EmailTemplateSlots,
+    pub created_at: DateTime<Utc>,
+}
+
+impl From<EmailTemplateConfig> for EmailTemplateConfigDto {
+    fn from(c: EmailTemplateConfig) -> Self {
+        Self {
+            id: c.id,
+            email_type: c.slots.to_string(),
+            owner_id: c.owner_id,
+            organization_id: c.organization_id,
+            slots: c.slots,
+            created_at: c.created_at,
+        }
+    }
+}

--- a/api/src/routes/email_template_configs/dto.rs
+++ b/api/src/routes/email_template_configs/dto.rs
@@ -3,7 +3,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::models::email_template_config::{EmailTemplateConfig, EmailTemplateSlots};
+use crate::models::email_template_config::{EmailTemplateConfig, EmailTemplateSlots, EmailType};
 
 /// Data transfer object (public API representation) for an EmailTemplateConfig.
 ///
@@ -17,7 +17,7 @@ use crate::models::email_template_config::{EmailTemplateConfig, EmailTemplateSlo
 #[serde(rename_all = "camelCase")]
 pub struct EmailTemplateConfigDto {
     pub id: Uuid,
-    pub email_type: String,
+    pub email_type: EmailType,
     pub owner_id: Uuid,
     pub organization_id: Option<Uuid>,
     pub slots: EmailTemplateSlots,
@@ -29,7 +29,7 @@ impl From<EmailTemplateConfig> for EmailTemplateConfigDto {
     fn from(c: EmailTemplateConfig) -> Self {
         Self {
             id: c.id,
-            email_type: c.slots.to_string(),
+            email_type: c.email_type,
             owner_id: c.owner_id,
             organization_id: c.organization_id,
             slots: c.slots,

--- a/api/src/routes/email_template_configs/dto.rs
+++ b/api/src/routes/email_template_configs/dto.rs
@@ -21,6 +21,7 @@ pub struct EmailTemplateConfigDto {
     pub owner_id: Uuid,
     pub organization_id: Option<Uuid>,
     pub slots: EmailTemplateSlots,
+    pub subject: Option<String>,
     pub created_at: DateTime<Utc>,
 }
 
@@ -32,6 +33,7 @@ impl From<EmailTemplateConfig> for EmailTemplateConfigDto {
             owner_id: c.owner_id,
             organization_id: c.organization_id,
             slots: c.slots,
+            subject: c.subject,
             created_at: c.created_at,
         }
     }

--- a/api/src/routes/event_attendances.rs
+++ b/api/src/routes/event_attendances.rs
@@ -110,20 +110,22 @@ pub async fn create(
                 event::get_localized_by_id(&state.db, &event_id, &conversation.primary_locale)
                     .await?;
 
+            let event_owner = users::get_user_by_id(&conversation.owner_id, &state.db).await?;
+
             event
                 .schedule_event_reminders(&state.db, &state.config, &user)
                 .await?;
 
-            let event_link = format!(
-                "{}/conversations/{}/events/{}",
-                state.config.domain, conversation.id, event.id
-            );
-            state.mailer.send_event_confirmation_email(
-                email.to_string(),
-                &event,
-                &None,
-                event_link,
-            )?;
+            state
+                .mailer
+                .send_event_confirmation_email(
+                    &state,
+                    email,
+                    event_id,
+                    event_owner.id,
+                    &conversation.primary_locale,
+                )
+                .await?;
         }
     }
 
@@ -298,7 +300,7 @@ mod tests {
         mailer
             .expect_send_event_confirmation_email()
             .once()
-            .returning(|_, _, _, _| Ok(()));
+            .returning(|_, _, _, _, _| Box::pin(async move { Ok(()) }));
         let state = test_state().db(pool).mailer(Arc::new(mailer)).call()?;
         let app = setup_server(Arc::new(state)).await?;
         let mut session = UserSession::new_admin();

--- a/api/src/routes/invites.rs
+++ b/api/src/routes/invites.rs
@@ -105,17 +105,17 @@ async fn create_conversation_invite(
     // Send out an email notification if we can
     match &invite.invite_type {
         InviteType::Email(email) => {
-            state.mailer.send_email(
-            email,
-            "Invitation to take part in a public consultation",
-            "conversation_invite.html",
-            context! {
-                conversation_hero => conversation.image_url,
-                conversation_title=> conversation.title,
-                invite_link => format!("{}/conversations/{}/invite/{}",state.config.domain, conversation.slug.unwrap_or_else(|| conversation.id.to_string()), invite.id )
-            },
-                None
-        )?;
+            state
+                .mailer
+                .send_conversation_invite_email(
+                    &state,
+                    email,
+                    conversation.id,
+                    user.id,
+                    invite.id,
+                    &conversation.primary_locale,
+                )
+                .await?;
         }
         InviteType::User(user_id) => {
             let user = models::users::get_user_by_id(user_id, &state.db).await?;
@@ -457,7 +457,6 @@ mod tests {
     use std::error::Error;
 
     use axum::body::Body;
-    use mockall::predicate::{always, eq};
     use serde_json::json;
     use sqlx::PgPool;
     use tracing_test::traced_test;
@@ -482,16 +481,9 @@ mod tests {
 
         // Setup mailer expectations
         mailer
-            .expect_send_email()
-            .with(
-                eq("stuart.lynn@gmail.com"),
-                eq("Invitation to take part in a public consultation"),
-                eq("conversation_invite.html"),
-                always(),
-                always(),
-            )
+            .expect_send_conversation_invite_email()
             .once()
-            .returning(|_, _, _, _, _| Ok(()));
+            .returning(|_, _, _, _, _, _| Box::pin(async move { Ok(()) }));
 
         mailer
             .expect_send_welcome_email()

--- a/api/src/routes/invites.rs
+++ b/api/src/routes/invites.rs
@@ -140,7 +140,7 @@ async fn create_conversation_invite(
 async fn create_event_invite(
     State(state): State<Arc<ComhairleState>>,
     Path(conversation_id): Path<Uuid>,
-    OptionalUser(user): OptionalUser,
+    RequiredAdminUser(user): RequiredAdminUser,
     Json(create_invite): Json<CreateInviteDTO>,
 ) -> Result<(StatusCode, Json<InviteDto>), ComhairleError> {
     if create_invite.event_id.is_none() {
@@ -150,13 +150,8 @@ async fn create_event_invite(
     let conversation = models::conversation::get_by_id(&state.db, &conversation_id).await?;
 
     // Create the invite
-    let invite = models::invites::create(
-        &state.db,
-        create_invite,
-        &conversation_id,
-        user.map(|u| u.id),
-    )
-    .await?;
+    let invite =
+        models::invites::create(&state.db, create_invite, &conversation_id, Some(user.id)).await?;
 
     let InviteType::Email(email) = &invite.invite_type else {
         return Err(ComhairleError::InvalidInviteType);
@@ -164,17 +159,17 @@ async fn create_event_invite(
 
     let event_id = &invite.event_id.ok_or(ComhairleError::InvalidInviteType)?;
 
-    let event =
-        event::get_localized_by_id(&state.db, event_id, &conversation.primary_locale).await?;
-
-    let invite_link = format!(
-        "{}/conversations/{}/events/{}/invite/{}",
-        state.config.domain, conversation.id, event.id, invite.id
-    );
-
     state
         .mailer
-        .send_event_registration_email(email.to_string(), &event, &None, invite_link)?;
+        .send_event_registration_email(
+            &state,
+            email,
+            *event_id,
+            user.id,
+            invite.id,
+            &conversation.primary_locale,
+        )
+        .await?;
 
     Ok((StatusCode::CREATED, Json(invite.into())))
 }

--- a/api/src/routes/invites.rs
+++ b/api/src/routes/invites.rs
@@ -321,18 +321,22 @@ async fn auto_register_event_attendance(
 
     let cookie = create_session_cookie(&user, &state);
 
-    let event_link = format!(
-        "{}/conversations/{}/events/{}",
-        state.config.domain, conversation.id, event.id
-    );
-
     event
         .schedule_event_reminders(&state.db, &state.config, &user)
         .await?;
 
+    let event_owner = users::get_user_by_id(&conversation.owner_id, &state.db).await?;
+
     state
         .mailer
-        .send_event_confirmation_email(email.to_string(), &event, &None, event_link)?;
+        .send_event_confirmation_email(
+            &state,
+            email,
+            event_id,
+            event_owner.id,
+            &conversation.primary_locale,
+        )
+        .await?;
 
     Ok((jar.add(cookie), (StatusCode::OK, Json(invite.into()))))
 }

--- a/ui/packages/api-client/src/api.ts
+++ b/ui/packages/api-client/src/api.ts
@@ -1930,11 +1930,10 @@ export type UpdateEmailTemplateConfig = z.infer<
 >;
 export const SlotSchemaDefinition = z
   .object({
+    default_content: z.string(),
     hint: z.string(),
     key: z.string(),
     label: z.string(),
-    max_chars: z.union([z.number(), z.null()]).optional(),
-    required: z.boolean(),
   })
   .passthrough();
 export type SlotSchemaDefinition = z.infer<typeof SlotSchemaDefinition>;

--- a/ui/packages/api-client/src/api.ts
+++ b/ui/packages/api-client/src/api.ts
@@ -1867,6 +1867,51 @@ export const CreateApiKeyRequest = z
 export type CreateApiKeyRequest = z.infer<typeof CreateApiKeyRequest>;
 export const CreateResponse2 = z.object({ key: z.string() }).passthrough();
 export type CreateResponse2 = z.infer<typeof CreateResponse2>;
+export const EmailTemplateSlots = z.union([
+  z
+    .object({
+      body: z.string(),
+      footer: z.string(),
+      heading: z.string(),
+      intro: z.string(),
+      type: z.literal("conversation_invite"),
+    })
+    .passthrough(),
+  z
+    .object({
+      body: z.string(),
+      footer: z.string(),
+      heading: z.string(),
+      intro: z.string(),
+      type: z.literal("event_registration_confirmation"),
+    })
+    .passthrough(),
+]);
+export type EmailTemplateSlots = z.infer<typeof EmailTemplateSlots>;
+export const EmailTemplateConfigDto = z
+  .object({
+    createdAt: z.string().datetime({ offset: true }),
+    emailType: z.string(),
+    id: z.string().uuid(),
+    organizationId: z.union([z.string(), z.null()]).optional(),
+    ownerId: z.string().uuid(),
+    slots: EmailTemplateSlots,
+  })
+  .passthrough();
+export type EmailTemplateConfigDto = z.infer<typeof EmailTemplateConfigDto>;
+export const CreateEmailTemplateConfig = z
+  .object({ slots: EmailTemplateSlots })
+  .passthrough();
+export type CreateEmailTemplateConfig = z.infer<
+  typeof CreateEmailTemplateConfig
+>;
+export const UpdateEmailTemplateConfig = z
+  .object({ slots: z.union([EmailTemplateSlots, z.null()]) })
+  .partial()
+  .passthrough();
+export type UpdateEmailTemplateConfig = z.infer<
+  typeof UpdateEmailTemplateConfig
+>;
 
 export const schemas: Record<string, z.ZodType<any>> = {
   AnnonLoginRequest,
@@ -2080,6 +2125,10 @@ export const schemas: Record<string, z.ZodType<any>> = {
   ComhairleServices,
   CreateApiKeyRequest,
   CreateResponse2,
+  EmailTemplateSlots,
+  EmailTemplateConfigDto,
+  CreateEmailTemplateConfig,
+  UpdateEmailTemplateConfig,
 };
 
 const endpoints = makeApi([
@@ -3335,6 +3384,72 @@ Use query param withUserProgress&#x3D;true to get the active user&#x27;s progres
     description: `This documentation page.`,
     requestFormat: "json",
     response: z.void(),
+  },
+  {
+    method: "get",
+    path: "/email_template_configs",
+    alias: "ListEmailTemplateConfigs",
+    description: `List custom email template configurations`,
+    requestFormat: "json",
+    parameters: [
+      {
+        name: "organization_id",
+        type: "Query",
+        schema: created_after,
+      },
+      {
+        name: "owner_id",
+        type: "Query",
+        schema: created_after,
+      },
+    ],
+    response: z.array(EmailTemplateConfigDto),
+  },
+  {
+    method: "post",
+    path: "/email_template_configs",
+    alias: "CreateEmailTemplateConfig",
+    description: `Create custom content for specific email template`,
+    requestFormat: "json",
+    parameters: [
+      {
+        name: "body",
+        type: "Body",
+        schema: CreateEmailTemplateConfig,
+      },
+    ],
+    response: EmailTemplateConfigDto,
+  },
+  {
+    method: "get",
+    path: "/email_template_configs/:email_config_id",
+    alias: "GetEmailTemplateConfig",
+    description: `Get custom email template configuration`,
+    requestFormat: "json",
+    response: EmailTemplateConfigDto,
+  },
+  {
+    method: "put",
+    path: "/email_template_configs/:email_config_id",
+    alias: "UpdateEmailTemplateConfig",
+    description: `Update custom email template configuration`,
+    requestFormat: "json",
+    parameters: [
+      {
+        name: "body",
+        type: "Body",
+        schema: UpdateEmailTemplateConfig,
+      },
+    ],
+    response: EmailTemplateConfigDto,
+  },
+  {
+    method: "delete",
+    path: "/email_template_configs/:email_config_id",
+    alias: "DeleteEmailTemplateConfig",
+    description: `Delete custom email template configuration`,
+    requestFormat: "json",
+    response: EmailTemplateConfigDto,
   },
   {
     method: "get",

--- a/ui/packages/api-client/src/api.ts
+++ b/ui/packages/api-client/src/api.ts
@@ -1946,6 +1946,18 @@ export const EmailTypeSchema = z
   })
   .passthrough();
 export type EmailTypeSchema = z.infer<typeof EmailTypeSchema>;
+export const PreviewEmailTemplateConfigRequest = z
+  .object({ slots: EmailTemplateSlots })
+  .passthrough();
+export type PreviewEmailTemplateConfigRequest = z.infer<
+  typeof PreviewEmailTemplateConfigRequest
+>;
+export const PreviewEmailTemplateConfigResponse = z
+  .object({ html: z.string() })
+  .passthrough();
+export type PreviewEmailTemplateConfigResponse = z.infer<
+  typeof PreviewEmailTemplateConfigResponse
+>;
 
 export const schemas: Record<string, z.ZodType<any>> = {
   AnnonLoginRequest,
@@ -2165,6 +2177,8 @@ export const schemas: Record<string, z.ZodType<any>> = {
   UpdateEmailTemplateConfig,
   SlotSchemaDefinition,
   EmailTypeSchema,
+  PreviewEmailTemplateConfigRequest,
+  PreviewEmailTemplateConfigResponse,
 };
 
 const endpoints = makeApi([
@@ -3496,6 +3510,21 @@ Use query param withUserProgress&#x3D;true to get the active user&#x27;s progres
     response: EmailTypeSchema,
   },
   {
+    method: "post",
+    path: "/email_template_configs/preview",
+    alias: "PreviewEmailTemplateConfig",
+    description: `Preview appearance of custom email before sending`,
+    requestFormat: "json",
+    parameters: [
+      {
+        name: "body",
+        type: "Body",
+        schema: PreviewEmailTemplateConfigRequest,
+      },
+    ],
+    response: z.object({ html: z.string() }).passthrough(),
+  },
+  {
     method: "get",
     path: "/email_template_configs/schemas",
     alias: "ListEmailTemplateSchemas",
@@ -4272,11 +4301,6 @@ Use a raw HTTP request and process the response body incrementally.
         name: "is_ai_generated",
         type: "Query",
         schema: is_complete,
-      },
-      {
-        name: "user_id",
-        type: "Query",
-        schema: created_after,
       },
       {
         name: "workflow_step_id",

--- a/ui/packages/api-client/src/api.ts
+++ b/ui/packages/api-client/src/api.ts
@@ -1932,7 +1932,11 @@ export const SlotSchemaDefinition = z
   .passthrough();
 export type SlotSchemaDefinition = z.infer<typeof SlotSchemaDefinition>;
 export const EmailTypeSchema = z
-  .object({ email_type: z.string(), slots: z.array(SlotSchemaDefinition) })
+  .object({
+    email_type: z.string(),
+    slots: z.array(SlotSchemaDefinition),
+    variables: z.array(z.string()),
+  })
   .passthrough();
 export type EmailTypeSchema = z.infer<typeof EmailTypeSchema>;
 
@@ -3479,18 +3483,18 @@ Use query param withUserProgress&#x3D;true to get the active user&#x27;s progres
   {
     method: "get",
     path: "/email_template_configs/:email_config_id/schemas",
-    alias: "GetEmailSlotSchema",
-    description: `Get slot schemas for an email config`,
+    alias: "GetEmailTemplateSchema",
+    description: `Get template schemas for an email config`,
     requestFormat: "json",
-    response: z.array(SlotSchemaDefinition),
+    response: EmailTypeSchema,
   },
   {
     method: "get",
     path: "/email_template_configs/schemas",
-    alias: "ListEmailSlotSchemas",
-    description: `List all slot schemas for each email template type`,
+    alias: "ListEmailTemplateSchemas",
+    description: `List all template schemas for each email template type`,
     requestFormat: "json",
-    response: z.array(EmailTypeSchema),
+    response: z.array(EmailTypeSchema).min(3).max(3),
   },
   {
     method: "get",

--- a/ui/packages/api-client/src/api.ts
+++ b/ui/packages/api-client/src/api.ts
@@ -1912,6 +1912,20 @@ export const UpdateEmailTemplateConfig = z
 export type UpdateEmailTemplateConfig = z.infer<
   typeof UpdateEmailTemplateConfig
 >;
+export const SlotSchemaDefinition = z
+  .object({
+    hint: z.string(),
+    key: z.string(),
+    label: z.string(),
+    max_chars: z.union([z.number(), z.null()]).optional(),
+    required: z.boolean(),
+  })
+  .passthrough();
+export type SlotSchemaDefinition = z.infer<typeof SlotSchemaDefinition>;
+export const EmailTypeSchema = z
+  .object({ email_type: z.string(), slots: z.array(SlotSchemaDefinition) })
+  .passthrough();
+export type EmailTypeSchema = z.infer<typeof EmailTypeSchema>;
 
 export const schemas: Record<string, z.ZodType<any>> = {
   AnnonLoginRequest,
@@ -2129,6 +2143,8 @@ export const schemas: Record<string, z.ZodType<any>> = {
   EmailTemplateConfigDto,
   CreateEmailTemplateConfig,
   UpdateEmailTemplateConfig,
+  SlotSchemaDefinition,
+  EmailTypeSchema,
 };
 
 const endpoints = makeApi([
@@ -3450,6 +3466,14 @@ Use query param withUserProgress&#x3D;true to get the active user&#x27;s progres
     description: `Delete custom email template configuration`,
     requestFormat: "json",
     response: EmailTemplateConfigDto,
+  },
+  {
+    method: "get",
+    path: "/email_template_configs/schemas",
+    alias: "ListEmailSlotSchemas",
+    description: `List all slot schemas for each email template type`,
+    requestFormat: "json",
+    response: z.array(EmailTypeSchema),
   },
   {
     method: "get",

--- a/ui/packages/api-client/src/api.ts
+++ b/ui/packages/api-client/src/api.ts
@@ -1883,6 +1883,15 @@ export const EmailTemplateSlots = z.union([
       footer: z.string(),
       heading: z.string(),
       intro: z.string(),
+      type: z.literal("event_registration_invite"),
+    })
+    .passthrough(),
+  z
+    .object({
+      body: z.string(),
+      footer: z.string(),
+      heading: z.string(),
+      intro: z.string(),
       type: z.literal("event_registration_confirmation"),
     })
     .passthrough(),

--- a/ui/packages/api-client/src/api.ts
+++ b/ui/packages/api-client/src/api.ts
@@ -1928,8 +1928,11 @@ export const UpdateEmailTemplateConfig = z
 export type UpdateEmailTemplateConfig = z.infer<
   typeof UpdateEmailTemplateConfig
 >;
+export const ContentType = z.enum(["plain_text", "rich_text"]);
+export type ContentType = z.infer<typeof ContentType>;
 export const SlotSchemaDefinition = z
   .object({
+    content_type: ContentType,
     default_content: z.string(),
     hint: z.string(),
     key: z.string(),
@@ -2174,6 +2177,7 @@ export const schemas: Record<string, z.ZodType<any>> = {
   EmailTemplateConfigDto,
   CreateEmailTemplateConfig,
   UpdateEmailTemplateConfig,
+  ContentType,
   SlotSchemaDefinition,
   EmailTypeSchema,
   PreviewEmailTemplateConfigRequest,

--- a/ui/packages/api-client/src/api.ts
+++ b/ui/packages/api-client/src/api.ts
@@ -1867,6 +1867,14 @@ export const CreateApiKeyRequest = z
 export type CreateApiKeyRequest = z.infer<typeof CreateApiKeyRequest>;
 export const CreateResponse2 = z.object({ key: z.string() }).passthrough();
 export type CreateResponse2 = z.infer<typeof CreateResponse2>;
+export const EmailType = z.enum([
+  "conversation_invite",
+  "event_registration_invite",
+  "event_registration_confirmation",
+]);
+export type EmailType = z.infer<typeof EmailType>;
+export const email_type = z.union([EmailType, z.null()]).optional();
+export type email_type = z.infer<typeof email_type>;
 export const EmailTemplateSlots = z.union([
   z
     .object({
@@ -1900,7 +1908,7 @@ export type EmailTemplateSlots = z.infer<typeof EmailTemplateSlots>;
 export const EmailTemplateConfigDto = z
   .object({
     createdAt: z.string().datetime({ offset: true }),
-    emailType: z.string(),
+    emailType: EmailType,
     id: z.string().uuid(),
     organizationId: z.union([z.string(), z.null()]).optional(),
     ownerId: z.string().uuid(),
@@ -1928,12 +1936,6 @@ export const UpdateEmailTemplateConfig = z
 export type UpdateEmailTemplateConfig = z.infer<
   typeof UpdateEmailTemplateConfig
 >;
-export const EmailType = z.enum([
-  "conversation_invite",
-  "event_registration_invite",
-  "event_registration_confirmation",
-]);
-export type EmailType = z.infer<typeof EmailType>;
 export const ContentType = z.enum(["plain_text", "rich_text"]);
 export type ContentType = z.infer<typeof ContentType>;
 export const SlotSchemaDefinition = z
@@ -2181,11 +2183,12 @@ export const schemas: Record<string, z.ZodType<any>> = {
   ComhairleServices,
   CreateApiKeyRequest,
   CreateResponse2,
+  EmailType,
+  email_type,
   EmailTemplateSlots,
   EmailTemplateConfigDto,
   CreateEmailTemplateConfig,
   UpdateEmailTemplateConfig,
-  EmailType,
   ContentType,
   SlotSchemaDefinition,
   EmailTypeSchema,
@@ -3455,14 +3458,9 @@ Use query param withUserProgress&#x3D;true to get the active user&#x27;s progres
     requestFormat: "json",
     parameters: [
       {
-        name: "organization_id",
+        name: "email_type",
         type: "Query",
-        schema: created_after,
-      },
-      {
-        name: "owner_id",
-        type: "Query",
-        schema: created_after,
+        schema: email_type,
       },
     ],
     response: z.array(EmailTemplateConfigDto),

--- a/ui/packages/api-client/src/api.ts
+++ b/ui/packages/api-client/src/api.ts
@@ -1928,6 +1928,12 @@ export const UpdateEmailTemplateConfig = z
 export type UpdateEmailTemplateConfig = z.infer<
   typeof UpdateEmailTemplateConfig
 >;
+export const EmailType = z.enum([
+  "conversation_invite",
+  "event_registration_invite",
+  "event_registration_confirmation",
+]);
+export type EmailType = z.infer<typeof EmailType>;
 export const ContentType = z.enum(["plain_text", "rich_text"]);
 export type ContentType = z.infer<typeof ContentType>;
 export const SlotSchemaDefinition = z
@@ -1942,8 +1948,10 @@ export const SlotSchemaDefinition = z
 export type SlotSchemaDefinition = z.infer<typeof SlotSchemaDefinition>;
 export const EmailTypeSchema = z
   .object({
-    email_type: z.string(),
+    default_subject: z.string(),
+    email_type: EmailType,
     slots: z.array(SlotSchemaDefinition),
+    template: z.string(),
     variables: z.array(z.string()),
   })
   .passthrough();
@@ -2177,6 +2185,7 @@ export const schemas: Record<string, z.ZodType<any>> = {
   EmailTemplateConfigDto,
   CreateEmailTemplateConfig,
   UpdateEmailTemplateConfig,
+  EmailType,
   ContentType,
   SlotSchemaDefinition,
   EmailTypeSchema,

--- a/ui/packages/api-client/src/api.ts
+++ b/ui/packages/api-client/src/api.ts
@@ -1905,17 +1905,24 @@ export const EmailTemplateConfigDto = z
     organizationId: z.union([z.string(), z.null()]).optional(),
     ownerId: z.string().uuid(),
     slots: EmailTemplateSlots,
+    subject: z.union([z.string(), z.null()]).optional(),
   })
   .passthrough();
 export type EmailTemplateConfigDto = z.infer<typeof EmailTemplateConfigDto>;
 export const CreateEmailTemplateConfig = z
-  .object({ slots: EmailTemplateSlots })
+  .object({
+    slots: EmailTemplateSlots,
+    subject: z.union([z.string(), z.null()]).optional(),
+  })
   .passthrough();
 export type CreateEmailTemplateConfig = z.infer<
   typeof CreateEmailTemplateConfig
 >;
 export const UpdateEmailTemplateConfig = z
-  .object({ slots: z.union([EmailTemplateSlots, z.null()]) })
+  .object({
+    slots: z.union([EmailTemplateSlots, z.null()]),
+    subject: z.union([z.string(), z.null()]),
+  })
   .partial()
   .passthrough();
 export type UpdateEmailTemplateConfig = z.infer<

--- a/ui/packages/api-client/src/api.ts
+++ b/ui/packages/api-client/src/api.ts
@@ -3469,6 +3469,14 @@ Use query param withUserProgress&#x3D;true to get the active user&#x27;s progres
   },
   {
     method: "get",
+    path: "/email_template_configs/:email_config_id/schemas",
+    alias: "GetEmailSlotSchema",
+    description: `Get slot schemas for an email config`,
+    requestFormat: "json",
+    response: z.array(SlotSchemaDefinition),
+  },
+  {
+    method: "get",
     path: "/email_template_configs/schemas",
     alias: "ListEmailSlotSchemas",
     description: `List all slot schemas for each email template type`,

--- a/ui/packages/comhairle/src/lib/components/AdminNav.svelte
+++ b/ui/packages/comhairle/src/lib/components/AdminNav.svelte
@@ -11,6 +11,7 @@
 		Settings,
 		ChevronRight,
 		Home,
+		Mail,
 		PanelLeftClose
 	} from 'lucide-svelte';
 	import { conversationSteps, NavLinkActiveStatus } from '$lib/config/conversation-steps';
@@ -82,6 +83,26 @@
 								<a {...btnProps} href="/admin/">
 									<LayoutDashboard class="size-4" />
 									Workspace
+								</a>
+							{/snippet}
+						</SideBar.MenuButton>
+					</SideBar.MenuItem>
+				</SideBar.Menu>
+			</SideBar.GroupContent>
+		</SideBar.Group>
+
+		<SideBar.Group>
+			<SideBar.GroupLabel class="text-sidebar-secondary text-xs font-medium">
+				Configuration
+			</SideBar.GroupLabel>
+			<SideBar.GroupContent>
+				<SideBar.Menu>
+					<SideBar.MenuItem>
+						<SideBar.MenuButton>
+							{#snippet child({ props: btnProps })}
+								<a {...btnProps} href="/admin/email-template-configs">
+									<Mail class="size-4" />
+									Emails
 								</a>
 							{/snippet}
 						</SideBar.MenuButton>

--- a/ui/packages/comhairle/src/lib/components/EmailConfigCard.svelte
+++ b/ui/packages/comhairle/src/lib/components/EmailConfigCard.svelte
@@ -1,0 +1,19 @@
+<script lang="ts">
+	import { snakeToSentenceCase } from '$lib/utils/casingUtils';
+	import type { EmailTemplateConfigDto } from '@crownshy/api-client/api';
+
+	type Props = {
+		emailConfig: EmailTemplateConfigDto;
+	};
+
+	let { emailConfig }: Props = $props();
+</script>
+
+<a href={`/admin/email-template-configs/${emailConfig.id}`}>
+	<article class="flex flex-col">
+		<div class="flex flex-col gap-1 px-6 pb-6">
+			<span class="text-sm">Email type:</span>
+			<p class="text-lg font-bold">{snakeToSentenceCase(emailConfig.emailType)}</p>
+		</div>
+	</article>
+</a>

--- a/ui/packages/comhairle/src/lib/components/NotificationForm.svelte
+++ b/ui/packages/comhairle/src/lib/components/NotificationForm.svelte
@@ -10,14 +10,13 @@
 	import { Label } from '$lib/components/ui/label';
 	import { AlertTriangle, ChevronDown, Users } from 'lucide-svelte';
 	import RichTextEditor from '$lib/components/RichTextEditor/RichTextEditor.svelte';
-	import { getBaseExtensions } from '$lib/components/RichTextEditor/editorConfig';
-	import { generateHTML } from '@tiptap/core';
 	import { apiClient } from '@crownshy/api-client/client';
 	import { notifications } from '$lib/notifications.svelte';
 	import { Send } from 'lucide-svelte';
 	import { superForm } from 'sveltekit-superforms';
 	import { zodClient } from 'sveltekit-superforms/adapters';
 	import { notificationFormSchema } from './NotificationForm/schema';
+	import { jsonToHtml } from '$lib/utils/rich-text';
 
 	let { conversationId }: { conversationId: string } = $props();
 
@@ -66,11 +65,6 @@
 	let failedRecipients = $state<string[]>([]);
 	let lastSendMessage = $state<string | null>(null);
 	let lastSendStatus = $state<'partial' | 'failed' | null>(null);
-
-	function jsonToHtml(jsonString: string): string {
-		const json = JSON.parse(jsonString);
-		return generateHTML(json, getBaseExtensions({ mode: 'renderer' }));
-	}
 
 	async function sendNotification({ cancel }: { cancel: () => void }) {
 		// Prevent SvelteKit's default form submission — this page has no

--- a/ui/packages/comhairle/src/lib/utils/rich-text.ts
+++ b/ui/packages/comhairle/src/lib/utils/rich-text.ts
@@ -2,6 +2,11 @@ import { getBaseExtensions } from '$lib/components/RichTextEditor/editorConfig';
 import { generateHTML } from '@tiptap/core';
 
 export function jsonToHtml(jsonString: string): string {
-	const json = JSON.parse(jsonString);
-	return generateHTML(json, getBaseExtensions({ mode: 'renderer' }));
+	try {
+		const json = JSON.parse(jsonString);
+		return generateHTML(json, getBaseExtensions({ mode: 'renderer' }));
+	} catch (e) {
+		console.error(e);
+		return '';
+	}
 }

--- a/ui/packages/comhairle/src/lib/utils/rich-text.ts
+++ b/ui/packages/comhairle/src/lib/utils/rich-text.ts
@@ -1,0 +1,7 @@
+import { getBaseExtensions } from '$lib/components/RichTextEditor/editorConfig';
+import { generateHTML } from '@tiptap/core';
+
+export function jsonToHtml(jsonString: string): string {
+	const json = JSON.parse(jsonString);
+	return generateHTML(json, getBaseExtensions({ mode: 'renderer' }));
+}

--- a/ui/packages/comhairle/src/routes/(admin)/admin/email-template-configs/+layout.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/email-template-configs/+layout.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+	import type { LayoutProps } from './$types';
+
+	let { children }: LayoutProps = $props();
+</script>
+
+<div
+	class="bg-muted flex w-full flex-col justify-between gap-11 border-b-black px-4 py-6 sm:px-8 md:px-16 md:py-8"
+>
+	{@render children()}
+</div>

--- a/ui/packages/comhairle/src/routes/(admin)/admin/email-template-configs/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/email-template-configs/+page.svelte
@@ -1,6 +1,33 @@
 <script lang="ts">
 	import Button from '$lib/components/ui/button/button.svelte';
+	import { Plus } from 'lucide-svelte';
+	import * as Card from '$lib/components/ui/card';
+	import EmailConfigCard from '$lib/components/EmailConfigCard.svelte';
+
+	let { data } = $props();
+	const { emailConfigs } = data;
 </script>
 
-<h1>List configs</h1>
-<Button href="/admin/email-template-configs/new">Create new custom email</Button>
+<svelte:head>
+	<title>Custom Emails - Comhairle Admin</title>
+</svelte:head>
+
+<h1 class="text-4xl font-bold">Custom emails</h1>
+
+<p class="text-muted-foreground mb-10 text-base font-medium">
+	Use this space to manage your custom emails.
+</p>
+
+<div class="mx-auto flex max-w-175 flex-col gap-6">
+	{#each emailConfigs as emailConfig (emailConfig.id)}
+		<Card.Root class="overflow-hidden rounded-3xl pb-0 shadow-sm">
+			<EmailConfigCard {emailConfig} />
+		</Card.Root>
+	{/each}
+
+	<div class="flex justify-center pt-6">
+		<Button href="/admin/email-template-configs/new">
+			<Plus class="h-4 w-4" /> Add custom email
+		</Button>
+	</div>
+</div>

--- a/ui/packages/comhairle/src/routes/(admin)/admin/email-template-configs/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/email-template-configs/+page.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+	import Button from '$lib/components/ui/button/button.svelte';
+</script>
+
+<h1>List configs</h1>
+<Button href="/admin/email-template-configs/new">Create new custom email</Button>

--- a/ui/packages/comhairle/src/routes/(admin)/admin/email-template-configs/+page.ts
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/email-template-configs/+page.ts
@@ -1,0 +1,16 @@
+import type { PageLoad } from './$types';
+import { redirect } from '@sveltejs/kit';
+
+export const load: PageLoad = async ({ parent }) => {
+	const { api } = await parent();
+
+	try {
+		const emailConfigs = await api.ListEmailTemplateConfigs();
+
+		return { emailConfigs };
+	} catch (e) {
+		console.error(e);
+
+		redirect(302, '/admin');
+	}
+};

--- a/ui/packages/comhairle/src/routes/(admin)/admin/email-template-configs/EmailTemplateVariables.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/email-template-configs/EmailTemplateVariables.svelte
@@ -1,6 +1,11 @@
 <script lang="ts">
+	import * as Popover from '$lib/components/ui/popover';
+	import { Info } from 'lucide-svelte';
+
 	type Props = { templateVariables: string[] };
 	let { templateVariables }: Props = $props();
+
+	let open = $state(false);
 </script>
 
 {#snippet quote(message: string)}
@@ -9,25 +14,36 @@
 	</blockquote>
 {/snippet}
 
-<div class="flex max-w-4xl flex-col gap-8">
-	<div class="flex flex-col gap-2">
-		<h2 class="text-lg font-bold">Personalise your email content</h2>
-		<p>
-			The fields below support dynamic <span class="font-semibold italic">variables</span>,
-			which are automatically replaced with real values when the email is sent. To use a
-			variable, include it in your content wrapped in double curly braces.
-		</p>
-	</div>
+<div class="flex flex-col gap-8">
+	<Popover.Root bind:open>
+		<Popover.Trigger class="flex justify-start">
+			<span class="flex items-center gap-2 font-bold">
+				Available variables <Info class="text-primary inline size-5 self-center" />
+			</span>
+		</Popover.Trigger>
+		<Popover.Content class="max-w-[70vw] overflow-y-auto" side="bottom" align="start">
+			<div class="flex flex-col gap-2">
+				<h2 class="text-lg font-bold">Personalise your email content</h2>
+				<p>
+					The fields below support dynamic <span class="font-semibold italic"
+						>variables</span
+					>, which are automatically replaced with real values when the email is sent. To
+					use a variable, include it in your content wrapped in double curly braces.
+				</p>
+			</div>
+
+			<div class="flex flex-col gap-2">
+				<p>For example, if <code>conversation_title</code> is available, writing:</p>
+				{@render quote('You are invited to take part in {{conversation_title}}.')}
+				<p>will be sent to recipients as:</p>
+				{@render quote(
+					'You are invited to take part in Town Centre Regeneration Consultation.'
+				)}
+			</div>
+		</Popover.Content>
+	</Popover.Root>
 
 	<div class="flex flex-col gap-2">
-		<p>For example, if <code>conversation_title</code> is available, writing:</p>
-		{@render quote('You are invited to take part in {{conversation_title}}.')}
-		<p>will be sent to recipients as:</p>
-		{@render quote('You are invited to take part in Town Centre Regeneration Consultation.')}
-	</div>
-
-	<div class="flex flex-col gap-2">
-		<h3 class="font-bold">Available variables</h3>
 		<p>The following variables can be used in any content field for this email:</p>
 		<ul class="list-inside list-disc">
 			{#each templateVariables as templateVar (templateVar)}

--- a/ui/packages/comhairle/src/routes/(admin)/admin/email-template-configs/EmailTemplateVariables.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/email-template-configs/EmailTemplateVariables.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+	type Props = { templateVariables: string[] };
+	let { templateVariables }: Props = $props();
+</script>
+
+{#snippet quote(message: string)}
+	<blockquote class="w-fit border-l-12 border-gray-600 bg-gray-300 p-4 text-gray-900 italic">
+		{message}
+	</blockquote>
+{/snippet}
+
+<div class="flex max-w-4xl flex-col gap-8">
+	<div class="flex flex-col gap-2">
+		<h2 class="text-lg font-bold">Personalise your email content</h2>
+		<p>
+			The fields below support dynamic <span class="font-semibold italic">variables</span>,
+			which are automatically replaced with real values when the email is sent. To use a
+			variable, include it in your content wrapped in double curly braces.
+		</p>
+	</div>
+
+	<div class="flex flex-col gap-2">
+		<p>For example, if <code>conversation_title</code> is available, writing:</p>
+		{@render quote('You are invited to take part in {{conversation_title}}.')}
+		<p>will be sent to recipients as:</p>
+		{@render quote('You are invited to take part in Town Centre Regeneration Consultation.')}
+	</div>
+
+	<div class="flex flex-col gap-2">
+		<h3 class="font-bold">Available variables</h3>
+		<p>The following variables can be used in any content field for this email:</p>
+		<ul class="list-inside list-disc">
+			{#each templateVariables as templateVar (templateVar)}
+				<li><code>{templateVar}</code></li>
+			{/each}
+		</ul>
+	</div>
+</div>

--- a/ui/packages/comhairle/src/routes/(admin)/admin/email-template-configs/[email_config_id]/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/email-template-configs/[email_config_id]/+page.svelte
@@ -1,14 +1,18 @@
 <script lang="ts">
 	import Label from '$lib/components/ui/label/label.svelte';
+	import * as Dialog from '$lib/components/ui/dialog';
+	import * as AlertDialog from '$lib/components/ui/alert-dialog';
 	import RichTextEditor from '$lib/components/RichTextEditor/RichTextEditor.svelte';
 	import { jsonToHtml } from '$lib/utils/rich-text.js';
 	import Button from '$lib/components/ui/button/button.svelte';
 	import { snakeToSentenceCase } from '$lib/utils/casingUtils.js';
 	import { apiClient } from '@crownshy/api-client/client';
 	import { notifications } from '$lib/notifications.svelte';
-	import { invalidateAll } from '$app/navigation';
+	import { goto, invalidateAll } from '$app/navigation';
 	import EmailTemplateVariables from '../EmailTemplateVariables.svelte';
 	import Input from '$lib/components/ui/input/input.svelte';
+	import { useDebounce } from 'runed';
+	import { LoaderCircle } from 'lucide-svelte';
 
 	const { data } = $props();
 	const { emailConfig, schema } = data;
@@ -27,6 +31,21 @@
 	});
 
 	let pageTitle = $derived(`Edit Custom Email: ${emailConfig.emailType}`);
+	let previewHtml = $state('');
+	let openPreviewModal = $state(false);
+	let previewIframeSrc = $state('');
+	let openDeleteModal = $state(false);
+	let deleting = $state(false);
+
+	$effect(() => {
+		if (!previewHtml) return;
+
+		const blob = new Blob([previewHtml], { type: 'text/html' });
+		const url = URL.createObjectURL(blob);
+		previewIframeSrc = url;
+
+		return () => URL.revokeObjectURL(url);
+	});
 
 	async function handleSubmit(e: Event) {
 		e.preventDefault();
@@ -57,6 +76,43 @@
 			});
 		}
 	}
+
+	async function handleDelete() {
+		try {
+			apiClient.DeleteEmailTemplateConfig(undefined, {
+				params: { email_config_id: emailConfig.id }
+			});
+
+			await invalidateAll();
+
+			goto('/admin/email-template-configs');
+		} catch (e) {
+			console.error(e);
+			notifications.send({
+				message: 'Something went wrong deleting your custom email',
+				priority: 'ERROR'
+			});
+		}
+	}
+
+	const debouncedPreviewEmail = useDebounce(async () => {
+		try {
+			const toHtml: { [key: string]: string } = {};
+			Object.entries(formState.slots).forEach(([key, value]) => {
+				if (value) {
+					toHtml[key] = jsonToHtml(value);
+				}
+			});
+
+			const response = await apiClient.PreviewEmailTemplateConfig({
+				slots: { type: schema.email_type, ...toHtml }
+			});
+
+			previewHtml = response.html;
+		} catch (e) {
+			console.error(e);
+		}
+	}, 300);
 </script>
 
 <svelte:head>
@@ -64,6 +120,20 @@
 </svelte:head>
 
 <h1 class="text-4xl font-bold">Custom email: {snakeToSentenceCase(emailConfig.emailType)}</h1>
+
+<div class="flex justify-end gap-2">
+	<Button variant="destructive" type="button" onclick={() => (openDeleteModal = true)}
+		>Delete</Button
+	>
+	<Button
+		variant="default"
+		type="button"
+		onclick={() => {
+			debouncedPreviewEmail();
+			openPreviewModal = true;
+		}}>Preview</Button
+	>
+</div>
 
 {#if schema.variables.length > 0}
 	<EmailTemplateVariables templateVariables={schema.variables} />
@@ -106,3 +176,41 @@
 		<Button type="submit">Submit</Button>
 	</div>
 </form>
+
+<Dialog.Root bind:open={openPreviewModal}>
+	<Dialog.Content class="h-[70vh] w-full max-w-6xl sm:w-full sm:max-w-6xl">
+		<Dialog.Header>
+			<Dialog.Title class="flex items-center gap-2">Email preview</Dialog.Title>
+			<Dialog.Description>
+				{#if previewIframeSrc}
+					<iframe
+						src={previewIframeSrc}
+						class="h-[63vh] w-full"
+						title="Email preview"
+						sandbox="allow-same-origin"
+					></iframe>
+				{/if}
+			</Dialog.Description>
+		</Dialog.Header>
+	</Dialog.Content>
+</Dialog.Root>
+
+<AlertDialog.Root open={openDeleteModal}>
+	<AlertDialog.Content>
+		<AlertDialog.Header>
+			<AlertDialog.Title>Delete custom email?</AlertDialog.Title>
+			<AlertDialog.Description>
+				This will permanently remove the custom email for this email type.
+			</AlertDialog.Description>
+		</AlertDialog.Header>
+		<AlertDialog.Footer>
+			<AlertDialog.Cancel disabled={deleting}>Cancel</AlertDialog.Cancel>
+			<AlertDialog.Action disabled={deleting} onclick={handleDelete}>
+				{#if deleting}
+					<LoaderCircle class="mr-2 h-4 w-4 animate-spin" />
+				{/if}
+				Delete
+			</AlertDialog.Action>
+		</AlertDialog.Footer>
+	</AlertDialog.Content>
+</AlertDialog.Root>

--- a/ui/packages/comhairle/src/routes/(admin)/admin/email-template-configs/[email_config_id]/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/email-template-configs/[email_config_id]/+page.svelte
@@ -1,0 +1,80 @@
+<script lang="ts">
+	import Label from '$lib/components/ui/label/label.svelte';
+	import RichTextEditor from '$lib/components/RichTextEditor/RichTextEditor.svelte';
+	import { jsonToHtml } from '$lib/utils/rich-text.js';
+	import Button from '$lib/components/ui/button/button.svelte';
+	import { snakeToSentenceCase } from '$lib/utils/casingUtils.js';
+	import { apiClient } from '@crownshy/api-client/client';
+	import { notifications } from '$lib/notifications.svelte';
+	import { invalidateAll } from '$app/navigation';
+
+	const { data } = $props();
+	const { emailConfig, schema } = data;
+
+	let formState = $derived.by(() => {
+		const output: { [key: string]: string } = {};
+		schema.map((slot) => (output[slot.key] = emailConfig.slots[slot.key] as string));
+		return output;
+	});
+
+	let pageTitle = $derived(`Edit Custom Email: ${emailConfig.emailType}`);
+
+	async function handleSubmit(e: Event) {
+		e.preventDefault();
+
+		const toHtml: { [key: string]: string } = {};
+		Object.entries(formState).map(([key, value]) => (toHtml[key] = jsonToHtml(value)));
+
+		try {
+			await apiClient.UpdateEmailTemplateConfig(
+				{
+					slots: { type: emailConfig.emailType, ...toHtml }
+				},
+				{ params: { email_config_id: emailConfig.id } }
+			);
+
+			notifications.send({
+				priority: 'INFO',
+				message: 'Successfully updated custom email'
+			});
+
+			await invalidateAll();
+		} catch (e) {
+			console.error(e);
+			notifications.send({
+				priority: 'ERROR',
+				message: 'Something went wrong updating your custom email'
+			});
+		}
+	}
+</script>
+
+<svelte:head>
+	<title>{pageTitle} - Comhairle Admin</title>
+</svelte:head>
+
+<h1 class="text-4xl font-bold">Custom email: {snakeToSentenceCase(emailConfig.emailType)}</h1>
+<form onsubmit={handleSubmit}>
+	{#each schema as slot (slot.key)}
+		<div
+			class="border-border flex flex-col gap-4 border-t py-6 lg:flex-row lg:items-start lg:gap-6"
+		>
+			<Label
+				class="flex flex-col items-start text-sm font-semibold lg:w-50 lg:shrink-0 lg:pt-2"
+				for={slot.key}
+			>
+				<span>{slot.label}</span>
+				<span class="text-sm font-normal">{slot.hint}</span>
+			</Label>
+			<RichTextEditor
+				value={formState[slot.key]}
+				placeholder="Enter email content..."
+				onChange={(json) => (formState[slot.key] = json)}
+			/>
+		</div>
+	{/each}
+
+	<div class="flex justify-center">
+		<Button type="submit">Submit</Button>
+	</div>
+</form>

--- a/ui/packages/comhairle/src/routes/(admin)/admin/email-template-configs/[email_config_id]/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/email-template-configs/[email_config_id]/+page.svelte
@@ -8,13 +8,21 @@
 	import { notifications } from '$lib/notifications.svelte';
 	import { invalidateAll } from '$app/navigation';
 	import EmailTemplateVariables from '../EmailTemplateVariables.svelte';
+	import Input from '$lib/components/ui/input/input.svelte';
 
 	const { data } = $props();
 	const { emailConfig, schema } = data;
 
 	let formState = $derived.by(() => {
-		const output: { [key: string]: string } = {};
-		schema.slots.map((slot) => (output[slot.key] = emailConfig.slots[slot.key] as string));
+		const output: { slots: { [key: string]: string }; subject?: string } = {
+			slots: {}
+		};
+		schema.slots.map(
+			(slot) => (output.slots[slot.key] = emailConfig.slots[slot.key] as string)
+		);
+
+		if (emailConfig.subject) output.subject = emailConfig.subject;
+
 		return output;
 	});
 
@@ -24,12 +32,13 @@
 		e.preventDefault();
 
 		const toHtml: { [key: string]: string } = {};
-		Object.entries(formState).map(([key, value]) => (toHtml[key] = jsonToHtml(value)));
+		Object.entries(formState.slots).map(([key, value]) => (toHtml[key] = jsonToHtml(value)));
 
 		try {
 			await apiClient.UpdateEmailTemplateConfig(
 				{
-					slots: { type: emailConfig.emailType, ...toHtml }
+					slots: { type: emailConfig.emailType, ...toHtml },
+					...(formState.subject && { subject: formState.subject })
 				},
 				{ params: { email_config_id: emailConfig.id } }
 			);
@@ -61,6 +70,18 @@
 {/if}
 
 <form onsubmit={handleSubmit}>
+	<div class="flex flex-col gap-4 py-6 lg:flex-row lg:items-start lg:gap-6">
+		<Label
+			class="flex flex-col items-start text-sm font-semibold lg:w-50 lg:shrink-0 lg:pt-2"
+			for="subject">Email subject</Label
+		>
+		<Input
+			placeholder="Subject"
+			name="subject"
+			defaultValue={formState.subject}
+			onchange={(e) => (formState.subject = e.target?.value ?? undefined)}
+		/>
+	</div>
 	{#each schema.slots as slot (slot.key)}
 		<div
 			class="border-border flex flex-col gap-4 border-t py-6 lg:flex-row lg:items-start lg:gap-6"
@@ -73,9 +94,10 @@
 				<span class="text-sm font-normal">{slot.hint}</span>
 			</Label>
 			<RichTextEditor
-				value={formState[slot.key]}
+				width="100%"
+				value={formState.slots[slot.key]}
 				placeholder="Enter email content..."
-				onChange={(json) => (formState[slot.key] = json)}
+				onChange={(json) => (formState.slots[slot.key] = json)}
 			/>
 		</div>
 	{/each}

--- a/ui/packages/comhairle/src/routes/(admin)/admin/email-template-configs/[email_config_id]/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/email-template-configs/[email_config_id]/+page.svelte
@@ -7,13 +7,14 @@
 	import { apiClient } from '@crownshy/api-client/client';
 	import { notifications } from '$lib/notifications.svelte';
 	import { invalidateAll } from '$app/navigation';
+	import EmailTemplateVariables from '../EmailTemplateVariables.svelte';
 
 	const { data } = $props();
 	const { emailConfig, schema } = data;
 
 	let formState = $derived.by(() => {
 		const output: { [key: string]: string } = {};
-		schema.map((slot) => (output[slot.key] = emailConfig.slots[slot.key] as string));
+		schema.slots.map((slot) => (output[slot.key] = emailConfig.slots[slot.key] as string));
 		return output;
 	});
 
@@ -54,8 +55,13 @@
 </svelte:head>
 
 <h1 class="text-4xl font-bold">Custom email: {snakeToSentenceCase(emailConfig.emailType)}</h1>
+
+{#if schema.variables.length > 0}
+	<EmailTemplateVariables templateVariables={schema.variables} />
+{/if}
+
 <form onsubmit={handleSubmit}>
-	{#each schema as slot (slot.key)}
+	{#each schema.slots as slot (slot.key)}
 		<div
 			class="border-border flex flex-col gap-4 border-t py-6 lg:flex-row lg:items-start lg:gap-6"
 		>

--- a/ui/packages/comhairle/src/routes/(admin)/admin/email-template-configs/[email_config_id]/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/email-template-configs/[email_config_id]/+page.svelte
@@ -50,13 +50,22 @@
 	async function handleSubmit(e: Event) {
 		e.preventDefault();
 
-		const toHtml: { [key: string]: string } = {};
-		Object.entries(formState.slots).map(([key, value]) => (toHtml[key] = jsonToHtml(value)));
+		const parsed: { [key: string]: string } = {};
+		Object.entries(formState.slots).map(([key, value]) => {
+			const matched = schema.slots.find((slot) => slot.key === key);
+			if (!matched) return;
+
+			if (matched.content_type === 'rich_text') {
+				parsed[key] = jsonToHtml(value);
+			} else {
+				parsed[key] = value;
+			}
+		});
 
 		try {
 			await apiClient.UpdateEmailTemplateConfig(
 				{
-					slots: { type: emailConfig.emailType, ...toHtml },
+					slots: { type: emailConfig.emailType, ...parsed },
 					...(formState.subject && { subject: formState.subject })
 				},
 				{ params: { email_config_id: emailConfig.id } }
@@ -97,15 +106,20 @@
 
 	const debouncedPreviewEmail = useDebounce(async () => {
 		try {
-			const toHtml: { [key: string]: string } = {};
-			Object.entries(formState.slots).forEach(([key, value]) => {
-				if (value) {
-					toHtml[key] = jsonToHtml(value);
+			const parsed: { [key: string]: string } = {};
+			Object.entries(formState.slots).map(([key, value]) => {
+				const matched = schema.slots.find((slot) => slot.key === key);
+				if (!matched) return;
+
+				if (matched.content_type === 'rich_text') {
+					parsed[key] = jsonToHtml(value);
+				} else {
+					parsed[key] = value;
 				}
 			});
 
 			const response = await apiClient.PreviewEmailTemplateConfig({
-				slots: { type: schema.email_type, ...toHtml }
+				slots: { type: schema.email_type, ...parsed }
 			});
 
 			previewHtml = response.html;
@@ -163,12 +177,20 @@
 				<span>{slot.label}</span>
 				<span class="text-sm font-normal">{slot.hint}</span>
 			</Label>
-			<RichTextEditor
-				width="100%"
-				value={formState.slots[slot.key]}
-				placeholder="Enter email content..."
-				onChange={(json) => (formState.slots[slot.key] = json)}
-			/>
+			{#if slot.content_type === 'plain_text'}
+				<Input
+					placeholder="Enter email content..."
+					defaultValue={formState.slots[slot.key]}
+					onchange={(e) => (formState.slots[slot.key] = e.target?.value)}
+				/>
+			{:else}
+				<RichTextEditor
+					width="100%"
+					value={formState.slots[slot.key]}
+					placeholder="Enter email content..."
+					onChange={(json) => (formState.slots[slot.key] = json)}
+				/>
+			{/if}
 		</div>
 	{/each}
 

--- a/ui/packages/comhairle/src/routes/(admin)/admin/email-template-configs/[email_config_id]/+page.ts
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/email-template-configs/[email_config_id]/+page.ts
@@ -1,0 +1,18 @@
+import { redirect } from '@sveltejs/kit';
+import type { PageLoad } from './$types';
+
+export const load: PageLoad = async ({ params, parent }) => {
+	const { api } = await parent();
+	const { email_config_id } = params;
+
+	try {
+		const emailConfig = await api.GetEmailTemplateConfig({ params: { email_config_id } });
+		const schema = await api.GetEmailSlotSchema({ params: { email_config_id } });
+
+		return { emailConfig, schema };
+	} catch (e) {
+		console.error(e);
+
+		redirect(302, '/admin/email-template-configs');
+	}
+};

--- a/ui/packages/comhairle/src/routes/(admin)/admin/email-template-configs/[email_config_id]/+page.ts
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/email-template-configs/[email_config_id]/+page.ts
@@ -7,7 +7,7 @@ export const load: PageLoad = async ({ params, parent }) => {
 
 	try {
 		const emailConfig = await api.GetEmailTemplateConfig({ params: { email_config_id } });
-		const schema = await api.GetEmailSlotSchema({ params: { email_config_id } });
+		const schema = await api.GetEmailTemplateSchema({ params: { email_config_id } });
 
 		return { emailConfig, schema };
 	} catch (e) {

--- a/ui/packages/comhairle/src/routes/(admin)/admin/email-template-configs/new/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/email-template-configs/new/+page.svelte
@@ -24,7 +24,8 @@
 	let selectedSchema = $state(schemas[0]);
 	let formState = $derived.by(() => {
 		const output: FormState = {
-			slots: {}
+			slots: {},
+			subject: selectedSchema.default_subject
 		};
 		selectedSchema.slots.map((slot) => (output.slots[slot.key] = slot.default_content));
 		return output;
@@ -162,6 +163,7 @@
 		<Input
 			placeholder="Subject"
 			name="subject"
+			defaultValue={formState.subject}
 			onchange={(e) => (formState.subject = e.target?.value ?? undefined)}
 		/>
 	</div>

--- a/ui/packages/comhairle/src/routes/(admin)/admin/email-template-configs/new/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/email-template-configs/new/+page.svelte
@@ -52,6 +52,10 @@
 	}
 </script>
 
+<svelte:head>
+	<title>New Custom Email - Comhairle Admin</title>
+</svelte:head>
+
 <Select.Root type="single" value={selectedSchema.email_type} onValueChange={handleSelectSchema}>
 	<Select.Trigger class=""
 		>Email type: {snakeToSentenceCase(selectedSchema.email_type)}</Select.Trigger

--- a/ui/packages/comhairle/src/routes/(admin)/admin/email-template-configs/new/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/email-template-configs/new/+page.svelte
@@ -1,0 +1,91 @@
+<script lang="ts">
+	import * as Select from '$lib/components/ui/select';
+	import { snakeToSentenceCase } from '$lib/utils/casingUtils';
+	import Label from '$lib/components/ui/label/label.svelte';
+	import RichTextEditor from '$lib/components/RichTextEditor/RichTextEditor.svelte';
+	import { notifications } from '$lib/notifications.svelte';
+	import { apiClient } from '@crownshy/api-client/client';
+	import { jsonToHtml } from '$lib/utils/rich-text.js';
+	import Button from '$lib/components/ui/button/button.svelte';
+	import { goto, invalidateAll } from '$app/navigation';
+
+	let { data } = $props();
+	const { schemas } = data;
+
+	let selectedSchema = $state(schemas[0]);
+	let formState = $derived.by(() => {
+		const output: { [key: string]: string } = {};
+		selectedSchema.slots.map((slot) => (output[slot.key] = ''));
+		return output;
+	});
+
+	function handleSelectSchema(value: string) {
+		selectedSchema = schemas.find((s) => s.email_type === value);
+	}
+
+	async function handleSubmit(e: Event) {
+		e.preventDefault();
+
+		const toHtml: { [key: string]: string } = {};
+		Object.entries(formState).map(([key, value]) => (toHtml[key] = jsonToHtml(value)));
+
+		try {
+			const emailConfig = await apiClient.CreateEmailTemplateConfig({
+				slots: { type: selectedSchema.email_type, ...toHtml }
+			});
+
+			notifications.send({
+				priority: 'INFO',
+				message: 'Successfully create new custom email'
+			});
+
+			await invalidateAll();
+
+			goto(`/admin/email-template-configs/${emailConfig.id}`);
+		} catch (e) {
+			console.error(e);
+			notifications.send({
+				priority: 'ERROR',
+				message: 'Something went wrong creating your custom email'
+			});
+		}
+	}
+</script>
+
+<Select.Root type="single" value={selectedSchema.email_type} onValueChange={handleSelectSchema}>
+	<Select.Trigger class=""
+		>Email type: {snakeToSentenceCase(selectedSchema.email_type)}</Select.Trigger
+	>
+	<Select.Content>
+		{#each schemas as schema (schema.email_type)}
+			<Select.Item value={schema.email_type}
+				>{snakeToSentenceCase(schema.email_type)}</Select.Item
+			>
+		{/each}
+	</Select.Content>
+</Select.Root>
+
+<form onsubmit={handleSubmit}>
+	{#each selectedSchema.slots as slot (slot.key)}
+		<div
+			class="border-border flex flex-col gap-4 border-t py-6 lg:flex-row lg:items-start lg:gap-6"
+		>
+			<Label
+				class="flex flex-col items-start text-sm font-semibold lg:w-50 lg:shrink-0 lg:pt-2"
+				for={slot.key}
+			>
+				<span>{slot.label}</span>
+				<span class="text-sm font-normal">{slot.hint}</span>
+			</Label>
+			<RichTextEditor
+				value={formState[slot.key]}
+				placeholder="Enter email content..."
+				onChange={(json) => (formState[slot.key] = json)}
+			/>
+		</div>
+	{/each}
+
+	<div class="flex justify-center">
+		<Button type="submit">Submit</Button>
+	</div>
+</form>

--- a/ui/packages/comhairle/src/routes/(admin)/admin/email-template-configs/new/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/email-template-configs/new/+page.svelte
@@ -9,14 +9,17 @@
 	import Button from '$lib/components/ui/button/button.svelte';
 	import { goto, invalidateAll } from '$app/navigation';
 	import EmailTemplateVariables from '../EmailTemplateVariables.svelte';
+	import Input from '$lib/components/ui/input/input.svelte';
 
 	let { data } = $props();
 	const { schemas } = data;
 
 	let selectedSchema = $state(schemas[0]);
 	let formState = $derived.by(() => {
-		const output: { [key: string]: string } = {};
-		selectedSchema.slots.map((slot) => (output[slot.key] = ''));
+		const output: { slots: { [key: string]: string }; subject?: string } = {
+			slots: {}
+		};
+		selectedSchema.slots.map((slot) => (output.slots[slot.key] = ''));
 		return output;
 	});
 
@@ -28,11 +31,15 @@
 		e.preventDefault();
 
 		const toHtml: { [key: string]: string } = {};
-		Object.entries(formState).map(([key, value]) => (toHtml[key] = jsonToHtml(value)));
+		Object.entries(formState.slots).map(([key, value]) => (toHtml[key] = jsonToHtml(value)));
 
 		try {
 			const emailConfig = await apiClient.CreateEmailTemplateConfig({
-				slots: { type: selectedSchema.email_type, ...toHtml }
+				slots: {
+					type: selectedSchema.email_type,
+					...toHtml
+				},
+				...(formState.subject && { subject: formState.subject })
 			});
 
 			notifications.send({
@@ -57,24 +64,38 @@
 	<title>New Custom Email - Comhairle Admin</title>
 </svelte:head>
 
-<Select.Root type="single" value={selectedSchema.email_type} onValueChange={handleSelectSchema}>
-	<Select.Trigger class=""
-		>Email type: {snakeToSentenceCase(selectedSchema.email_type)}</Select.Trigger
-	>
-	<Select.Content>
-		{#each schemas as schema (schema.email_type)}
-			<Select.Item value={schema.email_type}
-				>{snakeToSentenceCase(schema.email_type)}</Select.Item
-			>
-		{/each}
-	</Select.Content>
-</Select.Root>
+<h1 class="text-4xl font-bold">Create new custom email</h1>
+
+<div class="flex flex-col gap-4">
+	<h2 class="text-xl font-semibold">Email type:</h2>
+	<Select.Root type="single" value={selectedSchema.email_type} onValueChange={handleSelectSchema}>
+		<Select.Trigger class="">{snakeToSentenceCase(selectedSchema.email_type)}</Select.Trigger>
+		<Select.Content>
+			{#each schemas as schema (schema.email_type)}
+				<Select.Item value={schema.email_type}
+					>{snakeToSentenceCase(schema.email_type)}</Select.Item
+				>
+			{/each}
+		</Select.Content>
+	</Select.Root>
+</div>
 
 {#if selectedSchema.variables.length > 0}
 	<EmailTemplateVariables templateVariables={selectedSchema.variables} />
 {/if}
 
 <form onsubmit={handleSubmit}>
+	<div class="flex flex-col gap-4 py-6 lg:flex-row lg:items-start lg:gap-6">
+		<Label
+			class="flex flex-col items-start text-sm font-semibold lg:w-50 lg:shrink-0 lg:pt-2"
+			for="subject">Email subject</Label
+		>
+		<Input
+			placeholder="Subject"
+			name="subject"
+			onchange={(e) => (formState.subject = e.target?.value ?? undefined)}
+		/>
+	</div>
 	{#each selectedSchema.slots as slot (slot.key)}
 		<div
 			class="border-border flex flex-col gap-4 border-t py-6 lg:flex-row lg:items-start lg:gap-6"
@@ -87,9 +108,10 @@
 				<span class="text-sm font-normal">{slot.hint}</span>
 			</Label>
 			<RichTextEditor
-				value={formState[slot.key]}
+				width="100%"
+				value={formState.slots[slot.key]}
 				placeholder="Enter email content..."
-				onChange={(json) => (formState[slot.key] = json)}
+				onChange={(json) => (formState.slots[slot.key] = json)}
 			/>
 		</div>
 	{/each}

--- a/ui/packages/comhairle/src/routes/(admin)/admin/email-template-configs/new/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/email-template-configs/new/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import * as Select from '$lib/components/ui/select';
+	import * as Dialog from '$lib/components/ui/dialog';
 	import { snakeToSentenceCase } from '$lib/utils/casingUtils';
 	import Label from '$lib/components/ui/label/label.svelte';
 	import RichTextEditor from '$lib/components/RichTextEditor/RichTextEditor.svelte';
@@ -10,17 +11,36 @@
 	import { goto, invalidateAll } from '$app/navigation';
 	import EmailTemplateVariables from '../EmailTemplateVariables.svelte';
 	import Input from '$lib/components/ui/input/input.svelte';
+	import { useDebounce } from 'runed';
+
+	type FormState = {
+		subject?: string;
+		slots: { [key: string]: string };
+	};
 
 	let { data } = $props();
 	const { schemas } = data;
 
 	let selectedSchema = $state(schemas[0]);
 	let formState = $derived.by(() => {
-		const output: { slots: { [key: string]: string }; subject?: string } = {
+		const output: FormState = {
 			slots: {}
 		};
 		selectedSchema.slots.map((slot) => (output.slots[slot.key] = ''));
 		return output;
+	});
+	let previewHtml = $state('');
+	let openPreviewModal = $state(false);
+	let previewIframeSrc = $state('');
+
+	$effect(() => {
+		if (!previewHtml) return;
+
+		const blob = new Blob([previewHtml], { type: 'text/html' });
+		const url = URL.createObjectURL(blob);
+		previewIframeSrc = url;
+
+		return () => URL.revokeObjectURL(url);
 	});
 
 	function handleSelectSchema(value: string) {
@@ -58,6 +78,25 @@
 			});
 		}
 	}
+
+	const debouncedPreviewEmail = useDebounce(async () => {
+		try {
+			const toHtml: { [key: string]: string } = {};
+			Object.entries(formState.slots).forEach(([key, value]) => {
+				if (value) {
+					toHtml[key] = jsonToHtml(value);
+				}
+			});
+
+			const response = await apiClient.PreviewEmailTemplateConfig({
+				slots: { type: selectedSchema.email_type, ...toHtml }
+			});
+
+			previewHtml = response.html;
+		} catch (e) {
+			console.error(e);
+		}
+	}, 300);
 </script>
 
 <svelte:head>
@@ -66,18 +105,34 @@
 
 <h1 class="text-4xl font-bold">Create new custom email</h1>
 
-<div class="flex flex-col gap-4">
-	<h2 class="text-xl font-semibold">Email type:</h2>
-	<Select.Root type="single" value={selectedSchema.email_type} onValueChange={handleSelectSchema}>
-		<Select.Trigger class="">{snakeToSentenceCase(selectedSchema.email_type)}</Select.Trigger>
-		<Select.Content>
-			{#each schemas as schema (schema.email_type)}
-				<Select.Item value={schema.email_type}
-					>{snakeToSentenceCase(schema.email_type)}</Select.Item
-				>
-			{/each}
-		</Select.Content>
-	</Select.Root>
+<div class="flex justify-between">
+	<div class="flex flex-col gap-4">
+		<h2 class="text-xl font-semibold">Email type:</h2>
+		<Select.Root
+			type="single"
+			value={selectedSchema.email_type}
+			onValueChange={handleSelectSchema}
+		>
+			<Select.Trigger class=""
+				>{snakeToSentenceCase(selectedSchema.email_type)}</Select.Trigger
+			>
+			<Select.Content>
+				{#each schemas as schema (schema.email_type)}
+					<Select.Item value={schema.email_type}
+						>{snakeToSentenceCase(schema.email_type)}</Select.Item
+					>
+				{/each}
+			</Select.Content>
+		</Select.Root>
+	</div>
+	<Button
+		variant="default"
+		type="button"
+		onclick={() => {
+			debouncedPreviewEmail();
+			openPreviewModal = true;
+		}}>Preview</Button
+	>
 </div>
 
 {#if selectedSchema.variables.length > 0}
@@ -120,3 +175,21 @@
 		<Button type="submit">Submit</Button>
 	</div>
 </form>
+
+<Dialog.Root bind:open={openPreviewModal}>
+	<Dialog.Content class="h-[70vh] w-full max-w-6xl sm:w-full sm:max-w-6xl">
+		<Dialog.Header>
+			<Dialog.Title class="flex items-center gap-2">Email preview</Dialog.Title>
+			<Dialog.Description>
+				{#if previewIframeSrc}
+					<iframe
+						src={previewIframeSrc}
+						class="h-[63vh] w-full"
+						title="Email preview"
+						sandbox="allow-same-origin"
+					></iframe>
+				{/if}
+			</Dialog.Description>
+		</Dialog.Header>
+	</Dialog.Content>
+</Dialog.Root>

--- a/ui/packages/comhairle/src/routes/(admin)/admin/email-template-configs/new/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/email-template-configs/new/+page.svelte
@@ -50,14 +50,23 @@
 	async function handleSubmit(e: Event) {
 		e.preventDefault();
 
-		const toHtml: { [key: string]: string } = {};
-		Object.entries(formState.slots).map(([key, value]) => (toHtml[key] = jsonToHtml(value)));
+		const parsed: { [key: string]: string } = {};
+		Object.entries(formState.slots).map(([key, value]) => {
+			const matched = selectedSchema.slots.find((slot) => slot.key === key);
+			if (!matched) return;
+
+			if (matched.content_type === 'rich_text') {
+				parsed[key] = jsonToHtml(value);
+			} else {
+				parsed[key] = value;
+			}
+		});
 
 		try {
 			const emailConfig = await apiClient.CreateEmailTemplateConfig({
 				slots: {
 					type: selectedSchema.email_type,
-					...toHtml
+					...parsed
 				},
 				...(formState.subject && { subject: formState.subject })
 			});
@@ -81,15 +90,20 @@
 
 	const debouncedPreviewEmail = useDebounce(async () => {
 		try {
-			const toHtml: { [key: string]: string } = {};
-			Object.entries(formState.slots).forEach(([key, value]) => {
-				if (value) {
-					toHtml[key] = jsonToHtml(value);
+			const parsed: { [key: string]: string } = {};
+			Object.entries(formState.slots).map(([key, value]) => {
+				const matched = selectedSchema.slots.find((slot) => slot.key === key);
+				if (!matched) return;
+
+				if (matched.content_type === 'rich_text') {
+					parsed[key] = jsonToHtml(value);
+				} else {
+					parsed[key] = value;
 				}
 			});
 
 			const response = await apiClient.PreviewEmailTemplateConfig({
-				slots: { type: selectedSchema.email_type, ...toHtml }
+				slots: { type: selectedSchema.email_type, ...parsed }
 			});
 
 			previewHtml = response.html;
@@ -162,12 +176,20 @@
 				<span>{slot.label}</span>
 				<span class="text-sm font-normal">{slot.hint}</span>
 			</Label>
-			<RichTextEditor
-				width="100%"
-				value={formState.slots[slot.key]}
-				placeholder="Enter email content..."
-				onChange={(json) => (formState.slots[slot.key] = json)}
-			/>
+			{#if slot.content_type === 'plain_text'}
+				<Input
+					placeholder="Enter email content..."
+					defaultValue={formState.slots[slot.key]}
+					onchange={(e) => (formState.slots[slot.key] = e.target?.value)}
+				/>
+			{:else}
+				<RichTextEditor
+					width="100%"
+					value={formState.slots[slot.key]}
+					placeholder="Enter email content..."
+					onChange={(json) => (formState.slots[slot.key] = json)}
+				/>
+			{/if}
 		</div>
 	{/each}
 

--- a/ui/packages/comhairle/src/routes/(admin)/admin/email-template-configs/new/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/email-template-configs/new/+page.svelte
@@ -8,6 +8,7 @@
 	import { jsonToHtml } from '$lib/utils/rich-text.js';
 	import Button from '$lib/components/ui/button/button.svelte';
 	import { goto, invalidateAll } from '$app/navigation';
+	import EmailTemplateVariables from '../EmailTemplateVariables.svelte';
 
 	let { data } = $props();
 	const { schemas } = data;
@@ -68,6 +69,10 @@
 		{/each}
 	</Select.Content>
 </Select.Root>
+
+{#if selectedSchema.variables.length > 0}
+	<EmailTemplateVariables templateVariables={selectedSchema.variables} />
+{/if}
 
 <form onsubmit={handleSubmit}>
 	{#each selectedSchema.slots as slot (slot.key)}

--- a/ui/packages/comhairle/src/routes/(admin)/admin/email-template-configs/new/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/email-template-configs/new/+page.svelte
@@ -26,7 +26,7 @@
 		const output: FormState = {
 			slots: {}
 		};
-		selectedSchema.slots.map((slot) => (output.slots[slot.key] = ''));
+		selectedSchema.slots.map((slot) => (output.slots[slot.key] = slot.default_content));
 		return output;
 	});
 	let previewHtml = $state('');

--- a/ui/packages/comhairle/src/routes/(admin)/admin/email-template-configs/new/+page.ts
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/email-template-configs/new/+page.ts
@@ -1,0 +1,18 @@
+import type { PageLoad } from '../../$types';
+
+export const load: PageLoad = async ({ parent }) => {
+	const { api } = await parent();
+
+	try {
+		const schemas = await api.ListEmailSlotSchemas();
+
+		return { schemas };
+	} catch (e) {
+		console.error(e);
+
+		return {
+			schemas: [],
+			error: e.response?.data?.err || 'Something went wrong loading email schemas'
+		};
+	}
+};

--- a/ui/packages/comhairle/src/routes/(admin)/admin/email-template-configs/new/+page.ts
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/email-template-configs/new/+page.ts
@@ -4,7 +4,7 @@ export const load: PageLoad = async ({ parent }) => {
 	const { api } = await parent();
 
 	try {
-		const schemas = await api.ListEmailSlotSchemas();
+		const schemas = await api.ListEmailTemplateSchemas();
 
 		return { schemas };
 	} catch (e) {


### PR DESCRIPTION
Actions:

- new table and data model for email_template_configs, representing custom configurations for comhairle emails
- schemas to act as a source of truth for email template content, including fallback content
- refactor associated mailer methods to use email_template_configs if available and fallback content from schemas
- admin UI for creating, editing and previewing custom emails

Motiviation:

- allow client configuration of emails and remove hardcoded content

TODO:

- find a solution that will work with scheduled emails
- other mailer methods for other email templates