### PR TITLE
Pin frontend and api docker images simultaneously

### DIFF
--- a/.github/workflows/api-build-shared.yml
+++ b/.github/workflows/api-build-shared.yml
@@ -69,7 +69,7 @@ jobs:
           build-args: |
             BUILDKIT_INLINE_CACHE=1
 
-      - name: Dry run: skip build and push
+      - name: Dry run - skip build and push
         if: steps.check-existing.outputs.missing == 'true' && inputs.dry_run
         run: echo "Dry run enabled. Skipping API image build and push."
 

--- a/.github/workflows/api-build-shared.yml
+++ b/.github/workflows/api-build-shared.yml
@@ -1,0 +1,78 @@
+name: api-build-shared
+
+on:
+  workflow_call:
+    inputs:
+      tags:
+        description: Newline-delimited Docker tags
+        required: true
+        type: string
+      cache_from:
+        description: Newline-delimited cache-from sources
+        required: false
+        type: string
+      dry_run:
+        description: When true, do not push images
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    environment: base
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Check existing Docker tags
+        id: check-existing
+        run: |
+          set -euo pipefail
+
+          missing=false
+          while IFS= read -r tag; do
+            [[ -z "${tag}" ]] && continue
+
+            if docker buildx imagetools inspect "${tag}" >/dev/null 2>&1; then
+              echo "Found existing tag: ${tag}"
+            else
+              echo "Missing tag: ${tag}"
+              missing=true
+            fi
+          done <<< "${{ inputs.tags }}"
+
+          echo "missing=${missing}" >>"${GITHUB_OUTPUT}"
+
+      - name: Build and push API image
+        if: steps.check-existing.outputs.missing == 'true' && !inputs.dry_run
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ inputs.tags }}
+          cache-from: ${{ inputs.cache_from }}
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64
+          build-args: |
+            BUILDKIT_INLINE_CACHE=1
+
+      - name: Dry run: skip build and push
+        if: steps.check-existing.outputs.missing == 'true' && inputs.dry_run
+        run: echo "Dry run enabled. Skipping API image build and push."
+
+      - name: Skip build and push
+        if: steps.check-existing.outputs.missing != 'true'
+        run: echo "All requested API tags already exist on Docker Hub; skipping build."

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -1,97 +1,46 @@
 name: build-api-docker
 
 on:
-  push:
-    tags:
-      - 'v*'  # Runs only when a new tag starting with 'v' is pushed
-    branches:
-      - staging  # Runs when there is an update to the staging branch
   workflow_dispatch:  # Allows manual triggering
+    inputs:
+      dry_run:
+        description: When true, do not push images
+        required: false
+        default: false
+        type: boolean
+  workflow_call:  # Allows workflow to be called by other workflows
+    inputs:
+      dry_run:
+        description: When true, do not push images
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   build-and-push-release:
     if: startsWith(github.ref, 'refs/tags/v') && github.ref_type == 'tag'
-    runs-on: ubuntu-latest
-    environment: base 
-    steps:
-      -
-        name: Checkout
-        uses: actions/checkout@v4
-      -
-        name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      -
-        name: Build and push API image (release)
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: true
-          tags: |
-            crownshy/comhairle_api:${{ github.ref_name }}
-            crownshy/comhairle_api:latest
-          cache-from: |
-            type=gha
-            type=registry,ref=crownshy/comhairle_api:latest
-          cache-to: type=gha,mode=max
-          platforms: linux/amd64
-          build-args: |
-            BUILDKIT_INLINE_CACHE=1
+    uses: ./.github/workflows/api-build-shared.yml
+    with:
+      tags: |
+        crownshy/comhairle_api:${{ github.ref_name }}
+        crownshy/comhairle_api:latest
+      cache_from: |
+        type=gha
+        type=registry,ref=crownshy/comhairle_api:latest
+      dry_run: ${{ inputs.dry_run || false }}
+    secrets: inherit
       
-  build-and-run-staging:
+  build-and-push-staging:
     if: github.ref == 'refs/heads/staging'
