### PR TITLE
613 Polis admin: server-side endpoints for native management (PR 0/4)

### DIFF
--- a/api/src/tools/polis.rs
+++ b/api/src/tools/polis.rs
@@ -28,7 +28,8 @@ use crate::{
     },
     routes::auth::RequiredUser,
     wiki_poll_service::{
-        ModerationStatus, WikiPollLogin, WikiPollService, polis_service::WikiPollReport,
+        ModerationStatus, WikiPoll, WikiPollConfigUpdate, WikiPollLogin, WikiPollService,
+        polis_service::WikiPollReport,
     },
 };
 
@@ -132,6 +133,35 @@ impl ToolImpl for PolisTool {
                         .tag("Tools")
                         .summary("Get Polis report data for a workflow step")
                         .description("Fetches the polis data export for a given workflow step")
+                        .response::<200, Json<WikiPollReport>>()
+                }),
+            )
+            .api_route(
+                "/polis/config",
+                put_with(update_polis_config, |op| {
+                    op.id("PolisUpdateConfig")
+                        .tag("Tools")
+                        .summary("Update the Polis conversation configuration")
+                        .description(
+                            "Proxies topic, description, strict_moderation and is_active to the \
+                             Polis conversation via the server-side admin session. Only provided \
+                             fields are written.",
+                        )
+                        .response::<200, Json<WikiPoll>>()
+                }),
+            )
+            .api_route(
+                "/polis/seed",
+                post_with(post_seed, |op| {
+                    op.id("PolisPostSeed")
+                        .tag("Tools")
+                        .summary("Post a seed statement to the Polis conversation")
+                        .description(
+                            "Posts a moderator-authored seed statement (is_seed) to the active \
+                             Polis poll via the server-side admin session. Re-sync to surface it \
+                             in the local statement_aux table.",
+                        )
+                        .response::<201, Json<PostSeedResponse>>()
                 }),
             )
             .api_route(
@@ -370,6 +400,106 @@ async fn get_report_data(
         .await?;
 
     Ok((StatusCode::OK, Json(data)))
+}
+
+#[derive(Serialize, Deserialize, JsonSchema, Debug)]
+pub struct UpdatePolisConfigRequest {
+    pub workflow_step_id: Uuid,
+    pub is_active: Option<bool>,
+    pub topic: Option<String>,
+    pub description: Option<String>,
+    pub strict_moderation: Option<bool>,
+}
+
+/// Writes Polis conversation-level configuration (topic, description,
+/// strict_moderation, is_active) through the server-side admin session.
+#[instrument(err(Debug), skip(state))]
+async fn update_polis_config(
+    State(state): State<Arc<ComhairleState>>,
+    RequiredUser(user): RequiredUser,
+    Json(request): Json<UpdatePolisConfigRequest>,
+) -> Result<(StatusCode, Json<WikiPoll>), ComhairleError> {
+    let workflow_step =
+        models::workflow_step::get_by_id(&state.db, &request.workflow_step_id).await?;
+    models::workflow::check_user_is_owner(&state.db, &workflow_step.workflow_id, &user.id).await?;
+
+    let config = match (workflow_step.tool_config, workflow_step.preview_tool_config) {
+        (Some(ToolConfig::Polis(config)), _) => config,
+        (None, ToolConfig::Polis(config)) => config,
+        _ => return Err(ComhairleError::WorkflowStepHasWrongType("Polis".into())),
+    };
+
+    let client = &state.wiki_poll_service;
+    let auth_cookies = client
+        .login(&WikiPollLogin {
+            email: config.admin_user.clone(),
+            password: config.admin_password.clone(),
+        })
+        .await?;
+
+    let poll = client
+        .update_poll_config(
+            &config.poll_id,
+            &auth_cookies,
+            &WikiPollConfigUpdate {
+                is_active: request.is_active,
+                topic: request.topic,
+                description: request.description,
+                strict_moderation: request.strict_moderation,
+            },
+        )
+        .await?;
+
+    Ok((StatusCode::OK, Json(poll)))
+}
+
+#[derive(Serialize, Deserialize, JsonSchema, Debug)]
+pub struct PostSeedRequest {
+    pub workflow_step_id: Uuid,
+    pub statement_text: String,
+}
+
+#[derive(Serialize, Deserialize, JsonSchema, Debug)]
+pub struct PostSeedResponse {
+    /// The Polis statement id (tid) of the newly created seed.
+    pub polis_statement_id: String,
+}
+
+/// Posts a moderator-authored seed statement to the active Polis poll through
+/// the server-side admin session. Callers should re-sync afterwards to surface
+/// the seed in the local statement_aux table.
+#[instrument(err(Debug), skip(state))]
+async fn post_seed(
+    State(state): State<Arc<ComhairleState>>,
+    RequiredUser(user): RequiredUser,
+    Json(request): Json<PostSeedRequest>,
+) -> Result<(StatusCode, Json<PostSeedResponse>), ComhairleError> {
+    let workflow_step =
+        models::workflow_step::get_by_id(&state.db, &request.workflow_step_id).await?;
+    models::workflow::check_user_is_owner(&state.db, &workflow_step.workflow_id, &user.id).await?;
+
+    let config = match (workflow_step.tool_config, workflow_step.preview_tool_config) {
+        (Some(ToolConfig::Polis(config)), _) => config,
+        (None, ToolConfig::Polis(config)) => config,
+        _ => return Err(ComhairleError::WorkflowStepHasWrongType("Polis".into())),
+    };
+
+    let client = &state.wiki_poll_service;
+    let auth_cookies = client
+        .login(&WikiPollLogin {
+            email: config.admin_user.clone(),
+            password: config.admin_password.clone(),
+        })
+        .await?;
+
+    let polis_statement_id = client
+        .post_seed_comment(&request.statement_text, &config.poll_id, &auth_cookies)
+        .await?;
+
+    Ok((
+        StatusCode::CREATED,
+        Json(PostSeedResponse { polis_statement_id }),
+    ))
 }
 
 #[instrument(err(Debug), skip(state))]

--- a/api/src/tools/polis.rs
+++ b/api/src/tools/polis.rs
@@ -26,7 +26,7 @@ use crate::{
             ThemeStatistic, UpdatePolisStatementAux, UpsertFromPolis,
         },
     },
