### PR TITLE
486 disable send email button when email is being sent

### DIFF
--- a/ui/packages/comhairle/src/lib/components/NotificationForm.svelte
+++ b/ui/packages/comhairle/src/lib/components/NotificationForm.svelte
@@ -56,11 +56,17 @@
 			validators: zodClient(notificationFormSchema),
 			taintedMessage: false,
 			validationMethod: 'oninput',
-			onSubmit: sendNotification
+			onSubmit: async (actions) => {
+				submitting = true;
+				await sendNotification(actions);
+				submitting = false;
+			}
 		}
 	);
 
-	const { form, enhance, validateForm, submitting, reset } = notificationForm;
+	const { form, enhance, validateForm, reset } = notificationForm;
+
+	let submitting = $state<boolean>(false);
 
 	let failedRecipients = $state<string[]>([]);
 	let lastSendMessage = $state<string | null>(null);
@@ -241,7 +247,7 @@
 							placeholder={isEmail
 								? 'Enter email subject...'
 								: 'Enter notification title...'}
-							disabled={$submitting}
+							disabled={submitting}
 						/>
 						<Form.FieldErrors />
 					</div>
@@ -260,7 +266,7 @@
 							<RichTextEditor
 								value={$form.content || null}
 								placeholder="Compose your email..."
-								editable={!$submitting}
+								editable={!submitting}
 								onChange={(json) => ($form.content = json)}
 							/>
 							<input type="hidden" {...props} value={$form.content} />
@@ -270,7 +276,7 @@
 								bind:value={$form.content}
 								placeholder="Enter your notification message here..."
 								rows={4}
-								disabled={$submitting}
+								disabled={submitting}
 							/>
 						{/if}
 						<Form.FieldErrors />
@@ -280,9 +286,9 @@
 		</Form.Field>
 
 		<div class="flex flex-col gap-2 sm:flex-row">
-			<Form.Button class="flex-1" disabled={$submitting}>
+			<Form.Button class="flex-1" disabled={submitting}>
 				<Send class="mr-2 h-4 w-4" />
-				{#if $submitting}
+				{#if submitting}
 					Sending {isEmail ? 'email' : 'notification'}...
 				{:else}
 					Send {isEmail ? 'email' : 'notification'} to all participants
@@ -293,7 +299,7 @@
 				<Button
 					type="button"
 					variant="outline"
-					disabled={$submitting || testSending}
+					disabled={submitting || testSending}
 					onclick={() => {
 						testEmailError = null;
 						testDialogOpen = true;

--- a/ui/packages/comhairle/src/lib/components/NotificationForm.svelte
+++ b/ui/packages/comhairle/src/lib/components/NotificationForm.svelte
@@ -264,7 +264,7 @@
 					<div class="space-y-1">
 						{#if isEmail}
 							<RichTextEditor
-								value={$form.content || null}
+								bind:value={$form.content}
 								placeholder="Compose your email..."
 								editable={!submitting}
 								onChange={(json) => ($form.content = json)}

--- a/ui/packages/comhairle/src/lib/components/RichTextEditor/RichTextEditor.svelte
+++ b/ui/packages/comhairle/src/lib/components/RichTextEditor/RichTextEditor.svelte
@@ -2,10 +2,6 @@
 	import { onMount, onDestroy } from 'svelte';
 	import { useResizeObserver } from 'runed';
 	import { Editor } from '@tiptap/core';
-	import { Color } from '@tiptap/extension-color';
-	import { ListItem } from '@tiptap/extension-list-item';
-	import { TextStyle } from '@tiptap/extension-text-style';
-	import { Underline } from '@tiptap/extension-underline';
 	import EditorToolbar from './EditorToolbar.svelte';
 	import { type ActiveStates } from '$lib/components/RichTextEditor/types';
 	import { detectContentType } from '$lib/utils/contentDetection';
@@ -28,8 +24,7 @@
 	};
 
 	let {
-		value = null,
-		placeholder = 'Start typing...',
+		value = $bindable(),
 		editable = true,
 		class: className = '',
 		minHeight = '200px',


### PR DESCRIPTION
Fixes https://github.com/crownshy/comhairle/issues/486

### Testing summary

- Checked that the email button couldn't be clicked multiple times anymore

[Kooha-2026-06-23-17-29-43.webm](https://github.com/user-attachments/assets/b0ee5ae3-d5ab-4a18-bc93-2e9dcf3f8b82)

- Fixed issue where the body of the form wasn't being cleared after the email was sent
_Before:_

[Kooha-2026-06-23-17-33-34.webm](https://github.com/user-attachments/assets/cf82b982-f9fd-4a90-a0b1-b3b7ae3ed978)

_After:_

[Kooha-2026-06-23-17-34-02.webm](https://github.com/user-attachments/assets/6a051128-5e50-4d80-9933-eedc0db9f67e)