### PR TITLE
Adding recruitment target model and routes

### DIFF
--- a/api/migrations/20260625120000_create_recruitment_target_table.sql
+++ b/api/migrations/20260625120000_create_recruitment_target_table.sql
@@ -1,0 +1,19 @@
+-- Create recruitment_target table to store demographic recruitment goals for workflows.
+-- Each row records the target number of participants for a given metric/bucket combination
+-- (e.g. metric = 'age', bucket = '18-24', target_count = 30).
+CREATE TABLE recruitment_target (
+    id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+    workflow_id uuid NOT NULL REFERENCES workflow(id) ON DELETE CASCADE,
+    metric TEXT NOT NULL,
+    bucket TEXT NOT NULL,
+    target_count INTEGER NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Only one target row per (workflow, metric, bucket) combination
+CREATE UNIQUE INDEX recruitment_target_workflow_metric_bucket_unique
+    ON recruitment_target(workflow_id, metric, bucket);
+
+-- Index for listing all targets for a workflow
+CREATE INDEX recruitment_target_workflow_id_index ON recruitment_target(workflow_id);

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -230,6 +230,10 @@ pub async fn setup_server(state: Arc<ComhairleState>) -> Result<Router<()>, Comh
                         .nest_api_service(
                             "/{workflow_id}/progress",
                             routes::user_progress::router(state.clone()),
+                        )
+                        .nest_api_service(
+                            "/{workflow_id}/recruitment_targets",
+                            routes::recruitment_targets::router(state.clone()),
                         ),
                 )
                 .nest_api_service(

--- a/api/src/models.rs
+++ b/api/src/models.rs
@@ -21,6 +21,7 @@ pub mod pagination;
 pub mod polis_statement_aux;
 pub mod proposal;
 pub mod proposal_response;
+pub mod recruitment_target;
 pub mod region;
 pub mod report;
 pub mod report_impact;

--- a/api/src/models/recruitment_target.rs
+++ b/api/src/models/recruitment_target.rs
@@ -358,6 +358,14 @@ mod tests {
         )
         .await?;
 
+        // The workflow route auto-assigns the created workflow as the
+        // conversation's default_workflow_id, and that FK has no ON DELETE
+        // clause. Clear it so the workflow row can actually be deleted.
+        sqlx::query("UPDATE conversation SET default_workflow_id = NULL WHERE default_workflow_id = $1")
+            .bind(workflow_id)
+            .execute(&pool)
+            .await?;
+
         crate::models::workflow::delete(&pool, &workflow_id).await?;
 
         let result = get_by_id(&pool, &target.id).await;

--- a/api/src/models/recruitment_target.rs
+++ b/api/src/models/recruitment_target.rs
@@ -1,0 +1,367 @@
+use chrono::{DateTime, Utc};
+use partially::Partial;
+use schemars::JsonSchema;
+use sea_query::{enum_def, Expr, OnConflict, PostgresQueryBuilder, Query};
+use sea_query_binder::SqlxBinder;
+use serde::{Deserialize, Serialize};
+use sqlx::{prelude::FromRow, PgPool};
+use uuid::Uuid;
+
+use crate::error::ComhairleError;
+
+#[derive(Partial, Debug, Deserialize, Serialize, FromRow, Clone, JsonSchema)]
+#[enum_def(table_name = "recruitment_target")]
+#[partially(derive(Deserialize, Debug, JsonSchema, Default))]
+pub struct RecruitmentTarget {
+    #[partially(omit)]
+    pub id: Uuid,
+    #[partially(omit)]
+    pub workflow_id: Uuid,
+    pub metric: String,
+    pub bucket: String,
+    pub target_count: i32,
+    #[partially(omit)]
+    pub created_at: DateTime<Utc>,
+    #[partially(omit)]
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+pub struct CreateRecruitmentTarget {
+    pub metric: String,
+    pub bucket: String,
+    pub target_count: i32,
+}
+
+const DEFAULT_COLUMNS: [RecruitmentTargetIden; 7] = [
+    RecruitmentTargetIden::Id,
+    RecruitmentTargetIden::WorkflowId,
+    RecruitmentTargetIden::Metric,
+    RecruitmentTargetIden::Bucket,
+    RecruitmentTargetIden::TargetCount,
+    RecruitmentTargetIden::CreatedAt,
+    RecruitmentTargetIden::UpdatedAt,
+];
+
+pub async fn create(
+    db: &PgPool,
+    workflow_id: &Uuid,
+    create_request: &CreateRecruitmentTarget,
+) -> Result<RecruitmentTarget, ComhairleError> {
+    let (sql, values) = Query::insert()
+        .into_table(RecruitmentTargetIden::Table)
+        .columns([
+            RecruitmentTargetIden::WorkflowId,
+            RecruitmentTargetIden::Metric,
+            RecruitmentTargetIden::Bucket,
+            RecruitmentTargetIden::TargetCount,
+        ])
+        .values([
+            (*workflow_id).into(),
+            create_request.metric.clone().into(),
+            create_request.bucket.clone().into(),
+            create_request.target_count.into(),
+        ])
+        .unwrap()
+        .on_conflict(
+            OnConflict::columns([
+                RecruitmentTargetIden::WorkflowId,
+                RecruitmentTargetIden::Metric,
+                RecruitmentTargetIden::Bucket,
+            ])
+            .update_columns([
+                RecruitmentTargetIden::TargetCount,
+                RecruitmentTargetIden::UpdatedAt,
+            ])
+            .to_owned(),
+        )
+        .returning(Query::returning().columns(DEFAULT_COLUMNS))
+        .build_sqlx(PostgresQueryBuilder);
+
+    let target = sqlx::query_as_with::<_, RecruitmentTarget, _>(&sql, values)
+        .fetch_one(db)
+        .await?;
+
+    Ok(target)
+}
+
+pub async fn get_by_id(db: &PgPool, id: &Uuid) -> Result<RecruitmentTarget, ComhairleError> {
+    let (sql, values) = Query::select()
+        .columns(DEFAULT_COLUMNS)
+        .from(RecruitmentTargetIden::Table)
+        .and_where(Expr::col(RecruitmentTargetIden::Id).eq(*id))
+        .build_sqlx(PostgresQueryBuilder);
+
+    let target = sqlx::query_as_with::<_, RecruitmentTarget, _>(&sql, values)
+        .fetch_one(db)
+        .await
+        .map_err(|_| ComhairleError::ResourceNotFound("RecruitmentTarget".into()))?;
+
+    Ok(target)
+}
+
+pub async fn list_for_workflow(
+    db: &PgPool,
+    workflow_id: &Uuid,
+) -> Result<Vec<RecruitmentTarget>, ComhairleError> {
+    let (sql, values) = Query::select()
+        .columns(DEFAULT_COLUMNS)
+        .from(RecruitmentTargetIden::Table)
+        .and_where(Expr::col(RecruitmentTargetIden::WorkflowId).eq(*workflow_id))
+        .order_by(RecruitmentTargetIden::Metric, sea_query::Order::Asc)
+        .order_by(RecruitmentTargetIden::Bucket, sea_query::Order::Asc)
+        .build_sqlx(PostgresQueryBuilder);
+
+    let targets = sqlx::query_as_with::<_, RecruitmentTarget, _>(&sql, values)
+        .fetch_all(db)
+        .await?;
+
+    Ok(targets)
+}
+
+pub async fn update(
+    db: &PgPool,
+    id: &Uuid,
+    update_request: &PartialRecruitmentTarget,
+) -> Result<RecruitmentTarget, ComhairleError> {
+    let mut query = Query::update()
+        .table(RecruitmentTargetIden::Table)
+        .and_where(Expr::col(RecruitmentTargetIden::Id).eq(*id))
+        .to_owned();
+
+    let mut has_updates = false;
+
+    if let Some(value) = &update_request.metric {
+        query = query
+            .value(RecruitmentTargetIden::Metric, value.clone())
+            .to_owned();
+        has_updates = true;
+    }
+    if let Some(value) = &update_request.bucket {
+        query = query
+            .value(RecruitmentTargetIden::Bucket, value.clone())
+            .to_owned();
+        has_updates = true;
+    }
+    if let Some(value) = update_request.target_count {
+        query = query
+            .value(RecruitmentTargetIden::TargetCount, value)
+            .to_owned();
+        has_updates = true;
+    }
+
+    if !has_updates {
+        return get_by_id(db, id).await;
+    }
+
+    query = query
+        .value(RecruitmentTargetIden::UpdatedAt, Utc::now())
+        .to_owned();
+
+    let (sql, values) = query
+        .returning(Query::returning().columns(DEFAULT_COLUMNS))
+        .build_sqlx(PostgresQueryBuilder);
+
+    let target = sqlx::query_as_with::<_, RecruitmentTarget, _>(&sql, values)
+        .fetch_one(db)
+        .await
+        .map_err(|_| ComhairleError::ResourceNotFound("RecruitmentTarget".into()))?;
+
+    Ok(target)
+}
+
+pub async fn delete(db: &PgPool, id: &Uuid) -> Result<RecruitmentTarget, ComhairleError> {
+    let (sql, values) = Query::delete()
+        .from_table(RecruitmentTargetIden::Table)
+        .and_where(Expr::col(RecruitmentTargetIden::Id).eq(*id))
+        .returning(Query::returning().columns(DEFAULT_COLUMNS))
+        .build_sqlx(PostgresQueryBuilder);
+
+    let target = sqlx::query_as_with::<_, RecruitmentTarget, _>(&sql, values)
+        .fetch_one(db)
+        .await
+        .map_err(|_| ComhairleError::ResourceNotFound("RecruitmentTarget".into()))?;
+
+    Ok(target)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::model_test_helpers::setup_default_app_and_session;
+    use crate::routes::{conversations::dto::ConversationDto, workflows::dto::WorkflowDto};
+    use sqlx::PgPool;
+    use std::error::Error;
+
+    async fn make_workflow(pool: &PgPool) -> Result<Uuid, Box<dyn Error>> {
+        let (app, mut session) = setup_default_app_and_session(pool).await?;
+        let (_, conversation, _) = session.create_random_conversation(&app).await?;
+        let conversation: ConversationDto = serde_json::from_value(conversation)?;
+        let (_, workflow, _) = session
+            .create_random_workflow(&app, &conversation.id.to_string())
+            .await?;
+        let workflow: WorkflowDto = serde_json::from_value(workflow)?;
+        Ok(workflow.id)
+    }
+
+    #[sqlx::test]
+    async fn should_create_a_recruitment_target(pool: PgPool) -> Result<(), Box<dyn Error>> {
+        let workflow_id = make_workflow(&pool).await?;
+
+        let target = create(
+            &pool,
+            &workflow_id,
+            &CreateRecruitmentTarget {
+                metric: "age".into(),
+                bucket: "18-24".into(),
+                target_count: 30,
+            },
+        )
+        .await?;
+
+        assert_eq!(target.workflow_id, workflow_id);
+        assert_eq!(target.metric, "age");
+        assert_eq!(target.bucket, "18-24");
+        assert_eq!(target.target_count, 30);
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn should_upsert_when_same_metric_bucket(pool: PgPool) -> Result<(), Box<dyn Error>> {
+        let workflow_id = make_workflow(&pool).await?;
+
+        let first = create(
+            &pool,
+            &workflow_id,
+            &CreateRecruitmentTarget {
+                metric: "age".into(),
+                bucket: "18-24".into(),
+                target_count: 30,
+            },
+        )
+        .await?;
+
+        let second = create(
+            &pool,
+            &workflow_id,
+            &CreateRecruitmentTarget {
+                metric: "age".into(),
+                bucket: "18-24".into(),
+                target_count: 45,
+            },
+        )
+        .await?;
+
+        assert_eq!(first.id, second.id, "should be the same row");
+        assert_eq!(second.target_count, 45, "target count should be updated");
+
+        let all = list_for_workflow(&pool, &workflow_id).await?;
+        assert_eq!(all.len(), 1, "should only have one row");
+
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn should_list_targets_for_workflow(pool: PgPool) -> Result<(), Box<dyn Error>> {
+        let workflow_id = make_workflow(&pool).await?;
+
+        create(
+            &pool,
+            &workflow_id,
+            &CreateRecruitmentTarget {
+                metric: "age".into(),
+                bucket: "18-24".into(),
+                target_count: 10,
+            },
+        )
+        .await?;
+        create(
+            &pool,
+            &workflow_id,
+            &CreateRecruitmentTarget {
+                metric: "gender".into(),
+                bucket: "female".into(),
+                target_count: 50,
+            },
+        )
+        .await?;
+
+        let targets = list_for_workflow(&pool, &workflow_id).await?;
+
+        assert_eq!(targets.len(), 2);
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn should_update_a_target(pool: PgPool) -> Result<(), Box<dyn Error>> {
+        let workflow_id = make_workflow(&pool).await?;
+        let target = create(
+            &pool,
+            &workflow_id,
+            &CreateRecruitmentTarget {
+                metric: "age".into(),
+                bucket: "18-24".into(),
+                target_count: 10,
+            },
+        )
+        .await?;
+
+        let updated = update(
+            &pool,
+            &target.id,
+            &PartialRecruitmentTarget {
+                target_count: Some(20),
+                ..PartialRecruitmentTarget::default()
+            },
+        )
+        .await?;
+
+        assert_eq!(updated.target_count, 20);
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn should_delete_a_target(pool: PgPool) -> Result<(), Box<dyn Error>> {
+        let workflow_id = make_workflow(&pool).await?;
+        let target = create(
+            &pool,
+            &workflow_id,
+            &CreateRecruitmentTarget {
+                metric: "age".into(),
+                bucket: "18-24".into(),
+                target_count: 10,
+            },
+        )
+        .await?;
+
+        delete(&pool, &target.id).await?;
+
+        let result = get_by_id(&pool, &target.id).await;
+        assert!(result.is_err(), "target should be gone");
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn should_cascade_delete_when_workflow_deleted(
+        pool: PgPool,
+    ) -> Result<(), Box<dyn Error>> {
+        let workflow_id = make_workflow(&pool).await?;
+        let target = create(
+            &pool,
+            &workflow_id,
+            &CreateRecruitmentTarget {
+                metric: "age".into(),
+                bucket: "18-24".into(),
+                target_count: 10,
+            },
+        )
+        .await?;
+
+        crate::models::workflow::delete(&pool, &workflow_id).await?;
+
+        let result = get_by_id(&pool, &target.id).await;
+        assert!(result.is_err(), "target should cascade-delete with workflow");
+        Ok(())
+    }
+}

--- a/api/src/routes.rs
+++ b/api/src/routes.rs
@@ -13,6 +13,7 @@ pub mod jobs;
 pub mod media;
 pub mod notifications;
 pub mod organizations;
+pub mod recruitment_targets;
 pub mod regions;
 pub mod report_impacts;
 pub mod reports;

--- a/api/src/routes/recruitment_targets.rs
+++ b/api/src/routes/recruitment_targets.rs
@@ -1,0 +1,309 @@
+use std::sync::Arc;
+
+use aide::axum::{
+    routing::{delete_with, get_with, post_with, put_with},
+    ApiRouter,
+};
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    Json,
+};
+use uuid::Uuid;
+
+use crate::{
+    error::ComhairleError,
+    models::{
+        self,
+        recruitment_target::{CreateRecruitmentTarget, PartialRecruitmentTarget},
+    },
+    routes::{
+        auth::RequiredAdminUser, recruitment_targets::dto::RecruitmentTargetDto,
+        workflows::WorkflowPathCtx,
+    },
+    ComhairleState,
+};
+
+pub mod dto;
+
+async fn create_recruitment_target(
+    State(state): State<Arc<ComhairleState>>,
+    WorkflowPathCtx { workflow_id }: WorkflowPathCtx,
+    RequiredAdminUser(_user): RequiredAdminUser,
+    Json(create_request): Json<CreateRecruitmentTarget>,
+) -> Result<(StatusCode, Json<RecruitmentTargetDto>), ComhairleError> {
+    let target = models::recruitment_target::create(&state.db, &workflow_id, &create_request)
+        .await?
+        .into();
+    Ok((StatusCode::CREATED, Json(target)))
+}
+
+async fn list_recruitment_targets(
+    State(state): State<Arc<ComhairleState>>,
+    WorkflowPathCtx { workflow_id }: WorkflowPathCtx,
+    RequiredAdminUser(_user): RequiredAdminUser,
+) -> Result<(StatusCode, Json<Vec<RecruitmentTargetDto>>), ComhairleError> {
+    let targets = models::recruitment_target::list_for_workflow(&state.db, &workflow_id)
+        .await?
+        .into_iter()
+        .map(Into::into)
+        .collect();
+    Ok((StatusCode::OK, Json(targets)))
+}
+
+async fn get_recruitment_target(
+    State(state): State<Arc<ComhairleState>>,
+    Path((_conversation_id, _workflow_id, target_id)): Path<(Uuid, Uuid, Uuid)>,
+    RequiredAdminUser(_user): RequiredAdminUser,
+) -> Result<(StatusCode, Json<RecruitmentTargetDto>), ComhairleError> {
+    let target = models::recruitment_target::get_by_id(&state.db, &target_id)
+        .await?
+        .into();
+    Ok((StatusCode::OK, Json(target)))
+}
+
+async fn update_recruitment_target(
+    State(state): State<Arc<ComhairleState>>,
+    Path((_conversation_id, _workflow_id, target_id)): Path<(Uuid, Uuid, Uuid)>,
+    RequiredAdminUser(_user): RequiredAdminUser,
+    Json(update_request): Json<PartialRecruitmentTarget>,
+) -> Result<(StatusCode, Json<RecruitmentTargetDto>), ComhairleError> {
+    let target = models::recruitment_target::update(&state.db, &target_id, &update_request)
+        .await?
+        .into();
+    Ok((StatusCode::OK, Json(target)))
+}
+
+async fn delete_recruitment_target(
+    State(state): State<Arc<ComhairleState>>,
+    Path((_conversation_id, _workflow_id, target_id)): Path<(Uuid, Uuid, Uuid)>,
+    RequiredAdminUser(_user): RequiredAdminUser,
+) -> Result<(StatusCode, Json<RecruitmentTargetDto>), ComhairleError> {
+    let target = models::recruitment_target::delete(&state.db, &target_id)
+        .await?
+        .into();
+    Ok((StatusCode::OK, Json(target)))
+}
+
+pub fn router(state: Arc<ComhairleState>) -> ApiRouter {
+    ApiRouter::new()
+        .api_route(
+            "/",
+            post_with(create_recruitment_target, |op| {
+                op.id("CreateRecruitmentTarget")
+                    .tag("Recruitment Target")
+                    .security_requirement("JWT")
+                    .summary("Create a recruitment target for a workflow")
+                    .description(
+                        "Records the target number of participants for a given demographic \
+                         metric/bucket combination on this workflow. Upserts on \
+                         (workflow_id, metric, bucket).",
+                    )
+                    .response::<201, Json<RecruitmentTargetDto>>()
+            }),
+        )
+        .api_route(
+            "/",
+            get_with(list_recruitment_targets, |op| {
+                op.id("ListRecruitmentTargets")
+                    .tag("Recruitment Target")
+                    .security_requirement("JWT")
+                    .summary("List recruitment targets for a workflow")
+                    .response::<200, Json<Vec<RecruitmentTargetDto>>>()
+            }),
+        )
+        .api_route(
+            "/{recruitment_target_id}",
+            get_with(get_recruitment_target, |op| {
+                op.id("GetRecruitmentTarget")
+                    .tag("Recruitment Target")
+                    .security_requirement("JWT")
+                    .summary("Get a recruitment target by id")
+                    .response::<200, Json<RecruitmentTargetDto>>()
+            }),
+        )
+        .api_route(
+            "/{recruitment_target_id}",
+            put_with(update_recruitment_target, |op| {
+                op.id("UpdateRecruitmentTarget")
+                    .tag("Recruitment Target")
+                    .security_requirement("JWT")
+                    .summary("Update a recruitment target")
+                    .response::<200, Json<RecruitmentTargetDto>>()
+            }),
+        )
+        .api_route(
+            "/{recruitment_target_id}",
+            delete_with(delete_recruitment_target, |op| {
+                op.id("DeleteRecruitmentTarget")
+                    .tag("Recruitment Target")
+                    .security_requirement("JWT")
+                    .summary("Delete a recruitment target")
+                    .response::<200, Json<RecruitmentTargetDto>>()
+            }),
+        )
+        .with_state(state)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        models::model_test_helpers::setup_default_app_and_session,
+        routes::{conversations::dto::ConversationDto, workflows::dto::WorkflowDto},
+    };
+    use serde_json::json;
+    use sqlx::PgPool;
+    use std::error::Error;
+
+    async fn setup(
+        pool: &PgPool,
+    ) -> Result<
+        (
+            axum::Router,
+            crate::test_helpers::UserSession,
+            String,
+            String,
+        ),
+        Box<dyn Error>,
+    > {
+        let (app, mut session) = setup_default_app_and_session(pool).await?;
+        let (_, conversation, _) = session.create_random_conversation(&app).await?;
+        let conversation: ConversationDto = serde_json::from_value(conversation)?;
+        let (_, workflow, _) = session
+            .create_random_workflow(&app, &conversation.id.to_string())
+            .await?;
+        let workflow: WorkflowDto = serde_json::from_value(workflow)?;
+        Ok((
+            app,
+            session,
+            conversation.id.to_string(),
+            workflow.id.to_string(),
+        ))
+    }
+
+    #[sqlx::test]
+    async fn should_create_recruitment_target_via_api(pool: PgPool) -> Result<(), Box<dyn Error>> {
+        let (app, mut session, conversation_id, workflow_id) = setup(&pool).await?;
+
+        let url =
+            format!("/conversation/{conversation_id}/workflow/{workflow_id}/recruitment_targets");
+
+        let (status, target, _) = session
+            .post(
+                &app,
+                &url,
+                json!({
+                    "metric": "age",
+                    "bucket": "18-24",
+                    "target_count": 30
+                })
+                .to_string()
+                .into(),
+            )
+            .await?;
+
+        assert_eq!(status, StatusCode::CREATED, "should be created");
+        let target: RecruitmentTargetDto = serde_json::from_value(target)?;
+        assert_eq!(target.metric, "age");
+        assert_eq!(target.bucket, "18-24");
+        assert_eq!(target.target_count, 30);
+        assert_eq!(target.workflow_id.to_string(), workflow_id);
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn should_list_recruitment_targets_via_api(pool: PgPool) -> Result<(), Box<dyn Error>> {
+        let (app, mut session, conversation_id, workflow_id) = setup(&pool).await?;
+
+        let url =
+            format!("/conversation/{conversation_id}/workflow/{workflow_id}/recruitment_targets");
+
+        for (metric, bucket, count) in [
+            ("age", "18-24", 30),
+            ("age", "25-34", 40),
+            ("gender", "female", 50),
+        ] {
+            session
+                .post(
+                    &app,
+                    &url,
+                    json!({
+                        "metric": metric,
+                        "bucket": bucket,
+                        "target_count": count
+                    })
+                    .to_string()
+                    .into(),
+                )
+                .await?;
+        }
+
+        let (status, targets, _) = session.get(&app, &url).await?;
+        assert_eq!(status, StatusCode::OK);
+        let targets: Vec<RecruitmentTargetDto> = serde_json::from_value(targets)?;
+        assert_eq!(targets.len(), 3);
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn should_update_recruitment_target_via_api(pool: PgPool) -> Result<(), Box<dyn Error>> {
+        let (app, mut session, conversation_id, workflow_id) = setup(&pool).await?;
+
+        let base_url =
+            format!("/conversation/{conversation_id}/workflow/{workflow_id}/recruitment_targets");
+
+        let (_, target, _) = session
+            .post(
+                &app,
+                &base_url,
+                json!({"metric": "age", "bucket": "18-24", "target_count": 30})
+                    .to_string()
+                    .into(),
+            )
+            .await?;
+        let target: RecruitmentTargetDto = serde_json::from_value(target)?;
+
+        let (status, updated, _) = session
+            .put(
+                &app,
+                &format!("{base_url}/{}", target.id),
+                json!({"target_count": 99}).to_string().into(),
+            )
+            .await?;
+        assert_eq!(status, StatusCode::OK);
+        let updated: RecruitmentTargetDto = serde_json::from_value(updated)?;
+        assert_eq!(updated.target_count, 99);
+        Ok(())
+    }
+
+    #[sqlx::test]
+    async fn should_delete_recruitment_target_via_api(pool: PgPool) -> Result<(), Box<dyn Error>> {
+        let (app, mut session, conversation_id, workflow_id) = setup(&pool).await?;
+
+        let base_url =
+            format!("/conversation/{conversation_id}/workflow/{workflow_id}/recruitment_targets");
+
+        let (_, target, _) = session
+            .post(
+                &app,
+                &base_url,
+                json!({"metric": "age", "bucket": "18-24", "target_count": 30})
+                    .to_string()
+                    .into(),
+            )
+            .await?;
+        let target: RecruitmentTargetDto = serde_json::from_value(target)?;
+
+        let (status, _, _) = session
+            .delete(&app, &format!("{base_url}/{}", target.id))
+            .await?;
+        assert_eq!(status, StatusCode::OK);
+
+        let (status, _, _) = session
+            .get(&app, &format!("{base_url}/{}", target.id))
+            .await?;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        Ok(())
+    }
+}

--- a/api/src/routes/recruitment_targets/dto.rs
+++ b/api/src/routes/recruitment_targets/dto.rs
@@ -1,0 +1,32 @@
+use chrono::{DateTime, Utc};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::models::recruitment_target::RecruitmentTarget;
+
+#[derive(Serialize, Deserialize, JsonSchema, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct RecruitmentTargetDto {
+    pub id: Uuid,
+    pub workflow_id: Uuid,
+    pub metric: String,
+    pub bucket: String,
+    pub target_count: i32,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl From<RecruitmentTarget> for RecruitmentTargetDto {
+    fn from(target: RecruitmentTarget) -> Self {
+        Self {
+            id: target.id,
+            workflow_id: target.workflow_id,
+            metric: target.metric,
+            bucket: target.bucket,
+            target_count: target.target_count,
+            created_at: target.created_at,
+            updated_at: target.updated_at,
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces a recruitment_target model and api to be able to register different recruitment targets. 

This is mostly for civic os just now but will be useful more generally in Comhairle in the future