### PR TITLE
API changes to support individual audio recording uploads

### DIFF
--- a/api/migrations/20260626120000_make_audio_recording_per_room.sql
+++ b/api/migrations/20260626120000_make_audio_recording_per_room.sql
@@ -1,0 +1,20 @@
+-- Make audio_recording per-room instead of per-event.
+--
+-- Each row now represents a single named room within an event, and an event may
+-- have many rooms. The previous model kept one row per event with the breakout
+-- rooms stored in a TEXT[] array; that distinction (main vs. breakout) is gone.
+--
+-- The existing data is from a throwaway prototype with no users, so we discard it
+-- up front. That lets us add a NOT NULL `name` column without a backfill.
+DELETE FROM audio_recording;
+
+-- Many rooms per event now, so the event_id can no longer be unique on its own.
+ALTER TABLE audio_recording DROP CONSTRAINT audio_recording_event_id_key;
+
+-- The main-vs-breakout concept is gone; rooms are tracked as their own rows.
+ALTER TABLE audio_recording DROP COLUMN breakout_room_ids;
+
+-- User-supplied room name, unique within an event.
+ALTER TABLE audio_recording ADD COLUMN name TEXT NOT NULL;
+ALTER TABLE audio_recording
+    ADD CONSTRAINT audio_recording_event_id_name_key UNIQUE (event_id, name);

--- a/api/src/error.rs
+++ b/api/src/error.rs
@@ -115,8 +115,8 @@ pub enum ComhairleError {
     #[error("Slug {0} already taken")]
     DuplicateSlug(String),
 
-    #[error("A room named {0} already exists for this event")]
-    DuplicateRoomName(String),
+    #[error("A recording named {0} already exists for this event")]
+    DuplicateRecordingName(String),
 
     #[error("Failed to hash password")]
     PasswordHash,
@@ -346,7 +346,7 @@ impl IntoResponse for ComhairleError {
             | ComhairleError::EventAtCapacity
             | ComhairleError::InviteResponseAlreadyCreated
             | ComhairleError::DuplicateSlug(_)
-            | ComhairleError::DuplicateRoomName(_)
+            | ComhairleError::DuplicateRecordingName(_)
             | ComhairleError::UserAlreadyRegisteredForEvent(_)
             | ComhairleError::UserAlreadyParticipatingInWorkflow(_) => StatusCode::CONFLICT,
             ComhairleError::ResourceNotFound(_)

--- a/api/src/error.rs
+++ b/api/src/error.rs
@@ -115,6 +115,9 @@ pub enum ComhairleError {
     #[error("Slug {0} already taken")]
     DuplicateSlug(String),
 
+    #[error("A room named {0} already exists for this event")]
+    DuplicateRoomName(String),
+
     #[error("Failed to hash password")]
     PasswordHash,
 
@@ -343,6 +346,7 @@ impl IntoResponse for ComhairleError {
             | ComhairleError::EventAtCapacity
             | ComhairleError::InviteResponseAlreadyCreated
             | ComhairleError::DuplicateSlug(_)
+            | ComhairleError::DuplicateRoomName(_)
             | ComhairleError::UserAlreadyRegisteredForEvent(_)
             | ComhairleError::UserAlreadyParticipatingInWorkflow(_) => StatusCode::CONFLICT,
             ComhairleError::ResourceNotFound(_)

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -283,7 +283,7 @@ pub async fn setup_server(state: Arc<ComhairleState>) -> Result<Router<()>, Comh
                                 ),
                         )
                         .nest_api_service(
-                            "/{event_id}/audio-recordings",
+                            "/{event_id}/rooms",
                             routes::audio_recordings::router(state.clone()),
                         ),
                 ),

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -283,7 +283,7 @@ pub async fn setup_server(state: Arc<ComhairleState>) -> Result<Router<()>, Comh
                                 ),
                         )
                         .nest_api_service(
-                            "/{event_id}/rooms",
+                            "/{event_id}/audio_recordings",
                             routes::audio_recordings::router(state.clone()),
                         ),
                 ),

--- a/api/src/models/audio_recording.rs
+++ b/api/src/models/audio_recording.rs
@@ -92,26 +92,25 @@ impl AudioRecordingStatus {
     }
 }
 
-/// An audio recording associated with an event and its breakout rooms
+/// An audio recording for a single named room within an event.
 ///
-/// One record per event that tracks all breakout rooms and the overall status
-/// of transcription and report generation. The status reflects the entire
-/// multi-room processing pipeline.
+/// One record per room. An event may have many rooms, each with a name that is
+/// unique within that event. The status tracks transcription and report
+/// generation for this room only.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct AudioRecording {
-    /// Unique identifier for this recording set
+    /// Unique identifier for this room's recording
     pub id: Uuid,
-    /// Event this recording belongs to
+    /// Event this room belongs to
     pub event_id: Uuid,
-    /// List of breakout room IDs
-    pub breakout_room_ids: Vec<String>,
+    /// User-supplied room name, unique within the event
+    pub name: String,
     /// S3 key prefix (without extension) used for generating URLs
-    /// Used as base for main and breakout room recordings
     pub s3_key_prefix: String,
-    /// Audio format of the uploaded recording(s)
+    /// Audio format of the uploaded recording
     pub file_extension: AudioFormat,
-    /// Current status of transcription/processing for entire event
+    /// Current status of transcription & report processing for this room
     pub status: AudioRecordingStatus,
     /// When this recording was created
     pub created_at: DateTime<Utc>,
