### PR TITLE
584 default env for fallback convo image

### DIFF
--- a/api/src/config.rs
+++ b/api/src/config.rs
@@ -18,6 +18,7 @@ pub fn load() -> Result<ComhairleConfig, ComhairleError> {
         )?
         .set_default("redis_cache_ttl_secs", 300)?
         .set_default("domain", "http://localhost:5173")?
+        .set_default("default_conversation_image_url", "https://comhairle-media.s3.amazonaws.com/images/comhairle-conversation-placeholder.png")?
         .set_default("enable_rate_limiting", true)?
         .set_default("mailer.host", "")?
         .set_default("mailer.user", "")?


### PR DESCRIPTION
Actions:

+ provide default env value for fallback conversation image url

Motivation:

+ not really a secret and prevents config updates for local users and deployments