-    runs-on: ubuntu-latest
-    environment: base 
-    steps:
-      -
-        name: Checkout
-        uses: actions/checkout@v4
-      -
-        name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      -
-        name: Build and push API image (staging)
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          push: true
-          tags: |
-            crownshy/comhairle_api:${{github.sha}}
-            crownshy/comhairle_api:staging
-          cache-from: |
-            type=gha
-            type=registry,ref=crownshy/comhairle_api:staging
-            type=registry,ref=crownshy/comhairle_api:latest
-          cache-to: type=gha,mode=max
-          platforms: linux/amd64
-          build-args: |
-            BUILDKIT_INLINE_CACHE=1
-      - 
-        name: Update GitOps manifests
-        run: |
-            git clone https://${{ secrets.GITOPS_TOKEN }}@github.com/crownshy/helm_charts.git
-            cd helm_charts
-            sed -i "s|docker_tag_api:.*|docker_tag_api: \"${{ github.sha }}\"|g" comhairle/stage_values.yaml
-            git add .
-            git config --global user.email "stuart.lynn@gmail.com"
-            git config --global user.name "Stuart Lynn"
-            git commit -m "Updating stage api image tag to ${{ github.sha }}"
-            git push
+    uses: ./.github/workflows/api-build-shared.yml
+    with:
+      tags: |
+        crownshy/comhairle_api:${{ github.sha }}
+        crownshy/comhairle_api:staging
+      cache_from: |
+        type=gha
+        type=registry,ref=crownshy/comhairle_api:staging
+        type=registry,ref=crownshy/comhairle_api:latest
+      dry_run: ${{ inputs.dry_run || false }}
+    secrets: inherit
      

--- a/.github/workflows/build-and-pin-docker-images.yml
+++ b/.github/workflows/build-and-pin-docker-images.yml
@@ -1,0 +1,147 @@
+name: build-and-pin-docker-images
+
+on:
+  push:
+    tags:
+        - 'v*'
+    branches:
+      - staging
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: When true, do not push images or pin manifests
+        required: false
+        default: false
+        type: boolean
+      force_pin:
+        description: When true, skip ancestry validation for pinning
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  build-api:
+    uses: ./.github/workflows/api.yml
+    with:
+      dry_run: ${{ github.event.inputs.dry_run == 'true' }}
+    secrets: inherit
+
+  build-frontend:
+    uses: ./.github/workflows/frontend-docker-image.yml
+    with:
+      dry_run: ${{ github.event.inputs.dry_run == 'true' }}
+    secrets: inherit
+
+  #  It looks like we don't pin the release images yet.
+  build-and-push-release:
+    if: startsWith(github.ref, 'refs/tags/v') && github.ref_type == 'tag'
+    needs:
+      - build-api
+      - build-frontend
+    uses: ./.github/workflows/api.yml
+    with:
+      dry_run: ${{ github.event.inputs.dry_run == 'true' }}
+    secrets: inherit
+
+  pin-staging-manifests:
+    if: github.ref == 'refs/heads/staging'
+    needs:
+      - build-api
+      - build-frontend
+    runs-on: ubuntu-latest
+    environment: base
+    permissions:
+      contents: read
+    env:
+      SOURCE_SHA: ${{ github.sha }}
+      DRY_RUN: ${{ github.event.inputs.dry_run == 'true' }}
+      FORCE_PIN: ${{ github.event.inputs.force_pin == 'true' }}
+      GITOPS_TOKEN: ${{ secrets.GITOPS_TOKEN }}
+      GITOPS_REPO: crownshy/helm_charts
+      GITOPS_FILE_PATH: comhairle/stage_values.yaml
+    steps:
+      - name: Checkout source repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate ancestry and update pins via GitHub API
+        run: |
+          set -euo pipefail
+
+          API_URL="https://api.github.com/repos/${GITOPS_REPO}"
+          COMMON_HEADERS=(
+            -H "Accept: application/vnd.github+json"
+            -H "Authorization: Bearer ${GITOPS_TOKEN}"
+            -H "X-GitHub-Api-Version: 2022-11-28"
+          )
+
+          # Get existing pins from the downstream repo.
+          repo_info="$(curl -fsSL "${COMMON_HEADERS[@]}" "${API_URL}")"
+          default_branch="$(jq -r '.default_branch' <<<"${repo_info}")"
+
+          content_obj="$(curl -fsSL "${COMMON_HEADERS[@]}" "${API_URL}/contents/${GITOPS_FILE_PATH}?ref=${default_branch}")"
+          current_sha="$(jq -r '.sha' <<<"${content_obj}")"
+          current_text="$(jq -r '.content' <<<"${content_obj}" | tr -d '\n' | base64 -d)"
+
+          current_api_pin="$(printf '%s\n' "${current_text}" | sed -nE 's/^docker_tag_api:\s*"?([0-9a-f]{40})"?\s*$/\1/p' | head -n1)"
+          current_frontend_pin="$(printf '%s\n' "${current_text}" | sed -nE 's/^docker_tag_frontend:\s*"?([0-9a-f]{40})"?\s*$/\1/p' | head -n1)"
+
+          # Validate current pins are ancestors of the new pins before updating.
+          if [[ "${current_api_pin}" == "${SOURCE_SHA}" && "${current_frontend_pin}" == "${SOURCE_SHA}" ]]; then
+            echo "Pins already up to date; no commit needed."
+            exit 0
+          fi
+
+          if [[ "${FORCE_PIN}" != "true" ]]; then
+            if [[ -z "${current_api_pin}" || -z "${current_frontend_pin}" ]]; then
+              echo "Could not find pins in stage values" >&2
+              exit 1
+            fi
+
+            if ! git merge-base --is-ancestor "${current_api_pin}" "${SOURCE_SHA}"; then
+              echo "Refusing to pin api: current pin ${current_api_pin} is not an ancestor of ${SOURCE_SHA}" >&2
+              exit 1
+            fi
+
+            if ! git merge-base --is-ancestor "${current_frontend_pin}" "${SOURCE_SHA}"; then
+              echo "Refusing to pin frontend: current pin ${current_frontend_pin} is not an ancestor of ${SOURCE_SHA}" >&2
+              exit 1
+            fi
+          else
+            echo "force_pin enabled. Skipping pin ancestry validation."
+          fi
+
+          # Create new manifest content with updated pins.
+          updated_text="$(printf '%s\n' "${current_text}" \
+            | awk -v api="${SOURCE_SHA}" -v frontend="${SOURCE_SHA}" '
+                /^docker_tag_api:/      { $0 = "docker_tag_api: \"" api "\"" }
+                /^docker_tag_frontend:/ { $0 = "docker_tag_frontend: \"" frontend "\"" }
+                { print }
+              '
+          )"
+
+          # Push new commit via GitHub API.
+          encoded_content="$(printf '%s' "${updated_text}" | base64 -w 0)"
+
+          update_payload="$(jq -n \
+          --arg message "Pin staging frontend/api images to ${SOURCE_SHA}" \
+          --arg content "${encoded_content}" \
+          --arg sha "${current_sha}" \
+          --arg branch "${default_branch}" \
+          '{
+            message: $message,
+            content: $content,
+            sha: $sha,
+            branch: $branch
+          }')"
+
+          if [[ "${DRY_RUN}" == "true" ]]; then
+            echo "Dry run enabled. Skipping pin commit update."
+            exit 0
+          fi
+
+          curl -fsSL -X PUT "${COMMON_HEADERS[@]}" -d "${update_payload}" "${API_URL}/contents/${GITOPS_FILE_PATH}"