@@ -125,7 +124,7 @@ pub struct AudioRecording {
 pub struct RawAudioRecording {
     pub id: Uuid,
     pub event_id: Uuid,
-    pub breakout_room_ids: Vec<String>,
+    pub name: String,
     pub s3_key_prefix: String,
     pub file_extension: String,
     pub status: String,
@@ -136,7 +135,7 @@ pub struct RawAudioRecording {
 const DEFAULT_COLUMNS: [RawAudioRecordingIden; 8] = [
     RawAudioRecordingIden::Id,
     RawAudioRecordingIden::EventId,
-    RawAudioRecordingIden::BreakoutRoomIds,
+    RawAudioRecordingIden::Name,
     RawAudioRecordingIden::S3KeyPrefix,
     RawAudioRecordingIden::FileExtension,
     RawAudioRecordingIden::Status,
@@ -149,7 +148,7 @@ impl From<RawAudioRecording> for AudioRecording {
         Self {
             id: raw.id,
             event_id: raw.event_id,
-            breakout_room_ids: raw.breakout_room_ids,
+            name: raw.name,
             s3_key_prefix: raw.s3_key_prefix,
             file_extension: AudioFormat::try_from_extension(&raw.file_extension)
                 .unwrap_or(AudioFormat::Wav),
@@ -165,13 +164,14 @@ impl From<RawAudioRecording> for AudioRecording {
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct CreateAudioRecording {
+    pub id: Uuid,
     pub event_id: Uuid,
-    pub breakout_room_ids: Vec<String>,
+    pub name: String,
     pub s3_key_prefix: String,
     pub file_extension: AudioFormat,
 }
 
-/// Create a new audio recording in the database
+/// Create a new audio recording in the database.
 pub async fn create(
     db: &PgPool,
     create_recording: &CreateAudioRecording,
@@ -179,15 +179,17 @@ pub async fn create(
     let (sql, values) = Query::insert()
         .into_table(RawAudioRecordingIden::Table)
         .columns([
+            RawAudioRecordingIden::Id,
             RawAudioRecordingIden::EventId,
-            RawAudioRecordingIden::BreakoutRoomIds,
+            RawAudioRecordingIden::Name,
             RawAudioRecordingIden::S3KeyPrefix,
             RawAudioRecordingIden::FileExtension,
             RawAudioRecordingIden::Status,
         ])
         .values([
+            create_recording.id.into(),
             create_recording.event_id.into(),
-            create_recording.breakout_room_ids.clone().into(),
+            create_recording.name.clone().into(),
             create_recording.s3_key_prefix.clone().into(),
             create_recording.file_extension.extension().into(),
             "pending".into(),
@@ -196,11 +198,22 @@ pub async fn create(
         .returning(Query::returning().columns(DEFAULT_COLUMNS))
         .build_sqlx(PostgresQueryBuilder);
 
-    let recording = sqlx::query_as_with::<_, RawAudioRecording, _>(&sql, values)
+    match sqlx::query_as_with::<_, RawAudioRecording, _>(&sql, values)
         .fetch_one(db)
-        .await?;
-
-    Ok(recording.into())
+        .await
+    {
+        Ok(recording) => Ok(recording.into()),
+        Err(sqlx::Error::Database(db_err)) => {
+            let pg_err = db_err.downcast_ref::<sqlx::postgres::PgDatabaseError>();
+            if pg_err.code() == "23505" {
+                return Err(ComhairleError::DuplicateRoomName(
+                    create_recording.name.clone(),
+                ));
+            }
+            Err(ComhairleError::DatabaseError(sqlx::Error::Database(db_err)))
+        }
+        Err(e) => Err(ComhairleError::DatabaseError(e)),
+    }
 }
 
 /// Get an audio recording by ID
@@ -221,22 +234,23 @@ pub async fn get_by_id(db: &PgPool, recording_id: &Uuid) -> Result<AudioRecordin
     Ok(recording.into())
 }
 
-/// Get recording for an event (one per event)
-pub async fn get_by_event(db: &PgPool, event_id: &Uuid) -> Result<AudioRecording, ComhairleError> {
+/// List all rooms (recordings) for an event, oldest first.
+pub async fn list_by_event(
+    db: &PgPool,
+    event_id: &Uuid,
+) -> Result<Vec<AudioRecording>, ComhairleError> {
     let (sql, values) = Query::select()
         .columns(DEFAULT_COLUMNS)
         .from(RawAudioRecordingIden::Table)
         .and_where(Expr::col(RawAudioRecordingIden::EventId).eq(*event_id))
+        .order_by(RawAudioRecordingIden::CreatedAt, sea_query::Order::Asc)
         .build_sqlx(PostgresQueryBuilder);
 
-    let recording = sqlx::query_as_with::<_, RawAudioRecording, _>(&sql, values)
-        .fetch_optional(db)
-        .await?
-        .ok_or(ComhairleError::ResourceNotFound(
-            "Audio recording not found for event".to_string(),
-        ))?;
+    let recordings = sqlx::query_as_with::<_, RawAudioRecording, _>(&sql, values)
+        .fetch_all(db)
+        .await?;
 
-    Ok(recording.into())
+    Ok(recordings.into_iter().map(Into::into).collect())
 }
 
 /// Update the status of an audio recording
@@ -300,17 +314,70 @@ mod tests {
         let event = create_random_event(&mut session, &app).await?;
 
         let create_req = CreateAudioRecording {
+            id: Uuid::new_v4(),
             event_id: event.id,
-            breakout_room_ids: vec!["room1".to_string(), "room2".to_string()],
+            name: "Main Room".to_string(),
             s3_key_prefix: "test/prefix".to_string(),
             file_extension: AudioFormat::Wav,
         };
 
         let recording = create(&pool, &create_req).await?;
+        assert_eq!(recording.id, create_req.id);
         assert_eq!(recording.event_id, create_req.event_id);
-        assert_eq!(recording.breakout_room_ids, create_req.breakout_room_ids);
+        assert_eq!(recording.name, create_req.name);
         assert_eq!(recording.s3_key_prefix, create_req.s3_key_prefix);
         assert_eq!(recording.status, AudioRecordingStatus::Pending);
+        Ok(())
+    }
+
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
+    async fn test_create_duplicate_name_for_event_conflicts(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let mut config = test_config()?;
+        config.bot_service = None;
+        let state = Arc::new(test_state().db(pool.clone()).config(config).call()?);
+        let app = setup_server(state.clone()).await?;
+
+        let mut session = UserSession::new_admin();
+        session.signup(&app).await?;
+
+        let event = create_random_event(&mut session, &app).await?;
+
+        let create_req = CreateAudioRecording {
+            id: Uuid::new_v4(),
+            event_id: event.id,
+            name: "Room A".to_string(),
+            s3_key_prefix: "test/prefix".to_string(),
+            file_extension: AudioFormat::Wav,
+        };
+
+        // First create with this name succeeds.
+        create(&pool, &create_req).await?;
+
+        // A second room (distinct id) with the same name in the same event conflicts.
+        let err = create(
+            &pool,
+            &CreateAudioRecording {
+                id: Uuid::new_v4(),
+                ..create_req.clone()
+            },
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(err, ComhairleError::DuplicateRoomName(_)));
+
+        // A second room with a different name in the same event is allowed.
+        create(
+            &pool,
+            &CreateAudioRecording {
+                id: Uuid::new_v4(),
+                name: "Room B".to_string(),
+                ..create_req.clone()
+            },
+        )
+        .await?;
+
         Ok(())
     }
 
@@ -327,8 +394,9 @@ mod tests {
         let event = create_random_event(&mut session, &app).await?;
 
         let create_req = CreateAudioRecording {
+            id: Uuid::new_v4(),
             event_id: event.id,
-            breakout_room_ids: vec!["room1".to_string()],
+            name: "Room 1".to_string(),
             s3_key_prefix: "test/prefix".to_string(),
             file_extension: AudioFormat::Wav,
         };
@@ -343,7 +411,7 @@ mod tests {
     }
 
     #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
-    async fn test_get_by_event(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>> {
+    async fn test_list_by_event(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>> {
         let mut config = test_config()?;
         config.bot_service = None;
         let state = Arc::new(test_state().db(pool.clone()).config(config).call()?);
@@ -354,18 +422,39 @@ mod tests {
 
         let event = create_random_event(&mut session, &app).await?;
 
-        let create_req = CreateAudioRecording {
-            event_id: event.id,
-            breakout_room_ids: vec!["room1".to_string()],
-            s3_key_prefix: "test/prefix".to_string(),
-            file_extension: AudioFormat::Wav,
-        };
+        let room_a = create(
+            &pool,
+            &CreateAudioRecording {
+                id: Uuid::new_v4(),
+                event_id: event.id,
+                name: "Room A".to_string(),
+                s3_key_prefix: "test/prefix/a".to_string(),
+                file_extension: AudioFormat::Wav,
+            },
+        )
+        .await?;
+        let room_b = create(
+            &pool,
+            &CreateAudioRecording {
+                id: Uuid::new_v4(),
+                event_id: event.id,
+                name: "Room B".to_string(),
+                s3_key_prefix: "test/prefix/b".to_string(),
+                file_extension: AudioFormat::Wav,
+            },
+        )
+        .await?;
 
-        let created = create(&pool, &create_req).await?;
-        let fetched = get_by_event(&pool, &event.id).await?;
+        let rooms = list_by_event(&pool, &event.id).await?;
+        assert_eq!(rooms.len(), 2);
+        // Ordered oldest first.
+        assert_eq!(rooms[0].id, room_a.id);
+        assert_eq!(rooms[1].id, room_b.id);
 
-        assert_eq!(fetched.id, created.id);
-        assert_eq!(fetched.event_id, event.id);
+        // An event with no rooms returns an empty list (not an error).
+        let other_event = create_random_event(&mut session, &app).await?;
+        assert!(list_by_event(&pool, &other_event.id).await?.is_empty());
+
         Ok(())
     }
 
@@ -382,8 +471,9 @@ mod tests {
         let event = create_random_event(&mut session, &app).await?;
 
         let create_req = CreateAudioRecording {
+            id: Uuid::new_v4(),
             event_id: event.id,
-            breakout_room_ids: vec!["room1".to_string()],
+            name: "Room 1".to_string(),
             s3_key_prefix: "test/prefix".to_string(),
             file_extension: AudioFormat::Wav,
         };

--- a/api/src/models/audio_recording.rs
+++ b/api/src/models/audio_recording.rs
@@ -234,6 +234,32 @@ pub async fn get_by_id(db: &PgPool, recording_id: &Uuid) -> Result<AudioRecordin
     Ok(recording.into())
 }
 
+/// Get an audio recording by ID, scoped to the event it must belong to.
+///
+/// Returns [`ComhairleError::ResourceNotFound`] if no recording with that id
+/// exists for the given event.
+pub async fn get_by_id_and_event(
+    db: &PgPool,
+    recording_id: &Uuid,
+    event_id: &Uuid,
+) -> Result<AudioRecording, ComhairleError> {
+    let (sql, values) = Query::select()
+        .columns(DEFAULT_COLUMNS)
+        .from(RawAudioRecordingIden::Table)
+        .and_where(Expr::col(RawAudioRecordingIden::Id).eq(*recording_id))
+        .and_where(Expr::col(RawAudioRecordingIden::EventId).eq(*event_id))
+        .build_sqlx(PostgresQueryBuilder);
+
+    let recording = sqlx::query_as_with::<_, RawAudioRecording, _>(&sql, values)
+        .fetch_optional(db)
+        .await?
+        .ok_or(ComhairleError::ResourceNotFound(
+            "Audio recording not found".to_string(),
+        ))?;
+
+    Ok(recording.into())
+}
+
 /// List all recordings for an event, oldest first.
 pub async fn list_by_event(
     db: &PgPool,
@@ -407,6 +433,44 @@ mod tests {
         assert_eq!(fetched.id, created.id);
         assert_eq!(fetched.event_id, created.event_id);
         assert_eq!(fetched.s3_key_prefix, created.s3_key_prefix);
+        Ok(())
+    }
+
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
+    async fn test_get_by_id_and_event(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let mut config = test_config()?;
+        config.bot_service = None;
+        let state = Arc::new(test_state().db(pool.clone()).config(config).call()?);
+        let app = setup_server(state.clone()).await?;
+
+        let mut session = UserSession::new_admin();
+        session.signup(&app).await?;
+
+        let event = create_random_event(&mut session, &app).await?;
+
+        let created = create(
+            &pool,
+            &CreateAudioRecording {
+                id: Uuid::new_v4(),
+                event_id: event.id,
+                name: "Room 1".to_string(),
+                s3_key_prefix: "test/prefix".to_string(),
+                file_extension: AudioFormat::Wav,
+            },
+        )
+        .await?;
+
+        // Matching event scopes the lookup successfully.
+        let fetched = get_by_id_and_event(&pool, &created.id, &event.id).await?;
+        assert_eq!(fetched.id, created.id);
+
+        // A mismatched event id yields ResourceNotFound, not the row.
+        let other_event = create_random_event(&mut session, &app).await?;
+        let result = get_by_id_and_event(&pool, &created.id, &other_event.id).await;
+        assert!(matches!(result, Err(ComhairleError::ResourceNotFound(_))));
+
         Ok(())
     }
 

--- a/api/src/models/audio_recording.rs
+++ b/api/src/models/audio_recording.rs
@@ -94,23 +94,23 @@ impl AudioRecordingStatus {
 
 /// An audio recording for a single named room within an event.
 ///
-/// One record per room. An event may have many rooms, each with a name that is
+/// An event may have many recordings, each with a name (or "room name") that is
 /// unique within that event. The status tracks transcription and report
-/// generation for this room only.
+/// generation for this recording only.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct AudioRecording {
-    /// Unique identifier for this room's recording
+    /// Unique identifier for this recordings's recording
     pub id: Uuid,
-    /// Event this room belongs to
+    /// Event this recording belongs to
     pub event_id: Uuid,
-    /// User-supplied room name, unique within the event
+    /// User-supplied recording/room name, unique within the event
     pub name: String,
     /// S3 key prefix (without extension) used for generating URLs
     pub s3_key_prefix: String,
     /// Audio format of the uploaded recording
     pub file_extension: AudioFormat,
-    /// Current status of transcription & report processing for this room
+    /// Current status of transcription & report processing for this recording
     pub status: AudioRecordingStatus,
     /// When this recording was created
     pub created_at: DateTime<Utc>,
@@ -206,7 +206,7 @@ pub async fn create(
         Err(sqlx::Error::Database(db_err)) => {
             let pg_err = db_err.downcast_ref::<sqlx::postgres::PgDatabaseError>();
             if pg_err.code() == "23505" {
-                return Err(ComhairleError::DuplicateRoomName(
+                return Err(ComhairleError::DuplicateRecordingName(
                     create_recording.name.clone(),
                 ));
             }
@@ -234,7 +234,7 @@ pub async fn get_by_id(db: &PgPool, recording_id: &Uuid) -> Result<AudioRecordin
     Ok(recording.into())
 }
 
-/// List all rooms (recordings) for an event, oldest first.
+/// List all recordings for an event, oldest first.
 pub async fn list_by_event(
     db: &PgPool,
     event_id: &Uuid,
@@ -365,7 +365,7 @@ mod tests {
         )
         .await
         .unwrap_err();
-        assert!(matches!(err, ComhairleError::DuplicateRoomName(_)));
+        assert!(matches!(err, ComhairleError::DuplicateRecordingName(_)));
 
         // A second room with a different name in the same event is allowed.
         create(

--- a/api/src/models/audio_recording.rs
+++ b/api/src/models/audio_recording.rs
@@ -55,24 +55,32 @@ impl std::fmt::Display for AudioFormat {
     }
 }
 
-/// Status of an audio recording's transcription and processing
+/// Status of an audio recording as it moves through the transcription and
+/// categorization pipeline (recording → transcript → report).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum AudioRecordingStatus {
-    /// Recording uploaded, waiting to be processed
+    /// Recording uploaded; not yet processed (also covers queued/transcribing).
     Pending,
-    /// Recording has been transcribed and report generated
-    Completed,
-    /// Recording failed during transcription/processing
-    Failed,
+    /// Transcript produced and submitted to the categorization service; the
+    /// report has not arrived yet.
+    TranscriptAvailable,
+    /// Both the transcript and the categorization report are available.
+    BothAvailable,
+    /// The transcription stage failed.
+    TranscriptFailure,
+    /// The categorization stage failed.
+    CategorizationFailure,
 }
 
 impl ToString for AudioRecordingStatus {
     fn to_string(&self) -> String {
         match self {
             AudioRecordingStatus::Pending => "pending".to_string(),
-            AudioRecordingStatus::Completed => "completed".to_string(),
-            AudioRecordingStatus::Failed => "failed".to_string(),
+            AudioRecordingStatus::TranscriptAvailable => "transcript_available".to_string(),
+            AudioRecordingStatus::BothAvailable => "both_available".to_string(),
+            AudioRecordingStatus::TranscriptFailure => "transcript_failure".to_string(),
+            AudioRecordingStatus::CategorizationFailure => "categorization_failure".to_string(),
         }
     }
 }
@@ -82,8 +90,10 @@ impl AudioRecordingStatus {
     pub fn from_string(s: &str) -> Result<Self, ComhairleError> {
         match s {
             "pending" => Ok(AudioRecordingStatus::Pending),
-            "completed" => Ok(AudioRecordingStatus::Completed),
-            "failed" => Ok(AudioRecordingStatus::Failed),
+            "transcript_available" => Ok(AudioRecordingStatus::TranscriptAvailable),
+            "both_available" => Ok(AudioRecordingStatus::BothAvailable),
+            "transcript_failure" => Ok(AudioRecordingStatus::TranscriptFailure),
+            "categorization_failure" => Ok(AudioRecordingStatus::CategorizationFailure),
             _ => Err(ComhairleError::ResourceNotFound(format!(
                 "Unknown status: {}",
                 s
@@ -545,13 +555,14 @@ mod tests {
         let created = create(&pool, &create_req).await?;
         assert_eq!(created.status, AudioRecordingStatus::Pending);
 
-        let updated = update_status(&pool, &created.id, AudioRecordingStatus::Completed).await?;
-        assert_eq!(updated.status, AudioRecordingStatus::Completed);
+        let updated =
+            update_status(&pool, &created.id, AudioRecordingStatus::BothAvailable).await?;
+        assert_eq!(updated.status, AudioRecordingStatus::BothAvailable);
         assert!(updated.updated_at > created.updated_at);
         assert!(updated.created_at == created.created_at);
         Ok(())
     }
-
+    
     #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn test_get_by_id_not_found(
         pool: sqlx::PgPool,

--- a/api/src/routes/audio_recordings.rs
+++ b/api/src/routes/audio_recordings.rs
@@ -242,6 +242,13 @@ async fn submit_report(
         .upload_file(&path, bytes, metadata)
         .await?;
 
+    audio_recording::update_status(
+        &state.db,
+        &recording.id,
+        audio_recording::AudioRecordingStatus::BothAvailable,
+    )
+    .await?;
+
     Ok((
         StatusCode::CREATED,
         Json(SubmitReportResponse {
@@ -506,6 +513,103 @@ mod tests {
             .await?;
 
         assert_eq!(status, StatusCode::NOT_FOUND);
+        Ok(())
+    }
+
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
+    async fn test_submit_report_marks_both_available(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        use crate::bulk_storage_service::UploadResult;
+        use crate::routes::auth::build_webhook_signature;
+        use axum::body::Body;
+        use axum::http::{HeaderName, HeaderValue};
+        use chrono::Utc;
+        use std::str::FromStr;
+
+        let mut storage_service = crate::bulk_storage_service::MockBulkStorageService::new();
+        storage_service
+            .expect_upload_file()
+            .times(1)
+            .returning(|_, _, _| {
+                Box::pin(async move {
+                    Ok(UploadResult {
+                        url: "https://s3.example.com/report.json".to_string(),
+                    })
+                })
+            });
+
+        let mut config = test_config()?;
+        config.bot_service = None;
+        let webhook_secret = config
+            .categorization_service
+            .as_ref()
+            .expect("test config has a categorization service")
+            .webhook_secret
+            .clone();
+
+        let state = Arc::new(
+            test_state()
+                .db(pool.clone())
+                .config(config)
+                .bulk_storage_service(Arc::new(storage_service))
+                .call()?,
+        );
+        let app = setup_server(state.clone()).await?;
+
+        let mut session = UserSession::new_admin();
+        session.signup(&app).await?;
+
+        let (conversation, event) = create_random_event(&mut session, &app).await?;
+
+        // A recording that has its transcript but is awaiting its report.
+        let recording = audio_recording::create(
+            &pool,
+            &CreateAudioRecording {
+                id: Uuid::new_v4(),
+                event_id: event.id,
+                name: "Main Room".to_string(),
+                s3_key_prefix: format!("events/{}/recordings/{}", event.id, Uuid::new_v4()),
+                file_extension: AudioFormat::Wav,
+            },
+        )
+        .await?;
+
+        // Sign the payload the way the categorization service would.
+        let body = serde_json::json!({ "report": "done" }).to_string();
+        let timestamp = Utc::now().timestamp().to_string();
+        let signature = build_webhook_signature(&timestamp, &body, &webhook_secret)?;
+
+        let (status, _resp, _) = session
+            .post_with_headers(
+                &app,
+                &format!(
+                    "/conversation/{}/events/{}/audio_recordings/{}/report",
+                    conversation.id, event.id, recording.id
+                ),
+                Body::from(body),
+                &[
+                    (
+                        HeaderName::from_str("X-Webhook-Timestamp")?,
+                        HeaderValue::from_str(&timestamp)?,
+                    ),
+                    (
+                        HeaderName::from_str("X-Webhook-Signature")?,
+                        HeaderValue::from_str(&signature)?,
+                    ),
+                ],
+            )
+            .await?;
+
+        assert_eq!(status, StatusCode::CREATED);
+
+        // The recording is now both_available.
+        let refreshed = audio_recording::get_by_id(&pool, &recording.id).await?;
+        assert_eq!(
+            refreshed.status,
+            audio_recording::AudioRecordingStatus::BothAvailable
+        );
+
         Ok(())
     }
 }

--- a/api/src/routes/audio_recordings.rs
+++ b/api/src/routes/audio_recordings.rs
@@ -1,7 +1,7 @@
 //! Audio recording endpoints, mounted under
 //! `/conversation/{conversation_id}/events/{event_id}/audio_recordings`.
 //!
-//! Each recording is for a single named room within an event. The UI adds recordings one
+//! Each recording lives under an event. The UI adds recordings one
 //! at a time: create a recording (which returns a presigned upload URL), upload the
 //! file, then start processing. Status is tracked per recording.
 
@@ -38,7 +38,7 @@ use crate::ComhairleState;
 ///
 /// # Errors
 /// * `ComhairleError::NoBulkStorageServiceConfigured` if no bulk storage service is configured.
-/// * `ComhairleError::DuplicateRoomName` if a recording with this name already exists for the event.
+/// * `ComhairleError::DuplicateRecordingName` if a recording with this name already exists for the event.
 /// * `ComhairleError::DatabaseError` on database errors.
 #[instrument(err(Debug), skip(state))]
 async fn create_recording(
@@ -49,8 +49,6 @@ async fn create_recording(
 ) -> Result<(StatusCode, Json<CreateRecordingResponse>), ComhairleError> {
     let bulk_storage_service = state.required_bulk_storage_service()?;
 
-    // Generate the recording id up front so the S3 key prefix is fixed before the row
-    // is inserted. The human name lives only in the DB; the S3 path uses the id.
     let recording_id = Uuid::new_v4();
     let extension = request.file_extension.extension();
     let s3_key_prefix = format!("events/{event_id}/recordings/{recording_id}");
@@ -180,8 +178,7 @@ async fn process_recording(
 
 /// Webhook receiver for a recording's categorization report.
 ///
-/// Authenticated by the HMAC signature headers (not an admin JWT). Stores the
-/// report payload at the recording's S3 prefix.
+/// Authenticated by the HMAC signature headers (not an admin JWT).
 ///
 /// # Errors
 /// * `ComhairleError::AuthWebhookSignatureError` if the signature is missing or invalid.
@@ -226,7 +223,6 @@ async fn submit_report(
         ));
     }
 
-    // Confirm the event belongs to the conversation, then the recording to the event.
     let event = event::get_by_id(&state.db, &event_id).await?;
     if event.conversation_id != conversation_id {
         return Err(ComhairleError::ResourceNotFound(format!(

--- a/api/src/routes/audio_recordings.rs
+++ b/api/src/routes/audio_recordings.rs
@@ -108,7 +108,7 @@ async fn get_recording(
 ) -> Result<(StatusCode, Json<RecordingDetailResponse>), ComhairleError> {
     let bulk_storage_service = state.required_bulk_storage_service()?;
 
-    let recording = get_recording_for_event(&state, &event_id, &recording_id).await?;
+    let recording = audio_recording::get_by_id_and_event(&state.db, &recording_id, &event_id).await?;
     let extension = recording.file_extension.extension();
     let prefix = &recording.s3_key_prefix;
 
@@ -147,7 +147,7 @@ async fn process_recording(
     let worker_service = state.required_worker_service()?;
 
     // Ensure the recording exists and belongs to this event before enqueuing work.
-    let _recording = get_recording_for_event(&state, &event_id, &recording_id).await?;
+    let _recording = audio_recording::get_by_id_and_event(&state.db, &recording_id, &event_id).await?;
 
     let job = job::create(
         &state.db,
@@ -229,7 +229,7 @@ async fn submit_report(
             "No event {event_id} found for conversation {conversation_id}"
         )));
     }
-    let recording = get_recording_for_event(&state, &event_id, &recording_id).await?;
+    let recording = audio_recording::get_by_id_and_event(&state.db, &recording_id, &event_id).await?;
 
     let path = format!("{}/report.json", recording.s3_key_prefix);
     let bytes = serde_json::to_vec(&payload)?;
@@ -249,21 +249,6 @@ async fn submit_report(
             url: result.url,
         }),
     ))
-}
-
-/// Fetch a recording and verify it belongs to the given event.
-async fn get_recording_for_event(
-    state: &Arc<ComhairleState>,
-    event_id: &Uuid,
-    recording_id: &Uuid,
-) -> Result<audio_recording::AudioRecording, ComhairleError> {
-    let recording = audio_recording::get_by_id(&state.db, recording_id).await?;
-    if recording.event_id != *event_id {
-        return Err(ComhairleError::ResourceNotFound(format!(
-            "No recording {recording_id} found for event {event_id}"
-        )));
-    }
-    Ok(recording)
 }
 
 pub fn router(state: Arc<ComhairleState>) -> ApiRouter {

--- a/api/src/routes/audio_recordings.rs
+++ b/api/src/routes/audio_recordings.rs
@@ -1,9 +1,9 @@
-//! Per-room audio recording endpoints, mounted under
-//! `/conversation/{conversation_id}/events/{event_id}/rooms`.
+//! Audio recording endpoints, mounted under
+//! `/conversation/{conversation_id}/events/{event_id}/audio_recordings`.
 //!
-//! Each room is a single named recording within an event. The UI adds rooms one
-//! at a time: create a room (which returns a presigned upload URL), upload the
-//! file, then start processing. Status is tracked per room.
+//! Each recording is for a single named room within an event. The UI adds recordings one
+//! at a time: create a recording (which returns a presigned upload URL), upload the
+//! file, then start processing. Status is tracked per recording.
 
 pub mod dto;
 
@@ -27,38 +27,38 @@ use crate::models::audio_recording::{self, CreateAudioRecording};
 use crate::models::event;
 use crate::models::job::{self, CreateJob};
 use crate::routes::audio_recordings::dto::{
-    AudioRecordingDto, CreateRoomRequest, CreateRoomResponse, ProcessRoomResponse,
-    RecordingDownloadUrls, RoomDetailResponse, SubmitReportResponse,
+    AudioRecordingDto, CreateRecordingRequest, CreateRecordingResponse, ProcessRecordingResponse,
+    RecordingDownloadUrls, RecordingDetailResponse, SubmitReportResponse,
 };
 use crate::routes::auth::{verify_webhook_signature, RequiredAdminUser};
 use crate::worker_service::process_video_call_transcriptions::TranscribeRecording;
 use crate::ComhairleState;
 
-/// Create a room and return a presigned URL for uploading its recording.
+/// Create an audio recording and return a presigned URL for uploading its audio.
 ///
 /// # Errors
 /// * `ComhairleError::NoBulkStorageServiceConfigured` if no bulk storage service is configured.
-/// * `ComhairleError::DuplicateRoomName` if a room with this name already exists for the event.
+/// * `ComhairleError::DuplicateRoomName` if a recording with this name already exists for the event.
 /// * `ComhairleError::DatabaseError` on database errors.
 #[instrument(err(Debug), skip(state))]
-async fn create_room(
+async fn create_recording(
     State(state): State<Arc<ComhairleState>>,
     Path((_conversation_id, event_id)): Path<(Uuid, Uuid)>,
     RequiredAdminUser(_user): RequiredAdminUser,
-    Json(request): Json<CreateRoomRequest>,
-) -> Result<(StatusCode, Json<CreateRoomResponse>), ComhairleError> {
+    Json(request): Json<CreateRecordingRequest>,
+) -> Result<(StatusCode, Json<CreateRecordingResponse>), ComhairleError> {
     let bulk_storage_service = state.required_bulk_storage_service()?;
 
-    // Generate the room id up front so the S3 key prefix is fixed before the row
+    // Generate the recording id up front so the S3 key prefix is fixed before the row
     // is inserted. The human name lives only in the DB; the S3 path uses the id.
-    let room_id = Uuid::new_v4();
+    let recording_id = Uuid::new_v4();
     let extension = request.file_extension.extension();
-    let s3_key_prefix = format!("events/{event_id}/rooms/{room_id}");
+    let s3_key_prefix = format!("events/{event_id}/recordings/{recording_id}");
 
     let recording = audio_recording::create(
         &state.db,
         &CreateAudioRecording {
-            id: room_id,
+            id: recording_id,
             event_id,
             name: request.name,
             s3_key_prefix: s3_key_prefix.clone(),
@@ -73,44 +73,44 @@ async fn create_room(
 
     Ok((
         StatusCode::CREATED,
-        Json(CreateRoomResponse {
-            room: recording.into(),
+        Json(CreateRecordingResponse {
+            recording: recording.into(),
             upload_url,
         }),
     ))
 }
 
-/// List all rooms for an event with their per-room status.
+/// List all recordings for an event with their status.
 ///
 /// # Errors
 /// * `ComhairleError::DatabaseError` on database errors.
 #[instrument(err(Debug), skip(state))]
-async fn list_rooms(
+async fn list_recordings(
     State(state): State<Arc<ComhairleState>>,
     Path((_conversation_id, event_id)): Path<(Uuid, Uuid)>,
     RequiredAdminUser(_user): RequiredAdminUser,
 ) -> Result<(StatusCode, Json<Vec<AudioRecordingDto>>), ComhairleError> {
-    let rooms = audio_recording::list_by_event(&state.db, &event_id).await?;
+    let recordings = audio_recording::list_by_event(&state.db, &event_id).await?;
     Ok((
         StatusCode::OK,
-        Json(rooms.into_iter().map(AudioRecordingDto::from).collect()),
+        Json(recordings.into_iter().map(AudioRecordingDto::from).collect()),
     ))
 }
 
-/// Get a room's details and presigned download URLs (recording, transcript, report).
+/// Get a recording's details and presigned download URLs (recording, transcript, report).
 ///
 /// # Errors
 /// * `ComhairleError::NoBulkStorageServiceConfigured` if no bulk storage service is configured.
-/// * `ComhairleError::ResourceNotFound` if the room does not exist for this event.
+/// * `ComhairleError::ResourceNotFound` if the recording does not exist for this event.
 #[instrument(err(Debug), skip(state))]
-async fn get_room(
+async fn get_recording(
     State(state): State<Arc<ComhairleState>>,
-    Path((_conversation_id, event_id, room_id)): Path<(Uuid, Uuid, Uuid)>,
+    Path((_conversation_id, event_id, recording_id)): Path<(Uuid, Uuid, Uuid)>,
     RequiredAdminUser(_user): RequiredAdminUser,
-) -> Result<(StatusCode, Json<RoomDetailResponse>), ComhairleError> {
+) -> Result<(StatusCode, Json<RecordingDetailResponse>), ComhairleError> {
     let bulk_storage_service = state.required_bulk_storage_service()?;
 
-    let recording = get_room_for_event(&state, &event_id, &room_id).await?;
+    let recording = get_recording_for_event(&state, &event_id, &recording_id).await?;
     let extension = recording.file_extension.extension();
     let prefix = &recording.s3_key_prefix;
 
@@ -128,28 +128,28 @@ async fn get_room(
 
     Ok((
         StatusCode::OK,
-        Json(RoomDetailResponse {
-            room: recording.into(),
+        Json(RecordingDetailResponse {
+            recording: recording.into(),
             downloads,
         }),
     ))
 }
 
-/// Start processing (transcription + categorization) for a single room.
+/// Start processing (transcription + categorization) for a single recording.
 ///
 /// # Errors
-/// * `ComhairleError::ResourceNotFound` if the room does not exist for this event.
+/// * `ComhairleError::ResourceNotFound` if the recording does not exist for this event.
 /// * `ComhairleError::NoWorkerServiceConfigured` if no worker service is configured.
 #[instrument(err(Debug), skip(state))]
-async fn process_room(
+async fn process_recording(
     State(state): State<Arc<ComhairleState>>,
-    Path((conversation_id, event_id, room_id)): Path<(Uuid, Uuid, Uuid)>,
+    Path((conversation_id, event_id, recording_id)): Path<(Uuid, Uuid, Uuid)>,
     RequiredAdminUser(_user): RequiredAdminUser,
-) -> Result<(StatusCode, Json<ProcessRoomResponse>), ComhairleError> {
+) -> Result<(StatusCode, Json<ProcessRecordingResponse>), ComhairleError> {
     let worker_service = state.required_worker_service()?;
 
-    // Ensure the room exists and belongs to this event before enqueuing work.
-    let _recording = get_room_for_event(&state, &event_id, &room_id).await?;
+    // Ensure the recording exists and belongs to this event before enqueuing work.
+    let _recording = get_recording_for_event(&state, &event_id, &recording_id).await?;
 
     let job = job::create(
         &state.db,
@@ -164,33 +164,33 @@ async fn process_room(
         .push_transcription_job(TranscribeRecording {
             event_id,
             conversation_id,
-            room_id,
+            recording_id,
             job_id: job.id,
         })
         .await?;
 
     Ok((
         StatusCode::OK,
-        Json(ProcessRoomResponse {
-            message: "Room processing moved to a background job".to_string(),
+        Json(ProcessRecordingResponse {
+            message: "Recording processing moved to a background job".to_string(),
             job_id: job.id,
         }),
     ))
 }
 
-/// Webhook receiver for a room's categorization report.
+/// Webhook receiver for a recording's categorization report.
 ///
 /// Authenticated by the HMAC signature headers (not an admin JWT). Stores the
-/// report payload at the room's S3 prefix.
+/// report payload at the recording's S3 prefix.
 ///
 /// # Errors
 /// * `ComhairleError::AuthWebhookSignatureError` if the signature is missing or invalid.
-/// * `ComhairleError::ResourceNotFound` if the room/event does not match the path.
+/// * `ComhairleError::ResourceNotFound` if the recording/event does not match the path.
 #[instrument(err(Debug), skip(state))]
 async fn submit_report(
     State(state): State<Arc<ComhairleState>>,
     headers: HeaderMap,
-    Path((conversation_id, event_id, room_id)): Path<(Uuid, Uuid, Uuid)>,
+    Path((conversation_id, event_id, recording_id)): Path<(Uuid, Uuid, Uuid)>,
     payload: String,
 ) -> Result<(StatusCode, Json<SubmitReportResponse>), ComhairleError> {
     let bulk_storage_service = state.required_bulk_storage_service()?;
@@ -226,14 +226,14 @@ async fn submit_report(
         ));
     }
 
-    // Confirm the event belongs to the conversation, then the room to the event.
+    // Confirm the event belongs to the conversation, then the recording to the event.
     let event = event::get_by_id(&state.db, &event_id).await?;
     if event.conversation_id != conversation_id {
         return Err(ComhairleError::ResourceNotFound(format!(
             "No event {event_id} found for conversation {conversation_id}"
         )));
     }
-    let recording = get_room_for_event(&state, &event_id, &room_id).await?;
+    let recording = get_recording_for_event(&state, &event_id, &recording_id).await?;
 
     let path = format!("{}/report.json", recording.s3_key_prefix);
     let bytes = serde_json::to_vec(&payload)?;
@@ -255,16 +255,16 @@ async fn submit_report(
     ))
 }
 
-/// Fetch a room and verify it belongs to the given event.
-async fn get_room_for_event(
+/// Fetch a recording and verify it belongs to the given event.
+async fn get_recording_for_event(
     state: &Arc<ComhairleState>,
     event_id: &Uuid,
-    room_id: &Uuid,
+    recording_id: &Uuid,
 ) -> Result<audio_recording::AudioRecording, ComhairleError> {
-    let recording = audio_recording::get_by_id(&state.db, room_id).await?;
+    let recording = audio_recording::get_by_id(&state.db, recording_id).await?;
     if recording.event_id != *event_id {
         return Err(ComhairleError::ResourceNotFound(format!(
-            "No room {room_id} found for event {event_id}"
+            "No recording {recording_id} found for event {event_id}"
         )));
     }
     Ok(recording)
@@ -274,55 +274,55 @@ pub fn router(state: Arc<ComhairleState>) -> ApiRouter {
     ApiRouter::new()
         .api_route(
             "/",
-            post_with(create_room, |op| {
-                op.id("CreateRoom")
-                    .tag("Rooms")
-                    .summary("Create a room and get an upload URL")
-                    .description("Create a named room for an event and return a presigned S3 URL for uploading its recording.")
+            post_with(create_recording, |op| {
+                op.id("CreateAudioRecording")
+                    .tag("Audio Recordings")
+                    .summary("Create an audio recording and get an upload URL")
+                    .description("Create a named audio recording for an event and return a presigned S3 URL for uploading its audio.")
                     .security_requirement("JWT")
-                    .response::<201, Json<CreateRoomResponse>>()
+                    .response::<201, Json<CreateRecordingResponse>>()
             }),
         )
         .api_route(
             "/",
-            get_with(list_rooms, |op| {
-                op.id("ListRooms")
-                    .tag("Rooms")
-                    .summary("List rooms for an event")
-                    .description("List all rooms for an event with their per-room processing status.")
+            get_with(list_recordings, |op| {
+                op.id("ListAudioRecordings")
+                    .tag("Audio Recordings")
+                    .summary("List audio recordings for an event")
+                    .description("List all audio recordings for an event with their processing status.")
                     .security_requirement("JWT")
                     .response::<200, Json<Vec<AudioRecordingDto>>>()
             }),
         )
         .api_route(
-            "/{room_id}",
-            get_with(get_room, |op| {
-                op.id("GetRoom")
-                    .tag("Rooms")
-                    .summary("Get a room and its download URLs")
-                    .description("Get a room's details and presigned S3 URLs for its recording, transcript, and report.")
+            "/{recording_id}",
+            get_with(get_recording, |op| {
+                op.id("GetAudioRecording")
+                    .tag("Audio Recordings")
+                    .summary("Get an audio recording and its download URLs")
+                    .description("Get an audio recording's details and presigned S3 URLs for its audio, transcript, and report.")
                     .security_requirement("JWT")
-                    .response::<200, Json<RoomDetailResponse>>()
+                    .response::<200, Json<RecordingDetailResponse>>()
             }),
         )
         .api_route(
-            "/{room_id}/process",
-            post_with(process_room, |op| {
-                op.id("ProcessRoom")
-                    .tag("Rooms")
-                    .summary("Start processing a room")
-                    .description("Enqueue a background job to transcribe and categorize a single room's recording.")
+            "/{recording_id}/process",
+            post_with(process_recording, |op| {
+                op.id("ProcessAudioRecording")
+                    .tag("Audio Recordings")
+                    .summary("Start processing an audio recording")
+                    .description("Enqueue a background job to transcribe and categorize a single audio recording.")
                     .security_requirement("JWT")
-                    .response::<200, Json<ProcessRoomResponse>>()
+                    .response::<200, Json<ProcessRecordingResponse>>()
             }),
         )
         .api_route(
-            "/{room_id}/report",
+            "/{recording_id}/report",
             post_with(submit_report, |op| {
-                op.id("SubmitRoomReport")
-                    .tag("Rooms")
+                op.id("SubmitAudioRecordingReport")
+                    .tag("Audio Recordings")
                     .summary("Categorization report webhook")
-                    .description("Webhook for the categorization service to submit a room's report. Authenticated by HMAC signature headers.")
+                    .description("Webhook for the categorization service to submit a recording's report. Authenticated by HMAC signature headers.")
                     .response::<201, Json<SubmitReportResponse>>()
             }),
         )
@@ -357,7 +357,7 @@ mod tests {
     }
 
     #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
-    async fn test_create_room_success_with_mocked_storage(
+    async fn test_create_recording_success_with_mocked_storage(
         pool: sqlx::PgPool,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let mut storage_service = crate::bulk_storage_service::MockBulkStorageService::new();
@@ -384,7 +384,7 @@ mod tests {
 
         let (conversation, event) = create_random_event(&mut session, &app).await?;
 
-        let request = CreateRoomRequest {
+        let request = CreateRecordingRequest {
             name: "Main Room".to_string(),
             file_extension: AudioFormat::Wav,
         };
@@ -393,7 +393,7 @@ mod tests {
             .post(
                 &app,
                 &format!(
-                    "/conversation/{}/events/{}/rooms/",
+                    "/conversation/{}/events/{}/audio_recordings/",
                     conversation.id, event.id
                 ),
                 json!(request).to_string().into(),
@@ -401,21 +401,21 @@ mod tests {
             .await?;
 
         assert_eq!(status, StatusCode::CREATED);
-        let body: CreateRoomResponse = serde_json::from_value(response)?;
-        assert_eq!(body.room.name, "Main Room");
-        assert_eq!(body.room.event_id, event.id);
+        let body: CreateRecordingResponse = serde_json::from_value(response)?;
+        assert_eq!(body.recording.name, "Main Room");
+        assert_eq!(body.recording.event_id, event.id);
         assert_eq!(body.upload_url, "https://s3.example.com/signed-upload-url");
 
-        // The room is persisted and listed for the event.
-        let rooms = audio_recording::list_by_event(&pool, &event.id).await?;
-        assert_eq!(rooms.len(), 1);
-        assert_eq!(rooms[0].name, "Main Room");
+        // The recording is persisted and listed for the event.
+        let recordings = audio_recording::list_by_event(&pool, &event.id).await?;
+        assert_eq!(recordings.len(), 1);
+        assert_eq!(recordings[0].name, "Main Room");
 
         Ok(())
     }
 
     #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
-    async fn test_create_room_duplicate_name_conflicts(
+    async fn test_create_recording_duplicate_name_conflicts(
         pool: sqlx::PgPool,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let mut storage_service = crate::bulk_storage_service::MockBulkStorageService::new();
@@ -438,8 +438,8 @@ mod tests {
         session.signup(&app).await?;
 
         let (conversation, event) = create_random_event(&mut session, &app).await?;
-        let url = format!("/conversation/{}/events/{}/rooms/", conversation.id, event.id);
-        let request = CreateRoomRequest {
+        let url = format!("/conversation/{}/events/{}/audio_recordings/", conversation.id, event.id);
+        let request = CreateRecordingRequest {
             name: "Room A".to_string(),
             file_extension: AudioFormat::Wav,
         };
@@ -458,7 +458,7 @@ mod tests {
     }
 
     #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
-    async fn test_list_rooms_empty(
+    async fn test_list_recordings_empty(
         pool: sqlx::PgPool,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let mut config = test_config()?;
@@ -475,20 +475,20 @@ mod tests {
             .get(
                 &app,
                 &format!(
-                    "/conversation/{}/events/{}/rooms/",
+                    "/conversation/{}/events/{}/audio_recordings/",
                     conversation.id, event.id
                 ),
             )
             .await?;
 
         assert_eq!(status, StatusCode::OK);
-        let rooms: Vec<AudioRecordingDto> = serde_json::from_value(response)?;
-        assert_eq!(rooms.len(), 0);
+        let recordings: Vec<AudioRecordingDto> = serde_json::from_value(response)?;
+        assert_eq!(recordings.len(), 0);
         Ok(())
     }
 
     #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
-    async fn test_get_room_not_found(
+    async fn test_get_recording_not_found(
         pool: sqlx::PgPool,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let mut storage_service = crate::bulk_storage_service::MockBulkStorageService::new();
@@ -512,14 +512,14 @@ mod tests {
         session.signup(&app).await?;
 
         let (conversation, event) = create_random_event(&mut session, &app).await?;
-        let missing_room = Uuid::new_v4();
+        let missing_recording = Uuid::new_v4();
 
         let (status, _, _) = session
             .get(
                 &app,
                 &format!(
-                    "/conversation/{}/events/{}/rooms/{}",
-                    conversation.id, event.id, missing_room
+                    "/conversation/{}/events/{}/audio_recordings/{}",
+                    conversation.id, event.id, missing_recording
                 ),
             )
             .await?;

--- a/api/src/routes/audio_recordings.rs
+++ b/api/src/routes/audio_recordings.rs
@@ -1,3 +1,10 @@
+//! Per-room audio recording endpoints, mounted under
+//! `/conversation/{conversation_id}/events/{event_id}/rooms`.
+//!
+//! Each room is a single named recording within an event. The UI adds rooms one
+//! at a time: create a room (which returns a presigned upload URL), upload the
+//! file, then start processing. Status is tracked per room.
+
 pub mod dto;
 
 use std::sync::Arc;
@@ -10,189 +17,313 @@ use axum::{
     extract::{Json, Path, State},
     http::StatusCode,
 };
+use hyper::HeaderMap;
 use tracing::instrument;
 use uuid::Uuid;
 
+use crate::bulk_storage_service::FileMetadata;
 use crate::error::ComhairleError;
 use crate::models::audio_recording::{self, CreateAudioRecording};
+use crate::models::event;
+use crate::models::job::{self, CreateJob};
 use crate::routes::audio_recordings::dto::{
-    AudioRecordingDto, RecordingDownloadUrls, RequestUploadUrlsRequest, RequestUploadUrlsResponse,
-    SignedDownloadUrls,
+    AudioRecordingDto, CreateRoomRequest, CreateRoomResponse, ProcessRoomResponse,
+    RecordingDownloadUrls, RoomDetailResponse, SubmitReportResponse,
 };
-use crate::routes::auth::RequiredAdminUser;
+use crate::routes::auth::{verify_webhook_signature, RequiredAdminUser};
+use crate::worker_service::process_video_call_transcriptions::TranscribeRecording;
 use crate::ComhairleState;
 
-/// Request signed URLs for uploading audio recordings (main + breakout rooms)
+/// Create a room and return a presigned URL for uploading its recording.
 ///
 /// # Errors
-/// * Returns `ComhairleError::NoBulkStorageServiceConfigured` if no bulk storage service is configured.
-/// * Returns `ComhairleError::DatabaseError` if there is a database error when creating the audio recording record.
+/// * `ComhairleError::NoBulkStorageServiceConfigured` if no bulk storage service is configured.
+/// * `ComhairleError::DuplicateRoomName` if a room with this name already exists for the event.
+/// * `ComhairleError::DatabaseError` on database errors.
 #[instrument(err(Debug), skip(state))]
-async fn request_upload_urls(
+async fn create_room(
     State(state): State<Arc<ComhairleState>>,
-    Path((conversation_id, event_id)): Path<(Uuid, Uuid)>,
+    Path((_conversation_id, event_id)): Path<(Uuid, Uuid)>,
     RequiredAdminUser(_user): RequiredAdminUser,
-    Json(request): Json<RequestUploadUrlsRequest>,
-) -> Result<(StatusCode, Json<RequestUploadUrlsResponse>), ComhairleError> {
+    Json(request): Json<CreateRoomRequest>,
+) -> Result<(StatusCode, Json<CreateRoomResponse>), ComhairleError> {
     let bulk_storage_service = state.required_bulk_storage_service()?;
 
-    let event_id_str = event_id.to_string();
-    let base_key_prefix = format!("events/{}", event_id_str);
+    // Generate the room id up front so the S3 key prefix is fixed before the row
+    // is inserted. The human name lives only in the DB; the S3 path uses the id.
+    let room_id = Uuid::new_v4();
     let extension = request.file_extension.extension();
+    let s3_key_prefix = format!("events/{event_id}/rooms/{room_id}");
 
-    let create_recording = CreateAudioRecording {
-        event_id,
-        breakout_room_ids: request.breakout_rooms.clone(),
-        s3_key_prefix: base_key_prefix.clone(),
-        file_extension: request.file_extension,
-    };
-    let _ = audio_recording::create(&state.db, &create_recording).await?;
+    let recording = audio_recording::create(
+        &state.db,
+        &CreateAudioRecording {
+            id: room_id,
+            event_id,
+            name: request.name,
+            s3_key_prefix: s3_key_prefix.clone(),
+            file_extension: request.file_extension,
+        },
+    )
+    .await?;
 
-    let main_signed_url = bulk_storage_service
-        .get_write_file_url(&format!("{}/recording.{}", base_key_prefix, extension))
+    let upload_url = bulk_storage_service
+        .get_write_file_url(&format!("{s3_key_prefix}/recording.{extension}"))
         .await?;
 
-    let mut breakout_room_urls = Vec::new();
-    for room_id in request.breakout_rooms {
-        let breakout_key_prefix = format!("{}/rooms/{}", event_id_str, room_id);
-
-        let breakout_signed_url = bulk_storage_service
-            .get_write_file_url(&format!("{}/recording.{}", breakout_key_prefix, extension))
-            .await?;
-
-        breakout_room_urls.push((room_id, breakout_signed_url));
-    }
-
     Ok((
-        StatusCode::OK,
-        Json(RequestUploadUrlsResponse {
-            main: main_signed_url,
-            breakout_rooms: breakout_room_urls,
+        StatusCode::CREATED,
+        Json(CreateRoomResponse {
+            room: recording.into(),
+            upload_url,
         }),
     ))
 }
 
-/// Get signed URLs for downloading transcript and report
+/// List all rooms for an event with their per-room status.
 ///
 /// # Errors
-/// * Returns `ComhairleError::NoBulkStorageServiceConfigured` if no bulk storage service is configured.
-/// * Returns `ComhairleError::ResourceNotFound` if there is no audio recording for the given event.
-/// * Returns `ComhairleError::DatabaseError` if there is a database error when retrieving the audio recording.
+/// * `ComhairleError::DatabaseError` on database errors.
 #[instrument(err(Debug), skip(state))]
-async fn get_download_urls(
+async fn list_rooms(
     State(state): State<Arc<ComhairleState>>,
-    Path((conversation_id, event_id)): Path<(Uuid, Uuid)>,
+    Path((_conversation_id, event_id)): Path<(Uuid, Uuid)>,
     RequiredAdminUser(_user): RequiredAdminUser,
-) -> Result<(StatusCode, Json<SignedDownloadUrls>), ComhairleError> {
+) -> Result<(StatusCode, Json<Vec<AudioRecordingDto>>), ComhairleError> {
+    let rooms = audio_recording::list_by_event(&state.db, &event_id).await?;
+    Ok((
+        StatusCode::OK,
+        Json(rooms.into_iter().map(AudioRecordingDto::from).collect()),
+    ))
+}
+
+/// Get a room's details and presigned download URLs (recording, transcript, report).
+///
+/// # Errors
+/// * `ComhairleError::NoBulkStorageServiceConfigured` if no bulk storage service is configured.
+/// * `ComhairleError::ResourceNotFound` if the room does not exist for this event.
+#[instrument(err(Debug), skip(state))]
+async fn get_room(
+    State(state): State<Arc<ComhairleState>>,
+    Path((_conversation_id, event_id, room_id)): Path<(Uuid, Uuid, Uuid)>,
+    RequiredAdminUser(_user): RequiredAdminUser,
+) -> Result<(StatusCode, Json<RoomDetailResponse>), ComhairleError> {
     let bulk_storage_service = state.required_bulk_storage_service()?;
 
-    // Get the audio recording for this event
-    let recording = audio_recording::get_by_event(&state.db, &event_id).await?;
+    let recording = get_room_for_event(&state, &event_id, &room_id).await?;
     let extension = recording.file_extension.extension();
+    let prefix = &recording.s3_key_prefix;
 
-    // Generate signed URLs for transcript and report
-    let main_recording_url = bulk_storage_service
-        .get_read_file_url(&format!(
-            "{}/recording.{}",
-            recording.s3_key_prefix, extension
-        ))
-        .await?;
-    let main_transcript_url = bulk_storage_service
-        .get_read_file_url(&format!("{}/transcript.json", recording.s3_key_prefix))
-        .await?;
-    let main_report_url = bulk_storage_service
-        .get_read_file_url(&format!("{}/report.json", recording.s3_key_prefix))
-        .await?;
-
-    let mut output = SignedDownloadUrls {
-        main: RecordingDownloadUrls {
-            recording_url: main_recording_url,
-            transcript_url: main_transcript_url,
-            report_url: main_report_url,
-        },
-        breakout_rooms: Vec::new(),
+    let downloads = RecordingDownloadUrls {
+        recording_url: bulk_storage_service
+            .get_read_file_url(&format!("{prefix}/recording.{extension}"))
+            .await?,
+        transcript_url: bulk_storage_service
+            .get_read_file_url(&format!("{prefix}/transcript.json"))
+            .await?,
+        report_url: bulk_storage_service
+            .get_read_file_url(&format!("{prefix}/report.json"))
+            .await?,
     };
-    for room in &recording.breakout_room_ids {
-        let breakout_key_prefix = format!("{}/rooms/{}", event_id, room);
 
-        let breakout_recording_url = bulk_storage_service
-            .get_read_file_url(&format!("{}/recording.{}", breakout_key_prefix, extension))
-            .await?;
-        let breakout_transcript_url = bulk_storage_service
-            .get_read_file_url(&format!("{}/transcript.json", breakout_key_prefix))
-            .await?;
-        let breakout_report_url = bulk_storage_service
-            .get_read_file_url(&format!("{}/report.json", breakout_key_prefix))
-            .await?;
+    Ok((
+        StatusCode::OK,
+        Json(RoomDetailResponse {
+            room: recording.into(),
+            downloads,
+        }),
+    ))
+}
 
-        // Add to the response
-        output.breakout_rooms.push((
-            room.clone(),
-            RecordingDownloadUrls {
-                recording_url: breakout_recording_url,
-                transcript_url: breakout_transcript_url,
-                report_url: breakout_report_url,
-            },
+/// Start processing (transcription + categorization) for a single room.
+///
+/// # Errors
+/// * `ComhairleError::ResourceNotFound` if the room does not exist for this event.
+/// * `ComhairleError::NoWorkerServiceConfigured` if no worker service is configured.
+#[instrument(err(Debug), skip(state))]
+async fn process_room(
+    State(state): State<Arc<ComhairleState>>,
+    Path((conversation_id, event_id, room_id)): Path<(Uuid, Uuid, Uuid)>,
+    RequiredAdminUser(_user): RequiredAdminUser,
+) -> Result<(StatusCode, Json<ProcessRoomResponse>), ComhairleError> {
+    let worker_service = state.required_worker_service()?;
+
+    // Ensure the room exists and belongs to this event before enqueuing work.
+    let _recording = get_room_for_event(&state, &event_id, &room_id).await?;
+
+    let job = job::create(
+        &state.db,
+        CreateJob {
+            progress: Some(0.0),
+            ..Default::default()
+        },
+    )
+    .await?;
+
+    worker_service
+        .push_transcription_job(TranscribeRecording {
+            event_id,
+            conversation_id,
+            room_id,
+            job_id: job.id,
+        })
+        .await?;
+
+    Ok((
+        StatusCode::OK,
+        Json(ProcessRoomResponse {
+            message: "Room processing moved to a background job".to_string(),
+            job_id: job.id,
+        }),
+    ))
+}
+
+/// Webhook receiver for a room's categorization report.
+///
+/// Authenticated by the HMAC signature headers (not an admin JWT). Stores the
+/// report payload at the room's S3 prefix.
+///
+/// # Errors
+/// * `ComhairleError::AuthWebhookSignatureError` if the signature is missing or invalid.
+/// * `ComhairleError::ResourceNotFound` if the room/event does not match the path.
+#[instrument(err(Debug), skip(state))]
+async fn submit_report(
+    State(state): State<Arc<ComhairleState>>,
+    headers: HeaderMap,
+    Path((conversation_id, event_id, room_id)): Path<(Uuid, Uuid, Uuid)>,
+    payload: String,
+) -> Result<(StatusCode, Json<SubmitReportResponse>), ComhairleError> {
+    let bulk_storage_service = state.required_bulk_storage_service()?;
+    let webhook_secret = &state
+        .config
+        .categorization_service
+        .as_ref()
+        .ok_or(ComhairleError::NoCategorizationServiceConfigured)?
+        .webhook_secret;
+
+    let webhook_timestamp = headers
+        .get("X-Webhook-Timestamp")
+        .ok_or(ComhairleError::AuthWebhookSignatureError(
+            "Missing X-Webhook-Timestamp".to_string(),
+        ))?
+        .to_str()
+        .map_err(|_| {
+            ComhairleError::AuthWebhookSignatureError("Invalid X-Webhook-Timestamp".to_string())
+        })?;
+    let webhook_signature = headers
+        .get("X-Webhook-Signature")
+        .ok_or(ComhairleError::AuthWebhookSignatureError(
+            "Missing X-Webhook-Signature".to_string(),
+        ))?
+        .to_str()
+        .map_err(|_| {
+            ComhairleError::AuthWebhookSignatureError("Invalid X-Webhook-Signature".to_string())
+        })?;
+
+    if !verify_webhook_signature(webhook_signature, webhook_timestamp, &payload, webhook_secret)? {
+        return Err(ComhairleError::AuthWebhookSignatureError(
+            "Invalid X-Webhook-Signature".to_string(),
         ));
     }
 
-    Ok((StatusCode::OK, Json(output)))
+    // Confirm the event belongs to the conversation, then the room to the event.
+    let event = event::get_by_id(&state.db, &event_id).await?;
+    if event.conversation_id != conversation_id {
+        return Err(ComhairleError::ResourceNotFound(format!(
+            "No event {event_id} found for conversation {conversation_id}"
+        )));
+    }
+    let recording = get_room_for_event(&state, &event_id, &room_id).await?;
+
+    let path = format!("{}/report.json", recording.s3_key_prefix);
+    let bytes = serde_json::to_vec(&payload)?;
+    let metadata = FileMetadata {
+        is_public: false,
+        content_type: "application/json".to_string(),
+    };
+
+    let result = bulk_storage_service
+        .upload_file(&path, bytes, metadata)
+        .await?;
+
+    Ok((
+        StatusCode::CREATED,
+        Json(SubmitReportResponse {
+            success: true,
+            url: result.url,
+        }),
+    ))
 }
 
-/// List audio recordings for an event
-///
-/// # Errors
-/// * Returns `ComhairleError::DatabaseError` if there is a database error when retrieving the audio recording.
-#[instrument(err(Debug), skip(state))]
-async fn get_recording_for_event(
-    State(state): State<Arc<ComhairleState>>,
-    Path((conversation_id, event_id)): Path<(Uuid, Uuid)>,
-    RequiredAdminUser(_user): RequiredAdminUser,
-) -> Result<(StatusCode, Json<Vec<AudioRecordingDto>>), ComhairleError> {
-    // Get the single recording for this event
-    match audio_recording::get_by_event(&state.db, &event_id).await {
-        Ok(recording) => {
-            let dto = AudioRecordingDto::from(recording);
-            Ok((StatusCode::OK, Json(vec![dto])))
-        }
-        Err(ComhairleError::ResourceNotFound(_)) => Ok((StatusCode::OK, Json(vec![]))),
-        Err(e) => Err(e),
+/// Fetch a room and verify it belongs to the given event.
+async fn get_room_for_event(
+    state: &Arc<ComhairleState>,
+    event_id: &Uuid,
+    room_id: &Uuid,
+) -> Result<audio_recording::AudioRecording, ComhairleError> {
+    let recording = audio_recording::get_by_id(&state.db, room_id).await?;
+    if recording.event_id != *event_id {
+        return Err(ComhairleError::ResourceNotFound(format!(
+            "No room {room_id} found for event {event_id}"
+        )));
     }
+    Ok(recording)
 }
 
 pub fn router(state: Arc<ComhairleState>) -> ApiRouter {
     ApiRouter::new()
         .api_route(
-            "/upload",
-            post_with(request_upload_urls, |op| {
-                op.id("RequestAudioUploadUrls")
-                    .tag("Audio Recordings")
-                    .summary("Request signed URLs for uploading audio recordings")
-                    .description("Request signed S3 URLs for uploading main and breakout room audio recordings. Returns presigned URLs and creates DB records.")
+            "/",
+            post_with(create_room, |op| {
+                op.id("CreateRoom")
+                    .tag("Rooms")
+                    .summary("Create a room and get an upload URL")
+                    .description("Create a named room for an event and return a presigned S3 URL for uploading its recording.")
                     .security_requirement("JWT")
-                    .response::<200, Json<RequestUploadUrlsResponse>>()
-            }),
-        )
-        .api_route(
-            "/download",
-            get_with(get_download_urls, |op| {
-                op.id("GetAudioDownloadUrls")
-                    .tag("Audio Recordings")
-                    .summary("Get signed URLs for downloading transcript and report")
-                    .description("Get presigned S3 URLs for downloading transcript.json and report.json for a recording.")
-                    .security_requirement("JWT")
-                    .response::<200, Json<SignedDownloadUrls>>()
+                    .response::<201, Json<CreateRoomResponse>>()
             }),
         )
         .api_route(
             "/",
-            get_with(get_recording_for_event, |op| {
-                op.id("ListAudioRecordings")
-                    .tag("Audio Recordings")
-                    .summary("List audio recordings for an event")
-                    .description("List all audio recordings for an event. Optionally filter by room_id.")
+            get_with(list_rooms, |op| {
+                op.id("ListRooms")
+                    .tag("Rooms")
+                    .summary("List rooms for an event")
+                    .description("List all rooms for an event with their per-room processing status.")
                     .security_requirement("JWT")
                     .response::<200, Json<Vec<AudioRecordingDto>>>()
+            }),
+        )
+        .api_route(
+            "/{room_id}",
+            get_with(get_room, |op| {
+                op.id("GetRoom")
+                    .tag("Rooms")
+                    .summary("Get a room and its download URLs")
+                    .description("Get a room's details and presigned S3 URLs for its recording, transcript, and report.")
+                    .security_requirement("JWT")
+                    .response::<200, Json<RoomDetailResponse>>()
+            }),
+        )
+        .api_route(
+            "/{room_id}/process",
+            post_with(process_room, |op| {
+                op.id("ProcessRoom")
+                    .tag("Rooms")
+                    .summary("Start processing a room")
+                    .description("Enqueue a background job to transcribe and categorize a single room's recording.")
+                    .security_requirement("JWT")
+                    .response::<200, Json<ProcessRoomResponse>>()
+            }),
+        )
+        .api_route(
+            "/{room_id}/report",
+            post_with(submit_report, |op| {
+                op.id("SubmitRoomReport")
+                    .tag("Rooms")
+                    .summary("Categorization report webhook")
+                    .description("Webhook for the categorization service to submit a room's report. Authenticated by HMAC signature headers.")
+                    .response::<201, Json<SubmitReportResponse>>()
             }),
         )
         .with_state(state)
@@ -226,44 +357,108 @@ mod tests {
     }
 
     #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
-    async fn test_request_upload_urls_event_not_found(
+    async fn test_create_room_success_with_mocked_storage(
         pool: sqlx::PgPool,
     ) -> Result<(), Box<dyn std::error::Error>> {
+        let mut storage_service = crate::bulk_storage_service::MockBulkStorageService::new();
+        storage_service
+            .expect_get_write_file_url()
+            .times(1)
+            .returning(|_| {
+                Box::pin(async move { Ok("https://s3.example.com/signed-upload-url".to_string()) })
+            });
+
         let mut config = test_config()?;
         config.bot_service = None;
-        let state = Arc::new(test_state().db(pool).config(config).call()?);
+        let state = Arc::new(
+            test_state()
+                .db(pool.clone())
+                .config(config)
+                .bulk_storage_service(Arc::new(storage_service))
+                .call()?,
+        );
         let app = setup_server(state.clone()).await?;
 
         let mut session = UserSession::new_admin();
         session.signup(&app).await?;
 
-        let (conversation, _event) = create_random_event(&mut session, &app).await?;
-        let conversation_id: String = conversation.id.to_string();
-        let fake_event = Uuid::new_v4();
+        let (conversation, event) = create_random_event(&mut session, &app).await?;
 
-        let request = RequestUploadUrlsRequest {
-            breakout_rooms: vec!["room1".to_string(), "room2".to_string()],
+        let request = CreateRoomRequest {
+            name: "Main Room".to_string(),
             file_extension: AudioFormat::Wav,
         };
 
-        let (status, _response, _) = session
+        let (status, response, _) = session
             .post(
                 &app,
                 &format!(
-                    "/conversation/{}/events/{}/audio-recordings/upload",
-                    conversation_id, fake_event
+                    "/conversation/{}/events/{}/rooms/",
+                    conversation.id, event.id
                 ),
                 json!(request).to_string().into(),
             )
             .await?;
 
-        // Should fail with a database error because the event does not exist
-        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(status, StatusCode::CREATED);
+        let body: CreateRoomResponse = serde_json::from_value(response)?;
+        assert_eq!(body.room.name, "Main Room");
+        assert_eq!(body.room.event_id, event.id);
+        assert_eq!(body.upload_url, "https://s3.example.com/signed-upload-url");
+
+        // The room is persisted and listed for the event.
+        let rooms = audio_recording::list_by_event(&pool, &event.id).await?;
+        assert_eq!(rooms.len(), 1);
+        assert_eq!(rooms[0].name, "Main Room");
+
         Ok(())
     }
 
     #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
-    async fn test_get_download_urls_recording_not_found(
+    async fn test_create_room_duplicate_name_conflicts(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let mut storage_service = crate::bulk_storage_service::MockBulkStorageService::new();
+        storage_service
+            .expect_get_write_file_url()
+            .returning(|_| Box::pin(async move { Ok("https://s3.example.com/url".to_string()) }));
+
+        let mut config = test_config()?;
+        config.bot_service = None;
+        let state = Arc::new(
+            test_state()
+                .db(pool.clone())
+                .config(config)
+                .bulk_storage_service(Arc::new(storage_service))
+                .call()?,
+        );
+        let app = setup_server(state.clone()).await?;
+
+        let mut session = UserSession::new_admin();
+        session.signup(&app).await?;
+
+        let (conversation, event) = create_random_event(&mut session, &app).await?;
+        let url = format!("/conversation/{}/events/{}/rooms/", conversation.id, event.id);
+        let request = CreateRoomRequest {
+            name: "Room A".to_string(),
+            file_extension: AudioFormat::Wav,
+        };
+
+        let (status, _, _) = session
+            .post(&app, &url, json!(request).to_string().into())
+            .await?;
+        assert_eq!(status, StatusCode::CREATED);
+
+        let (status, _, _) = session
+            .post(&app, &url, json!(request).to_string().into())
+            .await?;
+        assert_eq!(status, StatusCode::CONFLICT);
+
+        Ok(())
+    }
+
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
+    async fn test_list_rooms_empty(
         pool: sqlx::PgPool,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let mut config = test_config()?;
@@ -275,246 +470,61 @@ mod tests {
         session.signup(&app).await?;
 
         let (conversation, event) = create_random_event(&mut session, &app).await?;
-        let conversation_id: String = conversation.id.to_string();
-        let event_id: String = event.id.to_string();
 
-        let (status, _response, _) = session
+        let (status, response, _) = session
             .get(
                 &app,
                 &format!(
-                    "/conversation/{}/events/{}/audio-recordings/download",
-                    conversation_id, event_id
+                    "/conversation/{}/events/{}/rooms/",
+                    conversation.id, event.id
+                ),
+            )
+            .await?;
+
+        assert_eq!(status, StatusCode::OK);
+        let rooms: Vec<AudioRecordingDto> = serde_json::from_value(response)?;
+        assert_eq!(rooms.len(), 0);
+        Ok(())
+    }
+
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
+    async fn test_get_room_not_found(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let mut storage_service = crate::bulk_storage_service::MockBulkStorageService::new();
+        storage_service.expect_get_read_file_url().returning(|path| {
+            let url = format!("https://s3.example.com/{path}");
+            Box::pin(async move { Ok(url) })
+        });
+
+        let mut config = test_config()?;
+        config.bot_service = None;
+        let state = Arc::new(
+            test_state()
+                .db(pool)
+                .config(config)
+                .bulk_storage_service(Arc::new(storage_service))
+                .call()?,
+        );
+        let app = setup_server(state.clone()).await?;
+
+        let mut session = UserSession::new_admin();
+        session.signup(&app).await?;
+
+        let (conversation, event) = create_random_event(&mut session, &app).await?;
+        let missing_room = Uuid::new_v4();
+
+        let (status, _, _) = session
+            .get(
+                &app,
+                &format!(
+                    "/conversation/{}/events/{}/rooms/{}",
+                    conversation.id, event.id, missing_room
                 ),
             )
             .await?;
 
         assert_eq!(status, StatusCode::NOT_FOUND);
-        Ok(())
-    }
-
-    // TODO: Mock bulk storage service for further tests.
-
-    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
-    async fn test_request_upload_urls_success_with_mocked_storage(
-        pool: sqlx::PgPool,
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        let mut storage_service = crate::bulk_storage_service::MockBulkStorageService::new();
-
-        // Mock the get_write_file_url calls for main and breakout rooms
-        storage_service
-            .expect_get_write_file_url()
-            .times(3) // 1 main + 2 breakout rooms
-            .returning(|_| {
-                Box::pin(async move { Ok("https://s3.example.com/signed-upload-url".to_string()) })
-            });
-
-        let mut config = test_config()?;
-        config.bot_service = None;
-        let state = Arc::new(
-            test_state()
-                .db(pool.clone())
-                .config(config)
-                .bulk_storage_service(Arc::new(storage_service))
-                .call()?,
-        );
-        let app = setup_server(state.clone()).await?;
-
-        let mut session = UserSession::new_admin();
-        session.signup(&app).await?;
-
-        let (conversation, event) = create_random_event(&mut session, &app).await?;
-        let conversation_id: String = conversation.id.to_string();
-        let event_id: String = event.id.to_string();
-
-        let request = RequestUploadUrlsRequest {
-            breakout_rooms: vec!["room1".to_string(), "room2".to_string()],
-            file_extension: AudioFormat::Wav,
-        };
-
-        let (status, response, _) = session
-            .post(
-                &app,
-                &format!(
-                    "/conversation/{}/events/{}/audio-recordings/upload",
-                    conversation_id, event_id
-                ),
-                json!(request).to_string().into(),
-            )
-            .await?;
-
-        assert_eq!(status, StatusCode::OK);
-
-        let upload_response: RequestUploadUrlsResponse = serde_json::from_value(response)?;
-
-        // Verify main room URL
-        assert!(!upload_response.main.is_empty());
-        assert_eq!(
-            upload_response.main,
-            "https://s3.example.com/signed-upload-url"
-        );
-
-        // Verify breakout room URLs
-        assert_eq!(upload_response.breakout_rooms.len(), 2);
-        for (i, room_urls) in upload_response.breakout_rooms.iter().enumerate() {
-            assert_eq!(room_urls.0, format!("room{}", i + 1));
-            assert_eq!(room_urls.1, "https://s3.example.com/signed-upload-url");
-        }
-
-        // Verify recording was created in database
-        let recording = audio_recording::get_by_event(&pool, &Uuid::parse_str(&event_id)?).await?;
-        assert_eq!(
-            recording.breakout_room_ids,
-            vec!["room1".to_string(), "room2".to_string()]
-        );
-        assert_eq!(
-            recording.status,
-            audio_recording::AudioRecordingStatus::Pending
-        );
-
-        Ok(())
-    }
-
-    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
-    async fn test_get_download_urls_after_status_update(
-        pool: sqlx::PgPool,
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        let mut storage_service = crate::bulk_storage_service::MockBulkStorageService::new();
-
-        // Mock the get_write_file_url calls for upload
-        storage_service
-            .expect_get_write_file_url()
-            .times(3) // 1 main + 2 breakout rooms
-            .returning(|_| {
-                Box::pin(async move { Ok("https://s3.example.com/signed-upload-url".to_string()) })
-            });
-
-        // Mock the get_read_file_url calls for download (3 files per room: recording, transcript, report)
-        // Main room: 3 files, Breakout rooms: 2 * 3 = 6 files, Total = 9 files
-        storage_service
-            .expect_get_read_file_url()
-            .times(9) // 3 main files + 6 breakout files (2 rooms * 3 files each)
-            .returning(|path| {
-                let url = format!("https://s3.example.com/signed-read-{}", path);
-                Box::pin(async move { Ok(url) })
-            });
-
-        let mut config = test_config()?;
-        config.bot_service = None;
-        let state = Arc::new(
-            test_state()
-                .db(pool.clone())
-                .config(config)
-                .bulk_storage_service(Arc::new(storage_service))
-                .call()?,
-        );
-        let app = setup_server(state.clone()).await?;
-
-        let mut session = UserSession::new_admin();
-        session.signup(&app).await?;
-
-        let (conversation, event) = create_random_event(&mut session, &app).await?;
-        let conversation_id: String = conversation.id.to_string();
-        let event_id: String = event.id.to_string();
-
-        let request = RequestUploadUrlsRequest {
-            breakout_rooms: vec!["room1".to_string(), "room2".to_string()],
-            file_extension: AudioFormat::Wav,
-        };
-
-        let (status, _response, _) = session
-            .post(
-                &app,
-                &format!(
-                    "/conversation/{}/events/{}/audio-recordings/upload",
-                    conversation_id, event_id
-                ),
-                json!(request).to_string().into(),
-            )
-            .await?;
-        assert_eq!(status, StatusCode::OK);
-
-        let recording = audio_recording::get_by_event(&pool, &event.id).await?;
-        audio_recording::update_status(
-            &pool,
-            &recording.id,
-            audio_recording::AudioRecordingStatus::Completed,
-        )
-        .await?;
-
-        let (status, response, _) = session
-            .get(
-                &app,
-                &format!(
-                    "/conversation/{}/events/{}/audio-recordings/download",
-                    conversation_id, event_id
-                ),
-            )
-            .await?;
-
-        assert_eq!(status, StatusCode::OK);
-
-        let download_response: SignedDownloadUrls = serde_json::from_value(response)?;
-
-        // Verify main room download URLs
-        assert!(!download_response.main.recording_url.is_empty());
-        assert!(!download_response.main.transcript_url.is_empty());
-        assert!(!download_response.main.report_url.is_empty());
-
-        // Verify main room URLs contain expected paths
-        assert!(download_response.main.recording_url.contains("signed-read"));
-        assert!(download_response
-            .main
-            .transcript_url
-            .contains("signed-read"));
-        assert!(download_response.main.report_url.contains("signed-read"));
-
-        // Verify breakout room download URLs
-        assert_eq!(download_response.breakout_rooms.len(), 2);
-        for (i, (room_id, urls)) in download_response.breakout_rooms.iter().enumerate() {
-            assert_eq!(room_id, &format!("room{}", i + 1));
-            assert!(!urls.recording_url.is_empty());
-            assert!(!urls.transcript_url.is_empty());
-            assert!(!urls.report_url.is_empty());
-        }
-
-        Ok(())
-    }
-
-    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
-    async fn test_get_recording_for_event_empty_list(
-        pool: sqlx::PgPool,
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        let mut config = test_config()?;
-        config.bot_service = None;
-        let state = Arc::new(test_state().db(pool).config(config).call()?);
-        let app = setup_server(state.clone()).await?;
-
-        let mut session = UserSession::new_admin();
-        session.signup(&app).await?;
-
-        let (conversation, event) = create_random_event(&mut session, &app).await?;
-        let conversation_id: String = conversation.id.to_string();
-        let event_id: String = event.id.to_string();
-
-        let (status, response, _) = session
-            .get(
-                &app,
-                &format!(
-                    "/conversation/{}/events/{}/audio-recordings/",
-                    conversation_id, event_id
-                ),
-            )
-            .await?;
-
-        assert_eq!(status, StatusCode::OK);
-
-        let recordings: Vec<AudioRecordingDto> = serde_json::from_value(response)?;
-        assert_eq!(
-            recordings.len(),
-            0,
-            "Should return empty list when no recording exists"
-        );
-
         Ok(())
     }
 }

--- a/api/src/routes/audio_recordings/dto.rs
+++ b/api/src/routes/audio_recordings/dto.rs
@@ -39,7 +39,7 @@ impl From<AudioRecording> for AudioRecordingDto {
 #[derive(Deserialize, JsonSchema, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateRecordingRequest {
-    /// Name for the recording (its room name), unique within the event.
+    /// Name for the recording, unique within the event.
     pub name: String,
     /// Audio format of the file being uploaded.
     pub file_extension: AudioFormat,

--- a/api/src/routes/audio_recordings/dto.rs
+++ b/api/src/routes/audio_recordings/dto.rs
@@ -5,13 +5,13 @@ use uuid::Uuid;
 
 use crate::models::audio_recording::{AudioFormat, AudioRecording, AudioRecordingStatus};
 
-/// Data transfer object for an AudioRecording
+/// Data transfer object for a room's audio recording.
 #[derive(Serialize, Deserialize, JsonSchema, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AudioRecordingDto {
     pub id: Uuid,
     pub event_id: Uuid,
-    pub breakout_room_ids: Vec<String>,
+    pub name: String,
     pub s3_key_prefix: String,
     pub file_extension: AudioFormat,
     pub status: AudioRecordingStatus,
@@ -24,7 +24,7 @@ impl From<AudioRecording> for AudioRecordingDto {
         Self {
             id: recording.id,
             event_id: recording.event_id,
-            breakout_room_ids: recording.breakout_room_ids,
+            name: recording.name,
             s3_key_prefix: recording.s3_key_prefix,
             file_extension: recording.file_extension,
             status: recording.status,
@@ -34,27 +34,27 @@ impl From<AudioRecording> for AudioRecordingDto {
     }
 }
 
-/// Request body for requesting signed upload URLs
+/// Request body for creating a room and requesting its upload URL.
 #[cfg_attr(test, derive(Serialize))]
 #[derive(Deserialize, JsonSchema, Debug)]
 #[serde(rename_all = "camelCase")]
-pub struct RequestUploadUrlsRequest {
-    /// List of breakout room IDs (empty list means only main room)
-    pub breakout_rooms: Vec<String>,
-    /// Audio format of the files being uploaded (all files share the same format)
+pub struct CreateRoomRequest {
+    /// Name for the room, unique within the event.
+    pub name: String,
+    /// Audio format of the file being uploaded.
     pub file_extension: AudioFormat,
 }
 
-/// Response with signed upload URLs for main and breakout rooms
+/// Response after creating a room: the created room plus a presigned upload URL.
 #[cfg_attr(test, derive(Deserialize))]
 #[derive(Serialize, JsonSchema, Debug)]
 #[serde(rename_all = "camelCase")]
-pub struct RequestUploadUrlsResponse {
-    pub main: String,
-    pub breakout_rooms: Vec<(String, String)>,
+pub struct CreateRoomResponse {
+    pub room: AudioRecordingDto,
+    pub upload_url: String,
 }
 
-/// Response with signed download URLs for main and breakout rooms
+/// Signed URLs for downloading a room's recording, transcript, and report.
 #[cfg_attr(test, derive(Deserialize))]
 #[derive(Serialize, JsonSchema, Debug)]
 #[serde(rename_all = "camelCase")]
@@ -64,11 +64,28 @@ pub struct RecordingDownloadUrls {
     pub report_url: String,
 }
 
-/// Signed URL information for downloading recordings, transcripts, and reports for main and breakout rooms.
+/// A room's details together with its signed download URLs.
 #[cfg_attr(test, derive(Deserialize))]
 #[derive(Serialize, JsonSchema, Debug)]
 #[serde(rename_all = "camelCase")]
-pub struct SignedDownloadUrls {
-    pub main: RecordingDownloadUrls,
-    pub breakout_rooms: Vec<(String, RecordingDownloadUrls)>,
+pub struct RoomDetailResponse {
+    pub room: AudioRecordingDto,
+    pub downloads: RecordingDownloadUrls,
+}
+
+/// Response after enqueuing processing for a room.
+#[derive(Serialize, Deserialize, JsonSchema, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct ProcessRoomResponse {
+    pub message: String,
+    pub job_id: Uuid,
+}
+
+/// Response after a categorization report is stored.
+#[cfg_attr(test, derive(Deserialize))]
+#[derive(Serialize, JsonSchema, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct SubmitReportResponse {
+    pub url: String,
+    pub success: bool,
 }

--- a/api/src/routes/audio_recordings/dto.rs
+++ b/api/src/routes/audio_recordings/dto.rs
@@ -5,7 +5,7 @@ use uuid::Uuid;
 
 use crate::models::audio_recording::{AudioFormat, AudioRecording, AudioRecordingStatus};
 
-/// Data transfer object for a room's audio recording.
+/// Data transfer object for an audio recording.
 #[derive(Serialize, Deserialize, JsonSchema, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct AudioRecordingDto {
@@ -34,27 +34,27 @@ impl From<AudioRecording> for AudioRecordingDto {
     }
 }
 
-/// Request body for creating a room and requesting its upload URL.
+/// Request body for creating an audio recording and requesting its upload URL.
 #[cfg_attr(test, derive(Serialize))]
 #[derive(Deserialize, JsonSchema, Debug)]
 #[serde(rename_all = "camelCase")]
-pub struct CreateRoomRequest {
-    /// Name for the room, unique within the event.
+pub struct CreateRecordingRequest {
+    /// Name for the recording (its room name), unique within the event.
     pub name: String,
     /// Audio format of the file being uploaded.
     pub file_extension: AudioFormat,
 }
 
-/// Response after creating a room: the created room plus a presigned upload URL.
+/// Response after creating an audio recording: the created recording plus a presigned upload URL.
 #[cfg_attr(test, derive(Deserialize))]
 #[derive(Serialize, JsonSchema, Debug)]
 #[serde(rename_all = "camelCase")]
-pub struct CreateRoomResponse {
-    pub room: AudioRecordingDto,
+pub struct CreateRecordingResponse {
+    pub recording: AudioRecordingDto,
     pub upload_url: String,
 }
 
-/// Signed URLs for downloading a room's recording, transcript, and report.
+/// Signed URLs for downloading a recording's audio, transcript, and report.
 #[cfg_attr(test, derive(Deserialize))]
 #[derive(Serialize, JsonSchema, Debug)]
 #[serde(rename_all = "camelCase")]
@@ -64,19 +64,19 @@ pub struct RecordingDownloadUrls {
     pub report_url: String,
 }
 
-/// A room's details together with its signed download URLs.
+/// A recording's details together with its signed download URLs.
 #[cfg_attr(test, derive(Deserialize))]
 #[derive(Serialize, JsonSchema, Debug)]
 #[serde(rename_all = "camelCase")]
-pub struct RoomDetailResponse {
-    pub room: AudioRecordingDto,
+pub struct RecordingDetailResponse {
+    pub recording: AudioRecordingDto,
     pub downloads: RecordingDownloadUrls,
 }
 
-/// Response after enqueuing processing for a room.
+/// Response after enqueuing processing for a recording.
 #[derive(Serialize, Deserialize, JsonSchema, Debug)]
 #[serde(rename_all = "camelCase")]
-pub struct ProcessRoomResponse {
+pub struct ProcessRecordingResponse {
     pub message: String,
     pub job_id: Uuid,
 }

--- a/api/src/routes/events.rs
+++ b/api/src/routes/events.rs
@@ -8,32 +8,26 @@ use axum::{
     extract::{Json, Path, Query, State},
     http::StatusCode,
 };
-use hyper::HeaderMap;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use tracing::instrument;
 use uuid::Uuid;
 
 use crate::{
-    bulk_storage_service::{extract_room_id_from_key, FileMetadata},
     error::ComhairleError,
     models::{
         event::{
-            self, get_by_id, CreateEvent, EventFilterOptions, EventOrderOptions,
-            EventWithTranslations, PartialEvent,
+            self, CreateEvent, EventFilterOptions, EventOrderOptions, EventWithTranslations,
+            PartialEvent,
         },
         event_attendance,
-        job::{self, CreateJob},
         pagination::{PageOptions, PaginatedResults},
     },
     routes::{
-        auth::{
-            generate_jwt, is_user_admin, verify_webhook_signature, RequiredAdminUser, RequiredUser,
-        },
+        auth::{generate_jwt, is_user_admin, RequiredAdminUser, RequiredUser},
         events::dto::{EventDto, LocalizedEventDto},
         translations::LocaleExtractor,
     },
-    worker_service::process_video_call_transcriptions::TranscribeRecording,
     ComhairleState,
 };
 
@@ -216,198 +210,6 @@ async fn get_jwt(
     Ok((StatusCode::OK, Json(JwtResponse { jwt, is_moderator })))
 }
 
-#[derive(Serialize, Deserialize, Debug, JsonSchema)]
-struct ProcessTranscriptionResponse {
-    message: String,
-    job_ids: Vec<Uuid>,
-}
-
-#[instrument(err(Debug), skip(state))]
-async fn process_transcriptions(
-    State(state): State<Arc<ComhairleState>>,
-    Path((conversation_id, event_id)): Path<(Uuid, Uuid)>,
-) -> Result<(StatusCode, Json<ProcessTranscriptionResponse>), ComhairleError> {
-    let _event = event::get_by_id(&state.db, &event_id).await?;
-    let worker_service = state.required_worker_service()?;
-    let bulk_storage_service = state.required_bulk_storage_service()?;
-    let bulk_storage_config = state
-        .config
-        .bulk_storage_service
-        .as_ref()
-        .ok_or(ComhairleError::NoBulkStorageServiceConfigured)?;
-
-    let entries = bulk_storage_service
-        .list_keys(
-            &bulk_storage_config.store_name,
-            Some(&format!("events/{event_id}/")),
-        )
-        .await?;
-
-    // Use the format recorded for this event when present (self-serve upload
-    // flow). Legacy bot-uploaded recordings have no audio_recording row, so
-    // fall back to the historical WAV default.
-    let expected_extension = crate::models::audio_recording::get_by_event(&state.db, &event_id)
-        .await
-        .map(|r| r.file_extension)
-        .unwrap_or(crate::models::audio_recording::AudioFormat::Wav)
-        .extension();
-    let expected_filename = format!("recording.{expected_extension}");
-
-    let is_missing_main_recording = !entries
-        .iter()
-        .any(|entry| entry.contains(&expected_filename) && !entry.contains("rooms/"));
-
-    if is_missing_main_recording {
-        return Err(ComhairleError::ResourceNotFound(format!(
-            "{expected_filename} for event {event_id}"
-        )));
-    }
-
-    let br_room_entries: Vec<String> = entries
-        .into_iter()
-        .filter(|entry| entry.contains("rooms/") && entry.contains(&expected_filename))
-        .collect();
-
-    let create_core_event_job = CreateJob {
-        progress: Some(0.0),
-        ..Default::default()
-    };
-    let core_event_job = job::create(&state.db, create_core_event_job).await?;
-
-    worker_service
-        .push_transcription_job(TranscribeRecording {
-            event_id,
-            conversation_id,
-            room_id: None,
-            job_id: core_event_job.id,
-        })
-        .await?;
-
-    let mut br_room_job_ids = vec![];
-    for entry in br_room_entries {
-        let room_id = extract_room_id_from_key(&entry);
-
-        if let Some(room_id) = room_id {
-            let create_job = CreateJob {
-                progress: Some(0.0),
-                ..Default::default()
-            };
-            let job = job::create(&state.db, create_job).await?;
-            br_room_job_ids.push(job.id);
-
-            worker_service
-                .push_transcription_job(TranscribeRecording {
-                    event_id,
-                    conversation_id,
-                    room_id: Some(room_id.to_string()),
-                    job_id: job.id,
-                })
-                .await?;
-        }
-    }
-
-    let mut job_ids = vec![core_event_job.id];
-    job_ids.extend(br_room_job_ids);
-
-    Ok((
-        StatusCode::OK,
-        Json(ProcessTranscriptionResponse {
-            message: "Transcription processing moved to background jobs".to_string(),
-            job_ids,
-        }),
-    ))
-}
-
-#[derive(Deserialize, JsonSchema, Debug, Default)]
-struct SubmitReportParams {
-    room_id: Option<String>,
-}
-
-#[derive(Serialize, Deserialize, JsonSchema, Debug)]
-struct SubmitReportResponse {
-    url: String,
-    success: bool,
-}
-
-#[instrument(err(Debug), skip(state))]
-async fn submit_report(
-    State(state): State<Arc<ComhairleState>>,
-    Query(params): Query<SubmitReportParams>,
-    headers: HeaderMap,
-    Path((conversation_id, event_id)): Path<(Uuid, Uuid)>,
-    payload: String,
-) -> Result<(StatusCode, Json<SubmitReportResponse>), ComhairleError> {
-    let bulk_storage_service = state.required_bulk_storage_service()?;
-    let webhook_secret = &state
-        .config
-        .categorization_service
-        .as_ref()
-        .ok_or(ComhairleError::NoCategorizationServiceConfigured)?
-        .webhook_secret;
-
-    let webhook_timestamp = headers
-        .get("X-Webhook-Timestamp")
-        .ok_or(ComhairleError::AuthWebhookSignatureError(
-            "Missing X-Webhook-Timestamp".to_string(),
-        ))?
-        .to_str()
-        .map_err(|_| {
-            ComhairleError::AuthWebhookSignatureError("Invalid X-Webhook-Timestamp".to_string())
-        })?;
-    let webhook_signature = headers
-        .get("X-Webhook-Signature")
-        .ok_or(ComhairleError::AuthWebhookSignatureError(
-            "Missing X-Webhook-Signature".to_string(),
-        ))?
-        .to_str()
-        .map_err(|_| {
-            ComhairleError::AuthWebhookSignatureError("Invalid X-Webhook-Signature".to_string())
-        })?;
-
-    if !verify_webhook_signature(
-        webhook_signature,
-        webhook_timestamp,
-        &payload,
-        webhook_secret,
-    )? {
-        return Err(ComhairleError::AuthWebhookSignatureError(
-            "Invalid X-Webhook-Signature".to_string(),
-        ));
-    }
-
-    let event = get_by_id(&state.db, &event_id).await?;
-
-    if event.conversation_id != conversation_id {
-        return Err(ComhairleError::ResourceNotFound(format!(
-            "No event {event_id} found for conversation {conversation_id}"
-        )));
-    }
-
-    let path = if let Some(room_id) = params.room_id {
-        format!("events/{}/rooms/{}/report.json", event_id, room_id)
-    } else {
-        format!("events/{}/report.json", event_id)
-    };
-
-    let bytes = serde_json::to_vec(&payload)?;
-    let metadata = FileMetadata {
-        is_public: false,
-        content_type: "application/json".to_string(),
-    };
-
-    let result = bulk_storage_service
-        .upload_file(&path, bytes, metadata)
-        .await?;
-
-    Ok((
-        StatusCode::CREATED,
-        Json(SubmitReportResponse {
-            success: true,
-            url: result.url,
-        }),
-    ))
-}
-
 pub fn router(state: Arc<ComhairleState>) -> ApiRouter {
     ApiRouter::new()
         .api_route("/", get_with(list, |op| {
@@ -468,46 +270,18 @@ pub fn router(state: Arc<ComhairleState>) -> ApiRouter {
                     .response::<200, Json<JwtResponse>>()
 
         }))
-        .api_route("/{event_id}/transcriptions", 
-            post_with(process_transcriptions, |op| {
-                op.id("ProcessVideoCallTranscriptions")
-                    .tag("Events")
-                    .summary("Process video call transcription")
-                    .description("Triggers transcription processing in a background worker")
-                    .security_requirement("JWT")
-                    .response::<200, Json<ProcessTranscriptionResponse>>()
-
-        }))
-        .api_route("/{event_id}/report", 
-            post_with(submit_report, |op| {
-                op.id("SubmitEventReport")
-                    .tag("Events")
-                    .summary("Categorization report")
-                    .description("Submit categorization report to bulk storage")
-                    .response::<201, Json<SubmitReportResponse>>()
-
-        }))
         .with_state(state)
 }
 
 #[cfg(test)]
 mod tests {
-    use axum::{
-        body::Body,
-        http::{HeaderName, HeaderValue},
-    };
     use chrono::Utc;
     use serde_json::json;
     use sqlx::PgPool;
-    use std::{error::Error, str::FromStr};
+    use std::error::Error;
 
-    use crate::{
-        bulk_storage_service::{MockBulkStorageService, UploadResult},
-        models::model_test_helpers::{get_random_conversation_id, setup_default_app_and_session},
-        routes::{auth::build_webhook_signature, conversations::dto::ConversationDto},
-        setup_server,
-        test_helpers::{test_state, UserSession},
-        worker_service::MockWorkerService,
+    use crate::models::model_test_helpers::{
+        get_random_conversation_id, setup_default_app_and_session,
     };
 
     use super::*;
@@ -869,235 +643,6 @@ mod tests {
             response.get("err").and_then(|v| v.as_str()).unwrap(),
             "Event not found",
             "incorrect error message"
-        );
-
-        Ok(())
-    }
-
-    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
-    async fn should_start_transcription_single_pipeline_for_event(
-        pool: PgPool,
-    ) -> Result<(), Box<dyn Error>> {
-        let mut worker_service = MockWorkerService::new();
-
-        worker_service
-            .expect_push_transcription_job()
-            .once()
-            .returning(|_| Box::pin(async move { Ok(()) }));
-
-        let mut storage_service = MockBulkStorageService::new();
-
-        storage_service
-            .expect_list_keys()
-            .once()
-            .returning(|_, _| Box::pin(async move { Ok(vec!["recording.wav".to_string()]) }));
-
-        let state = test_state()
-            .db(pool)
-            .worker_service(Arc::new(worker_service))
-            .bulk_storage_service(Arc::new(storage_service))
-            .call()?;
-        let app = setup_server(Arc::new(state)).await?;
-        let mut session = UserSession::new_admin();
-        session.signup(&app).await?;
-
-        let conversation_id = get_random_conversation_id(&app, &mut session).await?;
-
-        let (_, response, _) = session
-            .create_random_event(&app, &conversation_id.to_string())
-            .await?;
-        let event: EventDto = serde_json::from_value(response)?;
-
-        let (_, value, _) = session
-            .post(
-                &app,
-                &format!(
-                    "/conversation/{}/events/{}/transcriptions",
-                    conversation_id, event.id
-                ),
-                Body::empty(),
-            )
-            .await?;
-        let response: ProcessTranscriptionResponse = serde_json::from_value(value)?;
-
-        assert_eq!(
-            response.job_ids.len(),
-            1,
-            "incorrect number of jobs spawned"
-        );
-
-        Ok(())
-    }
-
-    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
-    async fn should_return_err_if_recording_missing(pool: PgPool) -> Result<(), Box<dyn Error>> {
-        let mut storage_service = MockBulkStorageService::new();
-
-        storage_service
-            .expect_list_keys()
-            .once()
-            .returning(|_, _| Box::pin(async move { Ok(vec!["not-a-recording.pdf".to_string()]) }));
-
-        let state = test_state()
-            .db(pool)
-            .bulk_storage_service(Arc::new(storage_service))
-            .call()?;
-        let app = setup_server(Arc::new(state)).await?;
-        let mut session = UserSession::new_admin();
-        session.signup(&app).await?;
-
-        let conversation_id = get_random_conversation_id(&app, &mut session).await?;
-
-        let (_, response, _) = session
-            .create_random_event(&app, &conversation_id.to_string())
-            .await?;
-        let event: EventDto = serde_json::from_value(response)?;
-
-        let (_, value, _) = session
-            .post(
-                &app,
-                &format!(
-                    "/conversation/{}/events/{}/transcriptions",
-                    conversation_id, event.id
-                ),
-                Body::empty(),
-            )
-            .await?;
-
-        assert_eq!(
-            value.get("err").and_then(|v| v.as_str()).unwrap(),
-            &format!("recording.wav for event {} not found", event.id),
-            "incorrect error message"
-        );
-
-        Ok(())
-    }
-
-    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
-    async fn should_start_transcription_pipelines_for_event_with_breakout_rooms(
-        pool: PgPool,
-    ) -> Result<(), Box<dyn Error>> {
-        let mut worker_service = MockWorkerService::new();
-
-        worker_service
-            .expect_push_transcription_job()
-            .times(5)
-            .returning(|_| Box::pin(async move { Ok(()) }));
-
-        let mut storage_service = MockBulkStorageService::new();
-
-        storage_service.expect_list_keys().once().returning(|_, _| {
-            Box::pin(async move {
-                Ok(vec![
-                    "recording.wav".to_string(),
-                    ".secret-file.temp".to_string(),
-                    "rooms/1234/recording.wav".to_string(),
-                    "rooms/1234/.secret-file.temp".to_string(),
-                    "rooms/4321/recording.wav".to_string(),
-                    "rooms/5678/recording.wav".to_string(),
-                    "rooms/8765/recording.wav".to_string(),
-                ])
-            })
-        });
-
-        let state = test_state()
-            .db(pool)
-            .worker_service(Arc::new(worker_service))
-            .bulk_storage_service(Arc::new(storage_service))
-            .call()?;
-        let app = setup_server(Arc::new(state)).await?;
-        let mut session = UserSession::new_admin();
-        session.signup(&app).await?;
-
-        let conversation_id = get_random_conversation_id(&app, &mut session).await?;
-
-        let (_, response, _) = session
-            .create_random_event(&app, &conversation_id.to_string())
-            .await?;
-        let event: EventDto = serde_json::from_value(response)?;
-
-        let (_, value, _) = session
-            .post(
-                &app,
-                &format!(
-                    "/conversation/{}/events/{}/transcriptions",
-                    conversation_id, event.id
-                ),
-                Body::empty(),
-            )
-            .await?;
-        let response: ProcessTranscriptionResponse = serde_json::from_value(value)?;
-
-        assert_eq!(
-            response.job_ids.len(),
-            5,
-            "incorrect number of jobs spawned"
-        );
-
-        Ok(())
-    }
-
-    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
-    async fn should_upload_report_to_bulk_storage(pool: PgPool) -> Result<(), Box<dyn Error>> {
-        let mut bulk_storage_service = MockBulkStorageService::new();
-
-        bulk_storage_service
-            .expect_upload_file()
-            .once()
-            .returning(|_, _, _| {
-                Box::pin(async move {
-                    Ok(UploadResult {
-                        url: "https://storage.com/some_file".to_owned(),
-                    })
-                })
-            });
-
-        let state = test_state()
-            .db(pool)
-            .bulk_storage_service(Arc::new(bulk_storage_service))
-            .call()?;
-        let app = setup_server(Arc::new(state.clone())).await?;
-        let mut session = UserSession::new_admin();
-        session.signup(&app).await?;
-
-        let (_, value, _) = session.create_random_conversation(&app).await?;
-        let conversation: ConversationDto = serde_json::from_value(value)?;
-        let (_, value, _) = session
-            .create_random_event(&app, &conversation.id.to_string())
-            .await?;
-        let event: EventDto = serde_json::from_value(value)?;
-
-        let secret = &state.config.categorization_service.unwrap().webhook_secret;
-
-        let timestamp = Utc::now().timestamp();
-        let timestamp_hname = HeaderName::from_str("X-Webhook-Timestamp")?;
-        let timestamp_hval = HeaderValue::from_str(&timestamp.to_string())?;
-
-        let body_str = include_str!("../../../fixtures/tttc-report.json");
-        let signature = build_webhook_signature(&timestamp.to_string(), body_str, secret)?;
-        let signature_hname = HeaderName::from_str("X-Webhook-Signature")?;
-        let signature_hval = HeaderValue::from_str(&signature)?;
-        let (_, value, _) = session
-            .post_with_headers(
-                &app,
-                &format!(
-                    "/conversation/{}/events/{}/report",
-                    conversation.id, event.id
-                ),
-                body_str.into(),
-                &[
-                    (signature_hname, signature_hval),
-                    (timestamp_hname, timestamp_hval),
-                ],
-            )
-            .await?;
-        let response: SubmitReportResponse = serde_json::from_value(value)?;
-
-        assert!(response.success, "incorrect success");
-        assert_eq!(
-            response.url,
-            "https://storage.com/some_file".to_string(),
-            "incorrect url"
         );
 
         Ok(())

--- a/api/src/worker_service/process_video_call_transcriptions.rs
+++ b/api/src/worker_service/process_video_call_transcriptions.rs
@@ -17,7 +17,8 @@ use super::error::{RecordWorkerError, Result, WorkerServiceError};
 pub struct TranscribeRecording {
     pub event_id: Uuid,
     pub conversation_id: Uuid,
-    pub room_id: Option<String>,
+    /// The room (audio_recording) being processed.
+    pub room_id: Uuid,
     pub job_id: Uuid,
 }
 
@@ -26,6 +27,8 @@ pub struct GenerateReport {
     pub transcription_key: String,
     pub event_id: Uuid,
     pub conversation_id: Uuid,
+    /// The room (audio_recording) being processed.
+    pub room_id: Uuid,
     pub job_id: Uuid,
 }
 
@@ -64,18 +67,11 @@ pub async fn transcribe_recording(
         "Starting transcription sensemaking pipeline"
     );
 
-    let recording_location = format!(
-        "events/{}{}",
-        req.event_id,
-        req.room_id
-            .as_deref()
-            .map_or(String::new(), |id| format!("/rooms/{id}"))
-    );
+    let recording_location = format!("events/{}/rooms/{}", req.event_id, req.room_id);
 
-    // Look up the audio_recording to find the uploaded file format. Recordings
-    // created by the legacy bot flow may not have a DB record yet — default to
-    // WAV in that case to preserve the historical behaviour.
-    let audio_format = crate::models::audio_recording::get_by_event(&state.db, &req.event_id)
+    // Look up the room to find the uploaded file format. Default to WAV if the
+    // room record can't be read, to preserve the historical behaviour.
+    let audio_format = crate::models::audio_recording::get_by_id(&state.db, &req.room_id)
         .await
         .map(|r| r.file_extension)
         .unwrap_or(AudioFormat::Wav);
@@ -103,6 +99,7 @@ pub async fn transcribe_recording(
         transcription_key: format!("{recording_location}/transcript.json"),
         event_id: req.event_id,
         conversation_id: req.conversation_id,
+        room_id: req.room_id,
         job_id: req.job_id,
     }))
 }
@@ -161,8 +158,8 @@ pub async fn generate_sensemaking_report(
         .create_analysis_job(
             comments,
             format!(
-                "{}/api/conversation/{}/events/{}/report",
-                state.config.domain, req.conversation_id, req.event_id
+                "{}/api/conversation/{}/events/{}/rooms/{}/report",
+                state.config.domain, req.conversation_id, req.event_id, req.room_id
             ),
             webhook_secret.to_string(),
         )
@@ -177,17 +174,14 @@ pub async fn generate_sensemaking_report(
         "Report job created in categorization service"
     );
 
-    // Update audio recording status to completed after all processing is done
-    if let Ok(audio_recording) =
-        crate::models::audio_recording::get_by_event(&state.db, &req.event_id).await
-    {
-        let _ = crate::models::audio_recording::update_status(
-            &state.db,
-            &audio_recording.id,
-            crate::models::audio_recording::AudioRecordingStatus::Completed,
-        )
-        .await;
-    }
+    // Mark this room's recording as completed once it has been submitted for
+    // categorization.
+    let _ = crate::models::audio_recording::update_status(
+        &state.db,
+        &req.room_id,
+        crate::models::audio_recording::AudioRecordingStatus::Completed,
+    )
+    .await;
 
     job::complete(
         &state.db,
@@ -263,7 +257,7 @@ mod tests {
         let request = TranscribeRecording {
             event_id: Uuid::from_str("3c22d53d-07df-4d46-802e-486b79dd1a80").unwrap(),
             conversation_id: Uuid::new_v4(),
-            room_id: None,
+            room_id: Uuid::new_v4(),
             job_id: Uuid::new_v4(),
         };
 
@@ -284,6 +278,7 @@ mod tests {
                 .to_string(),
             event_id: Uuid::from_str("3c22d53d-07df-4d46-802e-486b79dd1a80").unwrap(),
             conversation_id: Uuid::new_v4(),
+            room_id: Uuid::new_v4(),
             job_id: Uuid::new_v4(),
         };
 

--- a/api/src/worker_service/process_video_call_transcriptions.rs
+++ b/api/src/worker_service/process_video_call_transcriptions.rs
@@ -6,7 +6,10 @@ use uuid::Uuid;
 
 use crate::{
     categorization_service::Comment,
-    models::job,
+    models::{
+        audio_recording::{self, AudioRecordingStatus},
+        job,
+    },
     transcription_service::Transcription,
     ComhairleState,
 };
@@ -40,6 +43,22 @@ pub struct UploadReport {
 }
 
 pub async fn transcribe_recording(
+    req: TranscribeRecording,
+    state: Data<Arc<ComhairleState>>,
+) -> Result<GoTo<GenerateReport>> {
+    let recording_id = req.recording_id;
+    let db = state.db.clone();
+    let outcome = transcribe_recording_inner(req, state).await;
+    let status = if outcome.is_ok() {
+        AudioRecordingStatus::TranscriptAvailable
+    } else {
+        AudioRecordingStatus::TranscriptFailure
+    };
+    let _ = audio_recording::update_status(&db, &recording_id, status).await;
+    outcome
+}
+
+async fn transcribe_recording_inner(
     req: TranscribeRecording,
     state: Data<Arc<ComhairleState>>,
 ) -> Result<GoTo<GenerateReport>> {
@@ -104,6 +123,24 @@ pub async fn transcribe_recording(
 }
 
 pub async fn generate_sensemaking_report(
+    req: GenerateReport,
+    state: Data<Arc<ComhairleState>>,
+) -> Result<GoTo<&'static str>> {
+    let recording_id = req.recording_id;
+    let db = state.db.clone();
+    let outcome = generate_sensemaking_report_inner(req, state).await;
+    if outcome.is_err() {
+        let _ = audio_recording::update_status(
+            &db,
+            &recording_id,
+            AudioRecordingStatus::CategorizationFailure,
+        )
+        .await;
+    }
+    outcome
+}
+
+async fn generate_sensemaking_report_inner(
     req: GenerateReport,
     state: Data<Arc<ComhairleState>>,
 ) -> Result<GoTo<&'static str>> {
@@ -172,15 +209,6 @@ pub async fn generate_sensemaking_report(
         categorization_job_id = %analysis_job.id,
         "Report job created in categorization service"
     );
-
-    // Mark this recording as completed once it has been submitted for
-    // categorization.
-    let _ = crate::models::audio_recording::update_status(
-        &state.db,
-        &req.recording_id,
-        crate::models::audio_recording::AudioRecordingStatus::Completed,
-    )
-    .await;
 
     job::complete(
         &state.db,

--- a/api/src/worker_service/process_video_call_transcriptions.rs
+++ b/api/src/worker_service/process_video_call_transcriptions.rs
@@ -6,7 +6,7 @@ use uuid::Uuid;
 
 use crate::{
     categorization_service::Comment,
-    models::{audio_recording::AudioFormat, job},
+    models::job,
     transcription_service::Transcription,
     ComhairleState,
 };
@@ -17,8 +17,8 @@ use super::error::{RecordWorkerError, Result, WorkerServiceError};
 pub struct TranscribeRecording {
     pub event_id: Uuid,
     pub conversation_id: Uuid,
-    /// The room (audio_recording) being processed.
-    pub room_id: Uuid,
+    /// The audio recording being processed.
+    pub recording_id: Uuid,
     pub job_id: Uuid,
 }
 
@@ -27,8 +27,8 @@ pub struct GenerateReport {
     pub transcription_key: String,
     pub event_id: Uuid,
     pub conversation_id: Uuid,
-    /// The room (audio_recording) being processed.
-    pub room_id: Uuid,
+    /// The audio recording being processed.
+    pub recording_id: Uuid,
     pub job_id: Uuid,
 }
 
@@ -67,14 +67,15 @@ pub async fn transcribe_recording(
         "Starting transcription sensemaking pipeline"
     );
 
-    let recording_location = format!("events/{}/rooms/{}", req.event_id, req.room_id);
-
-    // Look up the room to find the uploaded file format. Default to WAV if the
-    // room record can't be read, to preserve the historical behaviour.
-    let audio_format = crate::models::audio_recording::get_by_id(&state.db, &req.room_id)
+    // The recording row is the single source of truth for both the S3 key prefix
+    // and the uploaded file format.
+    let recording = crate::models::audio_recording::get_by_id(&state.db, &req.recording_id)
         .await
-        .map(|r| r.file_extension)
-        .unwrap_or(AudioFormat::Wav);
+        .map_err(|e| WorkerServiceError::DbError(e.to_string()))
+        .ok_or_record_failure(&req.job_id, &state.db)
+        .await?;
+    let recording_location = recording.s3_key_prefix.clone();
+    let audio_format = recording.file_extension;
 
     let result = transcription_service
         .transcribe_from_bulk_store(
@@ -99,7 +100,7 @@ pub async fn transcribe_recording(
         transcription_key: format!("{recording_location}/transcript.json"),
         event_id: req.event_id,
         conversation_id: req.conversation_id,
-        room_id: req.room_id,
+        recording_id: req.recording_id,
         job_id: req.job_id,
     }))
 }
@@ -158,8 +159,8 @@ pub async fn generate_sensemaking_report(
         .create_analysis_job(
             comments,
             format!(
-                "{}/api/conversation/{}/events/{}/rooms/{}/report",
-                state.config.domain, req.conversation_id, req.event_id, req.room_id
+                "{}/api/conversation/{}/events/{}/audio_recordings/{}/report",
+                state.config.domain, req.conversation_id, req.event_id, req.recording_id
             ),
             webhook_secret.to_string(),
         )
@@ -174,11 +175,11 @@ pub async fn generate_sensemaking_report(
         "Report job created in categorization service"
     );
 
-    // Mark this room's recording as completed once it has been submitted for
+    // Mark this recording as completed once it has been submitted for
     // categorization.
     let _ = crate::models::audio_recording::update_status(
         &state.db,
-        &req.room_id,
+        &req.recording_id,
         crate::models::audio_recording::AudioRecordingStatus::Completed,
     )
     .await;
@@ -257,7 +258,7 @@ mod tests {
         let request = TranscribeRecording {
             event_id: Uuid::from_str("3c22d53d-07df-4d46-802e-486b79dd1a80").unwrap(),
             conversation_id: Uuid::new_v4(),
-            room_id: Uuid::new_v4(),
+            recording_id: Uuid::new_v4(),
             job_id: Uuid::new_v4(),
         };
 
@@ -278,7 +279,7 @@ mod tests {
                 .to_string(),
             event_id: Uuid::from_str("3c22d53d-07df-4d46-802e-486b79dd1a80").unwrap(),
             conversation_id: Uuid::new_v4(),
-            room_id: Uuid::new_v4(),
+            recording_id: Uuid::new_v4(),
             job_id: Uuid::new_v4(),
         };
 

--- a/api/src/worker_service/process_video_call_transcriptions.rs
+++ b/api/src/worker_service/process_video_call_transcriptions.rs
@@ -67,8 +67,6 @@ pub async fn transcribe_recording(
         "Starting transcription sensemaking pipeline"
     );
 
-    // The recording row is the single source of truth for both the S3 key prefix
-    // and the uploaded file format.
     let recording = crate::models::audio_recording::get_by_id(&state.db, &req.recording_id)
         .await
         .map_err(|e| WorkerServiceError::DbError(e.to_string()))


### PR DESCRIPTION
See issue #490

Reworks audio recordings from a single per-event record into one record per named recording; replaces the batch endpoints with a RESTful per-recording API, and tracks each recording's progress through the transcription → categorization pipeline
  with distinct states.

  Key changes

  - Data model. audio_recording is now one row per recording, each with a name that's unique within its event (UNIQUE(event_id, name)). Drops the old single-row-per-event model and its breakout_room_ids array. S3 layout is
  events/{event_id}/recordings/{recording_id}/….
  - New REST API under /conversation/{id}/events/{id}/audio_recordings: create (returns a presigned upload URL), list, get (with presigned download URLs), …/process, and the categorization …/report webhook — all scoped to a single recording. The old
  event-scoped upload / download / batch-transcriptions / report endpoints are removed.
  - Per-recording status lifecycle. Replaces the event-wide pending/completed/failed with pending → transcript_available → both_available, plus transcript_failure / categorization_failure. Completion is now driven by the report webhook actually
  arriving, not by submission to the categorization service.
  - Pipeline. The Apalis worker processes one recording by id, reads its stored S3 prefix as the single source of truth, and writes the recording's status at each stage boundary.

  Notes

  - Breaking: removes the old endpoints/model and will cause the generation of a new OpenAPI contract, causing the UI to fail to build. So this should not be merged quite yet, as it will break anybody who is changing any part of the API and moving the frontend forward. 
  - A migration alters audio_recording in place and clears existing rows (prototype data only). This PR will delete data when deployed to production. @stuartlynn and @alpinegeorge  please confirm this is OK.
  - Deferred: no reconciliation/timeout for a report webhook that never fires (recording stays transcript_available); no stage-specific retry endpoints yet (the status split sets this up).
