### PR TITLE
590/step deletion conflict

### DIFF
--- a/api/migrations/20260708142415_on_delete_cascade_for_user_progress_workflow_step.sql
+++ b/api/migrations/20260708142415_on_delete_cascade_for_user_progress_workflow_step.sql
@@ -1,0 +1,10 @@
+-- Drop existing foreign key constraint and replace with ON DELETE CASCADE added
+
+ALTER TABLE user_progress
+DROP CONSTRAINT user_progress_workflow_step_id_fkey;
+
+ALTER TABLE user_progress
+ADD CONSTRAINT user_progress_workflow_step_id_fkey
+FOREIGN KEY (workflow_step_id)
+REFERENCES workflow_step(id)
+ON DELETE CASCADE;

--- a/api/src/error.rs
+++ b/api/src/error.rs
@@ -295,6 +295,9 @@ pub enum ComhairleError {
     #[error("Bad request: {0}")]
     BadRequest(String),
 
+    #[error("Conflict: {0}")]
+    Conflict(String),
+
     #[error("Tool config error: {0}")]
     ToolConfigError(String),
 
@@ -363,6 +366,7 @@ impl IntoResponse for ComhairleError {
             | ComhairleError::DuplicateRecordingName(_)
             | ComhairleError::UserAlreadyRegisteredForEvent(_)
             | ComhairleError::UserAlreadyParticipatingInWorkflow(_)
+            | ComhairleError::Conflict(_)
             | ComhairleError::RoleAlreadyGranted(_) => StatusCode::CONFLICT,
             ComhairleError::RoleNotFound(_) => StatusCode::NOT_FOUND,
             ComhairleError::CannotRevokeLastAdmin => StatusCode::FORBIDDEN,

--- a/api/src/models.rs
+++ b/api/src/models.rs
@@ -1,3 +1,5 @@
+use sqlx::error::ErrorKind;
+
 use crate::error::ComhairleError;
 
 pub mod api_key;
@@ -43,15 +45,59 @@ pub mod workflow_step;
 #[cfg(test)]
 pub mod model_test_helpers;
 
+/// Extension trait for converting `sqlx` query results into domain-level
+/// [`ComhairleError`]s.
+///
+/// This centralizes the mapping from low-level database errors to the
+/// HTTP-facing error variants used throughout the API, so call sites don't
+/// need to pattern-match on `sqlx::Error` themselves.
 pub trait SqlxResultExt<T> {
-    fn not_found_as(self, resource: &str) -> Result<T, ComhairleError>;
+    /// Resolves a `sqlx` query result into a [`ComhairleError`], classifying
+    /// the underlying database error where possible.
+    ///
+    /// - `sqlx::Error::RowNotFound` is mapped to
+    ///   [`ComhairleError::ResourceNotFound`] (HTTP 404), using `resource` as a
+    ///   human-readable description of what was being looked up (e.g.
+    ///   `"User"`, `"Workflow Step"`).
+    /// - Foreign key and unique constraint violations are mapped to
+    ///   [`ComhairleError::Conflict`] (HTTP 409), since the request is
+    ///   well-formed but conflicts with the current state of the database
+    ///   (e.g. referencing a row that doesn't exist, or duplicating a
+    ///   unique value).
+    /// - All other database errors fall through to
+    ///   [`ComhairleError::DatabaseError`], preserving the original
+    ///   `sqlx::Error` for logging/debugging.
+    ///
+    /// # Arguments
+    ///
+    /// * `resource` - A short, human-readable name for the resource being
+    ///   queried. Used in the `ResourceNotFound` and `Conflict` error
+    ///   messages.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let user = sqlx::query_as!(User, "SELECT * FROM users WHERE id = $1", id)
+    ///     .fetch_one(&pool)
+    ///     .await
+    ///     .resolve_db_err("user")?;
+    /// ```
+    fn resolve_db_err(self, resource: &str) -> Result<T, ComhairleError>;
 }
 
 impl<T> SqlxResultExt<T> for Result<T, sqlx::Error> {
-    fn not_found_as(self, resource: &str) -> Result<T, ComhairleError> {
+    fn resolve_db_err(self, resource: &str) -> Result<T, ComhairleError> {
         self.map_err(|e| match e {
             sqlx::Error::RowNotFound => ComhairleError::ResourceNotFound(resource.into()),
-            other => ComhairleError::DatabaseError(other),
+            sqlx::Error::Database(ref db_err) => match db_err.kind() {
+                ErrorKind::ForeignKeyViolation | ErrorKind::UniqueViolation => {
+                    ComhairleError::Conflict(format!(
+                        "{resource} conflicts with an existing record"
+                    ))
+                }
+                _ => ComhairleError::DatabaseError(e),
+            },
+            _ => ComhairleError::DatabaseError(e),
         })
     }
 }

--- a/api/src/models/conversation.rs
+++ b/api/src/models/conversation.rs
@@ -14,7 +14,7 @@ use crate::{
     },
     config::ComhairleConfig,
     error::ComhairleError,
-    models,
+    models::{self, SqlxResultExt},
 };
 use chrono::{DateTime, Utc};
 use comhairle_macros::Translatable;
@@ -394,7 +394,7 @@ pub async fn delete(
         .fetch_one(db)
         .await
         .inspect_err(|e| println!("{e:#?}"))
-        .map_err(|_| ComhairleError::ResourceNotFound("Conversation".into()))?;
+        .resolve_db_err("Conversation")?;
 
     if let Some(bot_service) = bot_service {
         if let Some(ref knowledge_base_id) = conversation.knowledge_base_id {
@@ -444,7 +444,7 @@ pub async fn get_by_id(db: &PgPool, id: &Uuid) -> Result<Conversation, Comhairle
     let conversation = sqlx::query_as_with::<_, Conversation, _>(&sql, values)
         .fetch_one(db)
         .await
-        .map_err(|_| ComhairleError::ResourceNotFound("Conversation".into()))?;
+        .resolve_db_err("Conversation")?;
 
     Ok(conversation)
 }
@@ -469,7 +469,7 @@ pub async fn get_localised_by_id(
         .fetch_one(db)
         .await
         .inspect_err(|e| println!("{e:#?}"))
-        .map_err(|_| ComhairleError::ResourceNotFound("Conversation".into()))?;
+        .resolve_db_err("Conversation")?;
 
     Ok(conversation)
 }
@@ -486,7 +486,7 @@ pub async fn get_by_slug(db: &PgPool, slug: &str) -> Result<Conversation, Comhai
     let conversation = sqlx::query_as_with::<_, Conversation, _>(&sql, values)
         .fetch_one(db)
         .await
-        .map_err(|_| ComhairleError::ResourceNotFound("Conversation".into()))?;
+        .resolve_db_err("Conversation")?;
 
     Ok(conversation)
 }
@@ -509,7 +509,7 @@ pub async fn get_localised_by_slug(
     let conversation = sqlx::query_as_with::<_, LocalizedConversation, _>(&sql, values)
         .fetch_one(db)
         .await
-        .map_err(|_| ComhairleError::ResourceNotFound("Conversation".into()))?;
+        .resolve_db_err("Conversation")?;
 
     Ok(conversation)
 }

--- a/api/src/models/conversation_email_notification_recipients.rs
+++ b/api/src/models/conversation_email_notification_recipients.rs
@@ -1,4 +1,4 @@
-use crate::error::ComhairleError;
+use crate::{error::ComhairleError, models::SqlxResultExt};
 use chrono::{DateTime, Utc};
 use schemars::JsonSchema;
 use sea_query::{Expr, PostgresQueryBuilder, Query, enum_def};
@@ -101,9 +101,7 @@ pub async fn get_by_conversation_and_email(
         sqlx::query_as_with::<_, ConversationEmailNotificationRecipients, _>(&sql, values)
             .fetch_one(db)
             .await
-            .map_err(|_| {
-                ComhairleError::ResourceNotFound("ConversationEmailNotificationRecipients".into())
-            })?;
+            .resolve_db_err("Conversation Email Notification Recipients")?;
 
     Ok(recipient)
 }
@@ -150,9 +148,7 @@ pub async fn delete_by_conversation_and_email(
         sqlx::query_as_with::<_, ConversationEmailNotificationRecipients, _>(&sql, values)
             .fetch_one(db)
             .await
-            .map_err(|_| {
-                ComhairleError::ResourceNotFound("ConversationEmailNotificationRecipients".into())
-            })?;
+            .resolve_db_err("Conversation Email Notification Recipients")?;
 
     Ok(recipient)
 }

--- a/api/src/models/email_template_config.rs
+++ b/api/src/models/email_template_config.rs
@@ -524,7 +524,7 @@ pub async fn get_by_id(db: &PgPool, id: Uuid) -> Result<EmailTemplateConfig, Com
     let email_config = sqlx::query_as_with(&sql, values)
         .fetch_one(db)
         .await
-        .not_found_as("Email template config")?;
+        .resolve_db_err("Email Template Config")?;
 
     Ok(email_config)
 }
@@ -813,7 +813,7 @@ mod tests {
             ComhairleError::ResourceNotFound(e) => {
                 assert_eq!(
                     e,
-                    "Email template config".to_string(),
+                    "Email Template Config".to_string(),
                     "incorrect error message"
                 );
             }

--- a/api/src/models/event.rs
+++ b/api/src/models/event.rs
@@ -23,7 +23,7 @@ use crate::{
     error::ComhairleError,
     mailer::build_calendar_invite,
     models::{
-        otp,
+        SqlxResultExt, otp,
         pagination::{Order, PageOptions, PaginatedResults},
         scheduled_email::{self, CreateScheduledEmail, EmailTemplate, ScheduledEmailConfig},
         translations::{TextContentId, TextFormat, new_translation},
@@ -685,10 +685,7 @@ pub async fn get_by_id(db: &PgPool, id: &Uuid) -> Result<Event, ComhairleError> 
     let event = sqlx::query_as_with(&sql, values)
         .fetch_one(db)
         .await
-        .map_err(|e| match e {
-            sqlx::Error::RowNotFound => ComhairleError::ResourceNotFound("Event".into()),
-            other => ComhairleError::DatabaseError(other),
-        })?;
+        .resolve_db_err("Event")?;
 
     Ok(event)
 }
@@ -712,10 +709,7 @@ pub async fn get_localized_by_id(
     let event = sqlx::query_as_with(&sql, values)
         .fetch_one(db)
         .await
-        .map_err(|e| match e {
-            sqlx::Error::RowNotFound => ComhairleError::ResourceNotFound("Event".into()),
-            other => ComhairleError::DatabaseError(other),
-        })?;
+        .resolve_db_err("Event")?;
 
     Ok(event)
 }

--- a/api/src/models/event_attendance.rs
+++ b/api/src/models/event_attendance.rs
@@ -10,6 +10,7 @@ use uuid::Uuid;
 use crate::{
     error::ComhairleError,
     models::{
+        SqlxResultExt,
         event::EventIden,
         pagination::{Order, PageOptions, PaginatedResults},
         users::UserIden,
@@ -271,12 +272,7 @@ pub async fn get_by_id(db: &PgPool, id: &Uuid) -> Result<EventAttendance, Comhai
     let event_attendance = sqlx::query_as_with::<_, EventAttendance, _>(&sql, values)
         .fetch_one(db)
         .await
-        .map_err(|e| match e {
-            sqlx::Error::RowNotFound => {
-                ComhairleError::ResourceNotFound("EventAttendance".to_string())
-            }
-            other => ComhairleError::DatabaseError(other),
-        })?;
+        .resolve_db_err("Event Attendance")?;
 
     Ok(event_attendance)
 }
@@ -303,12 +299,7 @@ pub async fn get_by_event_and_user(
     let event_attendance = sqlx::query_as_with::<_, EventAttendance, _>(&sql, values)
         .fetch_one(db)
         .await
-        .map_err(|e| match e {
-            sqlx::Error::RowNotFound => {
-                ComhairleError::ResourceNotFound("EventAttendance".to_string())
-            }
-            other => ComhairleError::DatabaseError(other),
-        })?;
+        .resolve_db_err("Event Attendance")?;
 
     Ok(event_attendance)
 }
@@ -800,7 +791,7 @@ mod tests {
 
         match err {
             ComhairleError::ResourceNotFound(e) => {
-                assert_eq!(e, "EventAttendance".to_string(), "incorrect error message");
+                assert_eq!(e, "Event Attendance".to_string(), "incorrect error message");
             }
             _ => panic!("Expected ResourceNotFound error"),
         }

--- a/api/src/models/feedback.rs
+++ b/api/src/models/feedback.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use sqlx::{PgPool, prelude::FromRow};
 use uuid::Uuid;
 
-use crate::error::ComhairleError;
+use crate::{error::ComhairleError, models::SqlxResultExt};
 
 #[derive(Partial, Debug, Deserialize, Serialize, FromRow, Clone, JsonSchema)]
 #[enum_def(table_name = "feedback")]
@@ -100,7 +100,7 @@ pub async fn list_for_conversation(
     let feedback = sqlx::query_as_with::<_, Feedback, _>(&sql, values)
         .fetch_all(db)
         .await
-        .map_err(|_| ComhairleError::ResourceNotFound("Feedback".into()))?;
+        .resolve_db_err("Feedback")?;
 
     Ok(feedback)
 }
@@ -120,7 +120,7 @@ pub async fn list_for_user_on_conversation(
     let feedback = sqlx::query_as_with::<_, Feedback, _>(&sql, values)
         .fetch_all(db)
         .await
-        .map_err(|_| ComhairleError::ResourceNotFound("Feedback".into()))?;
+        .resolve_db_err("Feedback")?;
 
     Ok(feedback)
 }

--- a/api/src/models/invites.rs
+++ b/api/src/models/invites.rs
@@ -1,4 +1,4 @@
-use crate::error::ComhairleError;
+use crate::{error::ComhairleError, models::SqlxResultExt};
 use chrono::{DateTime, Utc};
 use comhairle_macros::{DbJsonBEnum, DbStringEnum};
 use partially::Partial;
@@ -260,10 +260,7 @@ pub async fn get_by_id(db: &PgPool, invite_id: &Uuid) -> Result<Invite, Comhairl
     let invite = sqlx::query_as_with::<_, Invite, _>(&sql, values)
         .fetch_one(db)
         .await
-        .map_err(|e| {
-            println!("{e:#?}");
-            ComhairleError::ResourceNotFound("Invite".into())
-        })?;
+        .resolve_db_err("Invite")?;
 
     Ok(invite)
 }
@@ -289,7 +286,7 @@ pub async fn update(
     let invite = sqlx::query_as_with::<_, Invite, _>(&sql, values)
         .fetch_one(db)
         .await
-        .map_err(|_| ComhairleError::ResourceNotFound("Invite".into()))?;
+        .resolve_db_err("Invite")?;
 
     Ok(invite)
 }
@@ -305,7 +302,7 @@ pub async fn delete(db: &PgPool, id: &Uuid) -> Result<Invite, ComhairleError> {
     let invite = sqlx::query_as_with::<_, Invite, _>(&sql, values)
         .fetch_one(db)
         .await
-        .map_err(|_| ComhairleError::ResourceNotFound("Invite".into()))?;
+        .resolve_db_err("Invite")?;
 
     Ok(invite)
 }

--- a/api/src/models/job.rs
+++ b/api/src/models/job.rs
@@ -8,7 +8,10 @@ use uuid::Uuid;
 
 use crate::{
     error::ComhairleError,
-    models::pagination::{Order, PageOptions, PaginatedResults},
+    models::{
+        SqlxResultExt,
+        pagination::{Order, PageOptions, PaginatedResults},
+    },
 };
 
 #[derive(Serialize, Deserialize, FromRow, Clone, JsonSchema, Debug)]
@@ -183,7 +186,7 @@ pub async fn delete(db: &PgPool, id: &Uuid) -> Result<Job, ComhairleError> {
     let job = sqlx::query_as_with::<_, Job, _>(&sql, values)
         .fetch_one(db)
         .await
-        .map_err(|_| ComhairleError::ResourceNotFound("Job".into()))?;
+        .resolve_db_err("Job")?;
 
     Ok(job)
 }
@@ -198,7 +201,7 @@ pub async fn get_id_id(db: &PgPool, id: &Uuid) -> Result<Job, ComhairleError> {
     let job = sqlx::query_as_with::<_, Job, _>(&sql, values)
         .fetch_one(db)
         .await
-        .map_err(|_| ComhairleError::ResourceNotFound("Job".into()))?;
+        .resolve_db_err("Job")?;
 
     Ok(job)
 }

--- a/api/src/models/media.rs
+++ b/api/src/models/media.rs
@@ -12,7 +12,10 @@ use fake::Dummy;
 
 use crate::{
     error::ComhairleError,
-    models::pagination::{Order, PageOptions, PaginatedResults},
+    models::{
+        SqlxResultExt,
+        pagination::{Order, PageOptions, PaginatedResults},
+    },
 };
 
 /// A media record, which references an upload in the bulk_storage_service.
@@ -223,10 +226,7 @@ pub async fn get_by_id(db: &PgPool, id: &Uuid) -> Result<Media, ComhairleError> 
     let media = sqlx::query_as_with(&sql, values)
         .fetch_one(db)
         .await
-        .map_err(|e| match e {
-            sqlx::Error::RowNotFound => ComhairleError::ResourceNotFound("Media".to_string()),
-            other => ComhairleError::DatabaseError(other),
-        })?;
+        .resolve_db_err("Media")?;
 
     Ok(media)
 }
@@ -329,7 +329,10 @@ pub async fn delete(db: &PgPool, id: &Uuid) -> Result<Media, ComhairleError> {
         .returning(Query::returning().columns(DEFAULT_COLUMNS))
         .build_sqlx(PostgresQueryBuilder);
 
-    let media = sqlx::query_as_with(&sql, values).fetch_one(db).await?;
+    let media = sqlx::query_as_with(&sql, values)
+        .fetch_one(db)
+        .await
+        .resolve_db_err("Media")?;
 
     Ok(media)
 }

--- a/api/src/models/notification.rs
+++ b/api/src/models/notification.rs
@@ -1,5 +1,5 @@
 use super::pagination::{Order, PageOptions, PaginatedResults};
-use crate::error::ComhairleError;
+use crate::{error::ComhairleError, models::SqlxResultExt};
 use chrono::{DateTime, Utc};
 use partially::Partial;
 use schemars::JsonSchema;
@@ -258,7 +258,7 @@ pub async fn get_by_id(db: &PgPool, id: &Uuid) -> Result<Notification, Comhairle
     let notification = sqlx::query_as_with::<_, Notification, _>(&sql, values)
         .fetch_one(db)
         .await
-        .map_err(|_| ComhairleError::ResourceNotFound("Notification".into()))?;
+        .resolve_db_err("Notification")?;
 
     Ok(notification)
 }
@@ -298,7 +298,7 @@ pub async fn delete(db: &PgPool, id: &Uuid) -> Result<Notification, ComhairleErr
     let notification = sqlx::query_as_with::<_, Notification, _>(&sql, values)
         .fetch_one(db)
         .await
-        .map_err(|_| ComhairleError::ResourceNotFound("Notification".into()))?;
+        .resolve_db_err("Notification")?;
 
     Ok(notification)
 }

--- a/api/src/models/notification_delivery.rs
+++ b/api/src/models/notification_delivery.rs
@@ -2,7 +2,8 @@ use super::notification::{Notification, NotificationIden};
 use super::pagination::{Order, PageOptions, PaginatedResults};
 use crate::routes::notifications::dto::{NotificationDeliveryDto, NotificationDto};
 use crate::{
-    error::ComhairleError, models::notification::DEFAULT_COLUMNS as NOTIFICATION_DEFAULT_COLUMNS,
+    error::ComhairleError,
+    models::{SqlxResultExt, notification::DEFAULT_COLUMNS as NOTIFICATION_DEFAULT_COLUMNS},
 };
 use chrono::{DateTime, Utc};
 use partially::Partial;
@@ -277,7 +278,7 @@ pub async fn get_by_id(db: &PgPool, id: &Uuid) -> Result<NotificationDelivery, C
     let delivery = sqlx::query_as_with::<_, NotificationDelivery, _>(&sql, values)
         .fetch_one(db)
         .await
-        .map_err(|_| ComhairleError::ResourceNotFound("NotificationDelivery".into()))?;
+        .resolve_db_err("Notification Delivery")?;
 
     Ok(delivery)
 }
@@ -356,7 +357,7 @@ pub async fn delete(db: &PgPool, id: &Uuid) -> Result<NotificationDelivery, Comh
     let delivery = sqlx::query_as_with::<_, NotificationDelivery, _>(&sql, values)
         .fetch_one(db)
         .await
-        .map_err(|_| ComhairleError::ResourceNotFound("NotificationDelivery".into()))?;
+        .resolve_db_err("Notification Delivery")?;
 
     Ok(delivery)
 }

