### PR TITLE
Add audio recording self-serve endpoints

### DIFF
--- a/api/migrations/20260622114306_create_audio_recording_table.sql
+++ b/api/migrations/20260622114306_create_audio_recording_table.sql
@@ -1,0 +1,14 @@
+-- Create audio recording table to track audio uploads for events
+-- One record per event with all breakout room IDs and overall status
+CREATE TABLE audio_recording (
+    id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+    event_id uuid NOT NULL UNIQUE REFERENCES event(id) ON DELETE CASCADE,
+    breakout_room_ids TEXT[] NOT NULL DEFAULT '{}',
+    s3_key_prefix TEXT NOT NULL,
+    status TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Add index for querying recordings by event
+CREATE INDEX idx_audio_recording_event_id ON audio_recording(event_id);

--- a/api/src/bulk_storage_service.rs
+++ b/api/src/bulk_storage_service.rs
@@ -172,9 +172,9 @@ impl MockBulkStorageService {
             Box::pin(async move { Ok("https://storage.com/signed_dowload_path".to_owned()) })
         });
 
-        storage.expect_list_keys().returning(|_, _| {
-            Box::pin(async move { Ok(vec!["recording.wav".to_string()]) })
-        });
+        storage
+            .expect_list_keys()
+            .returning(|_, _| Box::pin(async move { Ok(vec!["recording.wav".to_string()]) }));
 
         storage
     }

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -267,6 +267,10 @@ pub async fn setup_server(state: Arc<ComhairleState>) -> Result<Router<()>, Comh
                                         WorkflowRouterContext::Event,
                                     ),
                                 ),
+                        )
+                        .nest_api_service(
+                            "/{event_id}/audio-recordings",
+                            routes::audio_recordings::router(state.clone()),
                         ),
                 ),
         )

--- a/api/src/models.rs
+++ b/api/src/models.rs
@@ -1,6 +1,7 @@
 use crate::error::ComhairleError;
 
 pub mod api_key;
+pub mod audio_recording;
 pub mod bot_service_user_session;
 pub mod conversation;
 pub mod conversation_email_notification_recipients;

