### PR TITLE
Fixes sync bug and adds endpoints for moderation

### DIFF
--- a/api/src/models/polis_statement_aux.rs
+++ b/api/src/models/polis_statement_aux.rs
@@ -1,3 +1,4 @@
+use crate::models::{self, users::User};
 use chrono::{DateTime, Utc};
 use schemars::JsonSchema;
 use sea_query::{
@@ -9,31 +10,7 @@ use sqlx::{prelude::FromRow, query_as_with, PgPool};
 use tracing::instrument;
 use uuid::Uuid;
 
-use crate::error::ComhairleError;
-
-#[derive(Debug, Deserialize, Serialize, PartialEq, sqlx::Type, Clone, JsonSchema, Default)]
-#[sqlx(type_name = "TEXT")]
-#[serde(rename_all = "snake_case")]
-pub enum ModerationStatus {
-    #[sqlx(rename = "accepted")]
-    Accepted,
-    #[sqlx(rename = "rejected")]
-    Rejected,
-    #[sqlx(rename = "pending")]
-    #[default]
-    Pending,
-}
-
-impl std::fmt::Display for ModerationStatus {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let value = match self {
-            ModerationStatus::Accepted => "accepted",
-            ModerationStatus::Rejected => "rejected",
-            ModerationStatus::Pending => "pending",
-        };
-        write!(f, "{}", value)
-    }
-}
+use crate::{error::ComhairleError, wiki_poll_service::ModerationStatus};
 
 impl From<ModerationStatus> for sea_query::Value {
     fn from(val: ModerationStatus) -> Self {
@@ -157,6 +134,7 @@ pub struct UpsertFromPolis {
     pub polis_statement_id: i32,
     pub statement_text: String,
     pub is_seed: bool,
+    pub moderation_status: ModerationStatus,
 }
 
 /// Upsert a row from polis. On conflict (workflow_step_id, polis_statement_id),
@@ -176,6 +154,7 @@ pub async fn upsert_from_polis(
         PolisStatementAuxIden::PolisStatementId,
         PolisStatementAuxIden::StatementText,
         PolisStatementAuxIden::IsSeed,
+        PolisStatementAuxIden::ModerationStatus,
     ];
     let values: Vec<SimpleExpr> = vec![
         record.workflow_step_id.into(),
@@ -185,6 +164,7 @@ pub async fn upsert_from_polis(
         record.polis_statement_id.into(),
         record.statement_text.clone().into(),
         record.is_seed.into(),
+        record.moderation_status.clone().into(),
     ];
 
     let (sql, values) = Query::insert()
@@ -266,11 +246,11 @@ pub async fn update(
 }
 
 #[instrument(err(Debug))]
-pub async fn get_by_id(db: &PgPool, id: Uuid) -> Result<PolisStatementAux, ComhairleError> {
+pub async fn get_by_id(db: &PgPool, id: &Uuid) -> Result<PolisStatementAux, ComhairleError> {
     let (sql, values) = Query::select()
         .from(PolisStatementAuxIden::Table)
         .columns(DEFAULT_COLUMNS)
-        .and_where(Expr::col(PolisStatementAuxIden::Id).eq(id))
+        .and_where(Expr::col(PolisStatementAuxIden::Id).eq(*id))
         .build_sqlx(PostgresQueryBuilder);
 
     let aux = query_as_with(&sql, values)
@@ -316,6 +296,40 @@ impl PolisStatementAuxFilterOptions {
 
         query
     }
+}
+
+#[instrument(err(Debug))]
+pub async fn check_is_commentor(
+    db: &PgPool,
+    aux_id: &Uuid,
+    user_id: &Uuid,
+) -> Result<(), ComhairleError> {
+    let aux = get_by_id(db, aux_id).await?;
+
+    if aux.user_id != Some(*user_id) {
+        return Err(ComhairleError::UserNotAuthorized);
+    }
+
+    Ok(())
+}
+
+#[instrument(err(Debug))]
+pub async fn check_can_moderate(
+    db: &PgPool,
+    user: &User,
+    workflow_step_id: &Uuid,
+) -> Result<(), ComhairleError> {
+    let workflow_step = models::workflow_step::get_by_id(db, workflow_step_id).await?;
+
+    let workflow = models::workflow::get_by_id(db, &workflow_step.workflow_id).await?;
+    let conversation_id = workflow.conversation_id.ok_or(ComhairleError::BadRequest(
+        "workflow is not attached to a conversation".into(),
+    ))?;
+    let conversation = models::conversation::get_by_id(&db, &conversation_id).await?;
+    if conversation.owner_id != user.id {
+        return Err(ComhairleError::UserNotAuthorized);
+    }
+    Ok(())
 }
 
 #[instrument(err(Debug))]

--- a/api/src/models/user_participation.rs
+++ b/api/src/models/user_participation.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use sqlx::{prelude::FromRow, PgPool};
 use uuid::Uuid;
 
-use crate::error::ComhairleError;
+use crate::{error::ComhairleError, models::users::User};
 
 #[derive(Partial, Debug, Deserialize, Serialize, FromRow, Clone, JsonSchema)]
 #[enum_def(table_name = "user_participation")]
@@ -98,6 +98,34 @@ pub async fn delete(
         .map_err(|_| ComhairleError::ResourceNotFound("UserParticipation".into()))?;
 
     Ok(user_participation)
+}
+
+pub async fn check_user_participating(
+    db: &PgPool,
+    workflow_id: &Uuid,
+    user_id: &Uuid,
+) -> Result<(), ComhairleError> {
+    let (sql, values) = Query::select()
+        .from(UserParticipationIden::Table)
+        .column(UserParticipationIden::UserId)
+        .and_where(
+            Expr::col((
+                UserParticipationIden::Table,
+                UserParticipationIden::WorkflowId,
+            ))
+            .eq(*workflow_id),
+        )
+        .and_where(
+            Expr::col((UserParticipationIden::Table, UserParticipationIden::UserId)).eq(*user_id),
+        )
+        .build_sqlx(PostgresQueryBuilder);
+
+    sqlx::query_with(&sql, values)
+        .fetch_all(db)
+        .await
+        .map_err(|_| ComhairleError::ResourceNotFound("UserParticipation".into()))?;
+
+    Ok(())
 }
 
 pub async fn get_participant_user_ids_for_conversation(

--- a/api/src/models/workflow.rs
+++ b/api/src/models/workflow.rs
@@ -119,6 +119,23 @@ pub async fn launch(
     Ok(())
 }
 
+pub async fn check_user_is_owner(
+    db: &PgPool,
+    workflow_id: &Uuid,
+    user_id: &Uuid,
+) -> Result<(), ComhairleError> {
+    let workflow = get_by_id(&db, workflow_id).await?;
+    if let Some(conversation_id) = workflow.conversation_id {
+        let conversation = get_by_id(&db, &conversation_id).await?;
+        if conversation.owner_id != *user_id {
+            return Err(ComhairleError::UserNotAuthorized);
+        }
+    } else {
+        return Err(ComhairleError::UserNotAuthorized);
+    }
+    Ok(())
+}
+
 #[derive(Serialize, Deserialize, Debug, JsonSchema)]
 #[cfg_attr(test, derive(Dummy))]
 pub struct CreateWorkflow {

--- a/api/src/models/workflow_step.rs
+++ b/api/src/models/workflow_step.rs
@@ -791,7 +791,11 @@ mod tests {
 
         let initial_progress =
             models::user_progress::list_for_user_on_workflow(&pool, &user.id, &workflow.id).await?;
-        assert_eq!(initial_progress.len(), 1, "expected one progress row after register");
+        assert_eq!(
+            initial_progress.len(),
+            1,
+            "expected one progress row after register"
+        );
 
         let new_steps_res = session
             .create_random_workflow_steps(

--- a/api/src/tools/polis.rs
+++ b/api/src/tools/polis.rs
@@ -515,7 +515,7 @@ async fn moderate_statement_aux(
 
     let updated = models::polis_statement_aux::update(
         &state.db,
-        request.statement_id,
+        statement_id,
         &UpdatePolisStatementAux {
             statement_text: None,
             moderation_status: Some(request.decision.into()),

--- a/api/src/tools/polis.rs
+++ b/api/src/tools/polis.rs
@@ -549,34 +549,6 @@ async fn theme_stats(
     Ok((StatusCode::OK, Json(stats)))
 }
 
-/// Logs a user into polis and proxies the cookie
-/// to the frontend
-async fn admin_login(
-    State(state): State<Arc<ComhairleState>>,
-    Query(AdminLoginQuery { workflow_step_id }): Query<AdminLoginQuery>,
-    cookies: CookieJar,
-) -> Result<(CookieJar, (StatusCode, Json<String>)), ComhairleError> {
-    let workflow_step = models::workflow_step::get_by_id(&state.db, &workflow_step_id).await?;
-
-    if let ToolConfig::Polis(config) = workflow_step.preview_tool_config {
-        let client = &state.wiki_poll_service;
-        let cookie = client
-            .login(&WikiPollLogin {
-                email: config.admin_user,
-                password: config.admin_password,
-            })
-            .await?;
-        let mut parsed_cookie = Cookie::parse(cookie).map_err(|_| PolisError::FailedToLogin)?;
-        parsed_cookie.set_domain("comhairle.scot");
-
-        let new_cookies = cookies.add(parsed_cookie);
-
-        Ok((new_cookies, (StatusCode::OK, Json("logged in".into()))))
-    } else {
-        Err(ComhairleError::WorkflowStepHasWrongType("Polis".into()))
-    }
-}
-
 #[instrument(err(Debug), skip(client))]
 pub async fn launch(
     preview_config: &PolisToolConfig,

--- a/api/src/tools/polis.rs
+++ b/api/src/tools/polis.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use crate::models::polis_statement_aux;
 use aide::axum::{
     routing::{get_with, post_with, put_with},
     ApiRouter,
@@ -26,7 +27,9 @@ use crate::{
         },
     },
     routes::auth::RequiredUser,
-    wiki_poll_service::{polis_service::WikiPollReport, WikiPollLogin, WikiPollService},
+    wiki_poll_service::{
+        polis_service::WikiPollReport, ModerationStatus, WikiPollLogin, WikiPollService,
+    },
     ComhairleState,
 };
 
@@ -102,15 +105,6 @@ impl ToolImpl for PolisTool {
 
     fn routes(state: &Arc<ComhairleState>) -> ApiRouter {
         ApiRouter::new()
-            .api_route(
-                "/polis/admin_login",
-                post_with(admin_login, |op| {
-                    op.id("PolisAdminLogin")
-                        .tag("Tools")
-                        .summary("Login as Polis admin and proxy cookie")
-                        .description("Logs into Polis as admin and returns session cookie")
-                }),
-            )
             .api_route(
                 "/polis/report_data",
                 get_with(get_report_data, |op| {
@@ -189,6 +183,21 @@ impl ToolImpl for PolisTool {
                         .response::<200, Json<Vec<ThemeStatistic>>>()
                 }),
             )
+            .api_route(
+                "/polis/statement_aux/moderate",
+                post_with(moderate_statement_aux, |op| {
+                    op.id("PolisModerateStatementAux")
+                        .tag("Tools")
+                        .summary("Moderate a Polis statement")
+                        .description(
+                            "Forwards a moderation decision (accept/reject) to the Polis \
+                             server using the admin account, then updates the \
+                             polis_statement_aux row's moderation_status and \
+                             moderation_reason",
+                        )
+                        .response::<200, Json<PolisStatementAux>>()
+                }),
+            )
             .with_state(state.clone())
     }
 }
@@ -215,6 +224,9 @@ pub enum PolisError {
 
     #[error("Failed to post seed comment {0}")]
     FailedToPostSeedComment(String),
+
+    #[error("Failed to moderate comment {0}")]
+    FailedToModerateComment(String),
 
     #[error("Failed to proxy route {from} : {to}")]
     ProxyError { from: String, to: String },
@@ -312,6 +324,16 @@ async fn create_statement_aux(
     RequiredUser(user): RequiredUser,
     Json(create_request): Json<CreatePolisStatementAux>,
 ) -> Result<(StatusCode, Json<PolisStatementAux>), ComhairleError> {
+    let workflow_step =
+        models::workflow_step::get_by_id(&state.db, &create_request.workflow_step_id).await?;
+
+    models::user_participation::check_user_participating(
+        &state.db,
+        &workflow_step.workflow_id,
+        &user.id,
+    )
+    .await?;
+
     let aux = models::polis_statement_aux::create(&state.db, user.id, &create_request).await?;
     Ok((StatusCode::CREATED, Json(aux)))
 }
@@ -319,10 +341,11 @@ async fn create_statement_aux(
 #[instrument(err(Debug), skip(state))]
 async fn update_statement_aux(
     State(state): State<Arc<ComhairleState>>,
-    RequiredUser(_user): RequiredUser,
+    RequiredUser(user): RequiredUser,
     Path(id): Path<Uuid>,
     Json(update_request): Json<UpdatePolisStatementAux>,
 ) -> Result<(StatusCode, Json<PolisStatementAux>), ComhairleError> {
+    models::polis_statement_aux::check_is_commentor(&state.db, &id, &user.id).await?;
     let aux = models::polis_statement_aux::update(&state.db, id, &update_request).await?;
     Ok((StatusCode::OK, Json(aux)))
 }
@@ -369,10 +392,11 @@ pub struct SyncStatementAuxResponse {
 #[instrument(err(Debug), skip(state))]
 async fn sync_statement_aux(
     State(state): State<Arc<ComhairleState>>,
-    RequiredUser(_user): RequiredUser,
+    RequiredUser(user): RequiredUser,
     Json(SyncStatementAuxRequest { workflow_step_id }): Json<SyncStatementAuxRequest>,
 ) -> Result<(StatusCode, Json<SyncStatementAuxResponse>), ComhairleError> {
     let workflow_step = models::workflow_step::get_by_id(&state.db, &workflow_step_id).await?;
+    models::workflow::check_user_is_owner(&state.db, &workflow_step.workflow_id, &user.id).await?;
 
     let config = match (workflow_step.tool_config, workflow_step.preview_tool_config) {
         (Some(ToolConfig::Polis(config)), _) => config,
@@ -414,6 +438,7 @@ async fn sync_statement_aux(
                 polis_statement_id: comment.tid as i32,
                 statement_text: comment.txt,
                 is_seed: comment.is_seed,
+                moderation_status: comment.moderation.try_into()?,
             },
         )
         .await?;
@@ -428,6 +453,80 @@ async fn sync_statement_aux(
             statements,
         }),
     ))
+}
+
+#[derive(Serialize, Deserialize, JsonSchema, Debug, Clone, Copy)]
+#[serde(rename_all = "snake_case")]
+pub enum ModerationDecisionRequest {
+    Accept,
+    Reject,
+}
+
+impl From<ModerationDecisionRequest> for ModerationStatus {
+    fn from(value: ModerationDecisionRequest) -> Self {
+        match value {
+            ModerationDecisionRequest::Accept => ModerationStatus::Accepted,
+            ModerationDecisionRequest::Reject => ModerationStatus::Rejected,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, JsonSchema, Debug)]
+pub struct ModerateStatementAuxRequest {
+    pub decision: ModerationDecisionRequest,
+    pub moderation_reason: Option<String>,
+    pub statement_id: Uuid,
+}
+
+#[instrument(err(Debug), skip(state))]
+async fn moderate_statement_aux(
+    State(state): State<Arc<ComhairleState>>,
+    RequiredUser(user): RequiredUser,
+    Json(request): Json<ModerateStatementAuxRequest>,
+) -> Result<(StatusCode, Json<PolisStatementAux>), ComhairleError> {
+    let aux = models::polis_statement_aux::get_by_id(&state.db, &request.statement_id).await?;
+
+    polis_statement_aux::check_can_moderate(&state.db, &user, &aux.workflow_step_id).await?;
+
+    let workflow_step = models::workflow_step::get_by_id(&state.db, &aux.workflow_step_id).await?;
+
+    let config = match (workflow_step.tool_config, workflow_step.preview_tool_config) {
+        (Some(ToolConfig::Polis(config)), _) => config,
+        (None, ToolConfig::Polis(config)) => config,
+        _ => return Err(ComhairleError::WorkflowStepHasWrongType("Polis".into())),
+    };
+
+    let client = &state.wiki_poll_service;
+    let auth_cookies = client
+        .login(&WikiPollLogin {
+            email: config.admin_user.clone(),
+            password: config.admin_password.clone(),
+        })
+        .await?;
+
+    client
+        .moderate_comment(
+            &config.poll_id,
+            aux.polis_statement_id,
+            request.decision.into(),
+            &auth_cookies,
+        )
+        .await?;
+
+    let updated = models::polis_statement_aux::update(
+        &state.db,
+        request.statement_id,
+        &UpdatePolisStatementAux {
+            statement_text: None,
+            moderation_status: Some(request.decision.into()),
+            themes: None,
+            visible_statement_when_submitted: None,
+            moderation_reason: request.moderation_reason,
+        },
+    )
+    .await?;
+
+    Ok((StatusCode::OK, Json(updated)))
 }
 
 #[instrument(err(Debug), skip(state))]

--- a/api/src/tools/polis.rs
+++ b/api/src/tools/polis.rs
@@ -184,7 +184,7 @@ impl ToolImpl for PolisTool {
                 }),
             )
             .api_route(
-                "/polis/statement_aux/moderate",
+                "/polis/statement_aux/{id}/moderate",
                 post_with(moderate_statement_aux, |op| {
                     op.id("PolisModerateStatementAux")
                         .tag("Tools")
@@ -475,16 +475,16 @@ impl From<ModerationDecisionRequest> for ModerationStatus {
 pub struct ModerateStatementAuxRequest {
     pub decision: ModerationDecisionRequest,
     pub moderation_reason: Option<String>,
-    pub statement_id: Uuid,
 }
 
 #[instrument(err(Debug), skip(state))]
 async fn moderate_statement_aux(
     State(state): State<Arc<ComhairleState>>,
     RequiredUser(user): RequiredUser,
+    Path(statement_id): Path<Uuid>,
     Json(request): Json<ModerateStatementAuxRequest>,
 ) -> Result<(StatusCode, Json<PolisStatementAux>), ComhairleError> {
-    let aux = models::polis_statement_aux::get_by_id(&state.db, &request.statement_id).await?;
+    let aux = models::polis_statement_aux::get_by_id(&state.db, &statement_id).await?;
 
     polis_statement_aux::check_can_moderate(&state.db, &user, &aux.workflow_step_id).await?;
 

--- a/api/src/wiki_poll_service.rs
+++ b/api/src/wiki_poll_service.rs
@@ -4,7 +4,44 @@ pub mod polis_service;
 use crate::wiki_poll_service::{error::WikiPollServiceError, polis_service::WikiPollReport};
 
 use async_trait::async_trait;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Deserialize, Serialize, PartialEq, sqlx::Type, Clone, JsonSchema, Default)]
+#[sqlx(type_name = "TEXT")]
+#[serde(rename_all = "snake_case")]
+pub enum ModerationStatus {
+    #[sqlx(rename = "accepted")]
+    Accepted,
+    #[sqlx(rename = "rejected")]
+    Rejected,
+    #[sqlx(rename = "pending")]
+    #[default]
+    Pending,
+}
+
+impl std::fmt::Display for ModerationStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let value = match self {
+            ModerationStatus::Accepted => "accepted",
+            ModerationStatus::Rejected => "rejected",
+            ModerationStatus::Pending => "pending",
+        };
+        write!(f, "{}", value)
+    }
+}
+
+impl TryFrom<i32> for ModerationStatus {
+    type Error = WikiPollServiceError;
+    fn try_from(value: i32) -> Result<Self, WikiPollServiceError> {
+        match value {
+            -1 => Ok(ModerationStatus::Rejected),
+            1 => Ok(ModerationStatus::Accepted),
+            0 => Ok(ModerationStatus::Pending),
+            _ => Err(WikiPollServiceError::UnknownModerationStatus),
+        }
+    }
+}
 
 #[cfg(test)]
 use mockall::automock;
@@ -37,6 +74,28 @@ pub trait WikiPollService: Send + Sync {
     ) -> Result<Vec<WikiPollXid>, WikiPollServiceError>;
 
     async fn get_report_data(&self, poll_id: &str) -> Result<WikiPollReport, WikiPollServiceError>;
+
+    async fn moderate_comment(
+        &self,
+        poll_id: &str,
+        tid: i32,
+        decision: ModerationStatus,
+        auth_cookies: &str,
+    ) -> Result<(), WikiPollServiceError>;
+}
+
+impl ModerationStatus {
+    pub fn mod_value(self) -> i32 {
+        match self {
+            ModerationStatus::Accepted => 1,
+            ModerationStatus::Rejected => -1,
+            ModerationStatus::Pending => 0,
+        }
+    }
+
+    pub fn active(self) -> bool {
+        matches!(self, ModerationStatus::Accepted)
+    }
 }
 
 #[derive(Deserialize, Serialize)]
@@ -55,6 +114,8 @@ pub struct WikiPollComment {
     pub pid: u32,
     pub quote_src_url: Option<String>,
     pub created: String,
+    #[serde(alias = "mod")]
+    pub moderation: i32,
 }
 
 #[derive(Deserialize, Serialize, Debug, Default)]
@@ -91,6 +152,9 @@ impl MockWikiPollService {
         wiki_poll_service
             .expect_get_xids()
             .returning(|_, _| Box::pin(async move { Ok(vec![]) }));
+        wiki_poll_service
+            .expect_moderate_comment()
+            .returning(|_, _, _, _| Box::pin(async move { Ok(()) }));
 
         wiki_poll_service
     }

--- a/api/src/wiki_poll_service/error.rs
+++ b/api/src/wiki_poll_service/error.rs
@@ -11,4 +11,7 @@ pub enum WikiPollServiceError {
 
     #[error("HTTP error: {0}")]
     Http(#[from] reqwest::Error),
+
+    #[error("Moderation status integer not recognized")]
+    UnknownModerationStatus,
 }

--- a/api/src/wiki_poll_service/polis_service.rs
+++ b/api/src/wiki_poll_service/polis_service.rs
@@ -15,7 +15,8 @@ use tracing::{info, instrument, warn};
 use crate::{
     tools::polis::PolisError,
     wiki_poll_service::{
-        error::WikiPollServiceError, WikiPollComment, WikiPollLogin, WikiPollService, WikiPollXid,
+        error::WikiPollServiceError, ModerationStatus, WikiPollComment, WikiPollLogin,
+        WikiPollService, WikiPollXid,
     },
 };
 
@@ -167,6 +168,8 @@ pub struct PolisComment {
     pub pid: u32,
     pub quote_src_url: Option<String>,
     pub created: String,
+    #[serde(alias = "mod")]
+    pub moderation: i32,
 }
 
 impl PolisClient {
@@ -207,7 +210,7 @@ impl PolisClient {
 
     pub async fn get_comments(&self, poll_id: &str) -> Result<Vec<PolisComment>, PolisError> {
         let url = format!(
-            "https://{}/api/v3/comments?conversation_id={poll_id}",
+            "https://{}/api/v3/comments?conversation_id={poll_id}&moderation=true",
             self.base_url
         );
         let comments: Vec<PolisComment> =
@@ -586,6 +589,44 @@ impl WikiPollService for PolisClient {
 
         // Transform the raw data into structured report format
         self.transform_report_data(math_pca, comments_data)
+    }
+
+    #[instrument(err(Debug), skip(self, auth_cookies))]
+    async fn moderate_comment(
+        &self,
+        poll_id: &str,
+        tid: i32,
+        decision: ModerationStatus,
+        auth_cookies: &str,
+    ) -> Result<(), WikiPollServiceError> {
+        let body = json!({
+            "conversation_id": poll_id,
+            "tid": tid,
+            "active": decision.clone().active(),
+            "mod": decision.mod_value(),
+            "is_meta": false,
+            "velocity": 1,
+        });
+
+        let resp = self
+            .client
+            .put(format!("https://{}/api/v3/comments", self.base_url))
+            .header(COOKIE, auth_cookies)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| PolisError::FailedToModerateComment(e.to_string()))?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let text = resp.text().await.unwrap_or_default();
+            return Err(PolisError::FailedToModerateComment(format!(
+                "polis returned {status}: {text}"
+            ))
+            .into());
+        }
+
+        Ok(())
     }
 }
 

--- a/ui/packages/api-client/src/api.ts
+++ b/ui/packages/api-client/src/api.ts
@@ -411,6 +411,19 @@ export const ThemeStatistic = z
   .object({ count: z.number().int(), theme: z.string() })
   .passthrough();
 export type ThemeStatistic = z.infer<typeof ThemeStatistic>;
+export const ModerationDecisionRequest = z.enum(["accept", "reject"]);
+export type ModerationDecisionRequest = z.infer<
+  typeof ModerationDecisionRequest
+>;
+export const ModerateStatementAuxRequest = z
+  .object({
+    decision: ModerationDecisionRequest,
+    moderation_reason: z.union([z.string(), z.null()]).optional(),
+  })
+  .passthrough();
+export type ModerateStatementAuxRequest = z.infer<
+  typeof ModerateStatementAuxRequest
+>;
 export const Story = z
   .object({
     id: z.string().uuid(),
@@ -1919,6 +1932,8 @@ export const schemas: Record<string, z.ZodType<any>> = {
   SyncStatementAuxRequest,
   SyncStatementAuxResponse,
   ThemeStatistic,
+  ModerationDecisionRequest,
+  ModerateStatementAuxRequest,
   Story,
   ComhairleMessageReference,
   ComhairleSessionMessage,
@@ -3756,21 +3771,6 @@ Use a raw HTTP request and process the response body incrementally.
     response: z.void(),
   },
   {
-    method: "post",
-    path: "/tools/polis/admin_login",
-    alias: "PolisAdminLogin",
-    description: `Logs into Polis as admin and returns session cookie`,
-    requestFormat: "json",
-    parameters: [
-      {
-        name: "workflow_step_id",
-        type: "Query",
-        schema: z.string().uuid(),
-      },
-    ],
-    response: z.void(),
-  },
-  {
     method: "get",
     path: "/tools/polis/report_data",
     alias: "PolisGetReportData",
@@ -3831,6 +3831,21 @@ Use a raw HTTP request and process the response body incrementally.
         name: "body",
         type: "Body",
         schema: UpdatePolisStatementAux,
+      },
+    ],
+    response: PolisStatementAux,
+  },
+  {
+    method: "post",
+    path: "/tools/polis/statement_aux/:id/moderate",
+    alias: "PolisModerateStatementAux",
+    description: `Forwards a moderation decision (accept/reject) to the Polis server using the admin account, then updates the polis_statement_aux row&#x27;s moderation_status and moderation_reason`,
+    requestFormat: "json",
+    parameters: [
+      {
+        name: "body",
+        type: "Body",
+        schema: ModerateStatementAuxRequest,
       },
     ],
     response: PolisStatementAux,


### PR DESCRIPTION
This PR 

1. Fixes a quick bug where only approved statements where being synced from polis
2. Fixes a bug where the moderation state was not being synced properly
3. Adds an endpoint to moderate statements 
4. Adds some checking for permissions on polis operations