### PR TITLE
Bug Fixes: Improve Polis embed UI state handling 

### DIFF
--- a/ui/packages/comhairle/src/lib/tools/polis/PolisEmbed.svelte
+++ b/ui/packages/comhairle/src/lib/tools/polis/PolisEmbed.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Button } from '$lib/components/ui/button';
+	import { Button, LoadingButton } from '$lib/components/ui/button';
 	import { fly, fade } from 'svelte/transition';
 	import { cubicOut } from 'svelte/easing';
 	import {
@@ -14,6 +14,7 @@
 	} from 'lucide-svelte';
 	import PolisApi, { type PolisApiState, type PolisStatement } from './PolisApi';
 	import { getVoteData, incrementVotes, resetVoteCount } from './polisVoteStore';
+	import { opinionCounter } from './polisCounter';
 	import * as m from '$lib/paraglide/messages';
 	import Separator from '$lib/components/ui/separator/separator.svelte';
 	import { apiClient } from '@crownshy/api-client/client';
@@ -22,7 +23,7 @@
 		polis_id: string;
 		polis_url: string;
 		user_id: string;
-		onDone: () => void;
+		onDone: () => void | Promise<void>;
 		requiredVotes?: number;
 		workflowStepId?: string;
 		showRemainingStatementCount?: boolean;
@@ -67,10 +68,6 @@
 			previousText = newTxt;
 			waitingForNext = false;
 		}
-
-		if (screen === 'voting' && s.ready && !s.loading && !s.currentStatement && !s.error) {
-			screen = 'completed';
-		}
 	}
 
 	const polis = new PolisApi(user_id, polis_id, handlePolisChange, 'en', polis_url);
@@ -85,8 +82,19 @@
 	let voteCooldown = $state(false);
 	let opinionText = $state('');
 	let opinionSubmitted = $state(false);
+	let opinionSubmitting = $state(false);
+	let opinionError = $state(false);
+	let returningToVoting = $state(false);
+	const submitBusy = $derived(opinionSubmitting || returningToVoting);
 	let previousText = '';
 	let visibleStatementWhenOpened: PolisStatement | undefined = undefined;