--- a/.github/workflows/frontend-build-shared.yml
+++ b/.github/workflows/frontend-build-shared.yml
@@ -1,0 +1,74 @@
+name: frontend-build-shared
+
+on:
+  workflow_call:
+    inputs:
+      tags:
+        description: Newline-delimited Docker tags
+        required: true
+        type: string
+      dry_run:
+        description: When true, do not push images
+        required: false
+        default: false
+        type: boolean
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    environment: base
+    steps:
+      - name: Set Swap Space
+        uses: pierotofy/set-swap-space@master
+        with:
+          swap-size-gb: 10
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Check existing Docker tags
+        id: check-existing
+        run: |
+          set -euo pipefail
+
+          missing=false
+          while IFS= read -r tag; do
+            [[ -z "${tag}" ]] && continue
+
+            if docker buildx imagetools inspect "${tag}" >/dev/null 2>&1; then
+              echo "Found existing tag: ${tag}"
+            else
+              echo "Missing tag: ${tag}"
+              missing=true
+            fi
+          done <<< "${{ inputs.tags }}"
+
+          echo "missing=${missing}" >>"${GITHUB_OUTPUT}"
+
+      - name: Build and push frontend image
+        if: steps.check-existing.outputs.missing == 'true' && !inputs.dry_run
+        uses: docker/build-push-action@v6
+        with:
+          context: ./ui
+          push: true
+          tags: ${{ inputs.tags }}
+
+      - name: Dry run: skip build and push
+        if: steps.check-existing.outputs.missing == 'true' && inputs.dry_run
+        run: echo "Dry run enabled. Skipping frontend image build and push."
+
+      - name: Skip build and push
+        if: steps.check-existing.outputs.missing != 'true'
+        run: echo "All requested frontend tags already exist on Docker Hub; skipping build."

