### PR TITLE
Set color-scheme CSS property to match theme mode (and hopefully fix the flickering)

### DIFF
--- a/ui/packages/comhairle/src/app.html
+++ b/ui/packages/comhairle/src/app.html
@@ -18,9 +18,11 @@
 			(function () {
 				var storedMode = localStorage.getItem('comhairle-theme-mode');
 				var prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-				if ((storedMode || (prefersDark ? 'dark' : 'light')) === 'dark') {
+				var isDark = (storedMode || (prefersDark ? 'dark' : 'light')) === 'dark';
+				if (isDark) {
 					document.documentElement.classList.add('dark');
 				}
+				document.documentElement.style.colorScheme = isDark ? 'dark' : 'light';
 			})();
 		</script>
 		%sveltekit.head%

--- a/ui/packages/comhairle/src/lib/components/ThemeProvider.svelte
+++ b/ui/packages/comhairle/src/lib/components/ThemeProvider.svelte
@@ -12,7 +12,7 @@
 		if (typeof document === 'undefined') return;
 
 		const html = document.documentElement;
-		
+
 		const themeName = themeStore.name;
 		const isDark = themeStore.isDark;
 
@@ -27,6 +27,8 @@
 		} else {
 			html.classList.remove('dark');
 		}
+
+		html.style.colorScheme = isDark ? 'dark' : 'light';
 	});
 </script>
 

--- a/ui/packages/comhairle/src/lib/components/ui/sonner/sonner.svelte
+++ b/ui/packages/comhairle/src/lib/components/ui/sonner/sonner.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
-	import { Toaster as Sonner, type ToasterProps as SonnerProps } from "svelte-sonner";
-	import { mode } from "mode-watcher";
+	import { Toaster as Sonner, type ToasterProps as SonnerProps } from 'svelte-sonner';
+	import { themeStore } from '$lib/stores/theme.svelte';
 
 	let { ...restProps }: SonnerProps = $props();
 </script>
 
 <Sonner
-	theme={mode.current}
+	theme={themeStore.isDark ? 'dark' : 'light'}
 	class="toaster group"
 	style="--normal-bg: var(--color-popover); --normal-text: var(--color-popover-foreground); --normal-border: var(--color-border);"
 	{...restProps}


### PR DESCRIPTION
Actions: 

+ add color-scheme CSS property to document element in both initial theme script and ThemeProvider reactive block
+ update Sonner toast component to use themeStore instead of mode-watcher

Motivation:

+ ensure browser UI elements (scrollbars, form controls) respect the current theme mode
+ remove dependency on mode-watcher in favor of internal theme store