### PR TITLE
613/Polis admin: Moderation tab (PR 2/4)

### DIFF
--- a/ui/packages/comhairle/src/lib/tools/polis/PolisModeration.svelte
+++ b/ui/packages/comhairle/src/lib/tools/polis/PolisModeration.svelte
@@ -75,10 +75,10 @@
 		const text = draftText.trim();
 		if (!text || addingSeed) return;
 		addingSeed = true;
-		const { err } = await tryCatchAsync(() => postSeeds([text]));
+		const result = await tryCatchAsync(() => postSeeds([text]));
 		addingSeed = false;
-		if (err) {
-			console.error('PolisPostSeed failed', err);
+		if (result.err !== null) {
+			console.error('PolisPostSeed failed', result.err);
 			notifications.send({ priority: 'ERROR', message: 'Failed to add statement' });
 			return;
 		}
@@ -93,7 +93,7 @@
 		if (!file || csvImporting) return;
 		csvImporting = true;
 
-		const { ok: count, err } = await tryCatchAsync(async () => {
+		const result = await tryCatchAsync(async () => {
 			// One statement per line; strip wrapping quotes and a leading header row.
 			const lines = (await file.text())
 				.split(/\r?\n/)
@@ -108,15 +108,15 @@
 		csvImporting = false;
 		input.value = '';
 
-		if (err) {
-			console.error('CSV import failed', err);
+		if (result.err !== null) {
+			console.error('CSV import failed', result.err);
 			notifications.send({ priority: 'ERROR', message: 'CSV import failed' });
 			return;
 		}
-		if (count) {
+		if (result.ok) {
 			notifications.send({
 				priority: 'INFO',
-				message: `Imported ${count} statement${count === 1 ? '' : 's'}`
+				message: `Imported ${result.ok} statement${result.ok === 1 ? '' : 's'}`
 			});
 		}
 		showAddForm = false;

--- a/ui/packages/comhairle/src/lib/tools/polis/PolisModeration.svelte
+++ b/ui/packages/comhairle/src/lib/tools/polis/PolisModeration.svelte
@@ -1,0 +1,341 @@
+<script lang="ts">
+	import { invalidate } from '$app/navigation';
+	import { Button, LoadingButton } from '$lib/components/ui/button';
+	import { Textarea } from '$lib/components/ui/textarea';
+	import * as Card from '$lib/components/ui/card';
+	import * as Dialog from '$lib/components/ui/dialog';
+	import { notifications } from '$lib/notifications.svelte';
+	import { apiClient } from '@crownshy/api-client/client';
+	import type { PolisStatementAux } from '@crownshy/api-client/api';
+	import { Check, X, Plus, Upload, RefreshCw } from '@lucide/svelte';
+
+	let {
+		workflowStepId,
+		statements: initialStatements
+	}: {
+		workflowStepId: string;
+		statements: PolisStatementAux[];
+	} = $props();
+
+	// Local mutable copy so optimistic accept/reject re-renders without a refetch.
+	// Reset whenever the load re-runs (sync/seed invalidate `polis:statement-aux`).
+	let statements = $state<PolisStatementAux[]>(initialStatements);
+	$effect(() => {
+		statements = initialStatements;
+	});
+
+	// --- Sync from Polis ---
+	// Participant submissions only appear here after a sync — aux rows are synced
+	// from Polis, not created live. Existing moderation/themes are preserved.
+	let syncing = $state(false);
+
+	async function syncFromPolis() {
+		if (syncing) return;
+		syncing = true;
+		try {
+			const res = await apiClient.PolisSyncStatementAux({ workflow_step_id: workflowStepId });
+			notifications.send({
+				priority: 'INFO',
+				message: `Synced ${res.synced} statement${res.synced === 1 ? '' : 's'} from Polis${
+					res.skipped_invalid_xid ? ` (${res.skipped_invalid_xid} skipped)` : ''
+				}`
+			});
+			await invalidate('polis:statement-aux');
+		} catch (e) {
+			console.error('PolisSyncStatementAux failed', e);
+			notifications.send({
+				priority: 'ERROR',
+				message: 'Failed to sync statements from Polis'
+			});
+		} finally {
+			syncing = false;
+		}
+	}
+
+	// --- Add seed statements (moderator authoring) ---
+	// Seeds are posted server-side to the active poll via PolisPostSeed (no
+	// browser-side Polis auth / CORS), then we re-sync so the new comment comes
+	// back with its real Polis-issued ids.
+	let showAddForm = $state(false);
+	let draftText = $state('');
+	let addingSeed = $state(false);
+	let csvImporting = $state(false);
+	let fileInput = $state<HTMLInputElement>();
+
+	async function postSeeds(texts: string[]) {
+		for (const statement_text of texts) {
+			await apiClient.PolisPostSeed({ workflow_step_id: workflowStepId, statement_text });
+		}
+		await apiClient.PolisSyncStatementAux({ workflow_step_id: workflowStepId });
+		await invalidate('polis:statement-aux');
+	}
+
+	async function addSeed() {
+		const text = draftText.trim();
+		if (!text || addingSeed) return;
+		addingSeed = true;
+		try {
+			await postSeeds([text]);
+			draftText = '';
+			showAddForm = false;
+			notifications.send({ priority: 'INFO', message: 'Seed statement added' });
+		} catch (e) {
+			console.error('PolisPostSeed failed', e);
+			notifications.send({ priority: 'ERROR', message: 'Failed to add statement' });
+		} finally {
+			addingSeed = false;
+		}
+	}
+
+	async function importCsv(e: Event) {
+		const input = e.currentTarget as HTMLInputElement;
+		const file = input.files?.[0];
+		if (!file || csvImporting) return;
+		csvImporting = true;
+		try {
+			// One statement per line; strip wrapping quotes and a leading header row.
+			const lines = (await file.text())
+				.split(/\r?\n/)
+				.map((l) => l.replace(/^"(.*)"$/, '$1').trim())
+				.filter(Boolean);
+			if (['statement', 'statements', 'text'].includes(lines[0]?.toLowerCase())) {
+				lines.shift();
+			}
+			if (lines.length) {
+				await postSeeds(lines);
+				notifications.send({
+					priority: 'INFO',
+					message: `Imported ${lines.length} statement${lines.length === 1 ? '' : 's'}`
+				});
+			}
+			showAddForm = false;
+		} catch (err) {
+			console.error('CSV import failed', err);
+			notifications.send({ priority: 'ERROR', message: 'CSV import failed' });
+		} finally {
+			csvImporting = false;
+			input.value = '';
+		}
+	}
+
+	// --- Status filters ---
+	type Filter = 'all' | 'seeded' | 'accepted' | 'pending' | 'rejected';
+	let filter = $state<Filter>('all');
+
+	const counts = $derived({
+		all: statements.length,
+		seeded: statements.filter((s) => s.is_seed).length,
+		accepted: statements.filter((s) => s.moderation_status === 'accepted').length,
+		pending: statements.filter((s) => s.moderation_status === 'pending').length,
+		rejected: statements.filter((s) => s.moderation_status === 'rejected').length
+	});
+
+	const visible = $derived.by(() => {
+		let list = statements;
+		if (filter === 'seeded') list = list.filter((s) => s.is_seed);
+		else if (filter !== 'all') list = list.filter((s) => s.moderation_status === filter);
+		return [...list].sort((a, b) => b.polis_statement_id - a.polis_statement_id);
+	});
+
+	const filters: { key: Filter; label: string }[] = [
+		{ key: 'all', label: 'All' },
+		{ key: 'seeded', label: 'Seeded' },
+		{ key: 'accepted', label: 'Accepted' },
+		{ key: 'pending', label: 'Pending' },
+		{ key: 'rejected', label: 'Rejected' }
+	];
+
+	// --- Accept / reject ---
+	// Track in-flight requests per aux row so the buttons can disable mid-call.
+	let pending = $state<Record<string, boolean>>({});
+
+	async function setStatus(row: PolisStatementAux, status: 'accepted' | 'rejected') {
+		if (pending[row.id] || row.moderation_status === status) return;
+		const decision = status === 'accepted' ? 'accept' : 'reject';
+		pending = { ...pending, [row.id]: true };
+
+		// Optimistic update; roll back on failure.
+		const prevStatus = row.moderation_status;
+		statements = statements.map((s) =>
+			s.id === row.id ? { ...s, moderation_status: status } : s
+		);
+
+		try {
+			const updated = await apiClient.PolisModerateStatementAux(
+				{ decision },
+				{ params: { id: row.id } }
+			);
+			statements = statements.map((s) => (s.id === row.id ? updated : s));
+		} catch (e) {
+			console.error('PolisModerateStatementAux failed', e);
+			statements = statements.map((s) =>
+				s.id === row.id ? { ...s, moderation_status: prevStatus } : s
+			);
+			notifications.send({ priority: 'ERROR', message: 'Failed to update statement' });
+		} finally {
+			pending = { ...pending, [row.id]: false };
+		}
+	}
+
+	// Left accent bar colour keyed on seed/status. Olive-green primary stands in
+	// for "accepted"; there is no dedicated success token in the theme.
+	function accentFor(row: PolisStatementAux): string {
+		if (row.is_seed) return 'bg-accent';
+		if (row.moderation_status === 'accepted') return 'bg-primary';
+		if (row.moderation_status === 'rejected') return 'bg-destructive';
+		return 'bg-muted-foreground/40';
+	}
+</script>
+
+<div class="flex flex-col gap-6">
+	<!-- Heading + actions -->
+	<div class="flex items-start justify-between gap-4">
+		<div class="flex max-w-3xl flex-col gap-1">
+			<h2 class="text-2xl font-bold">Statements moderation</h2>
+			<p class="text-muted-foreground text-sm">Moderate and view all statements.</p>
+		</div>
+		<div class="flex shrink-0 items-center gap-2">
+			<LoadingButton
+				loading={syncing}
+				variant="outline"
+				onclick={syncFromPolis}
+				title="Pull the latest submitted statements from Polis"
+			>
+				<RefreshCw class="size-4" />
+				Sync from Polis
+			</LoadingButton>
+			<Button onclick={() => (showAddForm = true)} title="Add seed statements as moderator">
+				<Plus class="size-4" />
+				Add seed statements
+			</Button>
+		</div>
+	</div>
+
+	<!-- Add seed statements dialog -->
+	<Dialog.Root bind:open={showAddForm}>
+		<Dialog.Content class="sm:max-w-xl">
+			<Dialog.Header>
+				<Dialog.Title>Add seed statements</Dialog.Title>
+				<Dialog.Description>
+					Post statements to seed the conversation, or import many at once from a CSV.
+				</Dialog.Description>
+			</Dialog.Header>
+
+			<div class="flex flex-col gap-3">
+				<label class="text-muted-foreground text-sm font-medium" for="seed-text">
+					Write a statement
+				</label>
+				<Textarea
+					id="seed-text"
+					bind:value={draftText}
+					rows={3}
+					placeholder="Write a seed statement…"
+				/>
+
+				<div class="text-muted-foreground flex items-center gap-2 text-sm">
+					<span>or</span>
+					<Button
+						variant="secondary"
+						size="sm"
+						onclick={() => fileInput?.click()}
+						disabled={csvImporting}
+						title="Import seed statements from a CSV (one statement per line)"
+					>
+						<Upload class="size-4" />
+						{csvImporting ? 'Importing…' : 'Import CSV'}
+					</Button>
+					<span>to add many at once</span>
+				</div>
+				<input
+					bind:this={fileInput}
+					type="file"
+					accept=".csv,.txt"
+					class="hidden"
+					onchange={importCsv}
+				/>
+			</div>
+
+			<Dialog.Footer>
+				<Button variant="secondary" onclick={() => (showAddForm = false)}>Cancel</Button>
+				<Button onclick={addSeed} disabled={!draftText.trim() || addingSeed}>
+					{addingSeed ? 'Posting…' : 'Post seed'}
+				</Button>
+			</Dialog.Footer>
+		</Dialog.Content>
+	</Dialog.Root>
+
+	<!-- Status filter chips -->
+	<div class="flex flex-wrap items-center gap-2">
+		{#each filters as f (f.key)}
+			<button
+				type="button"
+				onclick={() => (filter = f.key)}
+				class={`inline-flex cursor-pointer items-center rounded-full px-3.5 py-2 text-sm font-medium transition-colors ${
+					filter === f.key
+						? 'bg-primary text-primary-foreground'
+						: 'bg-secondary text-secondary-foreground hover:bg-secondary/80'
+				}`}
+			>
+				{f.label} · {counts[f.key]}
+			</button>
+		{/each}
+	</div>
+
+	<!-- Statements list -->
+	<Card.Root class="gap-0 overflow-hidden py-0">
+		<div
+			class="text-muted-foreground grid grid-cols-[3rem_minmax(0,1fr)_auto] items-center gap-4 border-b px-4 py-3 text-xs font-semibold uppercase"
+		>
+			<div>#</div>
+			<div>Statement</div>
+			<div class="pr-2">Action</div>
+		</div>
+
+		{#if visible.length === 0}
+			<p class="text-muted-foreground px-4 py-6 text-sm italic">
+				No statements match this filter.
+			</p>
+		{:else}
+			{#each visible as row (row.id)}
+				<div
+					class="border-border group hover:bg-muted/40 relative grid grid-cols-[3rem_minmax(0,1fr)_auto] items-center gap-4 border-b py-4 pl-4 transition-colors last:border-b-0"
+				>
+					<!-- Left accent bar (status colour) -->
+					<span
+						class={`absolute top-0 bottom-0 left-0 w-1 transition-all group-hover:w-1.5 ${accentFor(row)}`}
+					></span>
+
+					<!-- # -->
+					<div class="text-muted-foreground text-center text-xs tabular-nums">
+						{row.polis_statement_id}
+					</div>
+
+					<!-- Statement text -->
+					<p class="min-w-0 text-base leading-7">{row.statement_text}</p>
+
+					<!-- Actions -->
+					<div class="flex items-center gap-1 self-center pr-2">
+						<button
+							type="button"
+							disabled={pending[row.id] || row.moderation_status === 'accepted'}
+							onclick={() => setStatus(row, 'accepted')}
+							title="Accept"
+							class="text-primary hover:bg-primary/15 inline-flex size-11 cursor-pointer items-center justify-center rounded-full transition-all hover:scale-110 active:scale-95 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:scale-100 disabled:hover:bg-transparent"
+						>
+							<Check class="size-6" />
+						</button>
+						<button
+							type="button"
+							disabled={pending[row.id] || row.moderation_status === 'rejected'}
+							onclick={() => setStatus(row, 'rejected')}
+							title="Reject"
+							class="text-destructive hover:bg-destructive/15 inline-flex size-11 cursor-pointer items-center justify-center rounded-full transition-all hover:scale-110 active:scale-95 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:scale-100 disabled:hover:bg-transparent"
+						>
+							<X class="size-6" />
+						</button>
+					</div>
+				</div>
+			{/each}
+		{/if}
+	</Card.Root>
+</div>

--- a/ui/packages/comhairle/src/lib/tools/polis/PolisModeration.svelte
+++ b/ui/packages/comhairle/src/lib/tools/polis/PolisModeration.svelte
@@ -93,32 +93,53 @@
 		if (!file || csvImporting) return;
 		csvImporting = true;
 
-		const result = await tryCatchAsync(async () => {
-			// One statement per line; strip wrapping quotes and a leading header row.
-			const lines = (await file.text())
-				.split(/\r?\n/)
-				.map((l) => l.replace(/^"(.*)"$/, '$1').trim())
-				.filter(Boolean);
-			if (['statement', 'statements', 'text'].includes(lines[0]?.toLowerCase())) {
-				lines.shift();
+		const result = await tryCatchAsync<number, 'INCORRECT_FILE_TYPE' | 'NO_VALUES_FOUND'>(
+			async () => {
+				if (!file.name.toLowerCase().endsWith('.csv')) throw 'INCORRECT_FILE_TYPE';
+
+				// One statement per line; strip wrapping quotes and a leading header row.
+				const lines = (await file.text())
+					.split(/\r?\n/)
+					.map((l) => l.replace(/^"(.*)"$/, '$1').trim())
+					.filter(Boolean);
+				if (['statement', 'statements', 'text'].includes(lines[0]?.toLowerCase())) {
+					lines.shift();
+				}
+				if (!lines.length) throw 'NO_VALUES_FOUND';
+
+				await postSeeds(lines);
+				return lines.length;
 			}
-			if (lines.length) await postSeeds(lines);
-			return lines.length;
-		});
+		);
 		csvImporting = false;
 		input.value = '';
 
 		if (result.err !== null) {
 			console.error('CSV import failed', result.err);
-			notifications.send({ priority: 'ERROR', message: 'CSV import failed' });
+			switch (result.err) {
+				case 'INCORRECT_FILE_TYPE':
+					notifications.send({
+						priority: 'ERROR',
+						message: 'Only CSV files are allowed'
+					});
+					break;
+				case 'NO_VALUES_FOUND':
+					notifications.send({
+						priority: 'ERROR',
+						message: 'No statements found in that file'
+					});
+					break;
+				default:
+					// postSeeds / network failures are not one of the typed strings.
+					notifications.send({ priority: 'ERROR', message: 'CSV import failed' });
+			}
 			return;
 		}
-		if (result.ok) {
-			notifications.send({
-				priority: 'INFO',
-				message: `Imported ${result.ok} statement${result.ok === 1 ? '' : 's'}`
-			});
-		}
+
+		notifications.send({
+			priority: 'INFO',
+			message: `Imported ${result.ok} statement${result.ok === 1 ? '' : 's'}`
+		});
 		showAddForm = false;
 	}
 

--- a/ui/packages/comhairle/src/lib/tools/polis/PolisModeration.svelte
+++ b/ui/packages/comhairle/src/lib/tools/polis/PolisModeration.svelte
@@ -5,6 +5,7 @@
 	import * as Card from '$lib/components/ui/card';
 	import * as Dialog from '$lib/components/ui/dialog';
 	import { notifications } from '$lib/notifications.svelte';
+	import { tryCatchAsync } from '$lib/utils/errorHandling';
 	import { apiClient } from '@crownshy/api-client/client';
 	import type { PolisStatementAux } from '@crownshy/api-client/api';
 	import { Check, X, Plus, Upload, RefreshCw } from '@lucide/svelte';
@@ -74,17 +75,16 @@
 		const text = draftText.trim();
 		if (!text || addingSeed) return;
 		addingSeed = true;
-		try {
-			await postSeeds([text]);
-			draftText = '';
-			showAddForm = false;
-			notifications.send({ priority: 'INFO', message: 'Seed statement added' });
-		} catch (e) {
-			console.error('PolisPostSeed failed', e);
+		const { err } = await tryCatchAsync(() => postSeeds([text]));
+		addingSeed = false;
+		if (err) {
+			console.error('PolisPostSeed failed', err);
 			notifications.send({ priority: 'ERROR', message: 'Failed to add statement' });
-		} finally {
-			addingSeed = false;
+			return;
 		}
+		draftText = '';
+		showAddForm = false;
+		notifications.send({ priority: 'INFO', message: 'Seed statement added' });
 	}
 
 	async function importCsv(e: Event) {
@@ -92,7 +92,8 @@
 		const file = input.files?.[0];
 		if (!file || csvImporting) return;
 		csvImporting = true;
-		try {
+
+		const { ok: count, err } = await tryCatchAsync(async () => {
 			// One statement per line; strip wrapping quotes and a leading header row.
 			const lines = (await file.text())
 				.split(/\r?\n/)
@@ -101,21 +102,24 @@
 			if (['statement', 'statements', 'text'].includes(lines[0]?.toLowerCase())) {
 				lines.shift();
 			}
-			if (lines.length) {
-				await postSeeds(lines);
-				notifications.send({
-					priority: 'INFO',
-					message: `Imported ${lines.length} statement${lines.length === 1 ? '' : 's'}`
-				});
-			}
-			showAddForm = false;
-		} catch (err) {
+			if (lines.length) await postSeeds(lines);
+			return lines.length;
+		});
+		csvImporting = false;
+		input.value = '';
+
+		if (err) {
 			console.error('CSV import failed', err);
 			notifications.send({ priority: 'ERROR', message: 'CSV import failed' });
-		} finally {
-			csvImporting = false;
-			input.value = '';
+			return;
 		}
+		if (count) {
+			notifications.send({
+				priority: 'INFO',
+				message: `Imported ${count} statement${count === 1 ? '' : 's'}`
+			});
+		}
+		showAddForm = false;
 	}
 
 	// --- Status filters ---

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/design/step/[step_id]/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/design/step/[step_id]/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import LearnManage from '$lib/tools/learn/LearnManage.svelte';
 	import PolisManage from '$lib/tools/polis/PolisManage.svelte';
+	import PolisModeration from '$lib/tools/polis/PolisModeration.svelte';
 	import CommonStepConfig from '$lib/components/CommonStepConfig/CommonStepConfig.svelte';
 	import HeyFormManage from '$lib/tools/heyform/HeyFormManage.svelte';
 	import ThinkingSpaceManage from '$lib/tools/thinking_space/ThinkingSpaceManage.svelte';
@@ -54,9 +55,8 @@
 			? [
 					{ label: 'Configure', value: 'configure' },
 					{ label: 'Setup', value: 'setup' },
-					{ label: 'Statements', value: 'statements' },
-					{ label: 'Participants', value: 'participants' },
-					{ label: 'Moderate', value: 'moderate' }
+					{ label: 'Moderation', value: 'moderation' },
+					{ label: 'Insights', value: 'insights' }
 				]
 			: [
 					{ label: 'Configure', value: 'configure' },
@@ -104,12 +104,10 @@
 		workflowStepId={step.id}
 		isLive={conversation.isLive}
 	/>
-{:else if isPolis && subtab === 'statements'}
-	<div class="text-muted-foreground py-12 text-center text-sm">Statements view coming soon.</div>
-{:else if isPolis && subtab === 'participants'}
-	<div class="text-muted-foreground py-12 text-center text-sm">
-		Participants view coming soon.
-	</div>
+{:else if step && isPolis && subtab === 'moderation'}
+	<PolisModeration workflowStepId={step.id} statements={data.statementAux ?? []} />
+{:else if isPolis && subtab === 'insights'}
+	<div class="text-muted-foreground py-12 text-center text-sm">Insights view coming soon.</div>
 {/if}
 
 {#if subtab === 'setup' && toolConfig?.type === 'heyform'}

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/design/step/[step_id]/+page.ts
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/design/step/[step_id]/+page.ts
@@ -1,9 +1,32 @@
-import type { PageLoad } from "./$types";
+import type { PolisStatementAux } from '@crownshy/api-client/api';
+import type { PageLoad } from './$types';
 
 export const load: PageLoad = async (event) => {
 	const step_id = event.params.step_id;
-	const { conversation, workflows, workflowSteps } = await event.parent();
+	const { api, conversation, workflows, workflowSteps } = await event.parent();
 
-	return { step_id, conversation, workflows, workflowSteps }
-}
+	// Polis Moderation/Insights subtabs read the statement_aux table for this
+	// step. Declared here so the tabs can invalidate just this after
+	// sync/moderate/seed, and so both subtabs share one fetch.
+	event.depends('polis:statement-aux');
 
+	const step = workflowSteps?.find((s) => s.id === step_id);
+	const toolConfig = step
+		? conversation.isLive
+			? step.toolConfig
+			: step.previewToolConfig
+		: null;
+
+	let statementAux: PolisStatementAux[] = [];
+	if (toolConfig?.type === 'polis') {
+		try {
+			statementAux = await api.PolisListStatementAux({
+				queries: { workflow_step_id: step_id }
+			});
+		} catch (e) {
+			console.error('Failed to load Polis statement aux', e);
+		}
+	}
+
+	return { step_id, conversation, workflows, workflowSteps, statementAux };
+};


### PR DESCRIPTION
First UI PR in the effort to replace the Polis admin iframe. Adds the native **Moderation** tab where moderators sync, seed, and accept/reject statements. Builds on the endpoints from PR 0.

## What changed

- **New `PolisModeration.svelte`**: sync from Polis, add seed statements (single or CSV import), accept/reject with optimistic updates, and status filter chips (all / seeded / accepted / pending / rejected) with live counts.
- **Retabbed the Polis step editor** to `Configure / Setup / Moderation / Insights`. Dropped the dead `Statements`, `Participants`, and `Moderate` tabs. Insights is a placeholder for PR 2.
- **`+page.ts`** now loads `statement_aux` for Polis steps under `depends('polis:statement-aux')`, so Moderation and the coming Insights share one fetch and mutations invalidate just that key.

## Decisions and assumptions

- Ported from the civic_os moderation page, with two changes: seeds go through the new server-side `PolisPostSeed` (no browser-side Polis auth or CORS), and colours use theme tokens only (no hardcoded colours, which we need to resolve in civic os). "Accepted" green maps to `--primary` since there is no `--success` token.
- Draft conversations show only moderator seeds (preview poll); once launched, the same tab shows participant statements (live poll). Same UI, driven by the existing `isLive` split.
- Statements only appear after a sync. Aux rows are synced from Polis, not created live.

## Testing
- Manual testing -> create a conversation with a polis step, add some statements, test if moderation and seeding works
- Not yet driven end to end (needs a running frontend plus a Polis step with synced statements).

<img width="1463" height="870" alt="image" src="https://github.com/user-attachments/assets/ff8e18f1-1ab3-497e-a6f1-5cf6b00e5505" />
<img width="1481" height="873" alt="image" src="https://github.com/user-attachments/assets/db8f08e0-8d9f-4a9e-a670-7e7dcb523705" />