--- a/api/src/models/organization.rs
+++ b/api/src/models/organization.rs
@@ -15,6 +15,7 @@ use fake::Dummy;
 use crate::{
     error::ComhairleError,
     models::{
+        SqlxResultExt,
         pagination::{Order, PageOptions, PaginatedResults},
         translations::{TextContentId, TextFormat, new_translation},
     },
@@ -290,10 +291,7 @@ pub async fn get_localized_by_id(
     let organization = query_as_with(&sql, values)
         .fetch_one(db)
         .await
-        .map_err(|e| match e {
-            sqlx::Error::RowNotFound => ComhairleError::ResourceNotFound("Organization".into()),
-            other => ComhairleError::DatabaseError(other),
-        })?;
+        .resolve_db_err("Organization")?;
 
     Ok(organization)
 }
@@ -309,10 +307,7 @@ pub async fn get_by_id(db: &PgPool, id: &Uuid) -> Result<Organization, Comhairle
     let organization = query_as_with(&sql, values)
         .fetch_one(db)
         .await
-        .map_err(|e| match e {
-            sqlx::Error::RowNotFound => ComhairleError::ResourceNotFound("Organization".into()),
-            other => ComhairleError::DatabaseError(other),
-        })?;
+        .resolve_db_err("Organization")?;
 
     Ok(organization)
 }