--- a/api/src/models/audio_recording.rs
+++ b/api/src/models/audio_recording.rs
@@ -1,0 +1,360 @@
+use chrono::{DateTime, Utc};
+use schemars::JsonSchema;
+use sea_query::{enum_def, Expr, PostgresQueryBuilder, Query};
+use sea_query_binder::SqlxBinder;
+use serde::{Deserialize, Serialize};
+use sqlx::{prelude::FromRow, PgPool};
+use uuid::Uuid;
+
+use crate::error::ComhairleError;
+
+/// Status of an audio recording's transcription and processing
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum AudioRecordingStatus {
+    /// Recording uploaded, waiting to be processed
+    Pending,
+    /// Recording has been transcribed and report generated
+    Completed,
+    /// Recording failed during transcription/processing
+    Failed,
+}
+
+impl ToString for AudioRecordingStatus {
+    fn to_string(&self) -> String {
+        match self {
+            AudioRecordingStatus::Pending => "pending".to_string(),
+            AudioRecordingStatus::Completed => "completed".to_string(),
+            AudioRecordingStatus::Failed => "failed".to_string(),
+        }
+    }
+}
+
+/// Parse status from string (handles database TEXT type)
+impl AudioRecordingStatus {
+    pub fn from_string(s: &str) -> Result<Self, ComhairleError> {
+        match s {
+            "pending" => Ok(AudioRecordingStatus::Pending),
+            "completed" => Ok(AudioRecordingStatus::Completed),
+            "failed" => Ok(AudioRecordingStatus::Failed),
+            _ => Err(ComhairleError::ResourceNotFound(format!(
+                "Unknown status: {}",
+                s
+            ))),
+        }
+    }
+}
+
+/// An audio recording associated with an event and its breakout rooms
+///
+/// One record per event that tracks all breakout rooms and the overall status
+/// of transcription and report generation. The status reflects the entire
+/// multi-room processing pipeline.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct AudioRecording {
+    /// Unique identifier for this recording set
+    pub id: Uuid,
+    /// Event this recording belongs to
+    pub event_id: Uuid,
+    /// List of breakout room IDs
+    pub breakout_room_ids: Vec<String>,
+    /// S3 key prefix (without extension) used for generating URLs
+    /// Used as base for main and breakout room recordings
+    pub s3_key_prefix: String,
+    /// Current status of transcription/processing for entire event
+    pub status: AudioRecordingStatus,
+    /// When this recording was created
+    pub created_at: DateTime<Utc>,
+    /// When this recording's status was last updated
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Intermediate struct for database queries (with enum_def for sea_query)
+#[derive(Debug, FromRow, Clone)]
+#[enum_def(table_name = "audio_recording")]
+pub struct RawAudioRecording {
+    pub id: Uuid,
+    pub event_id: Uuid,
+    pub breakout_room_ids: Vec<String>,
+    pub s3_key_prefix: String,
+    pub status: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+const DEFAULT_COLUMNS: [RawAudioRecordingIden; 7] = [
+    RawAudioRecordingIden::Id,
+    RawAudioRecordingIden::EventId,
+    RawAudioRecordingIden::BreakoutRoomIds,
+    RawAudioRecordingIden::S3KeyPrefix,
+    RawAudioRecordingIden::Status,
+    RawAudioRecordingIden::CreatedAt,
+    RawAudioRecordingIden::UpdatedAt,
+];
+
+impl From<RawAudioRecording> for AudioRecording {
+    fn from(raw: RawAudioRecording) -> Self {
+        Self {
+            id: raw.id,
+            event_id: raw.event_id,
+            breakout_room_ids: raw.breakout_room_ids,
+            s3_key_prefix: raw.s3_key_prefix,
+            status: AudioRecordingStatus::from_string(&raw.status)
+                .unwrap_or(AudioRecordingStatus::Pending),
+            created_at: raw.created_at,
+            updated_at: raw.updated_at,
+        }
+    }
+}
+
+/// Request to create a new audio recording record
+#[derive(Debug, Clone, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct CreateAudioRecording {
+    pub event_id: Uuid,
+    pub breakout_room_ids: Vec<String>,
+    pub s3_key_prefix: String,
+}
+
+/// Create a new audio recording in the database
+pub async fn create(
+    db: &PgPool,
+    create_recording: &CreateAudioRecording,
+) -> Result<AudioRecording, ComhairleError> {
+    let (sql, values) = Query::insert()
+        .into_table(RawAudioRecordingIden::Table)
+        .columns([
+            RawAudioRecordingIden::EventId,
+            RawAudioRecordingIden::BreakoutRoomIds,
+            RawAudioRecordingIden::S3KeyPrefix,
+            RawAudioRecordingIden::Status,
+        ])
+        .values([
+            create_recording.event_id.into(),
+            create_recording.breakout_room_ids.clone().into(),
+            create_recording.s3_key_prefix.clone().into(),
+            "pending".into(),
+        ])
+        .unwrap()
+        .returning(Query::returning().columns(DEFAULT_COLUMNS))
+        .build_sqlx(PostgresQueryBuilder);
+
+    let recording = sqlx::query_as_with::<_, RawAudioRecording, _>(&sql, values)
+        .fetch_one(db)
+        .await?;
+
+    Ok(recording.into())
+}
+
+/// Get an audio recording by ID
+pub async fn get_by_id(db: &PgPool, recording_id: &Uuid) -> Result<AudioRecording, ComhairleError> {
+    let (sql, values) = Query::select()
+        .columns(DEFAULT_COLUMNS)
+        .from(RawAudioRecordingIden::Table)
+        .and_where(Expr::col(RawAudioRecordingIden::Id).eq(*recording_id))
+        .build_sqlx(PostgresQueryBuilder);
+
+    let recording = sqlx::query_as_with::<_, RawAudioRecording, _>(&sql, values)
+        .fetch_optional(db)
+        .await?
+        .ok_or(ComhairleError::ResourceNotFound(
+            "Audio recording not found".to_string(),
+        ))?;
+
+    Ok(recording.into())
+}
+
+/// Get recording for an event (one per event)
+pub async fn get_by_event(db: &PgPool, event_id: &Uuid) -> Result<AudioRecording, ComhairleError> {
+    let (sql, values) = Query::select()
+        .columns(DEFAULT_COLUMNS)
+        .from(RawAudioRecordingIden::Table)
+        .and_where(Expr::col(RawAudioRecordingIden::EventId).eq(*event_id))
+        .build_sqlx(PostgresQueryBuilder);
+
+    let recording = sqlx::query_as_with::<_, RawAudioRecording, _>(&sql, values)
+        .fetch_optional(db)
+        .await?
+        .ok_or(ComhairleError::ResourceNotFound(
+            "Audio recording not found for event".to_string(),
+        ))?;
+
+    Ok(recording.into())
+}
+
+/// Update the status of an audio recording
+pub async fn update_status(
+    db: &PgPool,
+    recording_id: &Uuid,
+    status: AudioRecordingStatus,
+) -> Result<AudioRecording, ComhairleError> {
+    let (sql, values) = Query::update()
+        .table(RawAudioRecordingIden::Table)
+        .value(RawAudioRecordingIden::Status, status.to_string())
+        .value(RawAudioRecordingIden::UpdatedAt, Expr::cust("NOW()"))
+        .and_where(Expr::col(RawAudioRecordingIden::Id).eq(*recording_id))
+        .returning(Query::returning().columns(DEFAULT_COLUMNS))
+        .build_sqlx(PostgresQueryBuilder);
+
+    let recording = sqlx::query_as_with::<_, RawAudioRecording, _>(&sql, values)
+        .fetch_one(db)
+        .await?;
+
+    Ok(recording.into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::sync::Arc;
+
+    use crate::routes::conversations::dto::ConversationDto;
+    use crate::routes::events::dto::EventDto;
+    use crate::setup_server;
+    use crate::test_helpers::{test_config, test_state, UserSession};
+
+    async fn create_random_event(
+        session: &mut UserSession,
+        app: &axum::Router,
+    ) -> Result<EventDto, Box<dyn std::error::Error>> {
+        let conversation_response = session.create_random_conversation(app).await?;
+        let conversation: ConversationDto = serde_json::from_value(conversation_response.1)?;
+        let conversation_id: String = conversation.id.to_string();
+
+        let event_response = session.create_random_event(app, &conversation_id).await?;
+        let event: EventDto = serde_json::from_value(event_response.1)?;
+
+        Ok(event)
+    }
+
+    #[sqlx::test]
+    async fn test_create_audio_recording(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let mut config = test_config()?;
+        config.bot_service = None;
+        let state = Arc::new(test_state().db(pool.clone()).config(config).call()?);
+        let app = setup_server(state.clone()).await?;
+
+        let mut session = UserSession::new_admin();
+        session.signup(&app).await?;
+
+        let event = create_random_event(&mut session, &app).await?;
+
+        let create_req = CreateAudioRecording {
+            event_id: event.id,
+            breakout_room_ids: vec!["room1".to_string(), "room2".to_string()],
+            s3_key_prefix: "test/prefix".to_string(),
+        };
+
+        let recording = create(&pool, &create_req).await?;
+        assert_eq!(recording.event_id, create_req.event_id);
+        assert_eq!(recording.breakout_room_ids, create_req.breakout_room_ids);
+        assert_eq!(recording.s3_key_prefix, create_req.s3_key_prefix);
+        assert_eq!(recording.status, AudioRecordingStatus::Pending);
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn test_get_by_id(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>> {
+        let mut config = test_config()?;
+        config.bot_service = None;
+        let state = Arc::new(test_state().db(pool.clone()).config(config).call()?);
+        let app = setup_server(state.clone()).await?;
+
+        let mut session = UserSession::new_admin();
+        session.signup(&app).await?;
+
+        let event = create_random_event(&mut session, &app).await?;
+
+        let create_req = CreateAudioRecording {
+            event_id: event.id,
+            breakout_room_ids: vec!["room1".to_string()],
+            s3_key_prefix: "test/prefix".to_string(),
+        };
+
+        let created = create(&pool, &create_req).await?;
+        let fetched = get_by_id(&pool, &created.id).await?;
+
+        assert_eq!(fetched.id, created.id);
+        assert_eq!(fetched.event_id, created.event_id);
+        assert_eq!(fetched.s3_key_prefix, created.s3_key_prefix);
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn test_get_by_event(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>> {
+        let mut config = test_config()?;
+        config.bot_service = None;
+        let state = Arc::new(test_state().db(pool.clone()).config(config).call()?);
+        let app = setup_server(state.clone()).await?;
+
+        let mut session = UserSession::new_admin();
+        session.signup(&app).await?;
+
+        let event = create_random_event(&mut session, &app).await?;
+
+        let create_req = CreateAudioRecording {
+            event_id: event.id,
+            breakout_room_ids: vec!["room1".to_string()],
+            s3_key_prefix: "test/prefix".to_string(),
+        };
+
+        let created = create(&pool, &create_req).await?;
+        let fetched = get_by_event(&pool, &event.id).await?;
+
+        assert_eq!(fetched.id, created.id);
+        assert_eq!(fetched.event_id, event.id);
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn test_update_status(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>> {
+        let mut config = test_config()?;
+        config.bot_service = None;
+        let state = Arc::new(test_state().db(pool.clone()).config(config).call()?);
+        let app = setup_server(state.clone()).await?;
+
+        let mut session = UserSession::new_admin();
+        session.signup(&app).await?;
+
+        let event = create_random_event(&mut session, &app).await?;
+
+        let create_req = CreateAudioRecording {
+            event_id: event.id,
+            breakout_room_ids: vec!["room1".to_string()],
+            s3_key_prefix: "test/prefix".to_string(),
+        };
+
+        let created = create(&pool, &create_req).await?;
+        assert_eq!(created.status, AudioRecordingStatus::Pending);
+
+        let updated = update_status(&pool, &created.id, AudioRecordingStatus::Completed).await?;
+        assert_eq!(updated.status, AudioRecordingStatus::Completed);
+        assert!(updated.updated_at > created.updated_at);
+        assert!(updated.created_at == created.created_at);
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn test_get_by_id_not_found(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let mut config = test_config()?;
+        config.bot_service = None;
+        let state = Arc::new(test_state().db(pool.clone()).config(config).call()?);
+        let app = setup_server(state.clone()).await?;
+
+        let mut session = UserSession::new_admin();
+        session.signup(&app).await?;
+
+        let _event = create_random_event(&mut session, &app).await?;
+
+        let nonexistent_id = uuid::Uuid::new_v4();
+        let result = get_by_id(&pool, &nonexistent_id).await;
+        assert!(result.is_err());
+        Ok(())
+    }
+}

--- a/api/src/routes.rs
+++ b/api/src/routes.rs
@@ -1,4 +1,5 @@
 pub mod api_keys;
+pub mod audio_recordings;
 pub mod auth;
 pub mod chat_sessions;
 pub mod conversations;

--- a/api/src/routes/audio_recordings.rs
+++ b/api/src/routes/audio_recordings.rs
@@ -1,0 +1,507 @@
+pub mod dto;
+
+use std::sync::Arc;
+
+use aide::axum::{
+    routing::{get_with, post_with},
+    ApiRouter,
+};
+use axum::{
+    extract::{Json, Path, State},
+    http::StatusCode,
+};
+use tracing::instrument;
+use uuid::Uuid;
+
+use crate::error::ComhairleError;
+use crate::models::audio_recording::{self, CreateAudioRecording};
+use crate::routes::audio_recordings::dto::{
+    AudioRecordingDto, RecordingDownloadUrls, RequestUploadUrlsRequest, RequestUploadUrlsResponse,
+    SignedDownloadUrls,
+};
+use crate::routes::auth::RequiredAdminUser;
+use crate::ComhairleState;
+
+/// Request signed URLs for uploading audio recordings (main + breakout rooms)
+///
+/// # Errors
+/// * Returns `ComhairleError::NoBulkStorageServiceConfigured` if no bulk storage service is configured.
+/// * Returns `ComhairleError::DatabaseError` if there is a database error when creating the audio recording record.
+#[instrument(err(Debug), skip(state))]
+async fn request_upload_urls(
+    State(state): State<Arc<ComhairleState>>,
+    Path((conversation_id, event_id)): Path<(Uuid, Uuid)>,
+    RequiredAdminUser(_user): RequiredAdminUser,
+    Json(request): Json<RequestUploadUrlsRequest>,
+) -> Result<(StatusCode, Json<RequestUploadUrlsResponse>), ComhairleError> {
+    let bulk_storage_service = state.required_bulk_storage_service()?;
+
+    let event_id_str = event_id.to_string();
+    let base_key_prefix = format!("events/{}", event_id_str);
+
+    let create_recording = CreateAudioRecording {
+        event_id,
+        breakout_room_ids: request.breakout_rooms.clone(),
+        s3_key_prefix: base_key_prefix.clone(),
+    };
+    let _ = audio_recording::create(&state.db, &create_recording).await?;
+
+    let main_signed_url = bulk_storage_service
+        .get_write_file_url(&format!("{}/recording.wav", base_key_prefix))
+        .await?;
+
+    let mut breakout_room_urls = Vec::new();
+    for room_id in request.breakout_rooms {
+        let breakout_key_prefix = format!("{}/rooms/{}", event_id_str, room_id);
+
+        let breakout_signed_url = bulk_storage_service
+            .get_write_file_url(&format!("{}/recording.wav", breakout_key_prefix))
+            .await?;
+
+        breakout_room_urls.push((room_id, breakout_signed_url));
+    }
+
+    Ok((
+        StatusCode::OK,
+        Json(RequestUploadUrlsResponse {
+            main: main_signed_url,
+            breakout_rooms: breakout_room_urls,
+        }),
+    ))
+}
+
+/// Get signed URLs for downloading transcript and report
+///
+/// # Errors
+/// * Returns `ComhairleError::NoBulkStorageServiceConfigured` if no bulk storage service is configured.
+/// * Returns `ComhairleError::ResourceNotFound` if there is no audio recording for the given event.
+/// * Returns `ComhairleError::DatabaseError` if there is a database error when retrieving the audio recording.
+#[instrument(err(Debug), skip(state))]
+async fn get_download_urls(
+    State(state): State<Arc<ComhairleState>>,
+    Path((conversation_id, event_id)): Path<(Uuid, Uuid)>,
+    RequiredAdminUser(_user): RequiredAdminUser,
+) -> Result<(StatusCode, Json<SignedDownloadUrls>), ComhairleError> {
+    let bulk_storage_service = state.required_bulk_storage_service()?;
+
+    // Get the audio recording for this event
+    let recording = audio_recording::get_by_event(&state.db, &event_id).await?;
+
+    // Generate signed URLs for transcript and report
+    let main_recording_url = bulk_storage_service
+        .get_read_file_url(&format!("{}/recording.wav", recording.s3_key_prefix))
+        .await?;
+    let main_transcript_url = bulk_storage_service
+        .get_read_file_url(&format!("{}/transcript.json", recording.s3_key_prefix))
+        .await?;
+    let main_report_url = bulk_storage_service
+        .get_read_file_url(&format!("{}/report.txt", recording.s3_key_prefix))
+        .await?;
+
+    let mut output = SignedDownloadUrls {
+        main: RecordingDownloadUrls {
+            recording_url: main_recording_url,
+            transcript_url: main_transcript_url,
+            report_url: main_report_url,
+        },
+        breakout_rooms: Vec::new(),
+    };
+    for room in &recording.breakout_room_ids {
+        let breakout_key_prefix = format!("{}/rooms/{}", event_id, room);
+
+        let breakout_recording_url = bulk_storage_service
+            .get_read_file_url(&format!("{}/recording.wav", breakout_key_prefix))
+            .await?;
+        let breakout_transcript_url = bulk_storage_service
+            .get_read_file_url(&format!("{}/transcript.json", breakout_key_prefix))
+            .await?;
+        let breakout_report_url = bulk_storage_service
+            .get_read_file_url(&format!("{}/report.txt", breakout_key_prefix))
+            .await?;
+
+        // Add to the response
+        output.breakout_rooms.push((
+            room.clone(),
+            RecordingDownloadUrls {
+                recording_url: breakout_recording_url,
+                transcript_url: breakout_transcript_url,
+                report_url: breakout_report_url,
+            },
+        ));
+    }
+
+    Ok((StatusCode::OK, Json(output)))
+}
+
+/// List audio recordings for an event
+///
+/// # Errors
+/// * Returns `ComhairleError::DatabaseError` if there is a database error when retrieving the audio recording.
+#[instrument(err(Debug), skip(state))]
+async fn get_recording_for_event(
+    State(state): State<Arc<ComhairleState>>,
+    Path((conversation_id, event_id)): Path<(Uuid, Uuid)>,
+    RequiredAdminUser(_user): RequiredAdminUser,
+) -> Result<(StatusCode, Json<Vec<AudioRecordingDto>>), ComhairleError> {
+    // Get the single recording for this event
+    match audio_recording::get_by_event(&state.db, &event_id).await {
+        Ok(recording) => {
+            let dto = AudioRecordingDto::from(recording);
+            Ok((StatusCode::OK, Json(vec![dto])))
+        }
+        Err(ComhairleError::ResourceNotFound(_)) => Ok((StatusCode::OK, Json(vec![]))),
+        Err(e) => Err(e),
+    }
+}
+
+pub fn router(state: Arc<ComhairleState>) -> ApiRouter {
+    ApiRouter::new()
+        .api_route(
+            "/upload",
+            post_with(request_upload_urls, |op| {
+                op.id("RequestAudioUploadUrls")
+                    .tag("Audio Recordings")
+                    .summary("Request signed URLs for uploading audio recordings")
+                    .description("Request signed S3 URLs for uploading main and breakout room audio recordings. Returns presigned URLs and creates DB records.")
+                    .security_requirement("JWT")
+                    .response::<200, Json<RequestUploadUrlsResponse>>()
+            }),
+        )
+        .api_route(
+            "/download",
+            get_with(get_download_urls, |op| {
+                op.id("GetAudioDownloadUrls")
+                    .tag("Audio Recordings")
+                    .summary("Get signed URLs for downloading transcript and report")
+                    .description("Get presigned S3 URLs for downloading transcript.json and report.txt for a recording.")
+                    .security_requirement("JWT")
+                    .response::<200, Json<SignedDownloadUrls>>()
+            }),
+        )
+        .api_route(
+            "/",
+            get_with(get_recording_for_event, |op| {
+                op.id("ListAudioRecordings")
+                    .tag("Audio Recordings")
+                    .summary("List audio recordings for an event")
+                    .description("List all audio recordings for an event. Optionally filter by room_id.")
+                    .security_requirement("JWT")
+                    .response::<200, Json<Vec<AudioRecordingDto>>>()
+            }),
+        )
+        .with_state(state)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use serde_json::json;
+    use std::sync::Arc;
+
+    use crate::routes::conversations::dto::ConversationDto;
+    use crate::routes::events::dto::EventDto;
+    use crate::setup_server;
+    use crate::test_helpers::{test_config, test_state, UserSession};
+
+    async fn create_random_event(
+        session: &mut UserSession,
+        app: &axum::Router,
+    ) -> Result<(ConversationDto, EventDto), Box<dyn std::error::Error>> {
+        let conversation_response = session.create_random_conversation(app).await?;
+        let conversation: ConversationDto = serde_json::from_value(conversation_response.1)?;
+        let conversation_id: String = conversation.id.to_string();
+
+        let event_response = session.create_random_event(app, &conversation_id).await?;
+        let event: EventDto = serde_json::from_value(event_response.1)?;
+
+        Ok((conversation, event))
+    }
+
+    #[sqlx::test]
+    async fn test_request_upload_urls_event_not_found(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let mut config = test_config()?;
+        config.bot_service = None;
+        let state = Arc::new(test_state().db(pool).config(config).call()?);
+        let app = setup_server(state.clone()).await?;
+
+        let mut session = UserSession::new_admin();
+        session.signup(&app).await?;
+
+        let (conversation, _event) = create_random_event(&mut session, &app).await?;
+        let conversation_id: String = conversation.id.to_string();
+        let fake_event = Uuid::new_v4();
+
+        let request = RequestUploadUrlsRequest {
+            breakout_rooms: vec!["room1".to_string(), "room2".to_string()],
+        };
+
+        let (status, _response, _) = session
+            .post(
+                &app,
+                &format!(
+                    "/conversation/{}/events/{}/audio-recordings/upload",
+                    conversation_id, fake_event
+                ),
+                json!(request).to_string().into(),
+            )
+            .await?;
+
+        // Should fail with a database error because the event does not exist
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn test_get_download_urls_recording_not_found(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let mut config = test_config()?;
+        config.bot_service = None;
+        let state = Arc::new(test_state().db(pool).config(config).call()?);
+        let app = setup_server(state.clone()).await?;
+
+        let mut session = UserSession::new_admin();
+        session.signup(&app).await?;
+
+        let (conversation, event) = create_random_event(&mut session, &app).await?;
+        let conversation_id: String = conversation.id.to_string();
+        let event_id: String = event.id.to_string();
+
+        let (status, _response, _) = session
+            .get(
+                &app,
+                &format!(
+                    "/conversation/{}/events/{}/audio-recordings/download",
+                    conversation_id, event_id
+                ),
+            )
+            .await?;
+
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        Ok(())
+    }
+
+    // TODO: Mock bulk storage service for further tests.
+
+    #[sqlx::test]
+    async fn test_request_upload_urls_success_with_mocked_storage(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let mut storage_service = crate::bulk_storage_service::MockBulkStorageService::new();
+
+        // Mock the get_write_file_url calls for main and breakout rooms
+        storage_service
+            .expect_get_write_file_url()
+            .times(3) // 1 main + 2 breakout rooms
+            .returning(|_| {
+                Box::pin(async move {
+                    Ok("https://s3.example.com/signed-upload-url".to_string())
+                })
+            });
+
+        let mut config = test_config()?;
+        config.bot_service = None;
+        let state = Arc::new(
+            test_state()
+                .db(pool.clone())
+                .config(config)
+                .bulk_storage_service(Arc::new(storage_service))
+                .call()?,
+        );
+        let app = setup_server(state.clone()).await?;
+
+        let mut session = UserSession::new_admin();
+        session.signup(&app).await?;
+
+        let (conversation, event) = create_random_event(&mut session, &app).await?;
+        let conversation_id: String = conversation.id.to_string();
+        let event_id: String = event.id.to_string();
+
+        let request = RequestUploadUrlsRequest {
+            breakout_rooms: vec!["room1".to_string(), "room2".to_string()],
+        };
+
+        let (status, response, _) = session
+            .post(
+                &app,
+                &format!(
+                    "/conversation/{}/events/{}/audio-recordings/upload",
+                    conversation_id, event_id
+                ),
+                json!(request).to_string().into(),
+            )
+            .await?;
+
+        assert_eq!(status, StatusCode::OK);
+
+        let upload_response: RequestUploadUrlsResponse = serde_json::from_value(response)?;
+        
+        // Verify main room URL
+        assert!(!upload_response.main.is_empty());
+        assert_eq!(upload_response.main, "https://s3.example.com/signed-upload-url");
+
+        // Verify breakout room URLs
+        assert_eq!(upload_response.breakout_rooms.len(), 2);
+        for (i, room_urls) in upload_response.breakout_rooms.iter().enumerate() {
+            assert_eq!(room_urls.0, format!("room{}", i + 1));
+            assert_eq!(room_urls.1, "https://s3.example.com/signed-upload-url");
+        }
+
+        // Verify recording was created in database
+        let recording = audio_recording::get_by_event(&pool, &Uuid::parse_str(&event_id)?).await?;
+        assert_eq!(recording.breakout_room_ids, vec!["room1".to_string(), "room2".to_string()]);
+        assert_eq!(
+            recording.status,
+            audio_recording::AudioRecordingStatus::Pending
+        );
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn test_get_download_urls_after_status_update(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let mut storage_service = crate::bulk_storage_service::MockBulkStorageService::new();
+
+        // Mock the get_write_file_url calls for upload
+        storage_service
+            .expect_get_write_file_url()
+            .times(3) // 1 main + 2 breakout rooms
+            .returning(|_| {
+                Box::pin(async move {
+                    Ok("https://s3.example.com/signed-upload-url".to_string())
+                })
+            });
+
+        // Mock the get_read_file_url calls for download (3 files per room: recording, transcript, report)
+        // Main room: 3 files, Breakout rooms: 2 * 3 = 6 files, Total = 9 files
+        storage_service
+            .expect_get_read_file_url()
+            .times(9) // 3 main files + 6 breakout files (2 rooms * 3 files each)
+            .returning(|path| {
+                let url = format!("https://s3.example.com/signed-read-{}", path);
+                Box::pin(async move { Ok(url) })
+            });
+
+        let mut config = test_config()?;
+        config.bot_service = None;
+        let state = Arc::new(
+            test_state()
+                .db(pool.clone())
+                .config(config)
+                .bulk_storage_service(Arc::new(storage_service))
+                .call()?,
+        );
+        let app = setup_server(state.clone()).await?;
+
+        let mut session = UserSession::new_admin();
+        session.signup(&app).await?;
+
+        let (conversation, event) = create_random_event(&mut session, &app).await?;
+        let conversation_id: String = conversation.id.to_string();
+        let event_id: String = event.id.to_string();
+
+        let request = RequestUploadUrlsRequest {
+            breakout_rooms: vec!["room1".to_string(), "room2".to_string()],
+        };
+
+        let (status, _response, _) = session
+            .post(
+                &app,
+                &format!(
+                    "/conversation/{}/events/{}/audio-recordings/upload",
+                    conversation_id, event_id
+                ),
+                json!(request).to_string().into(),
+            )
+            .await?;
+        assert_eq!(status, StatusCode::OK);
+
+        let recording = audio_recording::get_by_event(&pool, &event.id).await?;
+        audio_recording::update_status(
+            &pool,
+            &recording.id,
+            audio_recording::AudioRecordingStatus::Completed,
+        )
+        .await?;
+
+        let (status, response, _) = session
+            .get(
+                &app,
+                &format!(
+                    "/conversation/{}/events/{}/audio-recordings/download",
+                    conversation_id, event_id
+                ),
+            )
+            .await?;
+
+        assert_eq!(status, StatusCode::OK);
+
+        let download_response: SignedDownloadUrls = serde_json::from_value(response)?;
+
+        // Verify main room download URLs
+        assert!(!download_response.main.recording_url.is_empty());
+        assert!(!download_response.main.transcript_url.is_empty());
+        assert!(!download_response.main.report_url.is_empty());
+
+        // Verify main room URLs contain expected paths
+        assert!(download_response
+            .main
+            .recording_url
+            .contains("signed-read"));
+        assert!(download_response
+            .main
+            .transcript_url
+            .contains("signed-read"));
+        assert!(download_response.main.report_url.contains("signed-read"));
+
+        // Verify breakout room download URLs
+        assert_eq!(download_response.breakout_rooms.len(), 2);
+        for (i, (room_id, urls)) in download_response.breakout_rooms.iter().enumerate() {
+            assert_eq!(room_id, &format!("room{}", i + 1));
+            assert!(!urls.recording_url.is_empty());
+            assert!(!urls.transcript_url.is_empty());
+            assert!(!urls.report_url.is_empty());
+        }
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn test_get_recording_for_event_empty_list(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let mut config = test_config()?;
+        config.bot_service = None;
+        let state = Arc::new(test_state().db(pool).config(config).call()?);
+        let app = setup_server(state.clone()).await?;
+
+        let mut session = UserSession::new_admin();
+        session.signup(&app).await?;
+
+        let (conversation, event) = create_random_event(&mut session, &app).await?;
+        let conversation_id: String = conversation.id.to_string();
+        let event_id: String = event.id.to_string();
+
+        let (status, response, _) = session
+            .get(
+                &app,
+                &format!(
+                    "/conversation/{}/events/{}/audio-recordings/",
+                    conversation_id, event_id
+                ),
+            )
+            .await?;
+
+        assert_eq!(status, StatusCode::OK);
+
+        let recordings: Vec<AudioRecordingDto> = serde_json::from_value(response)?;
+        assert_eq!(recordings.len(), 0, "Should return empty list when no recording exists");
+
+        Ok(())
+    }
+}

--- a/api/src/routes/audio_recordings/dto.rs
+++ b/api/src/routes/audio_recordings/dto.rs
@@ -1,0 +1,70 @@
+use chrono::{DateTime, Utc};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::models::audio_recording::{AudioRecording, AudioRecordingStatus};
+
+/// Data transfer object for an AudioRecording
+#[derive(Serialize, Deserialize, JsonSchema, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct AudioRecordingDto {
+    pub id: Uuid,
+    pub event_id: Uuid,
+    pub breakout_room_ids: Vec<String>,
+    pub s3_key_prefix: String,
+    pub status: AudioRecordingStatus,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl From<AudioRecording> for AudioRecordingDto {
+    fn from(recording: AudioRecording) -> Self {
+        Self {
+            id: recording.id,
+            event_id: recording.event_id,
+            breakout_room_ids: recording.breakout_room_ids,
+            s3_key_prefix: recording.s3_key_prefix,
+            status: recording.status,
+            created_at: recording.created_at,
+            updated_at: recording.updated_at,
+        }
+    }
+}
+
+/// Request body for requesting signed upload URLs
+#[cfg_attr(test, derive(Serialize))]
+#[derive(Deserialize, JsonSchema, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct RequestUploadUrlsRequest {
+    /// List of breakout room IDs (empty list means only main room)
+    pub breakout_rooms: Vec<String>,
+}
+
+/// Response with signed upload URLs for main and breakout rooms
+#[cfg_attr(test, derive(Deserialize))]
+#[derive(Serialize, JsonSchema, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct RequestUploadUrlsResponse {
+    pub main: String,
+    pub breakout_rooms: Vec<(String, String)>,
+}
+
+/// Response with signed download URLs for main and breakout rooms
+#[cfg_attr(test, derive(Deserialize))]
+#[derive(Serialize, JsonSchema, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct RecordingDownloadUrls {
+    pub recording_url: String,
+    pub transcript_url: String,
+    pub report_url: String,
+}
+
+/// Signed URL information for downloading recordings, transcripts, and reports for main and breakout rooms.
+#[cfg_attr(test, derive(Deserialize))]
+#[derive(Serialize, JsonSchema, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct SignedDownloadUrls {
+    pub main: RecordingDownloadUrls,
+    pub breakout_rooms: Vec<(String, RecordingDownloadUrls)>,
+}

--- a/api/src/worker_service/process_video_call_transcriptions.rs
+++ b/api/src/worker_service/process_video_call_transcriptions.rs
@@ -166,6 +166,18 @@ pub async fn generate_sensemaking_report(
         "Report job created in categorization service"
     );
 
+    // Update audio recording status to completed after all processing is done
+    if let Ok(audio_recording) =
+        crate::models::audio_recording::get_by_event(&state.db, &req.event_id).await
+    {
+        let _ = crate::models::audio_recording::update_status(
+            &state.db,
+            &audio_recording.id,
+            crate::models::audio_recording::AudioRecordingStatus::Completed,
+        )
+        .await;
+    }
+
     job::complete(
         &state.db,
         req.job_id,


### PR DESCRIPTION
Motivations:

 - We need a way for users to upload event recordings when not using jitsi.

Actions:

 - Added upload, download and list endpoints for per-event uploads