### PR TITLE
Add step deletion UI to CommonStepConfig component

### DIFF
--- a/ui/packages/comhairle/src/lib/components/CommonStepConfig/CommonStepConfig.svelte
+++ b/ui/packages/comhairle/src/lib/components/CommonStepConfig/CommonStepConfig.svelte
@@ -108,9 +108,11 @@
 
 	let deleteOpen = $state(false);
 	let deleting = $state(false);
+	let deleteError = $state<string | null>(null);
 
 	async function deleteStep() {
 		deleting = true;
+		deleteError = null;
 		try {
 			await apiClient.DeleteConversationWorkflowStep(undefined, {
 				params: {
@@ -126,6 +128,7 @@
 			});
 		} catch (e) {
 			console.error(e);
+			deleteError = 'Something went wrong while deleting this step. Please try again.';
 			notifications.send({ priority: 'ERROR', message: 'Failed to delete step' });
 		} finally {
 			deleting = false;
@@ -213,7 +216,14 @@
 			</p>
 		</div>
 		<div>
-			<Button variant="destructive" disabled={deleting} onclick={() => (deleteOpen = true)}>
+			<Button
+				variant="destructive"
+				disabled={deleting}
+				onclick={() => {
+					deleteError = null;
+					deleteOpen = true;
+				}}
+			>
 				<Trash2 class="mr-2 h-4 w-4" />
 				Delete step
 			</Button>
@@ -229,6 +239,15 @@
 					remaining steps. This action cannot be undone.
 				</AlertDialog.Description>
 			</AlertDialog.Header>
+
+			{#if deleteError}
+				<p
+					class="border-destructive/30 bg-destructive/10 text-destructive rounded-md border p-3 text-sm"
+					role="alert"
+				>
+					{deleteError}
+				</p>
+			{/if}
 			<AlertDialog.Footer class="flex-col-reverse sm:flex-row">
 				<AlertDialog.Cancel class="w-full sm:w-auto" disabled={deleting}>
 					Cancel

--- a/ui/packages/comhairle/src/lib/components/CommonStepConfig/CommonStepConfig.svelte
+++ b/ui/packages/comhairle/src/lib/components/CommonStepConfig/CommonStepConfig.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
 	import { Button } from '$lib/components/ui/button';
 	import * as Dialog from '$lib/components/ui/dialog';
+	import * as AlertDialog from '$lib/components/ui/alert-dialog';
 	import * as ScrollArea from '$lib/components/ui/scroll-area';
-	import { invalidateAll } from '$app/navigation';
+	import { goto, invalidateAll } from '$app/navigation';
+	import { Trash2, LoaderCircle } from 'lucide-svelte';
 	import { notifications } from '$lib/notifications.svelte';
 	import type {
 		ComhairleDocument,
@@ -103,6 +105,32 @@
 	function handleSwitchChange(checked: boolean, field: string) {
 		debouncedUpdateRequired(checked, field);
 	}
+
+	let deleteOpen = $state(false);
+	let deleting = $state(false);
+
+	async function deleteStep() {
+		deleting = true;
+		try {
+			await apiClient.DeleteConversationWorkflowStep(undefined, {
+				params: {
+					conversation_id,
+					workflow_id: step.workflowId,
+					workflow_step_id: step.id
+				}
+			});
+			notifications.send({ priority: 'INFO', message: 'Step deleted' });
+			deleteOpen = false;
+			await goto(`/admin/conversations/${conversation_id}/design`, {
+				invalidate: ['conversation:workflow']
+			});
+		} catch (e) {
+			console.error(e);
+			notifications.send({ priority: 'ERROR', message: 'Failed to delete step' });
+		} finally {
+			deleting = false;
+		}
+	}
 </script>
 
 {#snippet fields()}
@@ -175,11 +203,62 @@
 	</div>
 {/snippet}
 
+{#snippet dangerZone()}
+	<div class="border-destructive/30 flex flex-col gap-4 rounded-lg border p-6">
+		<div class="flex flex-col gap-1">
+			<span class="text-destructive text-lg font-semibold">Danger zone</span>
+			<p class="text-muted-foreground text-sm">
+				Deleting this step permanently removes it and its configuration. The remaining steps
+				will be renumbered. This action cannot be undone.
+			</p>
+		</div>
+		<div>
+			<Button variant="destructive" disabled={deleting} onclick={() => (deleteOpen = true)}>
+				<Trash2 class="mr-2 h-4 w-4" />
+				Delete step
+			</Button>
+		</div>
+	</div>
+
+	<AlertDialog.Root bind:open={deleteOpen}>
+		<AlertDialog.Content>
+			<AlertDialog.Header>
+				<AlertDialog.Title>Delete “{name || sourceName || 'this step'}”?</AlertDialog.Title>
+				<AlertDialog.Description>
+					This permanently removes the step and its configuration, and renumbers the
+					remaining steps. This action cannot be undone.
+				</AlertDialog.Description>
+			</AlertDialog.Header>
+			<AlertDialog.Footer class="flex-col-reverse sm:flex-row">
+				<AlertDialog.Cancel class="w-full sm:w-auto" disabled={deleting}>
+					Cancel
+				</AlertDialog.Cancel>
+				<AlertDialog.Action
+					class="bg-destructive hover:bg-destructive/90 w-full text-white sm:w-auto"
+					disabled={deleting}
+					onclick={(e) => {
+						e.preventDefault();
+						deleteStep();
+					}}
+				>
+					{#if deleting}
+						<LoaderCircle class="mr-2 h-4 w-4 animate-spin" />
+					{/if}
+					Delete step
+				</AlertDialog.Action>
+			</AlertDialog.Footer>
+		</AlertDialog.Content>
+	</AlertDialog.Root>
+{/snippet}
+
 {#if inline}
 	<div class="flex flex-col gap-6">
 		{@render fields()}
 		<div class="border-border flex flex-col gap-4 border-t pt-6">
 			{@render switches()}
+		</div>
+		<div class="border-border border-t pt-6">
+			{@render dangerZone()}
 		</div>
 	</div>
 {:else}

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/design/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/design/+page.svelte
@@ -31,8 +31,6 @@
 
 	let reorderedSteps = $state<WorkflowStepWithTranslations[]>([]);
 
-	let showTestButtons = $derived(page.url.searchParams.get('testButtons') === '1');
-
 	$effect(() => {
 		reorderedSteps = workflowSteps
 			? [...workflowSteps].sort((a, b) => a.stepOrder - b.stepOrder)
@@ -80,11 +78,6 @@
 		await handleCommit(next);
 	}
 
-	async function refreshWorkflowData() {
-		await invalidate('conversation:workflow');
-		notifications.send({ priority: 'INFO', message: 'Workflow data refreshed' });
-	}
-
 	function activeToolConfig(step: WorkflowStepWithTranslations) {
 		return conversation.isLive ? step.toolConfig : step.previewToolConfig;
 	}
@@ -109,24 +102,6 @@
 			Learn what makes for good process design.
 		</a>
 	</p>
-
-	{#if showTestButtons}
-		<Card.Root class="mb-6 border-orange-300 bg-orange-50/40">
-			<Card.Header>
-				<Card.Title class="text-base">Test Buttons</Card.Title>
-				<Card.Description>
-					Temporary controls for validating workflow-step backend behavior.
-				</Card.Description>
-			</Card.Header>
-			<Card.Content>
-				<div class="flex flex-wrap gap-2">
-					<Button variant="outline" onclick={refreshWorkflowData}
-						>Reload workflow data</Button
-					>
-				</div>
-			</Card.Content>
-		</Card.Root>
-	{/if}
 
 	<div class="mb-5 flex flex-col gap-y-5">
 		<DraggableList

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/design/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/design/+page.svelte
@@ -13,8 +13,7 @@
 		Bot,
 		GripVertical,
 		ChevronUp,
-		ChevronDown,
-		Trash2
+		ChevronDown
 	} from 'lucide-svelte';
 	import * as Card from '$lib/components/ui/card';
 	import Button from '$lib/components/ui/button/button.svelte';
@@ -31,7 +30,6 @@
 	let loading = $derived(workflowSteps === undefined);
 
 	let reorderedSteps = $state<WorkflowStepWithTranslations[]>([]);
-	let deletingStepId = $state<string | null>(null);
 
 	let showTestButtons = $derived(page.url.searchParams.get('testButtons') === '1');
 
@@ -85,31 +83,6 @@
 	async function refreshWorkflowData() {
 		await invalidate('conversation:workflow');
 		notifications.send({ priority: 'INFO', message: 'Workflow data refreshed' });
-	}
-
-	async function deleteStepForTest(step: WorkflowStepWithTranslations) {
-		const confirmed = window.confirm(
-			`Delete step \"${step.name}\"? This is a test action and cannot be undone.`
-		);
-		if (!confirmed) return;
-
-		deletingStepId = step.id;
-		try {
-			await apiClient.DeleteConversationWorkflowStep(undefined, {
-				params: {
-					conversation_id: conversation.id,
-					workflow_id: workflow.id,
-					workflow_step_id: step.id
-				}
-			});
-			await invalidate('conversation:workflow');
-			notifications.send({ priority: 'INFO', message: 'Step deleted' });
-		} catch (e) {
-			console.error(e);
-			notifications.send({ priority: 'ERROR', message: 'Failed to delete step' });
-		} finally {
-			deletingStepId = null;
-		}
 	}
 
 	function activeToolConfig(step: WorkflowStepWithTranslations) {
@@ -222,19 +195,6 @@
 								{activeToolConfig(step).type}
 							</a>
 							<div class="flex items-center gap-2">
-								{#if showTestButtons}
-									<Button
-										variant="destructive"
-										size="sm"
-										disabled={deletingStepId === step.id}
-										onclick={() => deleteStepForTest(step)}
-									>
-										<Trash2 class="mr-1 h-4 w-4" />
-										{deletingStepId === step.id
-											? 'Deleting...'
-											: 'Delete (test)'}
-									</Button>
-								{/if}
 								<Button
 									href={`/admin/conversations/${conversation.id}/design/step/${step.id}`}
 									class="secondary"


### PR DESCRIPTION
depends on #476 this is why i made that the target branch

Actions:
- Add danger zone section with delete button to step configuration
- Add confirmation dialog for step deletion using AlertDialog
- Remove test delete buttons from design page
- Handle step deletion with navigation back to design page
- Show loading state during deletion process

<img width="1069" height="871" alt="2026-06-24_22-24-20" src="https://github.com/user-attachments/assets/2d36232c-1e25-41a9-9f1f-bf2c86bffa71" />
<img width="404" height="292" alt="image" src="https://github.com/user-attachments/assets/cb233a97-62c0-4352-ab1a-39709b4e720b" />
<img width="1214" height="888" alt="image" src="https://github.com/user-attachments/assets/88534fa0-6834-4453-9066-f40e2b9971d3" />