@@ -325,7 +320,10 @@ pub async fn delete(db: &PgPool, id: &Uuid) -> Result<Organization, ComhairleErr
         .returning(Query::returning().columns(DEFAULT_COLUMNS))
         .build_sqlx(PostgresQueryBuilder);
 
-    let organization = sqlx::query_as_with(&sql, values).fetch_one(db).await?;
+    let organization = sqlx::query_as_with(&sql, values)
+        .fetch_one(db)
+        .await
+        .resolve_db_err("Organization")?;
 
     Ok(organization)
 }

--- a/api/src/models/otp.rs
+++ b/api/src/models/otp.rs
@@ -9,7 +9,10 @@ use uuid::Uuid;
 
 use crate::{
     error::ComhairleError,
-    models::users::{self, UserAuthType},
+    models::{
+        SqlxResultExt,
+        users::{self, UserAuthType},
+    },
     tools::id::gen_id,
 };
 
@@ -126,12 +129,7 @@ pub async fn get_by_id(db: &PgPool, id: &Uuid) -> Result<Otp, ComhairleError> {
     let otp = sqlx::query_as_with(&sql, values)
         .fetch_one(db)
         .await
-        .map_err(|e| match e {
-            sqlx::Error::RowNotFound => {
-                ComhairleError::ResourceNotFound("One time passcode".into())
-            }
-            other => ComhairleError::DatabaseError(other),
-        })?;
+        .resolve_db_err("One Time Passcode")?;
 
     Ok(otp)
 }
