### PR TITLE
557 fix disappearing navbar

### DIFF
--- a/ui/packages/comhairle/src/app.css
+++ b/ui/packages/comhairle/src/app.css
@@ -1,6 +1,6 @@
 @import 'tailwindcss';
 @import 'tw-animate-css';
-@import '$lib/styles/comhairle-themes.css';
+@import './lib/styles/comhairle-themes.css';
 @plugin '@tailwindcss/typography';
 
 @custom-variant dark (&:is(.dark *));

--- a/ui/packages/comhairle/src/lib/components/RichTextEditor/EditorToolbar.svelte
+++ b/ui/packages/comhairle/src/lib/components/RichTextEditor/EditorToolbar.svelte
@@ -371,7 +371,7 @@
 </div>
 
 <style>
-	@import 'tailwindcss';
+	@reference '../../../app.css';
 
 	.btn {
 		@apply flex h-7 min-w-7 shrink-0 cursor-pointer items-center justify-center rounded border-0 bg-transparent px-1.5 py-1 text-sm leading-none transition-all duration-150 disabled:cursor-not-allowed disabled:opacity-40;


### PR DESCRIPTION
Actions:

+ remove `@import 'tailwindcss` from rich text editor toolbar component and replace with reference to app.css
+ replace svelte style lib import with relative import

Motivation:

+ second import of tailwind was creating an additional compiled tailwind `<style>` tag that was conflicting with the root layout styles for the entire app, breaking components on certain pages
+ ensure import uses css format