### PR TITLE
564/sync custom and scheduled emails

### DIFF
--- a/api/migrations/20260706112259_email_template_context_user_type_index.sql
+++ b/api/migrations/20260706112259_email_template_context_user_type_index.sql
@@ -1,0 +1,13 @@
+-- Drop existing search indexes and replace with unique indexes
+
+DROP INDEX IF EXISTS idx_email_config_user_email_type;
+
+CREATE UNIQUE INDEX idx_email_config_user_email_type
+ON email_template_config(owner_id, email_type)
+WHERE owner_id IS NOT NULL;
+
+DROP INDEX IF EXISTS idx_email_config_organization_email_type;
+
+CREATE UNIQUE INDEX idx_email_config_organization_email_type
+ON email_template_config(organization_id, email_type)
+WHERE organization_id IS NOT NULL;

--- a/api/src/email_templates/event_confirmation.html
+++ b/api/src/email_templates/event_confirmation.html
@@ -10,7 +10,6 @@ Variables:
 - event_name
 - event_time
 - event_link
-- organization_email
 
 -->
 
@@ -32,14 +31,6 @@ Variables:
 	<p>If you are having trouble with the button above, copy and paste the URL below into your web browser.</p>
 
 	<p class="link">{{event_link}}</p>
-
-	{% if organization_email %}
-		<p>
-			For any questions, please contact us at
-			<br />
-			<a href="mailto:{{organization_email}}">{{organization_email}}</a>
-		</p>
-	{% endif %}
 
 	{{footer|safe}}
 {% endblock %}

--- a/api/src/email_templates/event_registration_invite.html
+++ b/api/src/email_templates/event_registration_invite.html
@@ -10,7 +10,6 @@ Variables:
 - event_name
 - event_time
 - invite_link
-- organization_email
 
 -->
 
@@ -32,14 +31,6 @@ Variables:
 	<p>If you are having trouble with the button above, copy and paste the URL below into your web browser.</p>
 
 	<p class="link">{{invite_link}}</p>
-
-	{% if organization_email %}
-		<p>
-			For any questions, please contact us at
-			<br />
-			<a href="mailto:{{organization_email}}">{{organization_email}}</a>
-		</p>
-	{% endif %}
 
 	{{footer|safe}}
 {% endblock %}

--- a/api/src/email_templates/event_reminder.html
+++ b/api/src/email_templates/event_reminder.html
@@ -1,8 +1,25 @@
+<!--
+
+Slots:
+- heading
+- intro
+- body
+- footer
+
+Variables:
+- event_name
+- event_time
+- event_link
+
+-->
+
 {% extends "email_layout.html" %}
 {% block content %}
-	<h1>Reminder!</h1>
-	<p>An event you recently registered for is starting soon.</p>
-	<p>{{event_name}} will begin at {{event_time}}. Click the button below to join the event.</p>
+	<h1>{{heading}}</h1>
+
+	{{intro|safe}}
+
+	{{body|safe}}
 
 	<div class="card">
 		<h2>{{event_name}}</h2>
@@ -14,15 +31,5 @@
 
 	<p class="link">{{event_link}}</p>
 
-	{% if organization_email %}
-		<p>
-			For any questions, please contact us at
-			<br />
-			<a href="mailto:{{organization_email}}">{{organization_email}}</a>
-		</p>
-	{% endif %}
-
-	<p>We look forward to seeing you there!</p>
-
-	<p><strong>{{organization_name}}</strong></p>
+	{{footer|safe}}
 {% endblock %}

--- a/api/src/mailer.rs
+++ b/api/src/mailer.rs
@@ -1,6 +1,6 @@
 use crate::models::email_template_config::{
     self, MailerContextMap, SCHEMA_CONVERSATION_INVITE, SCHEMA_EVENT_REGISTRATION_CONFIRMATION,
-    SCHEMA_EVENT_REGISTRATION_INVITE,
+    SCHEMA_EVENT_REGISTRATION_INVITE, SCHEMA_EVENT_REMINDER,
 };
 use crate::models::event::{self, ResolveTimeZone};
 use crate::models::users::{self, User};
