### PR TITLE
Adding endpoints to allow polis moderators the ability to add themes to statements in the aux table

### DIFF
--- a/api/src/models/polis_statement_aux.rs
+++ b/api/src/models/polis_statement_aux.rs
@@ -413,6 +413,55 @@ pub async fn theme_stats(
     Ok(stats)
 }
 
+#[instrument(err(Debug), skip(db))]
+pub async fn add_theme(
+    db: &PgPool,
+    id: Uuid,
+    theme: &str,
+) -> Result<PolisStatementAux, ComhairleError> {
+    let aux = sqlx::query_as::<_, PolisStatementAux>(
+        "UPDATE polis_statement_aux \
+         SET themes = CASE WHEN $2 = ANY(themes) THEN themes ELSE array_append(themes, $2) END, \
+             updated_at = NOW() \
+         WHERE id = $1 \
+         RETURNING *",
+    )
+    .bind(id)
+    .bind(theme)
+    .fetch_one(db)
+    .await
+    .map_err(|e| match e {
+        sqlx::Error::RowNotFound => ComhairleError::ResourceNotFound("Polis statement aux".into()),
+        other => ComhairleError::DatabaseError(other),
+    })?;
+
+    Ok(aux)
+}
+
+#[instrument(err(Debug), skip(db))]
+pub async fn remove_theme(
+    db: &PgPool,
+    id: Uuid,
+    theme: &str,
+) -> Result<PolisStatementAux, ComhairleError> {
+    let aux = sqlx::query_as::<_, PolisStatementAux>(
+        "UPDATE polis_statement_aux \
+         SET themes = array_remove(themes, $2), updated_at = NOW() \
+         WHERE id = $1 \
+         RETURNING *",
+    )
+    .bind(id)
+    .bind(theme)
+    .fetch_one(db)
+    .await
+    .map_err(|e| match e {
+        sqlx::Error::RowNotFound => ComhairleError::ResourceNotFound("Polis statement aux".into()),
+        other => ComhairleError::DatabaseError(other),
+    })?;
+
+    Ok(aux)
+}
+
 #[instrument(err(Debug))]
 pub async fn delete(db: &PgPool, id: Uuid) -> Result<PolisStatementAux, ComhairleError> {
     let (sql, values) = Query::delete()

--- a/api/src/test_helpers.rs
+++ b/api/src/test_helpers.rs
@@ -346,6 +346,38 @@ impl UserSession {
         Ok((status, value, cookie))
     }
 
+    pub async fn delete_with_body(
+        &mut self,
+        app: &Router,
+        url: &str,
+        body: Body,
+    ) -> Result<(StatusCode, Value, Option<HeaderValue>), Box<dyn Error>> {
+        let mut request = Request::builder()
+            .uri(url)
+            .method("DELETE")
+            .header("content-type", "application/json");
+
+        if let Some(cookie) = &self.cookie {
+            request = request.header(COOKIE, cookie)
+        }
+
+        let request = request.body(body).unwrap();
+        let response = app.clone().oneshot(request).await?;
+        let status = response.status();
+
+        let cookie = response
+            .headers()
+            .get(axum::http::header::SET_COOKIE)
+            .map(|cookie| cookie.to_owned());
+
+        if let Some(cookie) = &cookie {
+            self.cookie = Some(cookie.clone());
+        }
+
+        let value = response_to_json(response).await;
+        Ok((status, value, cookie))
+    }
+
     pub async fn post(
         &mut self,
         app: &Router,

--- a/api/src/tools/polis.rs
+++ b/api/src/tools/polis.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use crate::models::polis_statement_aux;
 use aide::axum::{
-    routing::{get_with, post_with, put_with},
+    routing::{delete_with, get_with, post_with, put_with},
     ApiRouter,
 };
 use async_trait::async_trait;
@@ -181,6 +181,34 @@ impl ToolImpl for PolisTool {
                              (at least one is required)",
                         )
                         .response::<200, Json<Vec<ThemeStatistic>>>()
+                }),
+            )
+            .api_route(
+                "/polis/statement_aux/{id}/themes",
+                post_with(add_statement_aux_theme, |op| {
+                    op.id("PolisAddStatementAuxTheme")
+                        .tag("Tools")
+                        .summary("Add a theme to a polis_statement_aux row")
+                        .description(
+                            "Adds a theme to the statement's themes array. Idempotent: \
+                             adding a theme that is already present is a no-op. Caller \
+                             must be the owner of the conversation the statement belongs to.",
+                        )
+                        .response::<200, Json<PolisStatementAux>>()
+                }),
+            )
+            .api_route(
+                "/polis/statement_aux/{id}/themes",
+                delete_with(remove_statement_aux_theme, |op| {
+                    op.id("PolisRemoveStatementAuxTheme")
+                        .tag("Tools")
+                        .summary("Remove a theme from a polis_statement_aux row")
+                        .description(
+                            "Removes a theme from the statement's themes array. Idempotent: \
+                             removing a theme that is not present is a no-op. Caller must be \
+                             the owner of the conversation the statement belongs to.",
+                        )
+                        .response::<200, Json<PolisStatementAux>>()
                 }),
             )
             .api_route(
@@ -529,6 +557,41 @@ async fn moderate_statement_aux(
     Ok((StatusCode::OK, Json(updated)))
 }
 
+#[derive(Serialize, Deserialize, JsonSchema, Debug)]
+pub struct ThemeRequest {
+    pub theme: String,
+}
+
+#[instrument(err(Debug), skip(state))]
+async fn add_statement_aux_theme(
+    State(state): State<Arc<ComhairleState>>,
+    RequiredUser(user): RequiredUser,
+    Path(statement_id): Path<Uuid>,
+    Json(request): Json<ThemeRequest>,
+) -> Result<(StatusCode, Json<PolisStatementAux>), ComhairleError> {
+    let aux = models::polis_statement_aux::get_by_id(&state.db, &statement_id).await?;
+    polis_statement_aux::check_can_moderate(&state.db, &user, &aux.workflow_step_id).await?;
+
+    let updated =
+        models::polis_statement_aux::add_theme(&state.db, statement_id, &request.theme).await?;
+    Ok((StatusCode::OK, Json(updated)))
+}
+
+#[instrument(err(Debug), skip(state))]
+async fn remove_statement_aux_theme(
+    State(state): State<Arc<ComhairleState>>,
+    RequiredUser(user): RequiredUser,
+    Path(statement_id): Path<Uuid>,
+    Json(request): Json<ThemeRequest>,
+) -> Result<(StatusCode, Json<PolisStatementAux>), ComhairleError> {
+    let aux = models::polis_statement_aux::get_by_id(&state.db, &statement_id).await?;
+    polis_statement_aux::check_can_moderate(&state.db, &user, &aux.workflow_step_id).await?;
+
+    let updated =
+        models::polis_statement_aux::remove_theme(&state.db, statement_id, &request.theme).await?;
+    Ok((StatusCode::OK, Json(updated)))
+}
+
 #[instrument(err(Debug), skip(state))]
 async fn theme_stats(
     State(state): State<Arc<ComhairleState>>,
@@ -593,6 +656,209 @@ pub async fn launch(
     }
 
     Ok(live_poll_config)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::error::Error;
+
+    use axum::Router;
+    use serde_json::json;
+    use sqlx::PgPool;
+
+    use crate::{
+        models::{
+            model_test_helpers::setup_default_app_and_session,
+            polis_statement_aux::{self, CreatePolisStatementAux},
+        },
+        test_helpers::{extract, polis_tool_config, UserSession},
+    };
+
+    use super::*;
+
+    async fn setup_polis_aux(
+        app: &Router,
+        pool: &PgPool,
+        session: &mut UserSession,
+        themes: Vec<String>,
+    ) -> Result<PolisStatementAux, Box<dyn Error>> {
+        let (_, conversation, _) = session.create_random_conversation(app).await?;
+        let conversation_id: String = extract("id", &conversation);
+
+        let (_, workflow, _) = session.create_random_workflow(app, &conversation_id).await?;
+        let workflow_id: String = extract("id", &workflow);
+
+        let (_, workflow_step, _) = session
+            .post(
+                app,
+                &format!("/conversation/{conversation_id}/workflow/{workflow_id}/workflow_step"),
+                json!({
+                    "name": "Polis step",
+                    "step_order": 1,
+                    "activation_rule": "manual",
+                    "description": "polis step",
+                    "is_offline": false,
+                    "required": true,
+                    "tool_setup": polis_tool_config(),
+                })
+                .to_string()
+                .into(),
+            )
+            .await?;
+        let workflow_step_id: String = extract("id", &workflow_step);
+        let workflow_step_id = Uuid::parse_str(&workflow_step_id)?;
+
+        let owner_id = session.id.expect("session to be signed up");
+        let aux = polis_statement_aux::create(
+            pool,
+            owner_id,
+            &CreatePolisStatementAux {
+                workflow_step_id,
+                zid: 1,
+                polis_conversation_id: "test-poll".into(),
+                polis_statement_id: 1,
+                statement_text: "test statement".into(),
+                is_seed: false,
+                themes,
+                ..Default::default()
+            },
+        )
+        .await?;
+
+        Ok(aux)
+    }
+
+    #[sqlx::test]
+    async fn owner_can_add_theme(pool: PgPool) -> Result<(), Box<dyn Error>> {
+        let (app, mut session) = setup_default_app_and_session(&pool).await?;
+        let aux = setup_polis_aux(&app, &pool, &mut session, vec![]).await?;
+
+        let (status, value, _) = session
+            .post(
+                &app,
+                &format!("/tools/polis/statement_aux/{}/themes", aux.id),
+                json!({ "theme": "alpha" }).to_string().into(),
+            )
+            .await?;
+
+        assert_eq!(status, StatusCode::OK, "owner should be able to add a theme");
+        let updated: PolisStatementAux = serde_json::from_value(value)?;
+        assert_eq!(updated.themes, vec!["alpha".to_string()]);
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn adding_theme_is_idempotent(pool: PgPool) -> Result<(), Box<dyn Error>> {
+        let (app, mut session) = setup_default_app_and_session(&pool).await?;
+        let aux = setup_polis_aux(&app, &pool, &mut session, vec!["alpha".into()]).await?;
+
+        let (status, value, _) = session
+            .post(
+                &app,
+                &format!("/tools/polis/statement_aux/{}/themes", aux.id),
+                json!({ "theme": "alpha" }).to_string().into(),
+            )
+            .await?;
+
+        assert_eq!(status, StatusCode::OK);
+        let updated: PolisStatementAux = serde_json::from_value(value)?;
+        assert_eq!(
+            updated.themes,
+            vec!["alpha".to_string()],
+            "re-adding an existing theme should be a no-op"
+        );
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn owner_can_remove_theme(pool: PgPool) -> Result<(), Box<dyn Error>> {
+        let (app, mut session) = setup_default_app_and_session(&pool).await?;
+        let aux = setup_polis_aux(
+            &app,
+            &pool,
+            &mut session,
+            vec!["alpha".into(), "beta".into()],
+        )
+        .await?;
+
+        let (status, value, _) = session
+            .delete_with_body(
+                &app,
+                &format!("/tools/polis/statement_aux/{}/themes", aux.id),
+                json!({ "theme": "alpha" }).to_string().into(),
+            )
+            .await?;
+
+        assert_eq!(status, StatusCode::OK);
+        let updated: PolisStatementAux = serde_json::from_value(value)?;
+        assert_eq!(updated.themes, vec!["beta".to_string()]);
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn removing_missing_theme_is_idempotent(pool: PgPool) -> Result<(), Box<dyn Error>> {
+        let (app, mut session) = setup_default_app_and_session(&pool).await?;
+        let aux = setup_polis_aux(&app, &pool, &mut session, vec!["alpha".into()]).await?;
+
+        let (status, value, _) = session
+            .delete_with_body(
+                &app,
+                &format!("/tools/polis/statement_aux/{}/themes", aux.id),
+                json!({ "theme": "missing" }).to_string().into(),
+            )
+            .await?;
+
+        assert_eq!(status, StatusCode::OK);
+        let updated: PolisStatementAux = serde_json::from_value(value)?;
+        assert_eq!(updated.themes, vec!["alpha".to_string()]);
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn non_owner_cannot_add_theme(pool: PgPool) -> Result<(), Box<dyn Error>> {
+        let (app, mut owner) = setup_default_app_and_session(&pool).await?;
+        let aux = setup_polis_aux(&app, &pool, &mut owner, vec![]).await?;
+
+        let mut intruder = UserSession::new("intruder", crate::test_helpers::TEST_PASSWORD, "intruder@example.com");
+        intruder.signup(&app).await?;
+
+        let (status, _, _) = intruder
+            .post(
+                &app,
+                &format!("/tools/polis/statement_aux/{}/themes", aux.id),
+                json!({ "theme": "alpha" }).to_string().into(),
+            )
+            .await?;
+
+        assert_eq!(status, StatusCode::FORBIDDEN, "non-owner should be forbidden");
+
+        let reloaded = polis_statement_aux::get_by_id(&pool, &aux.id).await?;
+        assert!(reloaded.themes.is_empty(), "themes must not have changed");
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn non_owner_cannot_remove_theme(pool: PgPool) -> Result<(), Box<dyn Error>> {
+        let (app, mut owner) = setup_default_app_and_session(&pool).await?;
+        let aux = setup_polis_aux(&app, &pool, &mut owner, vec!["alpha".into()]).await?;
+
+        let mut intruder = UserSession::new("intruder", crate::test_helpers::TEST_PASSWORD, "intruder@example.com");
+        intruder.signup(&app).await?;
+
+        let (status, _, _) = intruder
+            .delete_with_body(
+                &app,
+                &format!("/tools/polis/statement_aux/{}/themes", aux.id),
+                json!({ "theme": "alpha" }).to_string().into(),
+            )
+            .await?;
+
+        assert_eq!(status, StatusCode::FORBIDDEN);
+
+        let reloaded = polis_statement_aux::get_by_id(&pool, &aux.id).await?;
+        assert_eq!(reloaded.themes, vec!["alpha".to_string()]);
+        Ok(())
+    }
 }
 
 async fn polis_setup(

--- a/ui/packages/api-client/src/api.ts
+++ b/ui/packages/api-client/src/api.ts
@@ -411,6 +411,8 @@ export const ThemeStatistic = z
   .object({ count: z.number().int(), theme: z.string() })
   .passthrough();
 export type ThemeStatistic = z.infer<typeof ThemeStatistic>;
+export const ThemeRequest = z.object({ theme: z.string() }).passthrough();
+export type ThemeRequest = z.infer<typeof ThemeRequest>;
 export const ModerationDecisionRequest = z.enum(["accept", "reject"]);
 export type ModerationDecisionRequest = z.infer<
   typeof ModerationDecisionRequest
@@ -2092,6 +2094,7 @@ export const schemas: Record<string, z.ZodType<any>> = {
   SyncStatementAuxRequest,
   SyncStatementAuxResponse,
   ThemeStatistic,
+  ThemeRequest,
   ModerationDecisionRequest,
   ModerateStatementAuxRequest,
   Story,
@@ -2963,7 +2966,7 @@ curl -X POST \
     method: "get",
     path: "/conversation/:conversation_id/events/:event_id/audio-recordings/download",
     alias: "GetAudioDownloadUrls",
-    description: `Get presigned S3 URLs for downloading transcript.json and report.txt for a recording.`,
+    description: `Get presigned S3 URLs for downloading transcript.json and report.json for a recording.`,
     requestFormat: "json",
     response: SignedDownloadUrls,
   },
@@ -4148,6 +4151,36 @@ Use a raw HTTP request and process the response body incrementally.
         name: "body",
         type: "Body",
         schema: ModerateStatementAuxRequest,
+      },
+    ],
+    response: PolisStatementAux,
+  },
+  {
+    method: "post",
+    path: "/tools/polis/statement_aux/:id/themes",
+    alias: "PolisAddStatementAuxTheme",
+    description: `Adds a theme to the statement&#x27;s themes array. Idempotent: adding a theme that is already present is a no-op. Caller must be the owner of the conversation the statement belongs to.`,
+    requestFormat: "json",
+    parameters: [
+      {
+        name: "body",
+        type: "Body",
+        schema: z.object({ theme: z.string() }).passthrough(),
+      },
+    ],
+    response: PolisStatementAux,
+  },
+  {
+    method: "delete",
+    path: "/tools/polis/statement_aux/:id/themes",
+    alias: "PolisRemoveStatementAuxTheme",
+    description: `Removes a theme from the statement&#x27;s themes array. Idempotent: removing a theme that is not present is a no-op. Caller must be the owner of the conversation the statement belongs to.`,
+    requestFormat: "json",
+    parameters: [
+      {
+        name: "body",
+        type: "Body",
+        schema: z.object({ theme: z.string() }).passthrough(),
       },
     ],
     response: PolisStatementAux,


### PR DESCRIPTION
WE added a constraint in who can directly update the polis_statement_aux table, restricting it to the user who created the associated comment.

We need a way for moderators however to add / remove themes so I am adding that as an additional set of endpoints with a different constraint.