-    routes::auth::RequiredUser,
+    routes::auth::{RequiredAdminUser, RequiredUser},
     wiki_poll_service::{
         ModerationStatus, WikiPoll, WikiPollConfigUpdate, WikiPollLogin, WikiPollService,
         polis_service::WikiPollReport,
@@ -416,7 +416,7 @@ pub struct UpdatePolisConfigRequest {
 #[instrument(err(Debug), skip(state))]
 async fn update_polis_config(
     State(state): State<Arc<ComhairleState>>,
-    RequiredUser(user): RequiredUser,
+    RequiredAdminUser(user): RequiredAdminUser,
     Json(request): Json<UpdatePolisConfigRequest>,
 ) -> Result<(StatusCode, Json<WikiPoll>), ComhairleError> {
     let workflow_step =
@@ -471,7 +471,7 @@ pub struct PostSeedResponse {
 #[instrument(err(Debug), skip(state))]
 async fn post_seed(
     State(state): State<Arc<ComhairleState>>,
-    RequiredUser(user): RequiredUser,
+    RequiredAdminUser(user): RequiredAdminUser,
     Json(request): Json<PostSeedRequest>,
 ) -> Result<(StatusCode, Json<PostSeedResponse>), ComhairleError> {
     let workflow_step =

--- a/api/src/wiki_poll_service.rs
+++ b/api/src/wiki_poll_service.rs
@@ -88,6 +88,13 @@ pub trait WikiPollService: Send + Sync {
         poll_id: &str,
         auth_cookies: &str,
     ) -> Result<WikiPoll, WikiPollServiceError>;
+
+    async fn update_poll_config(
+        &self,
+        poll_id: &str,
+        auth_cookies: &str,
+        config: &WikiPollConfigUpdate,
+    ) -> Result<WikiPoll, WikiPollServiceError>;
 }
 
 impl ModerationStatus {
@@ -130,10 +137,20 @@ pub struct WikiPollXid {
     pub xid: String,
 }
 
-#[derive(Deserialize, Serialize, Debug, Default)]
+#[derive(Deserialize, Serialize, Debug, Default, JsonSchema)]
 pub struct WikiPoll {
     pub poll_id: String,
     pub is_active: Option<bool>,
+}
+
+/// Abstract, poll-provider-agnostic conversation-config update. Only the
+/// `Some` fields are written through to the underlying poll.
+#[derive(Deserialize, Serialize, Debug, Default)]
+pub struct WikiPollConfigUpdate {
+    pub is_active: Option<bool>,
+    pub topic: Option<String>,
+    pub description: Option<String>,
+    pub strict_moderation: Option<bool>,
 }
 
 #[cfg(test)]
@@ -174,6 +191,15 @@ impl MockWikiPollService {
                 })
             })
         });