@@ -308,7 +308,7 @@ impl ComhairleMailer for Mailer {
         let slots_map = email_config
             .as_ref()
             .map(|ec| ec.slots.mailer_context_map())
-            .unwrap_or(SCHEMA_CONVERSATION_INVITE.slots.mailer_context_map());
+            .unwrap_or_else(|| SCHEMA_CONVERSATION_INVITE.slots.mailer_context_map());
 
         let rendered_map = self.resolve_slots_map(&conversation_context, &slots_map)?;
 
@@ -435,7 +435,7 @@ impl ComhairleMailer for Mailer {
         let slots_map = email_config
             .as_ref()
             .map(|ec| ec.slots.mailer_context_map())
-            .unwrap_or(SCHEMA_EVENT_REGISTRATION_INVITE.slots.mailer_context_map());
+            .unwrap_or_else(|| SCHEMA_EVENT_REGISTRATION_INVITE.slots.mailer_context_map());
 
         let rendered_map = self.resolve_slots_map(&event_context, &slots_map)?;
 
@@ -449,7 +449,7 @@ impl ComhairleMailer for Mailer {
         self.send_email(
             email,
             &subject,
-            "event_registration_invite.html",
+            SCHEMA_EVENT_REGISTRATION_INVITE.template,
             context,
             None,
         )
@@ -498,11 +498,11 @@ impl ComhairleMailer for Mailer {
         let slots_map = email_config
             .as_ref()
             .map(|ec| ec.slots.mailer_context_map())
-            .unwrap_or(
+            .unwrap_or_else(|| {
                 SCHEMA_EVENT_REGISTRATION_CONFIRMATION
                     .slots
-                    .mailer_context_map(),
-            );
+                    .mailer_context_map()
+            });
 
         let rendered_map = self.resolve_slots_map(&event_context, &slots_map)?;
 
@@ -516,7 +516,7 @@ impl ComhairleMailer for Mailer {
         self.send_email(
             email,
             &subject,
-            "event_confirmation.html",
+            SCHEMA_EVENT_REGISTRATION_CONFIRMATION.template,
             context,
             Some(calendar_invite),
         )
@@ -528,7 +528,7 @@ impl ComhairleMailer for Mailer {
         email: &str,
         event_id: Uuid,
         recipient_id: Uuid,
-        _sender_id: Uuid,
+        sender_id: Uuid,
         locale: &str,
     ) -> Result<(), ComhairleError> {
         let event = event::get_localized_by_id(&state.db, &event_id, locale).await?;
@@ -573,16 +573,44 @@ impl ComhairleMailer for Mailer {
             event.end_time,
         )?;
 
+        let event_context = context! {
+            event_name => event.name,
+            event_time => event.format_date_with_time_zone(event.start_time, None),
+            event_link => otp_link,
+        };
+
+        let email_config = email_template_config::get_by_type_user(
+            &state.db,
+            sender_id,
+            &SCHEMA_EVENT_REMINDER.email_type,
+        )
+        .await?;
+
+        let subject = email_config
+            .as_ref()
+            .and_then(|ec| ec.subject.as_deref())
+            .unwrap_or(SCHEMA_EVENT_REMINDER.default_subject);
+        let subject = self.template_engine.render_str(subject, &event_context)?;
+
+        let slots_map = email_config
+            .as_ref()
+            .map(|ec| ec.slots.mailer_context_map())
+            .unwrap_or_else(|| SCHEMA_EVENT_REMINDER.slots.mailer_context_map());
+
+        let rendered_map = self.resolve_slots_map(&event_context, &slots_map)?;
+
+        let context = context! {
+            event_name => event.name,
+            event_time => event.format_date_with_time_zone(event.start_time, None),
+            event_link => otp_link,
+            ..rendered_map
+        };
+
         self.send_email(
             email,
-            "Upcoming event reminder",
-            "event_reminder.html",
-            context! {
-                event_name => event.name,
-                event_time => event.format_date_with_time_zone(event.start_time, None),
-                organization_name => "Bloom", // TODO:
-                event_link => otp_link,
-            },
+            &subject,
+            SCHEMA_EVENT_REMINDER.template,
+            context,
             Some(calendar_invite),
         )
     }

--- a/api/src/mailer.rs
+++ b/api/src/mailer.rs
@@ -1,11 +1,11 @@
-use crate::models::conversation;
 use crate::models::email_template_config::{
     self, MailerContextMap, SCHEMA_CONVERSATION_INVITE, SCHEMA_EVENT_REGISTRATION_CONFIRMATION,
     SCHEMA_EVENT_REGISTRATION_INVITE,
 };
-use crate::models::event::{self, LocalizedEvent, ResolveTimeZone};
-use crate::models::organization::Organization;
-use crate::models::users::User;
+use crate::models::event::{self, ResolveTimeZone};
+use crate::models::users::{self, User};
+use crate::models::{conversation, otp};
+use crate::routes::auth::{OtpClaims, generate_jwt};
 use crate::{ComhairleState, error::ComhairleError};
 
 use async_trait::async_trait;
@@ -93,12 +93,14 @@ pub trait ComhairleMailer: Send + Sync {
         locale: &str,
     ) -> Result<(), ComhairleError>;
 
-    fn send_event_reminder(
+    async fn send_event_reminder(
         &self,
-        email: String,
-        event: &LocalizedEvent,
-        organization: &Option<Organization>,
-        link_href: String,
+        state: &Arc<ComhairleState>,
+        email: &str,
+        event_id: Uuid,
+        recipient_id: Uuid,
+        sender_id: Uuid,
+        locale: &str,
     ) -> Result<(), ComhairleError>;
 
     fn send_conversation_broadcast_email(
@@ -150,7 +152,7 @@ impl MockComhairleMailer {
             .returning(|_, _, _, _, _| Box::pin(async move { Ok(()) }));
         mailer
             .expect_send_event_reminder()
-            .returning(|_, _, _, _| Ok(()));
+            .returning(|_, _, _, _, _, _| Box::pin(async move { Ok(()) }));
         mailer
             .expect_send_conversation_broadcast_email()
             .returning(|_, _, _| Ok(()));
@@ -520,13 +522,50 @@ impl ComhairleMailer for Mailer {
         )
     }
 
-    fn send_event_reminder(
+    async fn send_event_reminder(
         &self,
-        email: String,
-        event: &LocalizedEvent,
-        _organization: &Option<Organization>,
-        link_href: String,
+        state: &Arc<ComhairleState>,
+        email: &str,
+        event_id: Uuid,
+        recipient_id: Uuid,
+        _sender_id: Uuid,
+        locale: &str,
     ) -> Result<(), ComhairleError> {
+        let event = event::get_localized_by_id(&state.db, &event_id, locale).await?;
+        let recipient = users::get_user_by_id(&recipient_id, &state.db).await?;
+
+        let event_path = format!(
+            "/conversations/{}/events/{}/live",
+            event.conversation_id, event.id
+        );
+
+        let otp = otp::create(
+            &state.db,
+            &recipient.id,
+            Some(event_path),
+            Some(event.start_time),
+        )
+        .await?;
+
+        let claims = OtpClaims {
+            email: email.to_string(),
+            otp: otp.code.clone(),
+        };
+        // Ensure JWT doesn't expire before event begins
+        let event_jwt_duration = event.start_time - Utc::now();
+        let otp_token = generate_jwt()
+            .user(&recipient)
+            .secret(&state.config.jwt_secret)
+            .custom_claims(claims)
+            .duration(event_jwt_duration)
+            .call();
+
+        let encoded_redirect_url = urlencoding::encode(&otp.redirect_url);
+        let otp_link = format!(
+            "{}/auth/login-otp/{}?backTo={}",
+            state.config.domain, otp_token, encoded_redirect_url
+        );
+
         let calendar_invite = create_calendar_invite_attachment(
             &event.name,
             &event.description,
@@ -535,15 +574,14 @@ impl ComhairleMailer for Mailer {
         )?;
 
         self.send_email(
-            &email,
+            email,
             "Upcoming event reminder",
             "event_reminder.html",
             context! {
                 event_name => event.name,
                 event_time => event.format_date_with_time_zone(event.start_time, None),
                 organization_name => "Bloom", // TODO:
-                // organization_email => None,
-                event_link => link_href,
+                event_link => otp_link,
             },
             Some(calendar_invite),
         )

--- a/api/src/models/email_template_config.rs
+++ b/api/src/models/email_template_config.rs
@@ -48,6 +48,7 @@ pub enum EmailType {
     ConversationInvite,
     EventRegistrationInvite,
     EventRegistrationConfirmation,
+    EventReminder,
 }
 
 impl From<EmailType> for sea_query::Value {
@@ -62,6 +63,7 @@ impl std::fmt::Display for EmailType {
             EmailType::ConversationInvite => "conversation_invite",
             EmailType::EventRegistrationInvite => "event_registration_invite",
             EmailType::EventRegistrationConfirmation => "event_registration_confirmation",
+            EmailType::EventReminder => "event_reminder",
         };
         write!(f, "{}", value)
     }
@@ -119,6 +121,7 @@ pub enum EmailTemplateSlots {
     ConversationInvite(DefaultEmailSlots),
     EventRegistrationInvite(DefaultEmailSlots),
     EventRegistrationConfirmation(DefaultEmailSlots),
+    EventReminder(DefaultEmailSlots),
 }
 
 impl EmailTemplateSlots {
@@ -135,6 +138,7 @@ impl EmailTemplateSlots {
             EmailTemplateSlots::EventRegistrationInvite(DefaultEmailSlots::default()).schema(),
             EmailTemplateSlots::EventRegistrationConfirmation(DefaultEmailSlots::default())
                 .schema(),
+            EmailTemplateSlots::EventReminder(DefaultEmailSlots::default()).schema(),
         ]
     }
 
@@ -146,6 +150,7 @@ impl EmailTemplateSlots {
             EmailTemplateSlots::EventRegistrationConfirmation(_) => {
                 SCHEMA_EVENT_REGISTRATION_CONFIRMATION
             }
+            EmailTemplateSlots::EventReminder(_) => SCHEMA_EVENT_REMINDER,
         }
     }
 
@@ -170,6 +175,7 @@ impl EmailTemplateSlots {
             EmailTemplateSlots::ConversationInvite(slots) => slots.mailer_context_map(),
             EmailTemplateSlots::EventRegistrationInvite(slots) => slots.mailer_context_map(),
             EmailTemplateSlots::EventRegistrationConfirmation(slots) => slots.mailer_context_map(),
+            EmailTemplateSlots::EventReminder(slots) => slots.mailer_context_map(),
         }
     }
 
@@ -203,6 +209,17 @@ impl EmailTemplateSlots {
                 ),
             ]),
             EmailTemplateSlots::EventRegistrationInvite(_) => HashMap::from([
+                (
+                    "event_name".to_string(),
+                    "Prioritising accessibility in websites".to_string(),
+                ),
+                ("event_time".to_string(), "24 May, 2026".to_string()),
+                (
+                    "event_link".to_string(),
+                    "https://crown-shy.com/event".to_string(),
+                ),
+            ]),
+            EmailTemplateSlots::EventReminder(_) => HashMap::from([
                 (
                     "event_name".to_string(),
                     "Prioritising accessibility in websites".to_string(),
@@ -343,7 +360,7 @@ pub const SCHEMA_EVENT_REGISTRATION_INVITE: EmailTypeSchema = EmailTypeSchema {
             key: "footer",
             label: "Footer",
             hint: "Closing line",
-            default_content: "<p>We look forward to your participation!</p><p><strong>CrownShy</strong></p>",
+            default_content: "<p>For any questions, please contact us at<br /><a href=\"mailto:team@crown-shy.com\">team@crown-shy.com</a></p><p><p>We look forward to your participation!</p><p><strong>CrownShy</strong></p>",
             content_type: ContentType::RichText,
         },
     ],
@@ -380,7 +397,44 @@ pub const SCHEMA_EVENT_REGISTRATION_CONFIRMATION: EmailTypeSchema = EmailTypeSch
             key: "footer",
             label: "Footer",
             hint: "Closing line",
-            default_content: "<p>We look forward to seeing you there!</p><p><strong>CrownShy</strong></p>",
+            default_content: "<p>For any questions, please contact us at<br /><a href=\"mailto:team@crown-shy.com\">team@crown-shy.com</a></p><p><p>We look forward to seeing you there!</p><p><strong>CrownShy</strong></p>",
+            content_type: ContentType::RichText,
+        },
+    ],
+};
+
+pub const SCHEMA_EVENT_REMINDER: EmailTypeSchema = EmailTypeSchema {
+    email_type: EmailType::EventReminder,
+    template: "event_reminder.html",
+    default_subject: "Upcoming event reminder",
+    variables: &["event_name", "event_time", "event_link"],
+    slots: &[
+        SlotSchemaDefinition {
+            key: "heading",
+            label: "Heading",
+            hint: "The email heading",
+            default_content: "Reminder!",
+            content_type: ContentType::PlainText,
+        },
+        SlotSchemaDefinition {
+            key: "intro",
+            label: "Intro",
+            hint: "Opening paragraph",
+            default_content: "<p>An event you recently registered for is starting soon.</p>",
+            content_type: ContentType::RichText,
+        },
+        SlotSchemaDefinition {
+            key: "body",
+            label: "Body",
+            hint: "Main email content",
+            default_content: "<p><strong>{{event_name}}</strong> will begin at {{event_time}}. Click the button below to join the event.</p>",
+            content_type: ContentType::RichText,
+        },
+        SlotSchemaDefinition {
+            key: "footer",
+            label: "Footer",
+            hint: "Closing line",
+            default_content: "<p>For any questions, please contact us at<br /><a href=\"mailto:team@crown-shy.com\">team@crown-shy.com</a></p><p>We look forward to seeing you there!</p><p><strong>CrownShy</strong></p>",
             content_type: ContentType::RichText,
         },
     ],

--- a/api/src/models/event.rs
+++ b/api/src/models/event.rs
@@ -19,17 +19,14 @@ use uuid::Uuid;
 use fake::Dummy;
 
 use crate::{
-    config::ComhairleConfig,
     error::ComhairleError,
-    mailer::build_calendar_invite,
     models::{
-        SqlxResultExt, otp,
+        SqlxResultExt,
         pagination::{Order, PageOptions, PaginatedResults},
         scheduled_email::{self, CreateScheduledEmail, EmailTemplate, ScheduledEmailConfig},
         translations::{TextContentId, TextFormat, new_translation},
         users::User,
     },
-    routes::auth::{OtpClaims, generate_jwt},
 };
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema, Clone, PartialEq)]
@@ -185,140 +182,45 @@ impl ResolveTimeZone for LocalizedEvent {
     }
 }
 
-struct ScheduleEventEmail<'a> {
-    db: &'a PgPool,
-    config: &'a ComhairleConfig,
-    user: &'a User,
-    email: &'a str,
-    event_path: &'a str,
-    calendar_invite: &'a icalendar::Calendar,
-}
-
 impl LocalizedEvent {
     pub async fn schedule_event_reminders(
         &self,
         db: &PgPool,
-        config: &ComhairleConfig,
-        user: &User,
+        recipient: &User,
+        owner_id: Uuid,
+        locale: &str,
     ) -> Result<(), ComhairleError> {
         if self.start_time <= Utc::now() {
             warn!("Event has past");
             return Ok(());
         }
 
-        let calendar_invite = build_calendar_invite(
-            &self.name,
-            &self.description,
-            self.start_time,
-            self.end_time,
-        );
-
-        let email = user.email.as_ref().ok_or(ComhairleError::WrongUserType)?;
-        let event_path = format!("/conversations/{}/events/{}", self.conversation_id, self.id);
-
-        let params = ScheduleEventEmail {
-            db,
-            config,
-            user,
-            email,
-            event_path: &event_path,
-            calendar_invite: &calendar_invite,
-        };
-
-        self.schedule_first_reminder(&params).await?;
-        self.schedule_second_reminder(&params).await?;
-
-        Ok(())
-    }
-
-    async fn schedule_first_reminder(
-        &self,
-        params: &ScheduleEventEmail<'_>,
-    ) -> Result<(), ComhairleError> {
-        let ScheduleEventEmail {
-            db,
-            user: _user,
-            config,
-            email,
-            event_path,
-            calendar_invite,
-        } = params;
+        let email = recipient
+            .email
+            .as_ref()
+            .ok_or(ComhairleError::WrongUserType)?;
 
         let email_config = ScheduledEmailConfig {
-            subject: "Upcoming event reminder".to_string(),
             template: EmailTemplate::EventReminder {
-                event_name: self.name.clone(),
-                event_time: self.format_date_with_time_zone(self.start_time, None),
-                event_link: format!("{}{}", &config.domain, event_path),
-                organization_name: "Bloom".to_string(), // TODO:
-                organization_email: None,
+                event_id: self.id,
+                recipient_id: recipient.id,
+                owner_id,
+                locale: locale.to_string(),
             },
-            attachment: Some(calendar_invite.to_string()),
         };
-        let scheduled_email_params = CreateScheduledEmail {
+        let params_24_hours = CreateScheduledEmail {
             user_email: email.to_string(),
-            email_config,
+            email_config: email_config.clone(),
             send_at: self.start_time - chrono::Duration::days(1),
         };
-        scheduled_email::create(db, scheduled_email_params).await?;
+        scheduled_email::create(db, params_24_hours).await?;
 
-        Ok(())
-    }
-
-    async fn schedule_second_reminder(
-        &self,
-        params: &ScheduleEventEmail<'_>,
-    ) -> Result<(), ComhairleError> {
-        let ScheduleEventEmail {
-            db,
-            user,
-            config,
-            email,
-            event_path,
-            calendar_invite,
-        } = params;
-
-        let event_live_path = format!("{event_path}/live");
-
-        let otp = otp::create(db, &user.id, Some(event_live_path), Some(self.start_time)).await?;
-
-        let claims = OtpClaims {
-            email: email.to_string(),
-            otp: otp.code.clone(),
-        };
-        // Ensure JWT doesn't expire before event begins
-        let event_jwt_duration = self.start_time - Utc::now();
-        let otp_token = generate_jwt()
-            .user(user)
-            .secret(&config.jwt_secret)
-            .custom_claims(claims)
-            .duration(event_jwt_duration)
-            .call();
-
-        let encoded_redirect_url = urlencoding::encode(&otp.redirect_url);
-        let otp_link = format!(
-            "{}/auth/login-otp/{}?backTo={}",
-            config.domain, otp_token, encoded_redirect_url
-        );
-
-        let email_config = ScheduledEmailConfig {
-            subject: "Event beginning soon".to_string(),
-            template: EmailTemplate::EventReminder {
-                event_name: self.name.clone(),
-                event_time: self.format_date_with_time_zone(self.start_time, None),
-                event_link: otp_link,
-                organization_name: "Bloom".to_string(), // TODO:
-                organization_email: None,
-            },
-            attachment: Some(calendar_invite.to_string()),
-        };
-        let scheduled_email_params = CreateScheduledEmail {
+        let params_2_hours = CreateScheduledEmail {
             user_email: email.to_string(),
             email_config,
             send_at: self.start_time - chrono::Duration::hours(2),
         };
-
-        scheduled_email::create(db, scheduled_email_params).await?;
+        scheduled_email::create(db, params_2_hours).await?;
 
         Ok(())
     }

--- a/api/src/models/scheduled_email.rs
+++ b/api/src/models/scheduled_email.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use chrono::{DateTime, Utc};
 use schemars::JsonSchema;
 use sea_query::{Expr, PostgresQueryBuilder, Query, SelectStatement, SimpleExpr, enum_def};
@@ -17,6 +19,7 @@ use uuid::Uuid;
 use fake::Dummy;
 
 use crate::{
+    ComhairleState,
     error::ComhairleError,
     models::{
         SqlxResultExt,
@@ -39,8 +42,6 @@ pub struct ScheduledEmail {
 #[derive(Serialize, Deserialize, JsonSchema, Debug, Clone)]
 pub struct ScheduledEmailConfig {
     pub template: EmailTemplate,
-    pub subject: String,
-    pub attachment: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, JsonSchema, Debug, Clone)]
@@ -48,12 +49,33 @@ pub struct ScheduledEmailConfig {
 pub enum EmailTemplate {
     // Extend with other templates relevant to scheduling
     EventReminder {
-        event_name: String,
-        event_time: String,
-        event_link: String,
-        organization_name: String,
-        organization_email: Option<String>,
+        event_id: Uuid,
+        recipient_id: Uuid,
+        owner_id: Uuid,
+        locale: String,
     },
+}
+
+impl EmailTemplate {
+    pub async fn mailer_send(
+        &self,
+        email: &str,
+        state: &Arc<ComhairleState>,
+    ) -> Result<(), ComhairleError> {
+        match self {
+            EmailTemplate::EventReminder {
+                event_id,
+                recipient_id,
+                owner_id,
+                locale,
+            } => {
+                state
+                    .mailer
+                    .send_event_reminder(state, email, *event_id, *recipient_id, *owner_id, locale)
+                    .await
+            }
+        }
+    }
 }
 
 impl std::fmt::Display for EmailTemplate {
@@ -62,29 +84,6 @@ impl std::fmt::Display for EmailTemplate {
             EmailTemplate::EventReminder { .. } => "event_reminder.html",
         };
         write!(f, "{}", value)
-    }
-}
-
-impl EmailTemplate {
-    pub fn to_mailer_context(&self) -> minijinja::Value {
-        match self {
-            EmailTemplate::EventReminder {
-                event_name,
-                event_time,
-                event_link,
-                organization_name,
-                organization_email,
-                ..
-            } => {
-                minijinja::context! {
-                    event_name => event_name,
-                    event_time => event_time,
-                    event_link => event_link,
-                    organization_name => organization_name,
-                    organization_email => organization_email,
-                }
-            }
-        }
     }
 }
 
@@ -387,15 +386,12 @@ mod tests {
             user_email: "test@test.com".to_string(),
             send_at: Utc::now() + chrono::Duration::days(1),
             email_config: ScheduledEmailConfig {
-                subject: "test subject".to_string(),
                 template: EmailTemplate::EventReminder {
-                    event_name: "test_event".to_string(),
-                    event_time: (Utc::now() + chrono::Duration::days(1)).to_string(),
-                    event_link: "https://test.com".to_string(),
-                    organization_name: "Test org".to_string(),
-                    organization_email: None,
+                    event_id: Uuid::new_v4(),
+                    recipient_id: Uuid::new_v4(),
+                    owner_id: Uuid::new_v4(),
+                    locale: "en".to_string(),
                 },
-                attachment: None,
             },
         };
 
@@ -417,15 +413,12 @@ mod tests {
             user_email: "test@test.com".to_string(),
             send_at: Utc::now() + chrono::Duration::days(1),
             email_config: ScheduledEmailConfig {
-                subject: "test subject".to_string(),
                 template: EmailTemplate::EventReminder {
-                    event_name: "test_event".to_string(),
-                    event_time: (Utc::now() + chrono::Duration::days(1)).to_string(),
-                    event_link: "https://test.com".to_string(),
-                    organization_name: "Test org".to_string(),
-                    organization_email: None,
+                    event_id: Uuid::new_v4(),
+                    recipient_id: Uuid::new_v4(),
+                    owner_id: Uuid::new_v4(),
+                    locale: "en".to_string(),
                 },
-                attachment: None,
             },
         };
 
@@ -457,15 +450,12 @@ mod tests {
             user_email: "test@test.com".to_string(),
             send_at: Utc::now() + chrono::Duration::days(1),
             email_config: ScheduledEmailConfig {
-                subject: "test subject".to_string(),
                 template: EmailTemplate::EventReminder {
-                    event_name: "test_event".to_string(),
-                    event_time: (Utc::now() + chrono::Duration::days(1)).to_string(),
-                    event_link: "https://test.com".to_string(),
-                    organization_name: "Test org".to_string(),
-                    organization_email: None,
+                    event_id: Uuid::new_v4(),
+                    recipient_id: Uuid::new_v4(),
+                    owner_id: Uuid::new_v4(),
+                    locale: "en".to_string(),
                 },
-                attachment: None,
             },
         };
 
@@ -489,45 +479,36 @@ mod tests {
             user_email: "user-1@test.com".to_string(),
             send_at: Utc::now() + chrono::Duration::days(1),
             email_config: ScheduledEmailConfig {
-                subject: "test subject".to_string(),
                 template: EmailTemplate::EventReminder {
-                    event_name: "test_event".to_string(),
-                    event_time: (Utc::now() + chrono::Duration::days(1)).to_string(),
-                    event_link: "https://test.com".to_string(),
-                    organization_name: "Test org".to_string(),
-                    organization_email: None,
+                    event_id: Uuid::new_v4(),
+                    recipient_id: Uuid::new_v4(),
+                    owner_id: Uuid::new_v4(),
+                    locale: "en".to_string(),
                 },
-                attachment: None,
             },
         };
         let params_2 = CreateScheduledEmail {
             user_email: "user-2@test.com".to_string(),
             send_at: Utc::now() + chrono::Duration::days(2),
             email_config: ScheduledEmailConfig {
-                subject: "test subject".to_string(),
                 template: EmailTemplate::EventReminder {
-                    event_name: "test_event".to_string(),
-                    event_time: (Utc::now() + chrono::Duration::days(1)).to_string(),
-                    event_link: "https://test.com".to_string(),
-                    organization_name: "Test org".to_string(),
-                    organization_email: None,
+                    event_id: Uuid::new_v4(),
+                    recipient_id: Uuid::new_v4(),
+                    owner_id: Uuid::new_v4(),
+                    locale: "en".to_string(),
                 },
-                attachment: None,
             },
         };
         let params_3 = CreateScheduledEmail {
             user_email: "user-1@test.com".to_string(),
             send_at: Utc::now() + chrono::Duration::days(2),
             email_config: ScheduledEmailConfig {
-                subject: "test subject".to_string(),
                 template: EmailTemplate::EventReminder {
-                    event_name: "test_event".to_string(),
-                    event_time: (Utc::now() + chrono::Duration::days(1)).to_string(),
-                    event_link: "https://test.com".to_string(),
-                    organization_name: "Test org".to_string(),
-                    organization_email: None,
+                    event_id: Uuid::new_v4(),
+                    recipient_id: Uuid::new_v4(),
+                    owner_id: Uuid::new_v4(),
+                    locale: "en".to_string(),
                 },
-                attachment: None,
             },
         };
 
@@ -568,75 +549,60 @@ mod tests {
             user_email: "user-1@test.com".to_string(),
             send_at: Utc::now() + chrono::Duration::hours(23),
             email_config: ScheduledEmailConfig {
-                subject: "test subject".to_string(),
                 template: EmailTemplate::EventReminder {
-                    event_name: "test_event".to_string(),
-                    event_time: (Utc::now() + chrono::Duration::days(1)).to_string(),
-                    event_link: "https://test.com".to_string(),
-                    organization_name: "Test org".to_string(),
-                    organization_email: None,
+                    event_id: Uuid::new_v4(),
+                    recipient_id: Uuid::new_v4(),
+                    owner_id: Uuid::new_v4(),
+                    locale: "en".to_string(),
                 },
-                attachment: None,
             },
         };
         let params_2_days = CreateScheduledEmail {
             user_email: "user-2@test.com".to_string(),
             send_at: Utc::now() + chrono::Duration::days(2),
             email_config: ScheduledEmailConfig {
-                subject: "test subject".to_string(),
                 template: EmailTemplate::EventReminder {
-                    event_name: "test_event".to_string(),
-                    event_time: (Utc::now() + chrono::Duration::days(1)).to_string(),
-                    event_link: "https://test.com".to_string(),
-                    organization_name: "Test org".to_string(),
-                    organization_email: None,
+                    event_id: Uuid::new_v4(),
+                    recipient_id: Uuid::new_v4(),
+                    owner_id: Uuid::new_v4(),
+                    locale: "en".to_string(),
                 },
-                attachment: None,
             },
         };
         let params_past = CreateScheduledEmail {
             user_email: "user-1@test.com".to_string(),
             send_at: Utc::now() - chrono::Duration::days(1),
             email_config: ScheduledEmailConfig {
-                subject: "test subject".to_string(),
                 template: EmailTemplate::EventReminder {
-                    event_name: "test_event".to_string(),
-                    event_time: (Utc::now() + chrono::Duration::days(1)).to_string(),
-                    event_link: "https://test.com".to_string(),
-                    organization_name: "Test org".to_string(),
-                    organization_email: None,
+                    event_id: Uuid::new_v4(),
+                    recipient_id: Uuid::new_v4(),
+                    owner_id: Uuid::new_v4(),
+                    locale: "en".to_string(),
                 },
-                attachment: None,
             },
         };
         let params_sent = CreateScheduledEmail {
             user_email: "user-1@test.com".to_string(),
             send_at: Utc::now() + chrono::Duration::minutes(15),
             email_config: ScheduledEmailConfig {
-                subject: "test subject".to_string(),
                 template: EmailTemplate::EventReminder {
-                    event_name: "test_event".to_string(),
-                    event_time: (Utc::now() + chrono::Duration::days(1)).to_string(),
-                    event_link: "https://test.com".to_string(),
-                    organization_name: "Test org".to_string(),
-                    organization_email: None,
+                    event_id: Uuid::new_v4(),
+                    recipient_id: Uuid::new_v4(),
+                    owner_id: Uuid::new_v4(),
+                    locale: "en".to_string(),
                 },
-                attachment: None,
             },
         };
         let params_30_mins = CreateScheduledEmail {
             user_email: "user-1@test.com".to_string(),
             send_at: Utc::now() + chrono::Duration::minutes(30),
             email_config: ScheduledEmailConfig {
-                subject: "test subject".to_string(),
                 template: EmailTemplate::EventReminder {
-                    event_name: "test_event".to_string(),
-                    event_time: (Utc::now() + chrono::Duration::days(1)).to_string(),
-                    event_link: "https://test.com".to_string(),
-                    organization_name: "Test org".to_string(),
-                    organization_email: None,
+                    event_id: Uuid::new_v4(),
+                    recipient_id: Uuid::new_v4(),
+                    owner_id: Uuid::new_v4(),
+                    locale: "en".to_string(),
                 },
-                attachment: None,
             },
         };
 
@@ -666,15 +632,12 @@ mod tests {
             user_email: "test@test.com".to_string(),
             send_at: Utc::now() + chrono::Duration::days(1),
             email_config: ScheduledEmailConfig {
-                subject: "test subject".to_string(),
                 template: EmailTemplate::EventReminder {
-                    event_name: "test_event".to_string(),
-                    event_time: (Utc::now() + chrono::Duration::days(1)).to_string(),
-                    event_link: "https://test.com".to_string(),
-                    organization_name: "Test org".to_string(),
-                    organization_email: None,
+                    event_id: Uuid::new_v4(),
+                    recipient_id: Uuid::new_v4(),
+                    owner_id: Uuid::new_v4(),
+                    locale: "en".to_string(),
                 },
-                attachment: None,
             },
         };
 

--- a/api/src/routes/conversations.rs
+++ b/api/src/routes/conversations.rs
@@ -1927,7 +1927,7 @@ mod tests {
             .returning(|_, _, _, _, _| Box::pin(async move { Ok(()) }));
         mailer
             .expect_send_event_reminder()
-            .returning(|_, _, _, _| Ok(()));
+            .returning(|_, _, _, _, _, _| Box::pin(async move { Ok(()) }));
         mailer.expect_send_conversation_broadcast_email().returning(
             move |email, _subject, _html| {
                 sent.lock().unwrap().push(email.to_string());

--- a/api/src/routes/event_attendances.rs
+++ b/api/src/routes/event_attendances.rs
@@ -113,7 +113,12 @@ pub async fn create(
         let event_owner = users::get_user_by_id(&conversation.owner_id, &state.db).await?;
 
         event
-            .schedule_event_reminders(&state.db, &state.config, &user)
+            .schedule_event_reminders(
+                &state.db,
+                &user,
+                conversation.owner_id,
+                &conversation.primary_locale,
+            )
             .await?;
 
         state

--- a/api/src/routes/invites.rs
+++ b/api/src/routes/invites.rs
@@ -322,7 +322,12 @@ async fn auto_register_event_attendance(
     let cookie = create_session_cookie(&user, &state);
 
     event
-        .schedule_event_reminders(&state.db, &state.config, &user)
+        .schedule_event_reminders(
+            &state.db,
+            &user,
+            conversation.owner_id,
+            &conversation.primary_locale,
+        )
         .await?;
 
     let event_owner = users::get_user_by_id(&conversation.owner_id, &state.db).await?;

--- a/api/src/routes/invites.rs
+++ b/api/src/routes/invites.rs
@@ -86,12 +86,12 @@ async fn reject_invite(
 async fn create_conversation_invite(
     State(state): State<Arc<ComhairleState>>,
     Path(conversation_id): Path<Uuid>,
-    RequiredAdminUser(user): RequiredAdminUser,
+    RequiredAdminUser(admin_user): RequiredAdminUser,
     Json(create_invite): Json<CreateInviteDTO>,
 ) -> Result<(StatusCode, Json<InviteDto>), ComhairleError> {
     let conversation = models::conversation::get_by_id(&state.db, &conversation_id).await?;
 
-    if conversation.owner_id != user.id {
+    if conversation.owner_id != admin_user.id {
         return Err(ComhairleError::UserIsNotConversationOwner);
     }
 
@@ -99,8 +99,13 @@ async fn create_conversation_invite(
     // exists
 
     // Create the invite
-    let invite =
-        models::invites::create(&state.db, create_invite, &conversation_id, Some(user.id)).await?;
+    let invite = models::invites::create(
+        &state.db,
+        create_invite,
+        &conversation_id,
+        Some(admin_user.id),
+    )
+    .await?;
 
     // Send out an email notification if we can
     match &invite.invite_type {
@@ -111,22 +116,30 @@ async fn create_conversation_invite(
                     &state,
                     email,
                     conversation.id,
-                    user.id,
+                    admin_user.id,
                     invite.id,
                     &conversation.primary_locale,
                 )
                 .await?;
         }
-        InviteType::User(user_id) => {
-            let user = models::users::get_user_by_id(user_id, &state.db).await?;
-            if let Some(email) = &user.email {
-                state.mailer.send_email(
-                    email,
-                    "You have been invited to the conversation",
-                    "conversation_invite.html",
-                    context! {user=>user, conversation_title=>conversation.title},
-                    None,
-                )?;
+        InviteType::User(recipient_id) => {
+            // TODO: variant doesn't appear to be in use. If required in future
+            // consider how to adjust template variables and default slots for
+            // injecting user data, or split into separate email templates with
+            // separate schemas
+            let recipient = models::users::get_user_by_id(recipient_id, &state.db).await?;
+            if let Some(email) = &recipient.email {
+                state
+                    .mailer
+                    .send_conversation_invite_email(
+                        &state,
+                        email,
+                        conversation.id,
+                        admin_user.id,
+                        invite.id,
+                        &conversation.primary_locale,
+                    )
+                    .await?;
             }
         }
         models::invites::InviteType::Open | models::invites::InviteType::SingleUse => {}

--- a/api/src/worker_service/scheduled_emails.rs
+++ b/api/src/worker_service/scheduled_emails.rs
@@ -6,7 +6,6 @@ use uuid::Uuid;
 
 use crate::{
     ComhairleState,
-    mailer::build_invite_attachment,
     models::{
         job::{self, CreateJob},
         scheduled_email::{ScheduledEmail, list_upcoming_scheduled_emails},
@@ -31,26 +30,12 @@ pub async fn send_scheduled_email(
         "Sending scheduled email to recipient"
     );
 
-    let attachment = req
-        .scheduled_email
+    req.scheduled_email
+        .clone()
         .email_config
-        .attachment
-        .as_deref()
-        .and_then(|body| build_invite_attachment(body.to_string()).ok());
-
-    state
-        .mailer
-        .send_email(
-            &req.scheduled_email.user_email,
-            &req.scheduled_email.email_config.subject,
-            &req.scheduled_email.email_config.template.to_string(),
-            req.scheduled_email
-                .clone()
-                .email_config
-                .template
-                .to_mailer_context(),
-            attachment,
-        )
+        .template
+        .mailer_send(&req.scheduled_email.user_email, &state)
+        .await
         .map_err(|e| WorkerServiceError::MailerError(e.to_string()))
         .ok_or_record_failure(&req.job_id, &state.db)
         .await?;

--- a/ui/packages/api-client/src/api.ts
+++ b/ui/packages/api-client/src/api.ts
@@ -2058,6 +2058,7 @@ export const EmailType = z.enum([
   "conversation_invite",
   "event_registration_invite",
   "event_registration_confirmation",
+  "event_reminder",
 ]);
 export type EmailType = z.infer<typeof EmailType>;
 export const email_type = z.union([EmailType, z.null()]).optional();
@@ -2088,6 +2089,15 @@ export const EmailTemplateSlots = z.union([
       heading: z.string(),
       intro: z.string(),
       type: z.literal("event_registration_confirmation"),
+    })
+    .passthrough(),
+  z
+    .object({
+      body: z.string(),
+      footer: z.string(),
+      heading: z.string(),
+      intro: z.string(),
+      type: z.literal("event_reminder"),
     })
     .passthrough(),
 ]);
@@ -3868,7 +3878,7 @@ Use query param withUserProgress&#x3D;true to get the active user&#x27;s progres
     alias: "ListEmailTemplateSchemas",
     description: `List all template schemas for each email template type`,
     requestFormat: "json",
-    response: z.array(EmailTypeSchema).min(3).max(3),
+    response: z.array(EmailTypeSchema).min(4).max(4),
   },
   {
     method: "get",

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/events/[event_id]/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/events/[event_id]/+page.svelte
@@ -75,9 +75,10 @@
 	const timeZone = getLocalTimeZone();
 	const [startDate, _startTimeWithZone] = $derived(event.startTime.split('T'));
 	const [, _endTimeWithZone] = $derived(event.endTime.split('T'));
-	const availableTimeZones = Array.from(
-		new Set(['UTC', ...Intl.supportedValuesOf('timeZone')])
-	).map((tz) => ({ value: tz, label: tz }));
+	const availableTimeZones = Intl.supportedValuesOf('timeZone').map((tz) => ({
+		value: tz,
+		label: tz
+	}));
 
 	const eventForm = superForm(
 		{
@@ -518,7 +519,7 @@
 				<Form.Field form={eventForm} name="end_time" class="contents">
 					<Form.FieldErrors class="text-destructive text-sm" />
 				</Form.Field>
-				{#if $form.default_time_zone !== 'UTC'}
+				{#if $form.default_time_zone !== 'Europe/London'}
 					<div class="text-muted-foreground flex gap-2">
 						<span>{$form.default_time_zone}</span>
 						<span>-</span>

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/events/new/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/events/new/+page.svelte
@@ -35,12 +35,13 @@
 		formDefaults.data.facilitators = [user.email, ...(formDefaults.data.facilitators ?? [])];
 	}
 	if (!formDefaults.data.default_time_zone) {
-		formDefaults.data.default_time_zone = 'UTC';
+		formDefaults.data.default_time_zone = 'Europe/London';
 	}
 
-	const availableTimeZones = Array.from(
-		new Set(['UTC', ...Intl.supportedValuesOf('timeZone')])
-	).map((tz) => ({ value: tz, label: tz }));
+	const availableTimeZones = Intl.supportedValuesOf('timeZone').map((tz) => ({
+		value: tz,
+		label: tz
+	}));
 
 	const form = superForm(formDefaults, {
 		validators: zodClient(NewEventSchema),
@@ -166,7 +167,7 @@
 				priority: 'INFO'
 			});
 
-			goto(`/admin/conversations/${conversation.id}/events`);
+			goto(`/admin/conversations/${conversation.id}/events`, { invalidateAll: true });
 		} catch (e) {
 			console.error(e);
 			submitError = 'Something went wrong creating the event.';
@@ -377,7 +378,7 @@
 			<Form.Field {form} name="end_time" class="contents">
 				<Form.FieldErrors class="text-destructive text-sm" />
 			</Form.Field>
-			{#if $formData.default_time_zone && $formData.default_time_zone !== 'UTC' && $formData.start_date && $formData.start_time && $formData.end_time}
+			{#if $formData.default_time_zone && $formData.default_time_zone !== 'Europe/London' && $formData.start_date && $formData.start_time && $formData.end_time}
 				<div class="text-muted-foreground flex gap-2">
 					<span>{$formData.default_time_zone}</span>
 					<span>-</span>

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/events/new/NewEventSchema.ts
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/events/new/NewEventSchema.ts
@@ -10,7 +10,7 @@ const NewEventSchema = z
 			.number({ invalid_type_error: 'Capacity is required.' })
 			.int({ message: 'Capacity must be a whole number.' })
 			.min(2, { message: 'Capacity must be at least 2.' }),
-		default_time_zone: z.string().default('UTC'),
+		default_time_zone: z.string().default('Europe/London'),
 		start_date: z
 			.string()
 			.date()

--- a/ui/packages/comhairle/src/routes/(admin)/admin/email-template-configs/new/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/email-template-configs/new/+page.svelte
@@ -82,7 +82,8 @@
 			console.error(e);
 			notifications.send({
 				priority: 'ERROR',
-				message: 'Something went wrong creating your custom email'
+				message:
+					"Something went wrong creating your custom email. Please ensure you haven't already created a custom email for this type."
 			});
 		}
 	}


### PR DESCRIPTION
Actions:

+ refactor send_event_reminder method to take ids as params instead of text fields
+ refactor scheduled email for event reminder to hold appropriate ids
  and remove redundant fields
+ refactor sending of scheduled emails to use new `mailer_send` method
  that scopes to associated mailer method instead of generic `send_email` method
+ add custom email variant for event reminders
+ refactor send_event_reminder mailer method to use
  email_template_config if available
+ refactor event email templates to move hardcoded organization content
  into footer slot
+ migration to drop existing search indexes and replace with unique
  indexes
+ extend error message on admin create email config page

Motivation:

+ scope scheduled email variants to associated mailer method instead of
  generic send_email method to allow sync with custom emails
+ fix bug where one event reminder's otp link will invalidate others for
  the same user by only creating when email is sent
+ allow event reminder emails to be customizable
+ prevent users / ogranizations from creating more than one custom email
  template per email type
+ clarity to user until we migrate functionality to organizations