### PR TITLE
Allows other formats appart from wav to be used in the recoring transcriptions

### DIFF
--- a/api/migrations/20260623062118_add_file_extension_to_audio_recording.sql
+++ b/api/migrations/20260623062118_add_file_extension_to_audio_recording.sql
@@ -1,0 +1,4 @@
+-- Track the file extension (and therefore the audio format) of the uploaded
+-- recording so the transcription pipeline can support formats other than WAV.
+ALTER TABLE audio_recording
+    ADD COLUMN file_extension TEXT NOT NULL DEFAULT 'wav';

--- a/api/src/models/audio_recording.rs
+++ b/api/src/models/audio_recording.rs
@@ -8,6 +8,53 @@ use uuid::Uuid;
 
 use crate::error::ComhairleError;
 
+/// Audio format of an uploaded recording. Stored in the database as the
+/// lowercase file extension so it doubles as the on-disk/S3 suffix.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum AudioFormat {
+    Wav,
+    Mp3,
+    M4a,
+    Mp4,
+    Ogg,
+    Flac,
+    Webm,
+}
+
+impl AudioFormat {
+    pub fn extension(&self) -> &'static str {
+        match self {
+            AudioFormat::Wav => "wav",
+            AudioFormat::Mp3 => "mp3",
+            AudioFormat::M4a => "m4a",
+            AudioFormat::Mp4 => "mp4",
+            AudioFormat::Ogg => "ogg",
+            AudioFormat::Flac => "flac",
+            AudioFormat::Webm => "webm",
+        }
+    }
+
+    pub fn try_from_extension(extension: &str) -> Result<Self, ComhairleError> {
+        match extension.trim_start_matches('.').to_lowercase().as_str() {
+            "wav" => Ok(AudioFormat::Wav),
+            "mp3" => Ok(AudioFormat::Mp3),
+            "m4a" => Ok(AudioFormat::M4a),
+            "mp4" => Ok(AudioFormat::Mp4),
+            "ogg" | "oga" => Ok(AudioFormat::Ogg),
+            "flac" => Ok(AudioFormat::Flac),
+            "webm" => Ok(AudioFormat::Webm),
+            ext => Err(ComhairleError::UnsupportedContentType(ext.to_string())),
+        }
+    }
+}
+
+impl std::fmt::Display for AudioFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.extension())
+    }
+}
+
 /// Status of an audio recording's transcription and processing
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
@@ -62,6 +109,8 @@ pub struct AudioRecording {
     /// S3 key prefix (without extension) used for generating URLs
     /// Used as base for main and breakout room recordings
     pub s3_key_prefix: String,
+    /// Audio format of the uploaded recording(s)
+    pub file_extension: AudioFormat,
     /// Current status of transcription/processing for entire event
     pub status: AudioRecordingStatus,
     /// When this recording was created
@@ -78,16 +127,18 @@ pub struct RawAudioRecording {
     pub event_id: Uuid,
     pub breakout_room_ids: Vec<String>,
     pub s3_key_prefix: String,
+    pub file_extension: String,
     pub status: String,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
 
-const DEFAULT_COLUMNS: [RawAudioRecordingIden; 7] = [
+const DEFAULT_COLUMNS: [RawAudioRecordingIden; 8] = [
     RawAudioRecordingIden::Id,
     RawAudioRecordingIden::EventId,
     RawAudioRecordingIden::BreakoutRoomIds,
     RawAudioRecordingIden::S3KeyPrefix,
+    RawAudioRecordingIden::FileExtension,
     RawAudioRecordingIden::Status,
     RawAudioRecordingIden::CreatedAt,
     RawAudioRecordingIden::UpdatedAt,
@@ -100,6 +151,8 @@ impl From<RawAudioRecording> for AudioRecording {
             event_id: raw.event_id,
             breakout_room_ids: raw.breakout_room_ids,
             s3_key_prefix: raw.s3_key_prefix,
+            file_extension: AudioFormat::try_from_extension(&raw.file_extension)
+                .unwrap_or(AudioFormat::Wav),
             status: AudioRecordingStatus::from_string(&raw.status)
                 .unwrap_or(AudioRecordingStatus::Pending),
             created_at: raw.created_at,
@@ -115,6 +168,7 @@ pub struct CreateAudioRecording {
     pub event_id: Uuid,
     pub breakout_room_ids: Vec<String>,
     pub s3_key_prefix: String,
+    pub file_extension: AudioFormat,
 }
 
 /// Create a new audio recording in the database
@@ -128,12 +182,14 @@ pub async fn create(
             RawAudioRecordingIden::EventId,
             RawAudioRecordingIden::BreakoutRoomIds,
             RawAudioRecordingIden::S3KeyPrefix,
+            RawAudioRecordingIden::FileExtension,
             RawAudioRecordingIden::Status,
         ])
         .values([
             create_recording.event_id.into(),
             create_recording.breakout_room_ids.clone().into(),
             create_recording.s3_key_prefix.clone().into(),
+            create_recording.file_extension.extension().into(),
             "pending".into(),
         ])
         .unwrap()
@@ -247,6 +303,7 @@ mod tests {
             event_id: event.id,
             breakout_room_ids: vec!["room1".to_string(), "room2".to_string()],
             s3_key_prefix: "test/prefix".to_string(),
+            file_extension: AudioFormat::Wav,
         };
 
         let recording = create(&pool, &create_req).await?;
@@ -273,6 +330,7 @@ mod tests {
             event_id: event.id,
             breakout_room_ids: vec!["room1".to_string()],
             s3_key_prefix: "test/prefix".to_string(),
+            file_extension: AudioFormat::Wav,
         };
 
         let created = create(&pool, &create_req).await?;
@@ -300,6 +358,7 @@ mod tests {
             event_id: event.id,
             breakout_room_ids: vec!["room1".to_string()],
             s3_key_prefix: "test/prefix".to_string(),
+            file_extension: AudioFormat::Wav,
         };
 
         let created = create(&pool, &create_req).await?;
@@ -326,6 +385,7 @@ mod tests {
             event_id: event.id,
             breakout_room_ids: vec!["room1".to_string()],
             s3_key_prefix: "test/prefix".to_string(),
+            file_extension: AudioFormat::Wav,
         };
 
         let created = create(&pool, &create_req).await?;

--- a/api/src/routes/audio_recordings.rs
+++ b/api/src/routes/audio_recordings.rs
@@ -38,16 +38,18 @@ async fn request_upload_urls(
 
     let event_id_str = event_id.to_string();
     let base_key_prefix = format!("events/{}", event_id_str);
+    let extension = request.file_extension.extension();
 
     let create_recording = CreateAudioRecording {
         event_id,
         breakout_room_ids: request.breakout_rooms.clone(),
         s3_key_prefix: base_key_prefix.clone(),
+        file_extension: request.file_extension,
     };
     let _ = audio_recording::create(&state.db, &create_recording).await?;
 
     let main_signed_url = bulk_storage_service
-        .get_write_file_url(&format!("{}/recording.wav", base_key_prefix))
+        .get_write_file_url(&format!("{}/recording.{}", base_key_prefix, extension))
         .await?;
 
     let mut breakout_room_urls = Vec::new();
@@ -55,7 +57,7 @@ async fn request_upload_urls(
         let breakout_key_prefix = format!("{}/rooms/{}", event_id_str, room_id);
 
         let breakout_signed_url = bulk_storage_service
-            .get_write_file_url(&format!("{}/recording.wav", breakout_key_prefix))
+            .get_write_file_url(&format!("{}/recording.{}", breakout_key_prefix, extension))
             .await?;
 
         breakout_room_urls.push((room_id, breakout_signed_url));
@@ -86,10 +88,14 @@ async fn get_download_urls(
 
     // Get the audio recording for this event
     let recording = audio_recording::get_by_event(&state.db, &event_id).await?;
+    let extension = recording.file_extension.extension();
 
     // Generate signed URLs for transcript and report
     let main_recording_url = bulk_storage_service
-        .get_read_file_url(&format!("{}/recording.wav", recording.s3_key_prefix))
+        .get_read_file_url(&format!(
+            "{}/recording.{}",
+            recording.s3_key_prefix, extension
+        ))
         .await?;
     let main_transcript_url = bulk_storage_service
         .get_read_file_url(&format!("{}/transcript.json", recording.s3_key_prefix))
@@ -110,7 +116,10 @@ async fn get_download_urls(
         let breakout_key_prefix = format!("{}/rooms/{}", event_id, room);
 
         let breakout_recording_url = bulk_storage_service
-            .get_read_file_url(&format!("{}/recording.wav", breakout_key_prefix))
+            .get_read_file_url(&format!(
+                "{}/recording.{}",
+                breakout_key_prefix, extension
+            ))
             .await?;
         let breakout_transcript_url = bulk_storage_service
             .get_read_file_url(&format!("{}/transcript.json", breakout_key_prefix))
@@ -199,6 +208,7 @@ mod tests {
     use serde_json::json;
     use std::sync::Arc;
 
+    use crate::models::audio_recording::AudioFormat;
     use crate::routes::conversations::dto::ConversationDto;
     use crate::routes::events::dto::EventDto;
     use crate::setup_server;
@@ -236,6 +246,7 @@ mod tests {
 
         let request = RequestUploadUrlsRequest {
             breakout_rooms: vec!["room1".to_string(), "room2".to_string()],
+            file_extension: AudioFormat::Wav,
         };
 
         let (status, _response, _) = session
@@ -322,6 +333,7 @@ mod tests {
 
         let request = RequestUploadUrlsRequest {
             breakout_rooms: vec!["room1".to_string(), "room2".to_string()],
+            file_extension: AudioFormat::Wav,
         };
 
         let (status, response, _) = session
@@ -407,6 +419,7 @@ mod tests {
 
         let request = RequestUploadUrlsRequest {
             breakout_rooms: vec!["room1".to_string(), "room2".to_string()],
+            file_extension: AudioFormat::Wav,
         };
 
         let (status, _response, _) = session

--- a/api/src/routes/audio_recordings/dto.rs
+++ b/api/src/routes/audio_recordings/dto.rs
@@ -3,7 +3,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::models::audio_recording::{AudioRecording, AudioRecordingStatus};
+use crate::models::audio_recording::{AudioFormat, AudioRecording, AudioRecordingStatus};
 
 /// Data transfer object for an AudioRecording
 #[derive(Serialize, Deserialize, JsonSchema, Debug, Clone)]
@@ -13,6 +13,7 @@ pub struct AudioRecordingDto {
     pub event_id: Uuid,
     pub breakout_room_ids: Vec<String>,
     pub s3_key_prefix: String,
+    pub file_extension: AudioFormat,
     pub status: AudioRecordingStatus,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
@@ -25,6 +26,7 @@ impl From<AudioRecording> for AudioRecordingDto {
             event_id: recording.event_id,
             breakout_room_ids: recording.breakout_room_ids,
             s3_key_prefix: recording.s3_key_prefix,
+            file_extension: recording.file_extension,
             status: recording.status,
             created_at: recording.created_at,
             updated_at: recording.updated_at,
@@ -39,6 +41,8 @@ impl From<AudioRecording> for AudioRecordingDto {
 pub struct RequestUploadUrlsRequest {
     /// List of breakout room IDs (empty list means only main room)
     pub breakout_rooms: Vec<String>,
+    /// Audio format of the files being uploaded (all files share the same format)
+    pub file_extension: AudioFormat,
 }
 
 /// Response with signed upload URLs for main and breakout rooms

--- a/api/src/routes/events.rs
+++ b/api/src/routes/events.rs
@@ -243,19 +243,30 @@ async fn process_transcriptions(
         )
         .await?;
 
+    // Use the format recorded for this event when present (self-serve upload
+    // flow). Legacy bot-uploaded recordings have no audio_recording row, so
+    // fall back to the historical WAV default.
+    let expected_extension =
+        crate::models::audio_recording::get_by_event(&state.db, &event_id)
+            .await
+            .map(|r| r.file_extension)
+            .unwrap_or(crate::models::audio_recording::AudioFormat::Wav)
+            .extension();
+    let expected_filename = format!("recording.{expected_extension}");
+
     let is_missing_main_recording = !entries
         .iter()
-        .any(|entry| entry.contains("recording.wav") && !entry.contains("rooms/"));
+        .any(|entry| entry.contains(&expected_filename) && !entry.contains("rooms/"));
 
     if is_missing_main_recording {
         return Err(ComhairleError::ResourceNotFound(format!(
-            "recording.wav for event {event_id}"
+            "{expected_filename} for event {event_id}"
         )));
     }
 
     let br_room_entries: Vec<String> = entries
         .into_iter()
-        .filter(|entry| entry.contains("rooms/") && entry.contains("recording.wav"))
+        .filter(|entry| entry.contains("rooms/") && entry.contains(&expected_filename))
         .collect();
 
     let create_core_event_job = CreateJob {

--- a/api/src/transcription_service.rs
+++ b/api/src/transcription_service.rs
@@ -10,6 +10,7 @@ use tokio::sync::mpsc::Receiver;
 use mockall::{automock, predicate::*};
 
 use crate::bulk_storage_service::BulkStorageService;
+use crate::models::audio_recording::AudioFormat;
 
 pub mod amazon_transcriber;
 pub mod config;
@@ -49,6 +50,7 @@ pub trait Transcriber: Sync + Send {
         &self,
         store: &str,
         location: &str,
+        audio_format: AudioFormat,
         bulk_storage_service: &Arc<dyn BulkStorageService>,
     ) -> Result<TranscribeFromBulkResponse>;
     async fn transcribe_live(

--- a/api/src/transcription_service/amazon_transcriber.rs
+++ b/api/src/transcription_service/amazon_transcriber.rs
@@ -1,4 +1,5 @@
 use crate::bulk_storage_service::{BulkStorageService, FileMetadata};
+use crate::models::audio_recording::AudioFormat;
 use crate::transcription_service::TranscribeFromBulkResponse;
 
 use super::error::{Result, TranscriptionServiceError};
@@ -432,6 +433,18 @@ async fn get_and_convert_transcription(
     Ok(formatted_transcription)
 }
 
+fn to_aws_media_format(audio_format: AudioFormat) -> MediaFormat {
+    match audio_format {
+        AudioFormat::Wav => MediaFormat::Wav,
+        AudioFormat::Mp3 => MediaFormat::Mp3,
+        AudioFormat::M4a => MediaFormat::M4A,
+        AudioFormat::Mp4 => MediaFormat::Mp4,
+        AudioFormat::Ogg => MediaFormat::Ogg,
+        AudioFormat::Flac => MediaFormat::Flac,
+        AudioFormat::Webm => MediaFormat::Webm,
+    }
+}
+
 #[async_trait]
 impl Transcriber for AmazonTranscriber {
     async fn transcribe(&self, _audio: &Vec<u8>) -> Result<String> {
@@ -442,9 +455,11 @@ impl Transcriber for AmazonTranscriber {
         &self,
         store_name: &str,
         location: &str,
+        audio_format: AudioFormat,
         bulk_storage_service: &Arc<dyn BulkStorageService>,
     ) -> Result<TranscribeFromBulkResponse> {
-        let uri = format!("s3://{store_name}/{location}/recording.wav");
+        let extension = audio_format.extension();
+        let uri = format!("s3://{store_name}/{location}/recording.{extension}");
 
         let audio_file = Media::builder().media_file_uri(uri).build();
         let job_name = Uuid::new_v4().to_string();
@@ -463,7 +478,7 @@ impl Transcriber for AmazonTranscriber {
             .output_bucket_name(store_name)
             .output_key(&transcription_key)
             .media(audio_file)
-            .media_format(MediaFormat::Wav)
+            .media_format(to_aws_media_format(audio_format))
             .language_code(LanguageCode::EnUs)
             .send()
             .await
@@ -1079,6 +1094,7 @@ mod tests {
             .transcribe_from_bulk_store(
                 "comhairle-media-test",
                 "events/3c22d53d-07df-4d46-802e-486b79dd1a80",
+                AudioFormat::Wav,
                 bulk_storage_service,
             )
             .await?;

--- a/api/src/worker_service/process_video_call_transcriptions.rs
+++ b/api/src/worker_service/process_video_call_transcriptions.rs
@@ -5,7 +5,9 @@ use tracing::info;
 use uuid::Uuid;
 
 use crate::{
-    categorization_service::Comment, models::job, transcription_service::Transcription,
+    categorization_service::Comment,
+    models::{audio_recording::AudioFormat, job},
+    transcription_service::Transcription,
     ComhairleState,
 };
 
@@ -70,10 +72,19 @@ pub async fn transcribe_recording(
             .map_or(String::new(), |id| format!("/rooms/{id}"))
     );
 
+    // Look up the audio_recording to find the uploaded file format. Recordings
+    // created by the legacy bot flow may not have a DB record yet — default to
+    // WAV in that case to preserve the historical behaviour.
+    let audio_format = crate::models::audio_recording::get_by_event(&state.db, &req.event_id)
+        .await
+        .map(|r| r.file_extension)
+        .unwrap_or(AudioFormat::Wav);
+
     let result = transcription_service
         .transcribe_from_bulk_store(
             &bulk_storage_config.store_name,
             &recording_location,
+            audio_format,
             bulk_storage_service,
         )
         .await

--- a/ui/packages/api-client/src/api.ts
+++ b/ui/packages/api-client/src/api.ts
@@ -1688,8 +1688,18 @@ export const CreateFacilitatorRequest = z
   .object({ email: z.string() })
   .passthrough();
 export type CreateFacilitatorRequest = z.infer<typeof CreateFacilitatorRequest>;
+export const AudioFormat = z.enum([
+  "wav",
+  "mp3",
+  "m4a",
+  "mp4",
+  "ogg",
+  "flac",
+  "webm",
+]);
+export type AudioFormat = z.infer<typeof AudioFormat>;
 export const RequestUploadUrlsRequest = z
-  .object({ breakoutRooms: z.array(z.string()) })
+  .object({ breakoutRooms: z.array(z.string()), fileExtension: AudioFormat })
   .passthrough();
 export type RequestUploadUrlsRequest = z.infer<typeof RequestUploadUrlsRequest>;
 export const RequestUploadUrlsResponse = z
@@ -1727,6 +1737,7 @@ export const AudioRecordingDto = z
     breakoutRoomIds: z.array(z.string()),
     createdAt: z.string().datetime({ offset: true }),
     eventId: z.string().uuid(),
+    fileExtension: AudioFormat,
     id: z.string().uuid(),
     s3KeyPrefix: z.string(),
     status: AudioRecordingStatus,
@@ -2218,6 +2229,7 @@ export const schemas: Record<string, z.ZodType<any>> = {
   EventAttendanceDto,
   UpdateEventAttendanceRequest,
   CreateFacilitatorRequest,
+  AudioFormat,
   RequestUploadUrlsRequest,
   RequestUploadUrlsResponse,
   RecordingDownloadUrls,

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/events/[event_id]/EventRecordings.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/events/[event_id]/EventRecordings.svelte
@@ -23,7 +23,19 @@
 
 	const maxSizeMB = 500;
 	const maxSizeBytes = maxSizeMB * 1024 * 1024;
-	const accept = '.wav,.mp3,.m4a,.ogg,.webm,.flac,audio/*';
+	const accept = '.wav,.mp3,.m4a,.mp4,.ogg,.webm,.flac,audio/*';
+	const supportedExtensions = ['wav', 'mp3', 'm4a', 'mp4', 'ogg', 'webm', 'flac'] as const;
+	type SupportedExtension = (typeof supportedExtensions)[number];
+
+	function extractExtension(name: string): SupportedExtension | null {
+		const dot = name.lastIndexOf('.');
+		if (dot < 0) return null;
+		const ext = name.slice(dot + 1).toLowerCase();
+		const normalised = ext === 'oga' ? 'ogg' : ext;
+		return (supportedExtensions as readonly string[]).includes(normalised)
+			? (normalised as SupportedExtension)
+			: null;
+	}
 
 	type RoomSlot = {
 		key: string;
@@ -133,10 +145,31 @@
 			return;
 		}
 
+		const mainExt = extractExtension(main.file.name);
+		if (!mainExt) {
+			notifications.send({
+				message: `Unsupported audio format for "${main.file.name}". Use one of: ${supportedExtensions.join(', ')}.`,
+				priority: 'ERROR'
+			});
+			return;
+		}
+		// Transcription pipeline stores one format per recording — require all
+		// breakout files to match the main file's extension.
+		const mismatched = breakouts.find(
+			(b) => b.file && extractExtension(b.file.name) !== mainExt
+		);
+		if (mismatched) {
+			notifications.send({
+				message: `All recordings must share the same file format. "${mismatched.file?.name}" doesn't match the main room's .${mainExt} file.`,
+				priority: 'ERROR'
+			});
+			return;
+		}
+
 		isUploading = true;
 		try {
 			const urls = await apiClient.RequestAudioUploadUrls(
-				{ breakoutRooms: ids },
+				{ breakoutRooms: ids, fileExtension: mainExt },
 				{ params: { conversation_id, event_id } }
 			);
 


### PR DESCRIPTION
This PR adds the ability for audio files uploaded for transcription to be in formats other than wav's 

The only issue here is that each of the audio files (main room + breakout rooms) needs to have the same format. 

We might want to break out of the explicit association between breakout rooms and main recordings and just have multiple transcripts per event .