### PR TITLE
Improve github action build and test speeds

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,40 @@ on:
   workflow_dispatch:  # Allows manual triggering
     
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      api: ${{ steps.filter.outputs.api }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+    steps:
+      -
+        name: Checkout repository
+        uses: actions/checkout@v4
+
+      -
+        name: Detect API and frontend changes
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            api:
+              - 'api/**'
+              - 'adaptors/**'
+              - 'comhairle_macros/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'api/Cargo.toml'
+              - 'api/Cargo.lock'
+              - 'rust-toolchain'
+              - 'rust-toolchain.toml'
+              - '.github/workflows/tests.yml'
+            frontend:
+              - 'ui/**'
+              - '.github/workflows/tests.yml'
+
   frontend-unit-tests:
+    needs: changes
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
     environment: base 
 
@@ -30,12 +63,14 @@ jobs:
         working-directory: ui
         run: pnpm install --frozen-lockfile
 
-      - 
+      -
         name: Run tests
         working-directory: ui
         run: pnpm --filter comhairle test:unit
 
   api-unit-tests:
+    needs: changes
+    if: github.event_name == 'workflow_dispatch' || needs.changes.outputs.api == 'true'
     runs-on: ubuntu-latest
     environment: base 
 
@@ -57,7 +92,7 @@ jobs:
     steps:
       - 
         name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - 
         name: Install Rust
@@ -66,14 +101,38 @@ jobs:
           toolchain: stable
           override: true
 
-      - name: Cache
+      -
+        name: Resolve cargo-nextest version
+        id: nextest-version
+        shell: bash
+        run: |
+          set -euo pipefail
+          version=$(cargo search cargo-nextest --limit 1 | sed -n 's/^cargo-nextest = "\([^"]*\)".*/\1/p')
+          if [[ -z "$version" ]]; then
+            echo "Failed to resolve cargo-nextest version" >&2
+            exit 1
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      -
+        name: Cache cargo-nextest
+        id: cache-nextest
         uses: actions/cache@v4
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          path: ~/.cargo/bin/cargo-nextest
+          key: ${{ runner.os }}-cargo-nextest-${{ steps.nextest-version.outputs.version }}
+
+      -
+        name: Install cargo nextest
+        if: steps.cache-nextest.outputs.cache-hit != 'true'
+        run: cargo install cargo-nextest --locked --version ${{ steps.nextest-version.outputs.version }}
+
+      - 
+        name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            . -> target
 
       - 
         name: Wait for PostgreSQL to be ready
@@ -102,4 +161,4 @@ jobs:
           CATEGORIZATION_SERVICE__SERVER_URL: ${{ secrets.CATEGORIZATION_SERVICE__SERVER_URL }}
           CATEGORIZATION_SERVICE__WEBHOOK_SECRET: ${{ secrets.CATEGORIZATION_SERVICE__WEBHOOK_SECRET }}
           BULK_STORAGE_SERVICE__STORE_NAME: ${{ secrets.BULK_STORAGE_SERVICE__STORE_NAME }}
-        run: cargo test --verbose
+        run: cargo nextest run --verbose

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -157,5 +157,8 @@ hmac = "0.13.0"
 [dev-dependencies]
 fake = { version = "4", features = ["derive"] }
 
+[profile.dev.package.sqlx-macros]
+opt-level = 3
+
 [build-dependencies]
 minijinja-embed = "2.10.2"

--- a/api/src/categorization_service/tttc_categorizer.rs
+++ b/api/src/categorization_service/tttc_categorizer.rs
@@ -170,7 +170,7 @@ mod tests {
     use sqlx::PgPool;
     use std::error::Error;
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     #[ignore]
     async fn should_create_new_tttc_job(pool: PgPool) -> std::result::Result<(), Box<dyn Error>> {
         let state = test_state().db(pool).call()?;

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -29,6 +29,11 @@ use websockets::WebSocketService;
 
 #[cfg(test)]
 mod test_helpers;
+#[cfg(test)]
+// sqlx::test expands every migration into the test binary for every invocation.
+// So, it massively bloats both the binary size and compile time.
+// Using a common migrator for all tests avoids this issue.
+const SQLX_MIGRATOR: sqlx::migrate::Migrator = sqlx::migrate!();
 
 use std::sync::Arc;
 

--- a/api/src/middleware/rate_limit_tests.rs
+++ b/api/src/middleware/rate_limit_tests.rs
@@ -76,7 +76,7 @@ mod tests {
         Ok(app.clone().oneshot(request).await?)
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn test_signup_within_burst_limit_succeeds(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let state = test_state_with_rate_limiting(pool)?;
         let app = setup_rate_limited_server(state).await?;
@@ -114,7 +114,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn test_signup_exceeding_rate_limit_returns_429(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {
@@ -153,7 +153,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn test_login_exceeding_rate_limit_returns_429(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {
@@ -182,7 +182,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn test_different_ips_have_separate_rate_limits(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {
@@ -228,7 +228,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn test_rate_limit_headers_are_present(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let state = test_state_with_rate_limiting(pool)?;
         let app = setup_rate_limited_server(state).await?;
@@ -285,7 +285,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn test_rate_limit_decreases_with_each_request(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {

--- a/api/src/models/api_key.rs
+++ b/api/src/models/api_key.rs
@@ -151,7 +151,7 @@ mod tests {
         assert_eq!(hash, hash_api_key(&raw));
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_return_matching_user_id(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let user = users::create_annon_user(&pool).await?;
 

--- a/api/src/models/audio_recording.rs
+++ b/api/src/models/audio_recording.rs
@@ -285,7 +285,7 @@ mod tests {
         Ok(event)
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn test_create_audio_recording(
         pool: sqlx::PgPool,
     ) -> Result<(), Box<dyn std::error::Error>> {
@@ -314,7 +314,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn test_get_by_id(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>> {
         let mut config = test_config()?;
         config.bot_service = None;
@@ -342,7 +342,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn test_get_by_event(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>> {
         let mut config = test_config()?;
         config.bot_service = None;
@@ -369,7 +369,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn test_update_status(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>> {
         let mut config = test_config()?;
         config.bot_service = None;
@@ -398,7 +398,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn test_get_by_id_not_found(
         pool: sqlx::PgPool,
     ) -> Result<(), Box<dyn std::error::Error>> {

--- a/api/src/models/conversation.rs
+++ b/api/src/models/conversation.rs
@@ -874,7 +874,7 @@ mod tests {
     use super::*;
     use std::error::Error;
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_create_conversation_with_oranganization_id(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {
@@ -924,7 +924,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_filter_conversations_by_case_insensitive_keyword(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {
@@ -1061,7 +1061,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_list_conversations_by_organization_id(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {

--- a/api/src/models/email_template_config.rs
+++ b/api/src/models/email_template_config.rs
@@ -605,7 +605,7 @@ mod tests {
 
     use std::error::Error;
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_create_email_config(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let (_, current_user, _) = session.current_user(&app).await?;
@@ -631,7 +631,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_update_email_config(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let (_, current_user, _) = session.current_user(&app).await?;
@@ -681,7 +681,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_get_email_config_by_id(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let (_, current_user, _) = session.current_user(&app).await?;
@@ -706,7 +706,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_optionally_get_email_config_user_and_email_type(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {
@@ -747,7 +747,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_list_email_configs(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let (_, user, _) = session.current_user(&app).await?;
@@ -786,7 +786,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_delete_email_config(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let (_, current_user, _) = session.current_user(&app).await?;

--- a/api/src/models/event.rs
+++ b/api/src/models/event.rs
@@ -769,7 +769,7 @@ mod tests {
     use super::*;
     use std::error::Error;
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_create_and_return_new_event(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let conversation_id = get_random_conversation_id(&app, &mut session).await?;
@@ -799,7 +799,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_create_event_with_location(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let conversation_id = get_random_conversation_id(&app, &mut session).await?;
@@ -836,7 +836,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_update_event_data(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let conversation_id = get_random_conversation_id(&app, &mut session).await?;
@@ -881,7 +881,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_update_event_location_data(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let conversation_id = get_random_conversation_id(&app, &mut session).await?;
@@ -929,7 +929,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_get_event_by_id(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let conversation_id_1 = get_random_conversation_id(&app, &mut session).await?;
@@ -977,7 +977,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_get_event_with_current_attendance(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let conversation_id = get_random_conversation_id(&app, &mut session).await?;
@@ -1027,7 +1027,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_list_events(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let conversation_id = get_random_conversation_id(&app, &mut session).await?;
@@ -1087,7 +1087,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_filter_events_by_time_status(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let conversation_id = get_random_conversation_id(&app, &mut session).await?;
@@ -1170,7 +1170,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_filter_events_by_capacity(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let conversation_id = get_random_conversation_id(&app, &mut session).await?;
@@ -1348,7 +1348,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_delete_event(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let conversation_id = get_random_conversation_id(&app, &mut session).await?;

--- a/api/src/models/event_attendance.rs
+++ b/api/src/models/event_attendance.rs
@@ -340,7 +340,7 @@ mod tests {
     use super::*;
     use std::error::Error;
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_create_attendance_for_event_without_capacity(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {
@@ -368,7 +368,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_create_attendance_for_event_with_capacity(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {
@@ -397,7 +397,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_only_check_capacity_against_participant_attendees(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {
@@ -471,7 +471,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn user_cannot_attend_same_event_twice(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let conversation_id = get_random_conversation_id(&app, &mut session).await?;
@@ -511,7 +511,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn transaction_will_not_lock_on_failure(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let conversation_id = get_random_conversation_id(&app, &mut session).await?;
@@ -560,7 +560,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_update_attendance(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let conversation_id = get_random_conversation_id(&app, &mut session).await?;
@@ -595,7 +595,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_get_attendance_by_id(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let conversation_id = get_random_conversation_id(&app, &mut session).await?;
@@ -622,7 +622,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_get_attendance_by_user_id(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let conversation_id = get_random_conversation_id(&app, &mut session).await?;
@@ -649,7 +649,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_list_attendance(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let conversation_id = get_random_conversation_id(&app, &mut session).await?;
@@ -708,7 +708,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_filter_attendance_by_role(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let conversation_id = get_random_conversation_id(&app, &mut session).await?;
@@ -775,7 +775,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_delete_attendance(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let conversation_id = get_random_conversation_id(&app, &mut session).await?;

--- a/api/src/models/invites.rs
+++ b/api/src/models/invites.rs
@@ -446,7 +446,7 @@ mod tests {
         );
         Ok(())
     }
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_get_correct_stats_for_invite(db: PgPool) -> Result<(), Box<dyn Error>> {
         let user1 = users::create_user(&Faker.fake(), &db).await?;
         let user2 = users::create_user(&Faker.fake(), &db).await?;
@@ -530,7 +530,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn open_invite_should_remain_open_when_rejected(
         db: PgPool,
     ) -> Result<(), Box<dyn Error>> {
@@ -608,7 +608,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn pending_invite_should_be_marked_rejected_when_rejected(
         db: PgPool,
     ) -> Result<(), Box<dyn Error>> {
@@ -686,7 +686,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_list_invites_for_an_event(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let user1 = users::create_user(&Faker.fake(), &pool).await?;
         let user2 = users::create_user(&Faker.fake(), &pool).await?;

--- a/api/src/models/job.rs
+++ b/api/src/models/job.rs
@@ -302,7 +302,7 @@ mod tests {
 
     use std::error::Error;
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_create_job(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let job = create(
             &pool,
@@ -321,7 +321,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_mark_job_as_completed(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let job = create(
             &pool,

--- a/api/src/models/media.rs
+++ b/api/src/models/media.rs
@@ -330,7 +330,7 @@ mod tests {
 
     use std::error::Error;
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_create_media_record(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         session.signup(&app).await?;
@@ -363,7 +363,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_get_media_record_by_id(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         session.signup(&app).await?;
@@ -394,7 +394,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_return_paginated_list_of_media_records(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {
@@ -465,7 +465,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_filter_media_by_owner(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         session.signup(&app).await?;
@@ -517,7 +517,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_delete_media_record(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         session.signup(&app).await?;

--- a/api/src/models/organization.rs
+++ b/api/src/models/organization.rs
@@ -339,7 +339,7 @@ mod tests {
     use super::*;
     use std::error::Error;
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_create_organization(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let _ = setup_default_app_and_session(&pool).await?;
 
@@ -368,7 +368,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_update_an_organization(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let _ = setup_default_app_and_session(&pool).await?;
         let new_org = CreateOrganization {
@@ -411,7 +411,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_get_a_list_of_localized_organizations(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {
@@ -467,7 +467,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_filter_organizations_by_region(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let (_, region_res_1, _) = session.create_random_region(&app).await?;
@@ -566,7 +566,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_get_a_localized_organization(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let _ = setup_default_app_and_session(&pool).await?;
         let new_org = CreateOrganization {
@@ -588,7 +588,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_get_an_organization(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let _ = setup_default_app_and_session(&pool).await?;
         let new_org = CreateOrganization {
@@ -609,7 +609,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_delete_an_organization(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let _ = setup_default_app_and_session(&pool).await?;
         let new_org = CreateOrganization {

--- a/api/src/models/otp.rs
+++ b/api/src/models/otp.rs
@@ -174,7 +174,7 @@ mod tests {
 
     use std::error::Error;
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_create_otp_for_user_with_expiry(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let user = users::create_otp_user(
             &OtpSignupRequest {
@@ -201,7 +201,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_mark_existing_otps_as_error_when_new_otp_created(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {
@@ -228,7 +228,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_fail_otp_create_for_annon_users(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let user = users::create_annon_user(&pool).await?;
 
@@ -240,7 +240,7 @@ mod tests {
         }
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_get_otp_by_id(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let user = users::create_otp_user(
             &OtpSignupRequest {
@@ -260,7 +260,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_get_otp_by_user_code(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let user = users::create_otp_user(
             &OtpSignupRequest {
@@ -283,7 +283,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_return_error_for_expired_otps(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let user = users::create_otp_user(
             &OtpSignupRequest {
@@ -315,7 +315,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_return_error_if_user_or_code_incorrect(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {

--- a/api/src/models/polis_statement_aux.rs
+++ b/api/src/models/polis_statement_aux.rs
@@ -490,7 +490,7 @@ mod tests {
 
     use super::*;
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn upsert_from_polis_refreshes_moderation_status(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {

--- a/api/src/models/proposal.rs
+++ b/api/src/models/proposal.rs
@@ -191,7 +191,7 @@ mod tests {
 
     use std::error::Error;
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_create_new_proposal(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let conversation_id = get_random_conversation_id(&app, &mut session).await?;
@@ -229,7 +229,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_get_localized_proposal(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let conversation_id = get_random_conversation_id(&app, &mut session).await?;
@@ -275,7 +275,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_list_proposals(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let conversation_id = get_random_conversation_id(&app, &mut session).await?;
@@ -322,7 +322,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_delete_proposal(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let conversation_id = get_random_conversation_id(&app, &mut session).await?;

--- a/api/src/models/proposal_response.rs
+++ b/api/src/models/proposal_response.rs
@@ -186,7 +186,7 @@ mod tests {
 
     use std::error::Error;
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_create_new_proposal_response(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let conversation_id = get_random_conversation_id(&app, &mut session).await?;
@@ -239,7 +239,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_list_proposal_responses(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let conversation_id = get_random_conversation_id(&app, &mut session).await?;

--- a/api/src/models/region.rs
+++ b/api/src/models/region.rs
@@ -306,7 +306,7 @@ mod tests {
     use super::*;
     use std::error::Error;
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_create_a_region(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let _ = setup_default_app_and_session(&pool).await?;
 
@@ -333,7 +333,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_update_a_region(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let _ = setup_default_app_and_session(&pool).await?;
         let new_region = CreateRegion {
@@ -375,7 +375,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_list_ordered_regions(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let _ = setup_default_app_and_session(&pool).await?;
 
@@ -457,7 +457,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_list_regions_filtered_by_organization(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {
@@ -517,7 +517,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_get_a_localized_region(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let _ = setup_default_app_and_session(&pool).await?;
         let new_region = CreateRegion {
@@ -540,7 +540,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_delete_a_region(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let _ = setup_default_app_and_session(&pool).await?;
         let new_region = CreateRegion {

--- a/api/src/models/scheduled_email.rs
+++ b/api/src/models/scheduled_email.rs
@@ -380,7 +380,7 @@ mod tests {
 
     use std::error::Error;
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_create_scheduled_email(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let params = CreateScheduledEmail {
             user_email: "test@test.com".to_string(),
@@ -410,7 +410,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_update_scheduled_email(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let params = CreateScheduledEmail {
             user_email: "test@test.com".to_string(),
@@ -450,7 +450,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_get_scheduled_email_by_id(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let params = CreateScheduledEmail {
             user_email: "test@test.com".to_string(),
@@ -482,7 +482,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_list_scheduled_emails(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let params_1 = CreateScheduledEmail {
             user_email: "user-1@test.com".to_string(),
@@ -559,7 +559,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_list_scheduled_emails_upcoming_2_hours(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {
@@ -659,7 +659,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_delete_scheduled_email_by_id(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let params = CreateScheduledEmail {
             user_email: "test@test.com".to_string(),

--- a/api/src/models/thinking_space_answer.rs
+++ b/api/src/models/thinking_space_answer.rs
@@ -316,7 +316,7 @@ mod tests {
 
     use std::error::Error;
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_create_new_thinking_space_answer(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let conversation_id = get_random_conversation_id(&app, &mut session).await?;
@@ -358,7 +358,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_fail_thinking_space_answer_creation_if_missing_follow_up_params(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {
@@ -434,7 +434,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_get_thinking_space_answer_by_id(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let conversation_id = get_random_conversation_id(&app, &mut session).await?;
@@ -474,7 +474,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_list_thinking_space_answers(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let conversation_id = get_random_conversation_id(&app, &mut session).await?;
@@ -578,7 +578,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_update_thinking_space_answer(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let conversation_id = get_random_conversation_id(&app, &mut session).await?;
@@ -628,7 +628,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_delete_thinking_space_answer_by_id(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let conversation_id = get_random_conversation_id(&app, &mut session).await?;

--- a/api/src/models/thinking_space_follow_up_question.rs
+++ b/api/src/models/thinking_space_follow_up_question.rs
@@ -264,7 +264,7 @@ mod tests {
         Ok((user.id, workflow_step.id, tool_config))
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_create_follow_up_questions(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (user_id, workflow_step_id, tool_config) =
             create_thinking_space_resources(&pool).await?;
@@ -294,7 +294,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_update_follow_up_questions(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (user_id, workflow_step_id, tool_config) =
             create_thinking_space_resources(&pool).await?;
@@ -331,7 +331,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_get_follow_up_questions_by_id(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (user_id, workflow_step_id, tool_config) =
             create_thinking_space_resources(&pool).await?;
@@ -354,7 +354,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_list_follow_up_questions_for_workflow_step(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {
@@ -408,7 +408,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_delete_follow_up_questions_by_id(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (user_id, workflow_step_id, tool_config) =
             create_thinking_space_resources(&pool).await?;

--- a/api/src/models/thinking_space_summary.rs
+++ b/api/src/models/thinking_space_summary.rs
@@ -260,7 +260,7 @@ mod tests {
         Ok((user.id, workflow_step.id))
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_create_thinking_space_summary(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (user_id, workflow_step_id) = create_thinking_space_resources(&pool).await?;
 
@@ -280,7 +280,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_update_thinking_space_summary(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (user_id, workflow_step_id) = create_thinking_space_resources(&pool).await?;
 
@@ -312,7 +312,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_get_thinking_space_summary_by_id(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (user_id, workflow_step_id) = create_thinking_space_resources(&pool).await?;
 
@@ -330,7 +330,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_list_thinking_space_summaries(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (user_a_id, workflow_step_id) = create_thinking_space_resources(&pool).await?;
 
@@ -381,7 +381,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_delete_thinking_space_summary(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (user_id, workflow_step_id) = create_thinking_space_resources(&pool).await?;
 

--- a/api/src/models/user_profile.rs
+++ b/api/src/models/user_profile.rs
@@ -447,7 +447,7 @@ mod tests {
     use sqlx::PgPool;
     use std::error::Error;
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_create_user_profile(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let user = crate::models::users::create_user(
             &SignupRequest {
@@ -494,7 +494,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_get_profile_by_user_id(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let user = crate::models::users::create_user(
             &SignupRequest {
@@ -531,7 +531,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_update_profile(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let user = crate::models::users::create_user(
             &SignupRequest {
@@ -599,7 +599,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_enforce_one_profile_per_user(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let user = crate::models::users::create_user(
             &SignupRequest {
@@ -636,7 +636,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_cascade_delete_profile_when_user_deleted(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {
@@ -680,7 +680,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_generate_demographic_report_for_workflow(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {
@@ -859,7 +859,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn demographic_report_should_exclude_non_consented_users(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {
@@ -977,7 +977,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn demographic_report_should_handle_null_values(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {

--- a/api/src/models/user_progress.rs
+++ b/api/src/models/user_progress.rs
@@ -257,7 +257,7 @@ mod tests {
 
     use std::error::Error;
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_create_user_progress(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let conversation_id = get_random_conversation_id(&app, &mut session).await?;
@@ -294,7 +294,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_update_user_progress(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let conversation_id = get_random_conversation_id(&app, &mut session).await?;

--- a/api/src/models/users.rs
+++ b/api/src/models/users.rs
@@ -574,7 +574,7 @@ mod tests {
     use std::sync::Arc;
     use uuid::Uuid;
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     fn should_create_otp_user(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let user = create_otp_user(
             &OtpSignupRequest {
@@ -595,7 +595,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     fn user_has_resource_role_tests(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let state = test_state().db(pool.clone()).call()?;
         let app = setup_server(Arc::new(state)).await?;
@@ -720,7 +720,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_update_user_with_organization(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut admin_session) = setup_default_app_and_session(&pool).await?;
         let (_, response, _) = admin_session.create_random_organization(&app).await?;

--- a/api/src/models/workflow.rs
+++ b/api/src/models/workflow.rs
@@ -469,7 +469,7 @@ mod tests {
 
     use std::error::Error;
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_create_workflow_with_region_id(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let (_, convo_res, _) = session.create_random_conversation(&app).await?;
@@ -499,7 +499,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_update_workflow_region_id(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let (_, convo_res, _) = session.create_random_conversation(&app).await?;

--- a/api/src/models/workflow_step.rs
+++ b/api/src/models/workflow_step.rs
@@ -655,7 +655,7 @@ mod tests {
     use super::*;
     use std::error::Error;
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_create_step_for_live_conversation(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let conversation_id = get_random_conversation_id(&app, &mut session).await?;
@@ -694,7 +694,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_update_can_revisit_field(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let conversation_id = get_random_conversation_id(&app, &mut session).await?;
@@ -730,7 +730,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_list_localized_steps(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let conversation_id = get_random_conversation_id(&app, &mut session).await?;
@@ -754,7 +754,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_backfill_user_progress_for_existing_participants_when_step_added(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {
@@ -828,7 +828,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_list_localized_steps_with_user_progress(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {

--- a/api/src/routes/audio_recordings.rs
+++ b/api/src/routes/audio_recordings.rs
@@ -228,7 +228,7 @@ mod tests {
         Ok((conversation, event))
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn test_request_upload_urls_event_not_found(
         pool: sqlx::PgPool,
     ) -> Result<(), Box<dyn std::error::Error>> {
@@ -265,7 +265,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn test_get_download_urls_recording_not_found(
         pool: sqlx::PgPool,
     ) -> Result<(), Box<dyn std::error::Error>> {
@@ -297,7 +297,7 @@ mod tests {
 
     // TODO: Mock bulk storage service for further tests.
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn test_request_upload_urls_success_with_mocked_storage(
         pool: sqlx::PgPool,
     ) -> Result<(), Box<dyn std::error::Error>> {
@@ -373,7 +373,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn test_get_download_urls_after_status_update(
         pool: sqlx::PgPool,
     ) -> Result<(), Box<dyn std::error::Error>> {
@@ -484,7 +484,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn test_get_recording_for_event_empty_list(
         pool: sqlx::PgPool,
     ) -> Result<(), Box<dyn std::error::Error>> {

--- a/api/src/routes/auth.rs
+++ b/api/src/routes/auth.rs
@@ -1230,7 +1230,7 @@ mod tests {
     use std::{error::Error, sync::Arc};
     use uuid::Uuid;
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn user_should_be_able_to_sign_up(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let username = "test_user";
         let password = crate::test_helpers::TEST_PASSWORD;
@@ -1268,7 +1268,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn user_should_receive_signup_email(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let username = "test_user";
         let password = crate::test_helpers::TEST_PASSWORD;
@@ -1315,7 +1315,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_signup_otp_user(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let email = "test_email";
 
@@ -1348,7 +1348,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn user_should_receive_verification_email(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let mut mailer = MockComhairleMailer::new();
         mailer
@@ -1384,7 +1384,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn unverified_user_should_be_verified(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let username = "test_user";
         let password = crate::test_helpers::TEST_PASSWORD;
@@ -1433,7 +1433,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn annon_user_cannot_be_verified(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let username = "test_user";
         let password = crate::test_helpers::TEST_PASSWORD;
@@ -1478,7 +1478,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn user_cannot_be_verified_twice(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let username = "test_user";
         let password = crate::test_helpers::TEST_PASSWORD;
@@ -1526,7 +1526,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn user_should_not_be_able_to_login_with_wrong_password(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {
@@ -1552,7 +1552,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn user_should_be_able_to_login_with_email_with_different_case(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {
@@ -1577,7 +1577,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     fn other_user_types_should_not_be_able_to_annon_login(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {
@@ -1597,7 +1597,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     fn annon_user_should_be_able_to_login(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let state = test_state().db(pool).call()?;
         let app = setup_server(Arc::new(state)).await?;
@@ -1612,7 +1612,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     fn unknown_username_should_not_be_able_to_annon_login(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {
@@ -1632,7 +1632,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn username_and_email_should_be_unique(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let state = test_state().db(pool).call()?;
         let app = setup_server(Arc::new(state)).await?;
@@ -1664,7 +1664,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn user_should_be_able_to_logout(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let state = test_state().db(pool).call()?;
         let app = setup_server(Arc::new(state)).await?;
@@ -1697,7 +1697,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn annon_user_should_by_able_to_signup(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let state = test_state().db(pool).call()?;
         let app = setup_server(Arc::new(state)).await?;
@@ -1731,7 +1731,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn user_should_receive_password_reset_email(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let username = "test_user";
         let password = crate::test_helpers::TEST_PASSWORD;
@@ -1771,7 +1771,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn unknown_user_returns_not_found(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let username = "test_user";
         let password = crate::test_helpers::TEST_PASSWORD;
@@ -1803,7 +1803,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn users_password_should_be_updated(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let username = "test_user";
         let password = crate::test_helpers::TEST_PASSWORD;
@@ -1866,7 +1866,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn password_and_confirmation_should_match(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let username = "test_username";
         let email = "test_email";
@@ -1911,7 +1911,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn annon_users_cannot_reset_password(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let state = test_state().db(pool).call()?;
         let secret = state.config.jwt_secret.clone();
@@ -1957,7 +1957,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     fn user_requires_roles(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let state = test_state().db(pool.clone()).call()?;
         let app = setup_server(Arc::new(state)).await?;
@@ -2007,7 +2007,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_return_user_from_api_key(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         session
@@ -2140,7 +2140,7 @@ mod tests {
         assert!(result.is_ok());
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn test_signup_with_weak_password(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let username = "test_user_weak_pw";
         let password = "weak"; // Too short
@@ -2161,7 +2161,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn test_password_reset_with_weak_password(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let username = "test_user_reset";
         let password = "ValidPassword123!";
@@ -2210,7 +2210,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn test_update_user_with_weak_password(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let username = "test_user_update";
         let password = "ValidPassword123!";
@@ -2241,7 +2241,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_send_email_with_otp(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let email = "test_email@test.com";
         let username = "test_user";
@@ -2276,7 +2276,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_sign_user_in_with_otp(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let email = "test_email@test.com";
         let username = "test_user";
@@ -2312,7 +2312,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn otp_should_be_invalid_after_single_use(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let email = "test_email@test.com";
         let username = "test_user";
@@ -2358,7 +2358,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_login_user_from_otp_jwt(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let email = "test_email@test.com";
         let username = "test_user";

--- a/api/src/routes/chat_sessions.rs
+++ b/api/src/routes/chat_sessions.rs
@@ -149,7 +149,7 @@ mod tests {
     use serde_json::json;
     use sqlx::PgPool;
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_return_single_chat_session(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let chat_session = ComhairleChatSession {
             id: "456".to_string(),
@@ -245,7 +245,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_converse_with_chat_and_return_byte_stream(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {

--- a/api/src/routes/conversations.rs
+++ b/api/src/routes/conversations.rs
@@ -826,7 +826,7 @@ mod tests {
     use std::error::Error;
     use std::sync::Arc;
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     fn should_be_able_to_create_conversation_without_bot_service_resources(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {
@@ -874,7 +874,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     fn should_be_able_to_create_conversation_with_bot_service_resources(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {
@@ -929,7 +929,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     fn should_be_able_to_update_a_conversation(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let state = test_state().db(pool).call()?;
         let app = setup_server(Arc::new(state)).await?;
@@ -976,7 +976,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     fn should_not_be_able_to_udpate_owner_id(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let state = test_state().db(pool).call()?;
         let app = setup_server(Arc::new(state)).await?;
@@ -1026,7 +1026,7 @@ mod tests {
 
         Ok(())
     }
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     fn should_be_able_to_list_conversations(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let state = test_state().db(pool).call()?;
         let app = setup_server(Arc::new(state)).await?;
@@ -1093,7 +1093,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     fn should_be_able_to_search_conversations(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let state = test_state().db(pool).call()?;
         let app = setup_server(Arc::new(state)).await?;
@@ -1155,7 +1155,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     fn should_be_able_to_order_conversations(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let state = test_state().db(pool).call()?;
         let app = setup_server(Arc::new(state)).await?;
@@ -1229,7 +1229,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     fn should_be_able_to_correctly_page_conversations(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let state = test_state().db(pool).call()?;
         let app = setup_server(Arc::new(state)).await?;
@@ -1286,7 +1286,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     fn should_be_able_to_get_a_created_conversation_by_id(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {
@@ -1368,7 +1368,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     fn should_be_able_to_get_a_created_conversation_with_translations(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {
@@ -1486,7 +1486,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     fn should_be_able_to_delete_conversation(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let mut bot_service = MockComhairleBotService::new();
         bot_service
@@ -1564,7 +1564,7 @@ mod tests {
 
         Ok(())
     }
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     fn conversation_slugs_should_be_unique(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let state = test_state().db(pool).call()?;
         let app = setup_server(Arc::new(state)).await?;
@@ -1616,7 +1616,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     fn should_export_conversation_demographics(pool: PgPool) -> Result<(), Box<dyn Error>> {
         use crate::models::{user_participation, user_profile};
         use crate::routes::auth::SignupRequest;
@@ -1763,7 +1763,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     fn should_deny_demographics_export_to_non_owner(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let state = test_state().db(pool).call()?;
         let app = setup_server(Arc::new(state)).await?;
@@ -1873,7 +1873,7 @@ mod tests {
         Ok(conversation.id)
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn broadcast_email_only_sent_to_opted_in_authenticated_users(
         pool: sqlx::PgPool,
     ) -> Result<(), Box<dyn Error>> {
@@ -1992,7 +1992,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn broadcast_email_respects_anonymous_opt_in_flag(
         pool: sqlx::PgPool,
     ) -> Result<(), Box<dyn Error>> {
@@ -2065,7 +2065,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn broadcast_email_returns_zero_when_nobody_is_opted_in(
         pool: sqlx::PgPool,
     ) -> Result<(), Box<dyn Error>> {
@@ -2112,7 +2112,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn recipients_endpoint_lists_only_opted_in_emails(
         pool: sqlx::PgPool,
     ) -> Result<(), Box<dyn Error>> {
@@ -2241,7 +2241,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn recipients_endpoint_denies_non_owner(
         pool: sqlx::PgPool,
     ) -> Result<(), Box<dyn Error>> {

--- a/api/src/routes/documents.rs
+++ b/api/src/routes/documents.rs
@@ -449,7 +449,7 @@ mod tests {
         Ok((app, session, id))
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_return_document_list(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let document = ComhairleDocument {
             id: "456".to_string(),
@@ -491,7 +491,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_return_single_document(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let document = ComhairleDocument {
             id: "doc-456".to_string(),
@@ -529,7 +529,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_delete_document(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let kb_id = "kb-123".to_string();
         let (app, mut session, conversation_id) =
@@ -554,7 +554,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_upload_a_document(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let upload_request = UploadFileRequest {
             filename: "test.txt".to_string(),
@@ -632,7 +632,7 @@ mod tests {
             });
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn anon_can_list_documents_when_public_and_live(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {
@@ -660,7 +660,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn anon_forbidden_when_conversation_private(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let kb_id = "kb-123".to_string();
         let (app, _admin, conversation_id) = setup_test_app_with_conversation(pool, kb_id, |_bs| {
@@ -681,7 +681,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn non_participant_user_forbidden(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let kb_id = "kb-123".to_string();
         let (app, _admin, conversation_id) = setup_test_app_with_conversation(pool, kb_id, |_bs| {
@@ -708,7 +708,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn participant_can_list_documents(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let kb_id = "kb-123".to_string();
         let (app, mut admin, conversation_id) =

--- a/api/src/routes/email_template_configs.rs
+++ b/api/src/routes/email_template_configs.rs
@@ -254,7 +254,7 @@ mod tests {
 
     use sqlx::PgPool;
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_create_email_template_config(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let (_, current_user, _) = session.current_user(&app).await?;
@@ -289,7 +289,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_update_email_template_config(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
 
@@ -338,7 +338,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_get_email_template_config_by_id(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
 
@@ -375,7 +375,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_list_email_template_configs(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
 
@@ -429,7 +429,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_delete_email_template_config_by_id(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
 
@@ -476,7 +476,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_get_associated_schema_for_email_config_type(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {
@@ -523,7 +523,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_list_schemas_for_email_config_types(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {
@@ -541,7 +541,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_send_preview_html_of_email(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let html_str = "<html><h1>You're invite to a conversation</h1><p>You have been selected to take part in a public engagement</p><p>Test body content</p><p>Thank you for your time</p></html>";
         let mut mailer = MockComhairleMailer::new();

--- a/api/src/routes/event_attendances.rs
+++ b/api/src/routes/event_attendances.rs
@@ -290,7 +290,7 @@ mod tests {
 
     use super::*;
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_create_an_event_attendance(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let mut mailer = MockComhairleMailer::new();
         mailer
@@ -341,7 +341,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_create_an_event_attendance_from_email_address(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {
@@ -394,7 +394,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_get_an_event_attendance_by_id(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let conversation_id = get_random_conversation_id(&app, &mut session).await?;
@@ -429,7 +429,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_list_event_attendances(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let conversation_id = get_random_conversation_id(&app, &mut session).await?;
@@ -468,7 +468,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_update_an_event_attendance_by_id(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let conversation_id = get_random_conversation_id(&app, &mut session).await?;
@@ -512,7 +512,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_delete_an_event_attendance_by_id(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let conversation_id = get_random_conversation_id(&app, &mut session).await?;
@@ -564,7 +564,7 @@ mod tests {
         delta <= seconds
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_schedule_reminders_on_creation(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let conversation_id = get_random_conversation_id(&app, &mut session).await?;

--- a/api/src/routes/events.rs
+++ b/api/src/routes/events.rs
@@ -513,7 +513,7 @@ mod tests {
 
     use super::*;
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_create_an_event(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let conversation_id = get_random_conversation_id(&app, &mut session).await?;
@@ -551,7 +551,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_get_an_event_by_id(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let conversation_id = get_random_conversation_id(&app, &mut session).await?;
@@ -575,7 +575,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_list_events(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let conversation_id = get_random_conversation_id(&app, &mut session).await?;
@@ -606,7 +606,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_return_ordered_list_of_events(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let conversation_id = get_random_conversation_id(&app, &mut session).await?;
@@ -708,7 +708,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_return_filtered_list_of_events(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let conversation_id = get_random_conversation_id(&app, &mut session).await?;
@@ -812,7 +812,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_update_an_event(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let conversation_id = get_random_conversation_id(&app, &mut session).await?;
@@ -842,7 +842,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_delete_an_event(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let conversation_id = get_random_conversation_id(&app, &mut session).await?;
@@ -875,7 +875,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_start_transcription_single_pipeline_for_event(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {
@@ -930,7 +930,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_return_err_if_recording_missing(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let mut storage_service = MockBulkStorageService::new();
 
@@ -974,7 +974,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_start_transcription_pipelines_for_event_with_breakout_rooms(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {
@@ -1038,7 +1038,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_upload_report_to_bulk_storage(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let mut bulk_storage_service = MockBulkStorageService::new();
 

--- a/api/src/routes/invites.rs
+++ b/api/src/routes/invites.rs
@@ -474,7 +474,7 @@ mod tests {
 
     use super::*;
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     fn admin_should_be_able_to_create_invitation(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let mut mailer = MockComhairleMailer::new();
 
@@ -515,7 +515,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     fn non_admin_should_not_be_able_to_create_invitation(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {
@@ -549,7 +549,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     #[traced_test]
     fn only_correct_user_should_be_able_to_accept_email_invitation(
         pool: PgPool,
@@ -621,7 +621,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     fn should_create_attendance_for_existing_user_and_sign_in(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {
@@ -701,7 +701,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     fn should_continue_with_invite_update_if_user_already_registered(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {
@@ -792,7 +792,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     fn should_create_new_otp_user_with_attendance_and_signin(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {
@@ -867,7 +867,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     fn should_fail_if_invite_type_incorrect(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let state = test_state().db(pool.clone()).call()?;
         let app = setup_server(Arc::new(state)).await?;
@@ -918,7 +918,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     fn should_fail_if_invite_missing_event_id(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let state = test_state().db(pool.clone()).call()?;
         let app = setup_server(Arc::new(state)).await?;

--- a/api/src/routes/jobs.rs
+++ b/api/src/routes/jobs.rs
@@ -126,7 +126,7 @@ mod tests {
         test_helpers::{test_state, UserSession},
     };
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_create_new_job(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let job_1 = CreateJob {
             step: Some("initialize".to_string()),
@@ -151,7 +151,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_get_job_by_id(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let job_1 = CreateJob {
             step: Some("initialize".to_string()),
@@ -178,7 +178,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_retrieve_a_list_of_jobs(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let job_1 = CreateJob {
             step: Some("initialize".to_string()),
@@ -216,7 +216,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_retrieve_jobs_list_filtered_by_step(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {
@@ -261,7 +261,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_delete_a_job_by_id(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let job_1 = CreateJob {
             step: Some("initialize".to_string()),

--- a/api/src/routes/media.rs
+++ b/api/src/routes/media.rs
@@ -230,7 +230,7 @@ mod tests {
         media::create(db, &params, user_id).await
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_upload_media_to_bulk_storage_and_create_record(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {
@@ -278,7 +278,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_get_media_by_id(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         session.signup(&app).await?;
@@ -301,7 +301,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_list_media(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         session.signup(&app).await?;
@@ -329,7 +329,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_delete_media(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let mut bulk_storage_service = MockBulkStorageService::new();
         bulk_storage_service

--- a/api/src/routes/organizations.rs
+++ b/api/src/routes/organizations.rs
@@ -179,7 +179,7 @@ mod tests {
 
     use super::*;
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_create_an_organization(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
 
@@ -206,7 +206,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_get_an_organization_by_id(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
 
@@ -228,7 +228,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_list_organizations(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
 
@@ -251,7 +251,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_return_ordered_list_of_organizations(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {
@@ -336,7 +336,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_update_an_organization(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let (_, response, _) = session.create_random_organization(&app).await?;
@@ -366,7 +366,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_delete_an_organization(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
 

--- a/api/src/routes/regions.rs
+++ b/api/src/routes/regions.rs
@@ -168,7 +168,7 @@ mod tests {
 
     use super::*;
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_create_a_region(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
 
@@ -194,7 +194,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_get_a_region_by_id(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
 
@@ -216,7 +216,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_list_regions(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
 
@@ -238,7 +238,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_return_ordered_list_of_regions(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
 
@@ -315,7 +315,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_update_a_region(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let (_, response, _) = session.create_random_region(&app).await?;
@@ -346,7 +346,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_delete_a_region(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
 

--- a/api/src/routes/translations.rs
+++ b/api/src/routes/translations.rs
@@ -441,7 +441,7 @@ mod tests {
     use serde_json::json;
     use std::{error::Error, sync::Arc};
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn test_create_text_content(pool: sqlx::PgPool) -> Result<(), Box<dyn Error>> {
         let state = test_state().db(pool).call()?;
         let app = setup_server(Arc::new(state)).await?;
@@ -484,7 +484,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn test_get_text_content_with_translations(
         pool: sqlx::PgPool,
     ) -> Result<(), Box<dyn Error>> {
@@ -541,7 +541,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn test_update_text_content(pool: sqlx::PgPool) -> Result<(), Box<dyn Error>> {
         let state = test_state().db(pool).call()?;
         let app = setup_server(Arc::new(state)).await?;
@@ -586,7 +586,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn test_delete_text_content(pool: sqlx::PgPool) -> Result<(), Box<dyn Error>> {
         let state = test_state().db(pool).call()?;
         let app = setup_server(Arc::new(state)).await?;
@@ -627,7 +627,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn test_create_text_translation(pool: sqlx::PgPool) -> Result<(), Box<dyn Error>> {
         let state = test_state().db(pool).call()?;
         let app = setup_server(Arc::new(state)).await?;
@@ -674,7 +674,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn test_auto_generate_translation(pool: sqlx::PgPool) -> Result<(), Box<dyn Error>> {
         let mut mock_translation_service = MockTranslationService::new();
 
@@ -750,7 +750,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn test_auto_generate_all_translations(pool: sqlx::PgPool) -> Result<(), Box<dyn Error>> {
         let mut mock_translation_service = MockTranslationService::new();
 
@@ -862,7 +862,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn test_get_text_translation(pool: sqlx::PgPool) -> Result<(), Box<dyn Error>> {
         let state = test_state().db(pool).call()?;
         let app = setup_server(Arc::new(state)).await?;
@@ -911,7 +911,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn test_update_existing_translation_via_post(
         pool: sqlx::PgPool,
     ) -> Result<(), Box<dyn Error>> {
@@ -974,7 +974,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn test_update_text_translation_via_put(
         pool: sqlx::PgPool,
     ) -> Result<(), Box<dyn Error>> {
@@ -1037,7 +1037,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn test_delete_text_translation(pool: sqlx::PgPool) -> Result<(), Box<dyn Error>> {
         let state = test_state().db(pool).call()?;
         let app = setup_server(Arc::new(state)).await?;
@@ -1078,7 +1078,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn test_non_admin_access_denied(pool: sqlx::PgPool) -> Result<(), Box<dyn Error>> {
         let state = test_state().db(pool).call()?;
         let app = setup_server(Arc::new(state)).await?;
@@ -1103,7 +1103,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn test_get_nonexistent_text_content(pool: sqlx::PgPool) -> Result<(), Box<dyn Error>> {
         let state = test_state().db(pool).call()?;
         let app = setup_server(Arc::new(state)).await?;
@@ -1121,7 +1121,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn test_get_nonexistent_translation(pool: sqlx::PgPool) -> Result<(), Box<dyn Error>> {
         let state = test_state().db(pool).call()?;
         let app = setup_server(Arc::new(state)).await?;
@@ -1155,7 +1155,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn test_update_invalid_text_content(pool: sqlx::PgPool) -> Result<(), Box<dyn Error>> {
         let state = test_state().db(pool).call()?;
         let app = setup_server(Arc::new(state)).await?;
@@ -1181,7 +1181,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn test_empty_update_request(pool: sqlx::PgPool) -> Result<(), Box<dyn Error>> {
         let state = test_state().db(pool).call()?;
         let app = setup_server(Arc::new(state)).await?;

--- a/api/src/routes/user_profile.rs
+++ b/api/src/routes/user_profile.rs
@@ -112,7 +112,7 @@ mod tests {
     use sqlx::PgPool;
     use std::error::Error;
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_create_user_profile_via_api(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
 
@@ -152,7 +152,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_get_user_profile_via_api(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
 
@@ -185,7 +185,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_update_user_profile_via_api(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
 
@@ -242,7 +242,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_not_allow_user_to_access_another_users_profile(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {
@@ -323,7 +323,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_require_authentication(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, _) = setup_default_app_and_session(&pool).await?;
 

--- a/api/src/routes/user_progress.rs
+++ b/api/src/routes/user_progress.rs
@@ -87,7 +87,7 @@ mod tests {
         test_helpers::{extract, test_state, UserSession},
     };
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     fn should_be_able_to_register_a_user_for_a_workflow(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {

--- a/api/src/routes/workflow_steps.rs
+++ b/api/src/routes/workflow_steps.rs
@@ -327,7 +327,7 @@ mod tests {
     use sqlx::PgPool;
     use std::{error::Error, sync::Arc};
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     fn should_be_able_to_create_a_workflow_step(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let state = test_state().db(pool).call()?;
         let app = setup_server(Arc::new(state)).await?;
@@ -368,7 +368,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     fn should_create_workflow_step_for_an_event_workflow(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {
@@ -415,7 +415,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     fn should_be_able_to_list_workflow_steps(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let state = test_state().db(pool).call()?;
         let app = setup_server(Arc::new(state)).await?;
@@ -495,7 +495,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     fn should_be_able_to_retreive_workflow_step(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let state = test_state().db(pool).call()?;
         let app = setup_server(Arc::new(state)).await?;
@@ -570,7 +570,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     fn should_get_workflow_step_for_an_event_workflow(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let conversation_id = get_random_conversation_id(&app, &mut session).await?;
@@ -611,7 +611,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     fn workflow_steps_should_reorder_when_a_step_is_deleted(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {
@@ -698,7 +698,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     fn workflow_steps_should_return_in_correct_order(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let state = test_state().db(pool).call()?;
         let app = setup_server(Arc::new(state)).await?;
@@ -761,7 +761,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     fn workflow_steps_should_update_their_order_when_a_new_one_is_inserted(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {
@@ -847,7 +847,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     fn workflow_steps_should_rearange_properly_when_one_is_moved(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {

--- a/api/src/routes/workflows.rs
+++ b/api/src/routes/workflows.rs
@@ -410,7 +410,7 @@ mod tests {
     use sqlx::PgPool;
     use std::{error::Error, sync::Arc};
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     fn should_be_able_to_create_a_workflow_on_a_conversatin(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {
@@ -455,7 +455,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     fn should_create_a_workflow_for_an_event(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let conversation_id = get_random_conversation_id(&app, &mut session).await?;
@@ -494,7 +494,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     fn should_be_able_to_list_workflows_on_a_conversation(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {
@@ -548,7 +548,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     fn should_be_able_to_retrive_a_workflow(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let state = test_state().db(pool).call()?;
         let app = setup_server(Arc::new(state)).await?;
@@ -584,7 +584,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     fn should_list_workflows_for_an_event(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let conversation_id = get_random_conversation_id(&app, &mut session).await?;
@@ -626,7 +626,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     fn should_get_a_workflow_for_an_event(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let conversation_id = get_random_conversation_id(&app, &mut session).await?;
@@ -655,7 +655,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     fn should_be_able_to_delete_a_workflow(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let state = test_state().db(pool).call()?;
         let app = setup_server(Arc::new(state)).await?;
@@ -691,7 +691,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     fn should_delete_an_event_workflow(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let conversation_id = get_random_conversation_id(&app, &mut session).await?;
@@ -733,7 +733,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     fn should_be_able_to_update_a_workflow(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let state = test_state().db(pool).call()?;
         let app = setup_server(Arc::new(state)).await?;
@@ -781,7 +781,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     fn should_update_an_event_workflow(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let conversation_id = get_random_conversation_id(&app, &mut session).await?;
@@ -820,7 +820,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     fn should_get_the_correct_stats_for_a_workflow(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let state = test_state().db(pool).call()?;
         let app = setup_server(Arc::new(state)).await?;

--- a/api/src/tools/elicitation_bot.rs
+++ b/api/src/tools/elicitation_bot.rs
@@ -332,7 +332,7 @@ mod tests {
         Ok((app, session, workflow_step_id))
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_get_agent_session(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session, workflow_step_id) =
             setup_test_app_with_workflow_step(pool, |bot_service| {
@@ -375,7 +375,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_converse_with_agent_and_return_byte_stream(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {

--- a/api/src/tools/polis.rs
+++ b/api/src/tools/polis.rs
@@ -733,7 +733,7 @@ mod tests {
         Ok(aux)
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn owner_can_add_theme(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let aux = setup_polis_aux(&app, &pool, &mut session, vec![]).await?;
@@ -756,7 +756,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn adding_theme_is_idempotent(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let aux = setup_polis_aux(&app, &pool, &mut session, vec!["alpha".into()]).await?;
@@ -779,7 +779,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn owner_can_remove_theme(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let aux = setup_polis_aux(
@@ -804,7 +804,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn removing_missing_theme_is_idempotent(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let aux = setup_polis_aux(&app, &pool, &mut session, vec!["alpha".into()]).await?;
@@ -823,7 +823,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn non_owner_cannot_add_theme(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut owner) = setup_default_app_and_session(&pool).await?;
         let aux = setup_polis_aux(&app, &pool, &mut owner, vec![]).await?;
@@ -854,7 +854,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn non_owner_cannot_remove_theme(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut owner) = setup_default_app_and_session(&pool).await?;
         let aux = setup_polis_aux(&app, &pool, &mut owner, vec!["alpha".into()]).await?;

--- a/api/src/tools/prioritization.rs
+++ b/api/src/tools/prioritization.rs
@@ -433,7 +433,7 @@ mod tests {
 
     use std::error::Error;
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_create_proposal(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
 
@@ -480,7 +480,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_list_proposals(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
 
@@ -564,7 +564,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_create_new_proposal_response_via_api(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {
@@ -622,7 +622,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_list_proposal_responses_via_api(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         let conversation_id = get_random_conversation_id(&app, &mut session).await?;

--- a/api/src/tools/thinking_space.rs
+++ b/api/src/tools/thinking_space.rs
@@ -730,7 +730,7 @@ mod tests {
 
     use std::error::Error;
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_create_thinking_space_answer_via_api(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {
@@ -801,7 +801,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_list_thinking_space_answers_via_api(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {
@@ -883,7 +883,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_update_thinking_space_answer_via_api(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {

--- a/api/src/transcription_service/amazon_transcriber.rs
+++ b/api/src/transcription_service/amazon_transcriber.rs
@@ -1082,7 +1082,7 @@ mod tests {
         assert_eq!(consolidated.events[1].start_time, 9.876);
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     #[ignore]
     async fn test_transcription_of_bulk_storage_audio_file(
         pool: PgPool,

--- a/api/src/worker_service/process_video_call_transcriptions.rs
+++ b/api/src/worker_service/process_video_call_transcriptions.rs
@@ -253,7 +253,7 @@ mod tests {
         Ok(Data::new(Arc::new(state)))
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     #[ignore]
     async fn should_transcribe_audio_recording(
         pool: PgPool,
@@ -272,7 +272,7 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     #[ignore]
     async fn should_generate_sense_making_report_from_transcript(
         pool: PgPool,


### PR DESCRIPTION
Motivations:

 - We are currently running rust and vitest tests even when the correspnding code for each test set has not changed.
 - The rust cache size is currently around 1.4GB, taking 40-50s to re-populate from.
 - Tests all currently run in series which is slowing them down.
 - sqlx::test expands all migrations as a migrator for every test when a custom migrator is not set. This bloats both the test binary size and compile time.

Actions:

 - Created simple filters for frontend and backend tests.
 - Switched to using Swatinem/rust-cache to cache rust, nearly halving the cache usage and taking almost a third of the time to re-populate from as before.
 - Switched to using cargo nextest to run tests in parallel.
 - Switched to a single common migrator since we don't use different migrations for different tests.