+        wiki_poll_service
+            .expect_update_poll_config()
+            .returning(|_, _, _| {
+                Box::pin(async move {
+                    Ok(WikiPoll {
+                        ..Default::default()
+                    })
+                })
+            });
 
         wiki_poll_service
     }

--- a/api/src/wiki_poll_service/polis_service.rs
+++ b/api/src/wiki_poll_service/polis_service.rs
@@ -15,7 +15,8 @@ use tracing::{info, instrument, warn};
 use crate::tools::polis::PolisError;
 use crate::wiki_poll_service::error::WikiPollServiceError;
 use crate::wiki_poll_service::{
-    ModerationStatus, WikiPoll, WikiPollComment, WikiPollLogin, WikiPollService, WikiPollXid,
+    ModerationStatus, WikiPoll, WikiPollComment, WikiPollConfigUpdate, WikiPollLogin,
+    WikiPollService, WikiPollXid,
 };
 
 // Raw Polis API response structures
@@ -197,9 +198,16 @@ impl From<PolisPoll> for WikiPoll {
     }
 }
 
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, Default)]
 pub struct UpdatePollRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub is_active: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub topic: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub strict_moderation: Option<bool>,
 }
 
 impl PolisClient {
@@ -571,6 +579,29 @@ impl WikiPollService for PolisClient {
                 auth_cookies,
                 &UpdatePollRequest {
                     is_active: Some(false),
+                    ..Default::default()
+                },
+            )
+            .await?;
+
+        Ok(poll.into())
+    }
+
+    async fn update_poll_config(
+        &self,
+        poll_id: &str,
+        auth_cookies: &str,
+        config: &WikiPollConfigUpdate,
+    ) -> Result<WikiPoll, WikiPollServiceError> {
+        let poll = self
+            .update_poll(
+                poll_id,
+                auth_cookies,
+                &UpdatePollRequest {
+                    is_active: config.is_active,
+                    topic: config.topic.clone(),
+                    description: config.description.clone(),
+                    strict_moderation: config.strict_moderation,
                 },
             )
             .await?;
@@ -838,6 +869,7 @@ mod tests {
                 &cookies,
                 &UpdatePollRequest {
                     is_active: Some(false),
+                    ..Default::default()
                 },
             )
             .await?;
@@ -850,6 +882,7 @@ mod tests {
                 &cookies,
                 &UpdatePollRequest {
                     is_active: Some(true),
+                    ..Default::default()
                 },
             )
             .await?;

--- a/ui/packages/api-client/src/api.ts
+++ b/ui/packages/api-client/src/api.ts
@@ -344,6 +344,93 @@ export const CreateOrUpdateTextTranslationRequest = z
 export type CreateOrUpdateTextTranslationRequest = z.infer<
   typeof CreateOrUpdateTextTranslationRequest
 >;
+export const GroupVoteCounts = z
+  .object({
+    agrees: z.number().int().gte(0),
+    disagrees: z.number().int().gte(0),
+    group_id: z.number().int().gte(0),
+    passes: z.number().int().gte(0),
+  })
+  .passthrough();
+export type GroupVoteCounts = z.infer<typeof GroupVoteCounts>;
+export const VoteCounts = z
+  .object({
+    agrees: z.number().int().gte(0),
+    disagrees: z.number().int().gte(0),
+    passes: z.number().int().gte(0),
+  })
+  .passthrough();
+export type VoteCounts = z.infer<typeof VoteCounts>;
+export const CommentReportData = z
+  .object({
+    divisiveness: z.union([z.number(), z.null()]).optional(),
+    group_informed_consensus: z.union([z.number(), z.null()]).optional(),
+    group_votes: z.array(GroupVoteCounts),
+    is_seed: z.boolean(),
+    overall_votes: VoteCounts,
+    text: z.string(),
+    tid: z.number().int().gte(0),
+  })
+  .passthrough();
+export type CommentReportData = z.infer<typeof CommentReportData>;
+export const RepresentativeComment = z
+  .object({ text: z.string(), tid: z.number().int().gte(0) })
+  .passthrough();
+export type RepresentativeComment = z.infer<typeof RepresentativeComment>;
+export const GroupReportData = z
+  .object({
+    group_id: z.number().int().gte(0),
+    members: z.array(z.number().int().gte(0)),
+    representative_comments: z.array(RepresentativeComment),
+    total_members: z.number().int().gte(0),
+  })
+  .passthrough();
+export type GroupReportData = z.infer<typeof GroupReportData>;
+export const PcaPosition = z
+  .object({ x: z.number(), y: z.number() })
+  .passthrough();
+export type PcaPosition = z.infer<typeof PcaPosition>;
+export const ParticipantReportData = z
+  .object({
+    group_id: z.union([z.number(), z.null()]).optional(),
+    pca_position: z.union([PcaPosition, z.null()]).optional(),
+    pid: z.number().int().gte(0),
+  })
+  .passthrough();
+export type ParticipantReportData = z.infer<typeof ParticipantReportData>;
+export const WikiPollReport = z
+  .object({
+    comments: z.array(CommentReportData),
+    groups: z.array(GroupReportData),
+    participants: z.array(ParticipantReportData),
+  })
+  .passthrough();
+export type WikiPollReport = z.infer<typeof WikiPollReport>;
+export const UpdatePolisConfigRequest = z
+  .object({
+    description: z.union([z.string(), z.null()]).optional(),
+    is_active: z.union([z.boolean(), z.null()]).optional(),
+    strict_moderation: z.union([z.boolean(), z.null()]).optional(),
+    topic: z.union([z.string(), z.null()]).optional(),
+    workflow_step_id: z.string().uuid(),
+  })
+  .passthrough();
+export type UpdatePolisConfigRequest = z.infer<typeof UpdatePolisConfigRequest>;
+export const WikiPoll = z
+  .object({
+    is_active: z.union([z.boolean(), z.null()]).optional(),
+    poll_id: z.string(),
+  })
+  .passthrough();
+export type WikiPoll = z.infer<typeof WikiPoll>;
+export const PostSeedRequest = z
+  .object({ statement_text: z.string(), workflow_step_id: z.string().uuid() })
+  .passthrough();
+export type PostSeedRequest = z.infer<typeof PostSeedRequest>;
+export const PostSeedResponse = z
+  .object({ polis_statement_id: z.string() })
+  .passthrough();
+export type PostSeedResponse = z.infer<typeof PostSeedResponse>;
 export const ModerationStatus = z.enum(["accepted", "rejected", "pending"]);
 export type ModerationStatus = z.infer<typeof ModerationStatus>;
 export const PolisStatementAux = z
@@ -2144,6 +2231,18 @@ export const schemas: Record<string, z.ZodType<any>> = {
   UpdateTextContent,
   UpdateTextTranslation,
   CreateOrUpdateTextTranslationRequest,
+  GroupVoteCounts,
+  VoteCounts,
+  CommentReportData,
+  RepresentativeComment,
+  GroupReportData,
+  PcaPosition,
+  ParticipantReportData,
+  WikiPollReport,
+  UpdatePolisConfigRequest,
+  WikiPoll,
+  PostSeedRequest,
+  PostSeedResponse,
   ModerationStatus,
   PolisStatementAux,
   CreatePolisStatementAux,
@@ -4332,6 +4431,21 @@ Use a raw HTTP request and process the response body incrementally.
     response: z.void(),
   },
   {
+    method: "put",
+    path: "/tools/polis/config",
+    alias: "PolisUpdateConfig",
+    description: `Proxies topic, description, strict_moderation and is_active to the Polis conversation via the server-side admin session. Only provided fields are written.`,
+    requestFormat: "json",
+    parameters: [
+      {
+        name: "body",
+        type: "Body",
+        schema: UpdatePolisConfigRequest,
+      },
+    ],
+    response: WikiPoll,
+  },
+  {
     method: "get",
     path: "/tools/polis/report_data",
     alias: "PolisGetReportData",
@@ -4344,7 +4458,22 @@ Use a raw HTTP request and process the response body incrementally.
         schema: z.string().uuid(),
       },
     ],