@@ -156,12 +154,7 @@ pub async fn accept(
     let otp = sqlx::query_as_with(&sql, values)
         .fetch_one(db)
         .await
-        .map_err(|e| match e {
-            sqlx::Error::RowNotFound => {
-                ComhairleError::ResourceNotFound("One time passcode".into())
-            }
-            other => ComhairleError::DatabaseError(other),
-        })?;
+        .resolve_db_err("One Time Passcode")?;
 
     Ok(otp)
 }
@@ -305,7 +298,7 @@ mod tests {
             ComhairleError::ResourceNotFound(e) => {
                 assert_eq!(
                     e,
-                    "One time passcode".to_string(),
+                    "One Time Passcode".to_string(),
                     "incorrect error message"
                 );
             }
@@ -340,7 +333,7 @@ mod tests {
 
         match (first_error, second_error) {
             (ComhairleError::ResourceNotFound(first), ComhairleError::ResourceNotFound(second)) => {
-                let message = "One time passcode".to_string();
+                let message = "One Time Passcode".to_string();
                 assert_eq!(first, message, "incorrect error message");
                 assert_eq!(second, message, "incorrect error message")
             }

--- a/api/src/models/polis_statement_aux.rs
+++ b/api/src/models/polis_statement_aux.rs
@@ -1,4 +1,4 @@
-use crate::models::{self, users::User};
+use crate::models::{self, SqlxResultExt, users::User};
 use chrono::{DateTime, Utc};
 use schemars::JsonSchema;
 use sea_query::{
@@ -257,12 +257,7 @@ pub async fn get_by_id(db: &PgPool, id: &Uuid) -> Result<PolisStatementAux, Comh
     let aux = query_as_with(&sql, values)
         .fetch_one(db)
         .await
-        .map_err(|e| match e {
-            sqlx::Error::RowNotFound => {
-                ComhairleError::ResourceNotFound("Polis statement aux".into())
-            }
-            other => ComhairleError::DatabaseError(other),
-        })?;
+        .resolve_db_err("Polis Statement Aux")?;
 
     Ok(aux)
 }
@@ -431,10 +426,7 @@ pub async fn add_theme(
     .bind(theme)
     .fetch_one(db)
     .await
-    .map_err(|e| match e {
-        sqlx::Error::RowNotFound => ComhairleError::ResourceNotFound("Polis statement aux".into()),
-        other => ComhairleError::DatabaseError(other),
-    })?;
+    .resolve_db_err("Polis Statement Aux")?;
 
     Ok(aux)
 }
@@ -455,10 +447,7 @@ pub async fn remove_theme(
     .bind(theme)
     .fetch_one(db)
     .await
-    .map_err(|e| match e {
-        sqlx::Error::RowNotFound => ComhairleError::ResourceNotFound("Polis statement aux".into()),
-        other => ComhairleError::DatabaseError(other),
-    })?;
+    .resolve_db_err("Polis Statement Aux")?;
 
     Ok(aux)
 }

--- a/api/src/models/proposal.rs
+++ b/api/src/models/proposal.rs
@@ -11,7 +11,10 @@ use uuid::Uuid;
 
 use crate::{
     error::ComhairleError,
-    models::translations::{TextContentId, TextFormat, new_translation},
+    models::{
+        SqlxResultExt,
+        translations::{TextContentId, TextFormat, new_translation},
+    },
 };
 
 #[derive(Partial, Debug, Deserialize, Serialize, FromRow, Clone, JsonSchema, Translatable)]
@@ -154,10 +157,7 @@ pub async fn get_localized_by_id(
     let proposal = query_as_with(&sql, values)
         .fetch_one(db)
         .await
-        .map_err(|e| match e {
-            sqlx::Error::RowNotFound => ComhairleError::ResourceNotFound("Proposal".into()),
-            other => ComhairleError::DatabaseError(other),
-        })?;
+        .resolve_db_err("Proposal")?;
 
     Ok(proposal)
 }

--- a/api/src/models/recruitment_target.rs
+++ b/api/src/models/recruitment_target.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use sqlx::{PgPool, prelude::FromRow};
 use uuid::Uuid;
 
-use crate::error::ComhairleError;
+use crate::{error::ComhairleError, models::SqlxResultExt};
 
 #[derive(Partial, Debug, Deserialize, Serialize, FromRow, Clone, JsonSchema)]
 #[enum_def(table_name = "recruitment_target")]
@@ -95,7 +95,7 @@ pub async fn get_by_id(db: &PgPool, id: &Uuid) -> Result<RecruitmentTarget, Comh
     let target = sqlx::query_as_with::<_, RecruitmentTarget, _>(&sql, values)
         .fetch_one(db)
         .await
-        .map_err(|_| ComhairleError::ResourceNotFound("RecruitmentTarget".into()))?;
+        .resolve_db_err("Recruitment Target")?;
 
     Ok(target)
 }
@@ -165,7 +165,7 @@ pub async fn update(
     let target = sqlx::query_as_with::<_, RecruitmentTarget, _>(&sql, values)
         .fetch_one(db)
         .await
-        .map_err(|_| ComhairleError::ResourceNotFound("RecruitmentTarget".into()))?;
+        .resolve_db_err("Recruitment Target")?;
 
     Ok(target)
 }
@@ -180,7 +180,7 @@ pub async fn delete(db: &PgPool, id: &Uuid) -> Result<RecruitmentTarget, Comhair
     let target = sqlx::query_as_with::<_, RecruitmentTarget, _>(&sql, values)
         .fetch_one(db)
         .await
-        .map_err(|_| ComhairleError::ResourceNotFound("RecruitmentTarget".into()))?;
+        .resolve_db_err("Recruitment Target")?;
 
     Ok(target)
 }

--- a/api/src/models/region.rs
+++ b/api/src/models/region.rs
@@ -15,6 +15,7 @@ use fake::Dummy;
 use crate::{
     error::ComhairleError,
     models::{
+        SqlxResultExt,
         organization::OrganizationIden,
         pagination::{Order, PageOptions, PaginatedResults},
         translations::{TextContentId, TextFormat, new_translation},
@@ -273,10 +274,7 @@ pub async fn get_localized_by_id(
     let region = query_as_with(&sql, values)
         .fetch_one(db)
         .await
-        .map_err(|e| match e {
-            sqlx::Error::RowNotFound => ComhairleError::ResourceNotFound("Region".into()),
-            other => ComhairleError::DatabaseError(other),
-        })?;
+        .resolve_db_err("Region")?;
 
     Ok(region)
 }
@@ -289,7 +287,10 @@ pub async fn delete(db: &PgPool, id: &Uuid) -> Result<Region, ComhairleError> {
         .returning(Query::returning().columns(DEFAULT_COLUMNS))
         .build_sqlx(PostgresQueryBuilder);
 
-    let region = query_as_with(&sql, values).fetch_one(db).await?;
+    let region = query_as_with(&sql, values)
+        .fetch_one(db)
+        .await
+        .resolve_db_err("Region")?;
 
     Ok(region)
 }

--- a/api/src/models/report.rs
+++ b/api/src/models/report.rs
@@ -15,6 +15,7 @@ use uuid::Uuid;
 
 use crate::{
     error::ComhairleError,
+    models::SqlxResultExt,
     routes::{
         feedback::dto::FeedbackDto, report_impacts::dto::ReportImpactDto, reports::dto::ReportDto,
     },
@@ -164,7 +165,7 @@ pub async fn get_by_id(db: &PgPool, id: &Uuid) -> Result<Report, ComhairleError>
     let conversation = sqlx::query_as_with::<_, Report, _>(&sql, values)
         .fetch_one(db)
         .await
-        .map_err(|_| ComhairleError::ResourceNotFound("Conversation".into()))?;
+        .resolve_db_err("Report")?;
 
     Ok(conversation)
 }
@@ -274,7 +275,7 @@ pub async fn get_for_conversation(
     let report = sqlx::query_as_with::<_, Report, _>(&sql, values)
         .fetch_one(db)
         .await
-        .map_err(|_| ComhairleError::ResourceNotFound("Report".into()))?;
+        .resolve_db_err("Report")?;
 
     Ok(report)
 }

--- a/api/src/models/report_impact.rs
+++ b/api/src/models/report_impact.rs
@@ -8,7 +8,7 @@ use sqlx::{PgPool, prelude::FromRow};
 use tracing::instrument;
 use uuid::Uuid;
 
-use crate::error::ComhairleError;
+use crate::{error::ComhairleError, models::SqlxResultExt};
 
 #[derive(Partial, Debug, Deserialize, Serialize, FromRow, Clone, JsonSchema)]
 #[enum_def(table_name = "report_impact")]
@@ -126,5 +126,5 @@ pub async fn get_for_report(
     sqlx::query_as_with::<_, ReportImpact, _>(&sql, values)
         .fetch_all(db)
         .await
-        .map_err(|_| ComhairleError::ResourceNotFound("ReportImpacts".into()))
+        .resolve_db_err("Report Impact")
 }

--- a/api/src/models/scheduled_email.rs
+++ b/api/src/models/scheduled_email.rs
@@ -18,7 +18,10 @@ use fake::Dummy;
 
 use crate::{
     error::ComhairleError,
-    models::pagination::{Order, PageOptions, PaginatedResults},
+    models::{
+        SqlxResultExt,
+        pagination::{Order, PageOptions, PaginatedResults},
+    },
 };
 
 #[derive(Serialize, Deserialize, Debug, FromRow, Clone, JsonSchema)]
@@ -263,10 +266,7 @@ pub async fn get_by_id(db: &PgPool, id: Uuid) -> Result<ScheduledEmail, Comhairl
     let email = query_as_with(&sql, values)
         .fetch_one(db)
         .await
-        .map_err(|e| match e {
-            sqlx::Error::RowNotFound => ComhairleError::ResourceNotFound("Scheduled email".into()),
-            other => ComhairleError::DatabaseError(other),
-        })?;
+        .resolve_db_err("Scheduled Email")?;
 
     Ok(email)
 }
@@ -686,7 +686,7 @@ mod tests {
 
         match err {
             ComhairleError::ResourceNotFound(e) => {
-                assert_eq!(e, "Scheduled email".to_string(), "incorrect error message");
+                assert_eq!(e, "Scheduled Email".to_string(), "incorrect error message");
             }
             _ => panic!("Expected ResourceNotFound error"),
         }

--- a/api/src/models/thinking_space_answer.rs
+++ b/api/src/models/thinking_space_answer.rs
@@ -7,7 +7,7 @@ use sqlx::{PgPool, prelude::FromRow, query_as_with};
 use tracing::instrument;
 use uuid::Uuid;
 
-use crate::error::ComhairleError;
+use crate::{error::ComhairleError, models::SqlxResultExt};
 
 #[cfg(test)]
 use fake::Dummy;
@@ -167,12 +167,7 @@ pub async fn get_by_id(db: &PgPool, id: &Uuid) -> Result<ThinkingSpaceAnswer, Co
     let answer = query_as_with(&sql, values)
         .fetch_one(db)
         .await
-        .map_err(|e| match e {
-            sqlx::Error::RowNotFound => {
-                ComhairleError::ResourceNotFound("Thinking space answer".into())
-            }
-            other => ComhairleError::DatabaseError(other),
-        })?;
+        .resolve_db_err("Thinking Space Answer")?;
 
     Ok(answer)
 }
@@ -667,7 +662,7 @@ mod tests {
 
         match err {
             ComhairleError::ResourceNotFound(message) => {
-                assert!(message.contains("Thinking space answer"))
+                assert!(message.contains("Thinking Space Answer"))
             }
             _ => panic!("Expected ResourceNotFound error"),
         }

--- a/api/src/models/thinking_space_follow_up_question.rs
+++ b/api/src/models/thinking_space_follow_up_question.rs
@@ -7,7 +7,7 @@ use sqlx::{PgPool, prelude::FromRow, query_as_with};
 use tracing::instrument;
 use uuid::Uuid;
 
-use crate::error::ComhairleError;
+use crate::{error::ComhairleError, models::SqlxResultExt};
 
 #[derive(Debug, Deserialize, Serialize, FromRow, Clone, JsonSchema)]
 #[enum_def(table_name = "thinking_space_follow_up_question")]
@@ -122,12 +122,7 @@ pub async fn get_by_id(
     let follow_ups = query_as_with(&sql, values)
         .fetch_one(db)
         .await
-        .map_err(|e| match e {
-            sqlx::Error::RowNotFound => {
-                ComhairleError::ResourceNotFound("Thinking space follow up questions".into())
-            }
-            other => ComhairleError::DatabaseError(other),
-        })?;
+        .resolve_db_err("Thinking Space Follow Up Questions")?;
 
     Ok(follow_ups)
 }
@@ -430,7 +425,7 @@ mod tests {
 
         match err {
             ComhairleError::ResourceNotFound(message) => {
-                assert!(message.contains("Thinking space follow up questions"))
+                assert!(message.contains("Thinking Space Follow Up Questions"))
             }
             _ => panic!("Expected ResourceNotFound error"),
         }

--- a/api/src/models/thinking_space_summary.rs
+++ b/api/src/models/thinking_space_summary.rs
@@ -7,7 +7,7 @@ use sqlx::{PgPool, prelude::FromRow, query_as_with};
 use tracing::instrument;
 use uuid::Uuid;
 
-use crate::error::ComhairleError;
+use crate::{error::ComhairleError, models::SqlxResultExt};
 
 #[derive(Debug, Deserialize, Serialize, FromRow, Clone, JsonSchema)]
 #[enum_def(table_name = "thinking_space_summary")]
@@ -123,12 +123,7 @@ pub async fn get_by_id(db: &PgPool, id: Uuid) -> Result<ThinkingSpaceSummary, Co
     let summary = query_as_with(&sql, values)
         .fetch_one(db)
         .await
-        .map_err(|e| match e {
-            sqlx::Error::RowNotFound => {
-                ComhairleError::ResourceNotFound("Thinking space summary".into())
-            }
-            other => ComhairleError::DatabaseError(other),
-        })?;
+        .resolve_db_err("Thinking Space Summary")?;
 
     Ok(summary)
 }
@@ -398,7 +393,7 @@ mod tests {
 
         match err {
             ComhairleError::ResourceNotFound(message) => {
-                assert!(message.contains("Thinking space summary"))
+                assert!(message.contains("Thinking Space Summary"))
             }
             _ => panic!("Expected ResourceNotFound error"),
         }

--- a/api/src/models/translations.rs
+++ b/api/src/models/translations.rs
@@ -1,7 +1,9 @@
 use std::str::FromStr;
 use std::{fmt, sync::Arc};
 
-use crate::{error::ComhairleError, translation_service::TranslationService};
+use crate::{
+    error::ComhairleError, models::SqlxResultExt, translation_service::TranslationService,
+};
 use chrono::{DateTime, Utc};
 use schemars::JsonSchema;
 use sea_query::{Expr, PostgresQueryBuilder, Query, enum_def};
@@ -476,7 +478,7 @@ pub async fn get_text_content_by_id(
     let text_content = sqlx::query_as_with::<_, TextContent, _>(&sql, values)
         .fetch_one(db)
         .await
-        .map_err(|_| ComhairleError::ResourceNotFound("TextContent".into()))?;
+        .resolve_db_err("Text Content")?;
 
     Ok(text_content)
 }
@@ -524,10 +526,7 @@ pub async fn update_text_content(
     let text_content = sqlx::query_as_with::<_, TextContent, _>(&sql, values)
         .fetch_one(db)
         .await
-        .map_err(|e| match e {
-            sqlx::Error::RowNotFound => ComhairleError::ResourceNotFound("TextContent".into()),
-            _ => ComhairleError::DatabaseError(e),
-        })?;
+        .resolve_db_err("Text Content")?;
 
     Ok(text_content)
 }
@@ -561,7 +560,7 @@ pub async fn delete_text_content(
         .fetch_one(db)
         .await
         .inspect_err(|e| println!("{e:#?}"))
-        .map_err(|_| ComhairleError::ResourceNotFound("TextContent".into()))?;
+        .resolve_db_err("Text Content")?;
 
     Ok(text_content)
 }
@@ -634,7 +633,7 @@ pub async fn get_text_translation_by_id(
     let text_translation = sqlx::query_as_with::<_, TextTranslation, _>(&sql, values)
         .fetch_one(db)
         .await
-        .map_err(|_| ComhairleError::ResourceNotFound("TextTranslation".into()))?;
+        .resolve_db_err("Text Translation")?;
 
     Ok(text_translation)
 }
@@ -701,7 +700,7 @@ pub async fn get_text_translation_by_content_and_locale(
     let text_translation = sqlx::query_as_with::<_, TextTranslation, _>(&sql, values)
         .fetch_one(db)
         .await
-        .map_err(|_| ComhairleError::ResourceNotFound("TextTranslation".into()))?;
+        .resolve_db_err("Text Translation")?;
 
     Ok(text_translation)
 }
@@ -777,7 +776,7 @@ pub async fn delete_text_translation(
     let text_translation = sqlx::query_as_with::<_, TextTranslation, _>(&sql, values)
         .fetch_one(db)
         .await
-        .map_err(|_| ComhairleError::ResourceNotFound("TextTranslation".into()))?;
+        .resolve_db_err("Text Translation")?;
 
     Ok(text_translation)
 }

--- a/api/src/models/user_conversation_preferences.rs
+++ b/api/src/models/user_conversation_preferences.rs
@@ -1,6 +1,6 @@
-use crate::error::ComhairleError;
 use crate::models::conversation_email_notification_recipients::ConversationEmailNotificationRecipientsIden;
 use crate::models::users::UserIden;
+use crate::{error::ComhairleError, models::SqlxResultExt};
 use chrono::{DateTime, Utc};
 use schemars::JsonSchema;
 use sea_query::{Expr, JoinType, PostgresQueryBuilder, Query, UnionType, enum_def};
@@ -141,7 +141,7 @@ pub async fn get_by_user_and_conversation(
     let preferences = sqlx::query_as_with::<_, UserConversationPreferences, _>(&sql, values)
         .fetch_one(db)
         .await
-        .map_err(|_| ComhairleError::ResourceNotFound("UserConversationPreferences".into()))?;
+        .resolve_db_err("User Conversation Preferences")?;
 
     Ok(preferences)
 }
@@ -243,7 +243,7 @@ pub async fn delete(
     let preferences = sqlx::query_as_with::<_, UserConversationPreferences, _>(&sql, values)
         .fetch_one(db)
         .await
-        .map_err(|_| ComhairleError::ResourceNotFound("UserConversationPreferences".into()))?;
+        .resolve_db_err("User Conversation Preferences")?;
 
     Ok(preferences)
 }

--- a/api/src/models/user_participation.rs
+++ b/api/src/models/user_participation.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use sqlx::{PgPool, prelude::FromRow};
 use uuid::Uuid;
 
-use crate::error::ComhairleError;
+use crate::{error::ComhairleError, models::SqlxResultExt};
 
 #[derive(Partial, Debug, Deserialize, Serialize, FromRow, Clone, JsonSchema)]
 #[enum_def(table_name = "user_participation")]
@@ -95,7 +95,7 @@ pub async fn delete(
     let user_participation = sqlx::query_as_with::<_, UserParticipation, _>(&sql, values)
         .fetch_one(db)
         .await
-        .map_err(|_| ComhairleError::ResourceNotFound("UserParticipation".into()))?;
+        .resolve_db_err("User Participation")?;
 
     Ok(user_participation)
 }
@@ -123,7 +123,7 @@ pub async fn check_user_participating(
     sqlx::query_with(&sql, values)
         .fetch_all(db)
         .await
-        .map_err(|_| ComhairleError::ResourceNotFound("UserParticipation".into()))?;
+        .resolve_db_err("User Participation")?;
 
     Ok(())
 }

--- a/api/src/models/user_profile.rs
+++ b/api/src/models/user_profile.rs
@@ -1,4 +1,4 @@
-use crate::error::ComhairleError;
+use crate::{error::ComhairleError, models::SqlxResultExt};
 use chrono::{DateTime, Utc};
 use partially::Partial;
 use schemars::JsonSchema;
@@ -137,7 +137,7 @@ pub async fn get_by_id(db: &PgPool, id: &Uuid) -> Result<UserProfile, ComhairleE
     let profile = sqlx::query_as_with::<_, UserProfile, _>(&sql, values)
         .fetch_one(db)
         .await
-        .map_err(|_| ComhairleError::ResourceNotFound("UserProfile".into()))?;
+        .resolve_db_err("User Profile")?;
 
     Ok(profile)
 }
@@ -152,7 +152,7 @@ pub async fn get_by_user_id(db: &PgPool, user_id: &Uuid) -> Result<UserProfile, 
     let profile = sqlx::query_as_with::<_, UserProfile, _>(&sql, values)
         .fetch_one(db)
         .await
-        .map_err(|_| ComhairleError::ResourceNotFound("UserProfile".into()))?;
+        .resolve_db_err("User Profile")?;
 
     Ok(profile)
 }
@@ -226,7 +226,7 @@ pub async fn delete(db: &PgPool, id: &Uuid) -> Result<UserProfile, ComhairleErro
     let profile = sqlx::query_as_with::<_, UserProfile, _>(&sql, values)
         .fetch_one(db)
         .await
-        .map_err(|_| ComhairleError::ResourceNotFound("UserProfile".into()))?;
+        .resolve_db_err("User Profile")?;
 
     Ok(profile)
 }

--- a/api/src/models/workflow_step.rs
+++ b/api/src/models/workflow_step.rs
@@ -18,7 +18,10 @@ use tracing::{instrument, warn};
 use uuid::Uuid;
 
 use crate::error::ComhairleError;
-use crate::models::user_progress::{self, ProgressStatus, UserProgressIden};
+use crate::models::{
+    SqlxResultExt,
+    user_progress::{self, ProgressStatus, UserProgressIden},
+};
 use crate::tools::{ToolConfig, ToolSetup};
 
 #[derive(Serialize, Deserialize, Debug, Clone, JsonSchema, DbJsonBEnum, PartialEq)]
@@ -259,7 +262,7 @@ pub async fn get_by_id(db: &PgPool, id: &Uuid) -> Result<WorkflowStep, Comhairle
     let workflow_step = sqlx::query_as_with::<_, WorkflowStep, _>(&sql, values)
         .fetch_one(db)
         .await
-        .map_err(|_| ComhairleError::ResourceNotFound("WorkflowStep".into()))?;
+        .resolve_db_err("Workflow Step")?;
 
     Ok(workflow_step)
 }