+
+	// `required_votes` is optional in the tool config and can arrive as null/0,
+	// which would break the threshold and progress maths. Fall back to a sane
+	// positive default so "continue" still unlocks correctly.
+	const safeRequiredVotes = $derived(
+		typeof requiredVotes === 'number' && requiredVotes > 0 ? Math.floor(requiredVotes) : 10
+	);
 
 	async function createStatementAux(
 		newStatement: { tid: number; pid: number },
@@ -120,20 +128,34 @@
 	let anchoredTotal = $state<number | null>(null);
 
 	$effect(() => {
-		if (polisReady && !polisLoading && anchoredRemaining === null) {
+		if (!polisReady || polisLoading) return;
+
+		if (anchoredRemaining === null || anchoredTotal === null) {
 			anchoredRemaining = polisRemaining;
 			anchoredTotal = polisTotal;
+		} else if (polisTotal !== anchoredTotal) {
+			// The pool changed size. Re-sync to the live counts
+			anchoredTotal = polisTotal;
+			anchoredRemaining = polisRemaining;
 		}
 	});
 
-	const displayedRemaining = $derived(Math.max(0, anchoredRemaining ?? polisRemaining));
-	const displayedTotal = $derived(anchoredTotal ?? polisTotal);
-	const currentOpinionNumber = $derived(
-		displayedTotal > 0 ? displayedTotal - displayedRemaining : 0
+	const opinionPosition = $derived(
+		opinionCounter(anchoredTotal ?? polisTotal, anchoredRemaining ?? polisRemaining)
 	);
 
+	const poolExhausted = $derived(
+		polisReady && !polisLoading && !polisError && !polisCurrentStatement
+	);
+
+	$effect(() => {
+		if (screen === 'voting' && poolExhausted) {
+			screen = 'completed';
+		}
+	});
+
 	function doVote(type: 'agree' | 'disagree' | 'pass') {
-		if (voteCooldown) return;
+		if (voteCooldown || !polisCurrentStatement) return;
 		waitingForNext = true;
 		voteCooldown = true;
 
@@ -144,10 +166,10 @@
 			anchoredRemaining--;
 		}
 
-		const data = incrementVotes(user_id, polis_id, requiredVotes);
+		const data = incrementVotes(user_id, polis_id, safeRequiredVotes);
 		hasMetThreshold = data.hasMetThreshold;
 
-		if (data.totalVotes === requiredVotes) {
+		if (data.totalVotes === safeRequiredVotes) {
 			setTimeout(() => {
 				screen = 'continue-prompt';
 				voteCooldown = false;
@@ -167,38 +189,66 @@
 		screen = 'voting';
 	}
 
-	async function handleSubmitOpinion() {
-		if (!opinionText.trim()) return;
-		const text = opinionText.trim();
-		const visibleTid = visibleStatementWhenOpened?.tid;
-		opinionText = '';
-		opinionSubmitted = true;
-		setTimeout(() => {
-			screen = 'voting';
-			opinionSubmitted = false;
-		}, 2000);
-		const result = await polis.submitStatement(text);
-		if (result) {
-			await createStatementAux(result, text, visibleTid);
+	let continuing = $state(false);
+
+	async function handleContinue() {
+		if (continuing) return;
+		continuing = true;
+		try {
+			await onDone();
+		} finally {
+			// Navigation usually unmounts us first; reset as a safety net if it didn't.
+			continuing = false;
 		}
 	}
 
-	async function handleSubmitAndAddAnother() {
-		if (!opinionText.trim()) return;
-		const text = opinionText.trim();
+	async function submitOpinion(text: string): Promise<boolean> {
 		const visibleTid = visibleStatementWhenOpened?.tid;
-		opinionText = '';
-		opinionSubmitted = false;
+		opinionSubmitting = true;
+		opinionError = false;
 		const result = await polis.submitStatement(text);
-		if (result) {
-			await createStatementAux(result, text, visibleTid);
+		opinionSubmitting = false;
+		if (!result) {
+			opinionError = true;
+			return false;
 		}
+		await createStatementAux(result, text, visibleTid);
+		opinionText = '';
+
+		polis.fetchNextStatement();
+		return true;
+	}
+
+	async function handleSubmitOpinion() {
+		const text = opinionText.trim();
+		if (!text || opinionSubmitting) return;
+		if (!(await submitOpinion(text))) return;
+		opinionSubmitted = true;
+		returningToVoting = true;
+		setTimeout(() => {
+			screen = 'voting';
+			opinionSubmitted = false;
+			returningToVoting = false;
+		}, 2000);
+	}
+
+	async function handleSubmitAndAddAnother() {
+		const text = opinionText.trim();
+		if (!text || opinionSubmitting) return;
+		if (!(await submitOpinion(text))) return;
+
+		opinionSubmitted = true;
+		setTimeout(() => {
+			opinionSubmitted = false;
+		}, 2000);
 	}
 
 	function openAddOpinion() {
 		visibleStatementWhenOpened = polisCurrentStatement;
 		screen = 'add-opinion';
 		opinionSubmitted = false;
+		opinionError = false;
+		returningToVoting = false;
 	}
 
 	function closeAddOpinion() {
@@ -209,10 +259,8 @@
 		}
 	}
 
-	const remainingBeforeContinue = $derived(requiredVotes - totalVotes);
-	const progress = $derived(
-		requiredVotes > 0 ? ((requiredVotes - remainingBeforeContinue) / requiredVotes) * 100 : 0
-	);
+	const remainingBeforeContinue = $derived(safeRequiredVotes - totalVotes);
+	const progress = $derived(Math.min(100, Math.max(0, (totalVotes / safeRequiredVotes) * 100)));
 </script>
 
 <div
@@ -227,11 +275,11 @@
 			<!-- Opinion counter -->
 			{#if !polisReady}
 				<div class="bg-foreground/10 h-5 w-32 animate-pulse rounded md:h-6"></div>
-			{:else if !polisError && showRemainingStatementCount}
+			{:else if !polisError && !poolExhausted && showRemainingStatementCount}
 				<p class="text-muted-foreground tex-base font-semibold md:text-lg">
 					{m.polis_opinion_counter({
-						current: currentOpinionNumber + 1,
-						total: displayedTotal
+						current: opinionPosition.current,
+						total: opinionPosition.total
 					})}
 				</p>
 				<div class="bg-secondary/30 relative h-1.5 w-full">
@@ -257,7 +305,9 @@
 							{m.polis_error_description()}
 						</p>
 					</div>
-				{:else if !polisReady || waitingForNext}
+				{:else if !polisReady || waitingForNext || !polisCurrentStatement}
+					<!-- Loading, between statements, or briefly empty before the screen
+					     flips to "completed" — show a skeleton, never a blank card. -->
 					<div in:fade={{ duration: 200 }} class="w-full animate-pulse">
 						<div class="space-y-3">
 							<div class="bg-foreground/10 h-8 w-full rounded"></div>
@@ -284,7 +334,7 @@
 				{/if}
 			</div>
 
-			{#if !polisError}
+			{#if !polisError && polisCurrentStatement}
 				<!-- Vote buttons -->
 				<div class="flex flex-wrap items-start gap-4 md:gap-6">
 					<Button
@@ -338,15 +388,16 @@
 			<!-- Continue to next step (only after threshold) -->
 			{#if canContinue}
 				<div class="mt-4 w-full border-t pt-6" in:fade={{ duration: 300 }}>
-					<Button
+					<LoadingButton
 						variant="primaryDark"
 						size="lg"
-						onclick={onDone}
+						loading={continuing}
+						onclick={handleContinue}
 						class="gap-2 px-6 py-4 text-lg"
 					>
 						{m.polis_continue_to_next_step()}
-						<ChevronRight class="h-5 w-5" />
-					</Button>
+						{#if !continuing}<ChevronRight class="h-5 w-5" />{/if}
+					</LoadingButton>
 				</div>
 			{/if}
 		</div>
@@ -389,36 +440,45 @@
 				>
 					{m.polis_opinion_submitted()}
 				</div>
+			{:else if opinionError}
+				<div
+					class="bg-destructive/10 text-destructive w-full rounded-lg p-4 text-center font-medium"
+				>
+					{m.something_went_wrong()}
+				</div>
 			{/if}
 
 			<div class="w-full pb-6">
 				<textarea
 					bind:value={opinionText}
+					oninput={() => (opinionError = false)}
 					placeholder={m.polis_opinion_placeholder()}
 					class="bg-background text-foreground placeholder:text-muted-foreground border-input focus:ring-primary/30 h-28 w-full resize-none rounded-lg border p-4 text-base shadow-sm outline-none focus:ring-2"
 				></textarea>
 			</div>
 
 			<div class="flex flex-wrap items-start gap-6">
-				<Button
+				<LoadingButton
 					variant="default"
 					size="lg"
+					loading={submitBusy}
 					disabled={!opinionText.trim()}
 					onclick={handleSubmitOpinion}
 					class="gap-2 px-6 py-4 text-lg"
 				>
 					{m.submit()}
-				</Button>
-				<Button
+				</LoadingButton>
+				<LoadingButton
 					variant="ghost"
 					size="lg"
 					class="text-lg"
+					loading={submitBusy}
 					disabled={!opinionText.trim()}
 					onclick={handleSubmitAndAddAnother}
 				>
 					{m.polis_submit_and_add_another()}
-					<ChevronRight class="h-5 w-5" />
-				</Button>
+					{#if !submitBusy}<ChevronRight class="h-5 w-5" />{/if}
+				</LoadingButton>
 			</div>
 
 			<button
@@ -450,15 +510,16 @@
 				>
 					{m.polis_continue_voting()}
 				</Button>
-				<Button
+				<LoadingButton
 					variant="ghost"
 					size="lg"
+					loading={continuing}
 					class="text-muted-foreground hover:text-foreground flex items-center gap-2 px-6 py-4 text-lg font-medium transition-colors"
-					onclick={onDone}
+					onclick={handleContinue}
 				>
 					{m.polis_continue_to_next_step()}
-					<ChevronRight class="h-5 w-5" />
-				</Button>
+					{#if !continuing}<ChevronRight class="h-5 w-5" />{/if}
+				</LoadingButton>
 			</div>
 		</div>
 	{:else if screen === 'completed'}
@@ -487,14 +548,15 @@
 			</Button>
 		</div>
 
-		<Button
+		<LoadingButton
 			variant="primaryDark"
 			size="lg"
-			onclick={onDone}
+			loading={continuing}
+			onclick={handleContinue}
 			class="mb-5 gap-2 px-6 py-4 text-lg"
 		>
 			{m.continue_()}
-			<ChevronRight class="h-5 w-5" />
-		</Button>
+			{#if !continuing}<ChevronRight class="h-5 w-5" />{/if}
+		</LoadingButton>
 	{/if}
 </div>

--- a/ui/packages/comhairle/src/lib/tools/polis/PolisManage.svelte
+++ b/ui/packages/comhairle/src/lib/tools/polis/PolisManage.svelte
@@ -34,12 +34,17 @@
 
 	let base_url = $derived(polisUrl.startsWith('https://') ? polisUrl : `https://${polisUrl}`);
 	let url = $derived(`${base_url}/m/${polisId}`);
-	let iframe = $state();
+	let iframe = $state<HTMLIFrameElement>();
 	let firstLoad = $state(true);
+
+	let requiredVotesInput = $state(requiredVotes);
+	$effect(() => {
+		requiredVotesInput = requiredVotes;
+	});
 
 	function tryLogin() {
 		if (firstLoad) {
-			iframe.contentWindow.postMessage(
+			iframe?.contentWindow?.postMessage(
 				{ user: adminUser, password: adminPassword, type: 'POLIS_LOGIN' },
 				base_url
 			);
@@ -48,7 +53,10 @@
 	}
 
 	const debouncedUpdateToolConfig = useDebounce(async (e: Event, field: string) => {
-		const value = +(e.target as HTMLInputElement).value;
+		const raw = (e.target as HTMLInputElement).value;
+		const value = Number(raw);
+		// Don't persist an empty, invalid, or non-positive number
+		if (raw.trim() === '' || !Number.isFinite(value) || value < 1) return;
 
 		try {
 			await apiClient.UpdateConversationWorkflowStep(
@@ -146,8 +154,10 @@
 			id="requiredVotes"
 			name="requiredVotes"
 			type="number"
+			min="1"
+			step="1"
 			class="w-1/4"
-			defaultvalue={requiredVotes}
+			bind:value={requiredVotesInput}
 			oninput={(e) => handleUpdateToolConfig(e, 'requiredVotes')}
 		/>
 	</div>

--- a/ui/packages/comhairle/src/lib/tools/polis/polisCounter.test.ts
+++ b/ui/packages/comhairle/src/lib/tools/polis/polisCounter.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+
+import { opinionCounter } from './polisCounter';
+
+describe('opinionCounter', () => {
+	it('shows the first opinion when nothing has been voted on', () => {
+		expect(opinionCounter(4, 4)).toEqual({ current: 1, total: 4 });
+	});
+
+	it('advances as the participant votes', () => {
+		expect(opinionCounter(4, 3)).toEqual({ current: 2, total: 4 });
+		expect(opinionCounter(4, 2)).toEqual({ current: 3, total: 4 });
+		expect(opinionCounter(4, 1)).toEqual({ current: 4, total: 4 });
+	});
+
+	it('never exceeds the total once every statement is voted on (no "5 of 4")', () => {
+		expect(opinionCounter(4, 0)).toEqual({ current: 4, total: 4 });
+	});
+
+	it('grows the denominator when new opinions are added to the pool', () => {
+		// A 5th opinion was added; the participant has one left to vote on.
+		expect(opinionCounter(5, 1)).toEqual({ current: 5, total: 5 });
+		expect(opinionCounter(5, 0)).toEqual({ current: 5, total: 5 });
+	});
+
+	it('returns a zeroed counter for an empty pool', () => {
+		expect(opinionCounter(0, 0)).toEqual({ current: 0, total: 0 });
+	});
+
+	it('clamps remaining that is larger than total', () => {
+		expect(opinionCounter(4, 10)).toEqual({ current: 1, total: 4 });
+	});
+
+	it('defends against negative inputs', () => {
+		expect(opinionCounter(4, -1)).toEqual({ current: 4, total: 4 });
+		expect(opinionCounter(-3, 2)).toEqual({ current: 0, total: 0 });
+	});
+
+	it('handles a single-statement conversation', () => {
+		expect(opinionCounter(1, 1)).toEqual({ current: 1, total: 1 });
+		expect(opinionCounter(1, 0)).toEqual({ current: 1, total: 1 });
+	});
+});

--- a/ui/packages/comhairle/src/lib/tools/polis/polisCounter.ts
+++ b/ui/packages/comhairle/src/lib/tools/polis/polisCounter.ts
@@ -1,0 +1,25 @@
+/**
+ * Compute the "Opinion X of Y" counter shown to participants while voting.
+ *
+ * `total` is the number of statements in the conversation and `remaining` is how
+ * many the participant still has to vote on. The returned `current` is 1-based
+ * (the position being shown) and is clamped so it can never exceed `total` — i.e.
+ * once every statement has been voted on we show "Opinion 4 of 4", never "5 of 4".
+ *
+ * Inputs are defended against out-of-range values (negative, or remaining larger
+ * than total) so a jittery Polis response can't produce a nonsensical counter.
+ */
+export function opinionCounter(
+	total: number,
+	remaining: number
+): { current: number; total: number } {
+	const safeTotal = Math.max(0, Math.floor(total));
+	if (safeTotal === 0) {
+		return { current: 0, total: 0 };
+	}
+
+	const safeRemaining = Math.min(safeTotal, Math.max(0, Math.floor(remaining)));
+	const voted = Math.min(safeTotal - safeRemaining, safeTotal - 1);
+
+	return { current: voted + 1, total: safeTotal };
+}


### PR DESCRIPTION
Should fix #372 #171 #352 

- Extract opinion counter calculation into separate module with tests
- Fix progress bar calculation to use safe required votes default
- Prevent "Opinion X of Y" counter from exceeding total when pool exhausted
- Add loading states to opinion submission and continue buttons
- Display error message when opinion submission fails
- Anchor opinion counter to prevent jumps when pool size changes mid-session
- Improve skeleton state
----

### Some context, if you have questions:

- `voting` shows the current statement, the "Opinion X of Y" counter, and the Agree / Disagree / Pass + "Add your own" buttons.
- `add-opinion` the participant is writing their own opinion.
- `continue-prompt` reached the required number of votes; offered "keep voting" or "continue to next step".
- `completed` nothing (left) to vote on; shows "you've voted on everything / come back later" + "Add your own".

The counter is only rendered when the **"Show remaining statements"** toggle is on (`show_remaining_statements` in the tool config).

## "Opinion X of Y" counter (`opinionCounter` in `polisCounter.ts`)

`X` = position currently shown (1-based), `Y` = total statements in the pool.
Logic is a pure function, and I wrote tests for it (`polisCounter.test.ts`) to avoid another bug.

| total (Y) | remaining | shows    | why                                                        |
| --------- | --------- | -------- | ---------------------------------------------------------- |
| 4         | 4         | `1 of 4` | nothing voted yet                                          |
| 4         | 1         | `4 of 4` | on the last statement                                      |
| 4         | 0         | `4 of 4` | **all voted — never `5 of 4`** (the original bug)          |
| 5         | 1         | `5 of 5` | a 5th opinion was added; denominator grew                  |
| 0         | 0         | `0 of 0` | empty pool (but screen flips to `completed`, so not shown) |
| 4         | 10        | `1 of 4` | remaining clamped to ≤ total (jittery Polis response)      |
| 4         | -1        | `4 of 4` | negative remaining clamped to 0                            |

Key rules:

- `X` can never exceed `Y`. It is capped so finishing the pool shows "Y of Y".
- `Y` grows when opinions are added. The anchored counts re-sync to the live Polis totals whenever the pool grows (`PolisEmbed` anchor effect), and the pool is refreshed immediately after a participant submits an opinion
  (`fetchNextStatement` in the submit handlers).
- A participant generally can't vote on their **own** submitted opinion, so after adding one you may see e.g. "4 of 5" and then go straight to `completed` -> `Y` grew even though there's nothing new for _you_ to vote on. This is expected.

## Empty / exhausted pool

`poolExhausted` = Polis is ready, not loading, not in error, and has **no current statement**. Covers:

1. A poll with no statements at all (e.g. admin preview of a fresh poll).
2. A poll where the participant has voted on everything available.
3. The moment right after submitting your own (non-votable) opinion empties the queue.

In all three cases the screen must show **`completed`**, not the voting UI. This is enforced by a reactive effect (not just the Polis callback) so that screen changes made elsewhere, e.g. the timed return-to-voting after submitting an opinion (can't strand the user on "Opinion 0 of 0" with live vote buttons). As a belt-and-braces measure the counter and vote buttons are also hidden when there is no current statement.

## Submitting an opinion

- Only show statements **from other participants**. This is enforced by Polis: submitting a statement sends `vote: -1` (an auto-vote on your own comment), so `nextComment?...&not_voted_by_pid=<pid>` excludes it. Your own opinion is never shown back to you to vote on.
    - **PID race:** `not_voted_by_pid` is only sent once `_pid` is known. If `participationInit` fails, the first fetch is unfiltered -> harmless for a new voter (nothing voted yet), but a returning voter could briefly be shown an already-voted statement until a pid is resolved from the next response.
- A failed submission keeps the participant's text and shows an error, rather than flashing a fake "submitted" confirmation and discarding what they wrote.
- Submit buttons are disabled while a submission is in flight (no double-submit).

## Required votes (admin `PolisManage.svelte`)

- The field mirrors the saved value via local state synced with an effect, so it  always reflects what's persisted after a reload / `invalidateAll`.
- Empty, non-numeric, or `< 1` input is **not** saved (empty would wipe the value mid-edit; `< 1` breaks the threshold/progress maths). Input has `min="1"`.
- On the participant side, a missing/`0`/`null` `required_votes` falls back to `10` (`safeRequiredVotes`) so "continue" still unlocks and the progress bar is sane.
- Saves to `tool_config` when the conversation is live, otherwise `preview_tool_config`: test in the same mode you edited in.

## Counted toward the "continue" threshold

- **Pass / Unsure counts as a vote** toward the required-votes threshold (same as Agree/Disagree). Aka, all
  three button types call `incrementVotes`.
- A stray vote with no statement on screen is ignored (`doVote` guards on `polisCurrentStatement`).

## Manual test checklist

Voting (incognito, "Show remaining statements" on, poll with ~4 statements):

- [ ] Fresh start shows `Opinion 1 of N`.
- [ ] Counter advances and never exceeds `N`.
- [ ] Voting the final statement shows `N of N`, then `completed`, never `N+1 of N`.
- [ ] Add an opinion → total `N` grows.
- [ ] Empty poll / after submitting your own opinion → `completed` screen, never "Opinion 0 of 0" with vote buttons.
- [ ] Your own submitted opinion is never shown back to you to vote on.
- [ ] Submit an opinion while offline → text is kept + error shown (no fake "submitted").

Required votes (admin → Design → Polis step → Setup):

- [ ] Change 10 → 5, hard-refresh → still 5.
- [ ] Clear the field, or enter `0` → no garbage persisted.