-    response: z.void(),
+    response: WikiPollReport,
+  },
+  {
+    method: "post",
+    path: "/tools/polis/seed",
+    alias: "PolisPostSeed",
+    description: `Posts a moderator-authored seed statement (is_seed) to the active Polis poll via the server-side admin session. Re-sync to surface it in the local statement_aux table.`,
+    requestFormat: "json",
+    parameters: [
+      {
+        name: "body",
+        type: "Body",
+        schema: PostSeedRequest,
+      },
+    ],
+    response: z.object({ polis_statement_id: z.string() }).passthrough(),
   },
   {
     method: "get",


### PR DESCRIPTION
<p>We're replacing the embedded <strong>Pol.is admin iframe</strong> with a native comhairle UI (more PRs coming up). The new Setup / Moderation / Insights tabs all need to <em>read from</em> and <em>write to</em> Pol.is, but today the only Pol.is config path is the iframe's browser-side <code>POLIS_LOGIN</code>, and the backend's write methods (<code>update_poll</code>, <code>post_seed_comment</code>) are internal-only. The report export is also returned untyped (<code>z.void()</code>).</p>

<p>This PR is <strong>backend + generated client only, no UI</strong> it adds three endpoints the future PRs depend on, so the reviews after this are pure frontend. 


Endpoint | Method | Purpose
-- | -- | --
PolisUpdateConfig | PUT /tools/polis/config | Writes conversation config (topic, description, strict_moderation, is_active) to Pol.is via the server-side admin session → powers the Setup tab
PolisPostSeed | POST /tools/polis/seed | Posts a moderator seed statement (is_seed) to the active poll → powers add-seed in Setup + Moderation
PolisGetReportData | GET /tools/polis/report_data | Now typed as WikiPollReport (was void) → powers Insights


<p><strong>Backend</strong></p>
<ul>
<li><code>wiki_poll_service.rs</code>: new provider-agnostic <code>WikiPollConfigUpdate</code> + <code>update_poll_config</code> trait method; <code>WikiPoll</code> now derives <code>JsonSchema</code>.</li>
<li><code>polis_service.rs</code>: widened <code>UpdatePollRequest</code> (only <code>Some</code> fields are PUT, so we never blank an unset field); implemented <code>update_poll_config</code> over the existing <code>update_poll</code>.</li>
<li><code>tools/polis.rs</code>: two owner-checked handlers + the one-line <code>.response::&lt;200, Json&lt;WikiPollReport&gt;&gt;()</code> typing.</li>
</ul>
<p><strong>Client</strong></p>
<ul>
<li>Regenerated <code>api.ts</code>: <code>PolisUpdateConfig</code>, <code>PolisPostSeed</code>, and a typed <code>PolisGetReportData</code>.</li>
</ul>
<h2>Decisions</h2>
<ul>
<li><strong>Config is written server-side, not via the iframe or a browser-side Pol.is login.</strong> The backend already authenticates to Pol.is as admin (<code>polis_service::login</code>); we reuse it. No Pol.is credentials in the browser.</li>
<li><strong>Only Pol.is-owned fields are proxied here.</strong> comhairle display flags (<code>required_votes</code>, <code>show_remaining_statements</code>, "label seeds as conversation starter") stay in <code>tool_config</code> via the existing <code>UpdateConversationWorkflowStep</code> not part of this PR.</li>
<li><strong><code>report_data</code> is typed via the backend, not hand-copied types.</strong> Adding the aide <code>.response()</code> annotation regenerates a typed client method, strictly better than fetching it raw. (civic_os's local mirror types can migrate onto this later.)</li>
<li><strong>Seed posting is one responsibility.</strong> The endpoint posts to Pol.is and returns the new <code>tid</code>; callers re-sync (<code>PolisSyncStatementAux</code>) to surface it in <code>statement_aux</code>. Matches the existing sync-driven model.</li>
</ul>
<h2>Assumptions / things reviewers should know</h2>
<ul>
<li>⚠️ <strong><code>launch</code> mints a <em>fresh</em> live Pol.is poll and migrates only seed <em>text</em>.</strong> Moderation status / themes set on the preview poll do <strong>not</strong> carry over, and rejected seeds aren't filtered yet (pre-existing <code>// TODO: filter seed statements</code>). <strong>Not touched here</strong>, flagged as a follow-up so pre-launch moderation eventually survives launch.</li>
<li>Config writes target the <strong>active</strong> poll, preview while the conversation is a draft, live once launched (same <code>isLive</code> split the step editor already uses).</li>
<li>Both new routes are <strong>owner-gated</strong> (<code>check_user_is_owner</code>), consistent with sync/moderate.</li>
<li><code>WikiPollConfigUpdate</code> is intentionally provider-agnostic (mirrors the <code>WikiPoll</code>/<code>WikiPollComment</code> abstraction) even though Pol.is is the only implementation today.</li>
</ul>
<h2>Testing</h2>
<ul>
<li><code>cargo check</code> (lib + <code>--tests</code>) clean; mock (<code>MockWikiPollService::base</code>) updated for the new trait method.</li>
<li>Spec + client regenerated (<code>--export-api-spec</code> → <code>generateAPI</code>); <code>report_data</code> 200 now references <code>WikiPollReport</code>. The single <code>tsc</code> <code>TS7056</code> on <code>makeApi([...])</code> is <strong>pre-existing</strong> (present on the base branch).</li>
</ul>
<h2>Follow-ups (not this PR)</h2>

- moderation tab
- insights tab 
- native setup + remove iframe 
- launch rejected-seed filter (+ aux migration maybe)