@@ -283,7 +286,7 @@ pub async fn get_localised_by_id(
     let workflow_step = sqlx::query_as_with::<_, LocalizedWorkflowStep, _>(&sql, values)
         .fetch_one(db)
         .await
-        .map_err(|_| ComhairleError::ResourceNotFound("WorkflowStep".into()))?;
+        .resolve_db_err("Workflow Step")?;
 
     Ok(workflow_step)
 }
@@ -321,7 +324,7 @@ pub async fn delete(
     let deleted_step = sqlx::query_as_with::<_, WorkflowStep, _>(&delete_sql, delete_values)
         .fetch_one(&mut *transaction)
         .await
-        .map_err(|_| ComhairleError::ResourceNotFound("workflow_step".into()))?;
+        .resolve_db_err("Workflow Step")?;
 
     reset_orders(&mut transaction, &deleted_step.workflow_id).await?;
 

--- a/api/src/routes/email_template_configs.rs
+++ b/api/src/routes/email_template_configs.rs
@@ -469,7 +469,7 @@ mod tests {
 
         assert_eq!(
             response.get("err").and_then(|v| v.as_str()).unwrap(),
-            "Email template config not found",
+            "Email Template Config not found",
             "incorrect error message"
         );
 

--- a/api/src/routes/event_attendances.rs
+++ b/api/src/routes/event_attendances.rs
@@ -551,7 +551,7 @@ mod tests {
 
         assert_eq!(
             response.get("err").and_then(|v| v.as_str()).unwrap(),
-            "EventAttendance not found",
+            "Event Attendance not found",
             "incorrect event_id"
         );
 

--- a/ui/packages/api-client/src/api.ts
+++ b/ui/packages/api-client/src/api.ts
@@ -2070,6 +2070,35 @@ export const PreviewEmailTemplateConfigResponse = z
 export type PreviewEmailTemplateConfigResponse = z.infer<
   typeof PreviewEmailTemplateConfigResponse
 >;
+export const ResourcePermission = z
+  .object({
+    grant_reason: z.string(),
+    granted_at: z.string().datetime({ offset: true }),
+    granted_by: z.union([z.string(), z.null()]).optional(),
+    id: z.string().uuid(),
+    organization_id: z.union([z.string(), z.null()]).optional(),
+    resource_id: z.string().uuid(),
+    resource_type: z.string(),
+    role_name: z.string(),
+    user_id: z.union([z.string(), z.null()]).optional(),
+  })
+  .passthrough();
+export type ResourcePermission = z.infer<typeof ResourcePermission>;
+export const PaginatedResults_for_ResourcePermission = z
+  .object({ records: z.array(ResourcePermission), total: z.number().int() })
+  .passthrough();
+export type PaginatedResults_for_ResourcePermission = z.infer<
+  typeof PaginatedResults_for_ResourcePermission
+>;
+export const GrantPermissionBody = z
+  .object({
+    grant_reason: z.string(),
+    organization_id: z.union([z.string(), z.null()]).optional(),
+    role_name: z.string(),
+    user_id: z.union([z.string(), z.null()]).optional(),
+  })
+  .passthrough();
+export type GrantPermissionBody = z.infer<typeof GrantPermissionBody>;
 
 export const schemas: Record<string, z.ZodType<any>> = {
   AnnonLoginRequest,
@@ -2308,6 +2337,9 @@ export const schemas: Record<string, z.ZodType<any>> = {
   EmailTypeSchema,
   PreviewEmailTemplateConfigRequest,
   PreviewEmailTemplateConfigResponse,
+  ResourcePermission,
+  PaginatedResults_for_ResourcePermission,
+  GrantPermissionBody,
 };
 
 const endpoints = makeApi([
@@ -4040,6 +4072,147 @@ curl -X POST \
     description: `Delete an organization`,
     requestFormat: "json",
     response: OrganizationDto,
+  },
+  {
+    method: "get",
+    path: "/permissions",
+    alias: "ListPermissions",
+    description: `Returns role assignments using offset-based pagination. Optionally filter by user_id, organization_id, or role_name. Use the &#x60;offset&#x60; and &#x60;limit&#x60; query params to page through results.`,
+    requestFormat: "json",
+    parameters: [
+      {
+        name: "limit",
+        type: "Query",
+        schema: limit,
+      },
+      {
+        name: "offset",
+        type: "Query",
+        schema: limit,
+      },
+      {
+        name: "organization_id",
+        type: "Query",
+        schema: created_after,
+      },
+      {
+        name: "role_name",
+        type: "Query",
+        schema: created_after,
+      },
+      {
+        name: "user_id",
+        type: "Query",
+        schema: created_after,
+      },
+    ],
+    response: PaginatedResults_for_ResourcePermission,
+  },
+  {
+    method: "get",
+    path: "/permissions/:resource_type/:resource_id",
+    alias: "ListResourcePermissions",
+    description: `Returns role assignments for a specific resource using offset-based pagination. Optionally filter by user_id, organization_id, or role_name. The caller must hold the Owner role on the resource.`,
+    requestFormat: "json",
+    parameters: [
+      {
+        name: "resource_id",
+        type: "Path",
+        schema: z.string().uuid(),
+      },
+      {
+        name: "resource_type",
+        type: "Path",
+        schema: z.string(),
+      },
+      {
+        name: "limit",
+        type: "Query",
+        schema: limit,
+      },
+      {
+        name: "offset",
+        type: "Query",
+        schema: limit,
+      },
+      {
+        name: "organization_id",
+        type: "Query",
+        schema: created_after,
+      },
+      {
+        name: "role_name",
+        type: "Query",
+        schema: created_after,
+      },
+      {
+        name: "user_id",
+        type: "Query",
+        schema: created_after,
+      },
+    ],
+    response: PaginatedResults_for_ResourcePermission,
+  },
+  {
+    method: "post",
+    path: "/permissions/:resource_type/:resource_id",
+    alias: "GrantPermission",
+    description: `Grants a role to a user or organisation on a resource. The caller must hold the Owner role on the resource.`,
+    requestFormat: "json",
+    parameters: [
+      {
+        name: "body",
+        description: `Represents a request body for granting a permission to a user or organization.`,
+        type: "Body",
+        schema: GrantPermissionBody,
+      },
+      {
+        name: "resource_id",
+        type: "Path",
+        schema: z.string().uuid(),
+      },
+      {
+        name: "resource_type",
+        type: "Path",
+        schema: z.string(),
+      },
+    ],
+    response: ResourcePermission,
+  },
+  {
+    method: "delete",
+    path: "/permissions/:resource_type/:resource_id",
+    alias: "RevokePermission",
+    description: `Revokes a role from a user or organisation on a resource. The actor (user_id or organization_id) and role_name are provided as query parameters. The caller must hold the Owner role on the resource.`,
+    requestFormat: "json",
+    parameters: [
+      {
+        name: "resource_id",
+        type: "Path",
+        schema: z.string().uuid(),
+      },
+      {
+        name: "resource_type",
+        type: "Path",
+        schema: z.string(),
+      },
+      {
+        name: "organization_id",
+        type: "Query",
+        schema: created_after,
+      },
+      {
+        name: "role_name",
+        type: "Query",
+        schema: z.string(),
+      },
+      {
+        name: "user_id",
+        type: "Query",
+        schema: created_after,
+      },
+    ],
+    response: z.void(),
   },
   {
     method: "get",

--- a/ui/packages/comhairle/src/lib/components/CommonStepConfig/CommonStepConfig.svelte
+++ b/ui/packages/comhairle/src/lib/components/CommonStepConfig/CommonStepConfig.svelte
@@ -235,8 +235,9 @@
 			<AlertDialog.Header>
 				<AlertDialog.Title>Delete “{name || sourceName || 'this step'}”?</AlertDialog.Title>
 				<AlertDialog.Description>
-					This permanently removes the step and its configuration, and renumbers the
-					remaining steps. This action cannot be undone.
+					This permanently removes the step and its configuration along with any
+					associated data (e.g. user participation data), and renumbers the remaining
+					steps. This action cannot be undone.
 				</AlertDialog.Description>
 			</AlertDialog.Header>
 


### PR DESCRIPTION
Actions:

+ refactor not_found_as trait method to resolve_db_err and extend to
  cover mapping contraint violations as Conflict (409) variant
+ refactor manual mapping of sqlx errors for not found to use
  resolve_db_err
+ migration to replace user_progress workflow_step foreign key
  constraint with same constraint + on delete cascade
+ update delete step message to warn of user data deletion

Motivation:

+ better error handling for frontend use cases
+ dry up code and cover conflict cases instead of mapping all db errors
  to ResourceNotFound (404)
+ allow steps with user_progress rows added to be deleted