--- a/.github/workflows/frontend-build-shared.yml
+++ b/.github/workflows/frontend-build-shared.yml
@@ -65,7 +65,7 @@ jobs:
           push: true
           tags: ${{ inputs.tags }}
 
-      - name: Dry run: skip build and push
+      - name: Dry run - skip build and push
         if: steps.check-existing.outputs.missing == 'true' && inputs.dry_run
         run: echo "Dry run enabled. Skipping frontend image build and push."
 

--- a/.github/workflows/frontend-docker-image.yml
+++ b/.github/workflows/frontend-docker-image.yml
@@ -1,88 +1,34 @@
 name: build-frontend-docker
 
 on:
-  push:
-    tags:
-      - 'v*'  # Runs only when a new tag starting with 'v' is pushed
-    branches:
-      - staging  # Runs when there is an update to the staging branch
   workflow_dispatch:  # Allows manual triggering
+    inputs:
+      dry_run:
+        description: When true, do not push images
+        required: false
+        default: false
+        type: boolean
+  workflow_call:  # Allows workflow to be called by other workflows
+    inputs:
+      dry_run:
+        description: When true, do not push images
+        required: false
+        default: false
+        type: boolean
 
 jobs:
   build-and-push-release:
     if: startsWith(github.ref, 'refs/tags/v') && github.ref_type == 'tag'
-    runs-on: ubuntu-latest
-    environment: base 
-    steps:
-      - 
-        name: Set Swap Space 
-        uses: pierotofy/set-swap-space@master
-        with:
-          swap-size-gb: 10
-      -
-        name: Checkout
-        uses: actions/checkout@v4
-      -
-        name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      -
-        name: Build and push frotnend
-        uses: docker/build-push-action@v6
-        with:
-          context: ./ui
-          push: true
-          tags: crownshy/comhairle_frontend:${{ github.ref_name }}
+    uses: ./.github/workflows/frontend-build-shared.yml
+    with:
+      tags: crownshy/comhairle_frontend:${{ github.ref_name }}
+      dry_run: ${{ inputs.dry_run || false }}
+    secrets: inherit
           
-  build-and-run-staging:
+  build-and-push-staging:
     if: github.ref == 'refs/heads/staging'
-    runs-on: ubuntu-latest
-    environment: base 
-    steps:
-      - 
-        name: Set Swap Space 
-        uses: pierotofy/set-swap-space@master
-        with:
-          swap-size-gb: 10
-      -
-        name: Checkout
-        uses: actions/checkout@v4
-      -
-        name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      -
-        name: Build and push API image (staging)
-        uses: docker/build-push-action@v6
-        with:
-          context: ./ui
-          push: true
-          tags: crownshy/comhairle_frontend:${{github.sha}}
-      - 
-        name: Update GitOps manifests
-        run: |
-            git clone https://${{ secrets.GITOPS_TOKEN }}@github.com/crownshy/helm_charts.git
-            cd helm_charts
-            sed -i "s|docker_tag_frontend:.*|docker_tag_frontend: \"${{ github.sha }}\"|g" comhairle/stage_values.yaml
-            git add .
-            git config --global user.email "stuart.lynn@gmail.com"
-            git config --global user.name "Stuart Lynn"
-            git commit -m "Updating stage frontend image tag to ${{ github.sha }}"
-            git push
-     
+    uses: ./.github/workflows/frontend-build-shared.yml
+    with:
+      tags: crownshy/comhairle_frontend:${{ github.sha }}
+      dry_run: ${{ inputs.dry_run || false }}
+    secrets: inherit


### PR DESCRIPTION
Motivations:

 - The frontend and api can currently get pinned out of sync due to build and push races.

Actions:

 - Kick both build-and-push jobs off from one parent build and wait for both to complete before pinning.
 - Factored out common build and push code for release and staging builds.
 - Check that previous pin is an ancestor of the new pin before pinning to ensure we don't overwrite newer versions.
 - Added dry_run workflow input for testing.
 - Added force_pin workflow input to ensure we can overwrite invalid pins.