### PR TITLE
613/Polis admin: Insights tab (PR 3/4)

### DIFF
--- a/ui/packages/comhairle/src/lib/components/polis-report/ColumnFilterHeader.svelte
+++ b/ui/packages/comhairle/src/lib/components/polis-report/ColumnFilterHeader.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+	import { ChevronDown, Check } from '@lucide/svelte';
+	import * as Popover from '$lib/components/ui/popover';
+
+	interface Props {
+		/** Column header label, e.g. "Author". */
+		label: string;
+		/** Popover option label, phrased as the positive action, e.g. "Include all statements". */
+		optionLabel: string;
+		/** Controlled — checked = the option is INCLUDED (shown). */
+		checked?: boolean;
+		align?: 'left' | 'center' | 'right';
+		onchange?: (next: boolean) => void;
+	}
+
+	let { label, optionLabel, checked = false, align = 'left', onchange }: Props = $props();
+
+	const justify = {
+		left: 'justify-start',
+		center: 'justify-center',
+		right: 'justify-end'
+	} as const;
+
+	function toggle() {
+		onchange?.(!checked);
+	}
+</script>
+
+<Popover.Root>
+	<Popover.Trigger
+		class={`text-foreground hover:text-foreground/70 flex w-full cursor-pointer items-center gap-1 text-sm font-semibold whitespace-nowrap uppercase transition-colors ${justify[align]}`}
+	>
+		{label}
+		<ChevronDown class="size-3 shrink-0" />
+	</Popover.Trigger>
+	<Popover.Content align="start" class="w-72 overflow-hidden rounded-[10px] p-0 shadow-md">
+		<button
+			type="button"
+			onclick={toggle}
+			class="hover:bg-muted/50 border-border flex w-full cursor-pointer items-center justify-between gap-3 border-b px-4 py-3 text-left transition-colors"
+		>
+			<span class="text-foreground text-base font-medium whitespace-nowrap"
+				>{optionLabel}</span
+			>
+			{#if checked}<Check class="text-primary size-5 shrink-0" />{/if}
+		</button>
+	</Popover.Content>
+</Popover.Root>

--- a/ui/packages/comhairle/src/lib/components/polis-report/ColumnFilterHeader.svelte
+++ b/ui/packages/comhairle/src/lib/components/polis-report/ColumnFilterHeader.svelte
@@ -10,7 +10,7 @@
 		/** Controlled — checked = the option is INCLUDED (shown). */
 		checked?: boolean;
 		align?: 'left' | 'center' | 'right';
-		onchange?: (next: boolean) => void;
+		onchange: (next: boolean) => void;
 	}
 
 	let { label, optionLabel, checked = false, align = 'left', onchange }: Props = $props();
@@ -22,7 +22,7 @@
 	} as const;
 
 	function toggle() {
-		onchange?.(!checked);
+		onchange(!checked);
 	}
 </script>
 

--- a/ui/packages/comhairle/src/lib/components/polis-report/FilterToggle.svelte
+++ b/ui/packages/comhairle/src/lib/components/polis-report/FilterToggle.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+	import { Check } from '@lucide/svelte';
+
+	/**
+	 * Spreadsheet-style filter control. Renders as a bordered "dropdown" box with
+	 * the label and a checkmark reflecting state; the whole box is the hitbox
+	 * (per design feedback — not just an arrow). Less discoverable than a visible
+	 * switch, which is an accepted trade-off for the spreadsheet-familiar pattern.
+	 */
+	interface Props {
+		label: string;
+		checked: boolean;
+		onchange?: (next: boolean) => void;
+	}
+
+	let { label, checked = $bindable(false), onchange }: Props = $props();
+
+	function toggle() {
+		checked = !checked;
+		onchange?.(checked);
+	}
+</script>
+
+<button
+	type="button"
+	role="switch"
+	aria-checked={checked}
+	onclick={toggle}
+	class="border-border bg-card hover:bg-muted/50 inline-flex cursor-pointer items-center justify-between gap-3 rounded-[10px] border px-3 py-2 text-xs font-medium shadow-sm transition-colors"
+>
+	<span class="text-foreground">{label}</span>
+	<span
+		class={`flex size-4 shrink-0 items-center justify-center rounded border transition-colors ${
+			checked ? 'border-primary bg-primary/10 text-primary' : 'border-border text-transparent'
+		}`}
+	>
+		<Check class="size-3" />
+	</span>
+</button>

--- a/ui/packages/comhairle/src/lib/components/polis-report/GroupCircle.svelte
+++ b/ui/packages/comhairle/src/lib/components/polis-report/GroupCircle.svelte
@@ -60,10 +60,7 @@
 	const pct = (n: number) => (total > 0 ? Math.round((n / total) * 100) : 0);
 </script>
 
-<!-- Vote-breakdown on hover. HoverCard (bits-ui) portals the panel to the body and
-     uses Floating UI collision handling, so it flips/shifts to stay on-screen and
-     never extends or is clipped by the page — unlike the old CSS-only tooltip that
-     ran off the right edge on the last column. -->
+<!-- Vote-breakdown on hover-->
 <HoverCard.Root openDelay={80} closeDelay={80}>
 	<HoverCard.Trigger
 		class="flex cursor-default flex-col items-center gap-0.5 outline-none"

--- a/ui/packages/comhairle/src/lib/components/polis-report/GroupCircle.svelte
+++ b/ui/packages/comhairle/src/lib/components/polis-report/GroupCircle.svelte
@@ -1,0 +1,126 @@
+<script lang="ts">
+	import * as HoverCard from '$lib/components/ui/hover-card';
+
+	/**
+	 * Compact agree% visualization for one group on a single statement. A colored
+	 * arc whose length is the group's agree% and whose color grades the extent of
+	 * agreement — low (< 33%) destructive, mid (33–66%) muted, high (66%+) primary.
+	 * The non-agree remainder shows as the neutral track. Hovering reveals the full
+	 * vote breakdown (agree/disagree/pass) for that group + statement.
+	 */
+	interface Props {
+		/** Group letter (A, B, …). Shown in the tooltip header and optional label. */
+		label?: string;
+		/**
+		 * Agree% driving the arc length + center number, 0–100. This is the value
+		 * already reflecting the section's include/exclude-passes toggle, so the arc
+		 * matches the "Agree %" column.
+		 */
+		agreePct: number;
+		/** Raw vote counts — power the tooltip's honest full breakdown (always incl. passes) and N. */
+		agrees: number;
+		disagrees: number;
+		passes: number;
+		size?: 'sm' | 'md';
+		/** Show the group label beneath the ring. Off in dense statement rows. */
+		showLabel?: boolean;
+	}
+
+	let {
+		label = '',
+		agreePct,
+		agrees,
+		disagrees,
+		passes,
+		size = 'sm',
+		showLabel = true
+	}: Props = $props();
+
+	const clamped = $derived(Math.min(100, Math.max(0, agreePct)));
+
+	// Extent-of-agreement color buckets mapped to theme tokens: < 33% destructive,
+	// 33–66% muted-foreground, 66%+ primary. `currentColor` on the arc stroke lets
+	// the text-* class drive it.
+	const arcColor = $derived(
+		clamped < 33 ? 'text-destructive' : clamped <= 66 ? 'text-muted-foreground' : 'text-primary'
+	);
+
+	// SVG geometry. viewBox is 40×40; the ring sits inside the stroke so r leaves
+	// half the stroke width on each side. Rotated -90° so the arc starts at 12
+	// o'clock and grows clockwise.
+	const R = 17.5;
+	const CIRC = 2 * Math.PI * R;
+	const dash = $derived((clamped / 100) * CIRC);
+
+	const ringSize = $derived(size === 'md' ? 'size-11' : 'size-10');
+
+	// Tooltip: the TRUE full breakdown over all votes cast (incl. passes), so the
+	// three rows always sum to ~100% regardless of the exclude-passes toggle.
+	const total = $derived(agrees + disagrees + passes);
+	const pct = (n: number) => (total > 0 ? Math.round((n / total) * 100) : 0);
+</script>
+
+<!-- Vote-breakdown on hover. HoverCard (bits-ui) portals the panel to the body and
+     uses Floating UI collision handling, so it flips/shifts to stay on-screen and
+     never extends or is clipped by the page — unlike the old CSS-only tooltip that
+     ran off the right edge on the last column. -->
+<HoverCard.Root openDelay={80} closeDelay={80}>
+	<HoverCard.Trigger
+		class="flex cursor-default flex-col items-center gap-0.5 outline-none"
+		aria-label={`Group ${label} vote breakdown`}
+	>
+		<div class={`relative ${ringSize}`}>
+			<svg class="size-full -rotate-90" viewBox="0 0 40 40" aria-hidden="true">
+				<circle
+					class="text-border"
+					cx="20"
+					cy="20"
+					r={R}
+					fill="none"
+					stroke="currentColor"
+					stroke-width="5"
+				/>
+				<circle
+					class={arcColor}
+					cx="20"
+					cy="20"
+					r={R}
+					fill="none"
+					stroke="currentColor"
+					stroke-width="5"
+					stroke-linecap="round"
+					stroke-dasharray={`${dash} ${CIRC - dash}`}
+				/>
+			</svg>
+			<span
+				class="text-foreground absolute inset-0 flex items-center justify-center text-xs leading-none font-bold"
+			>
+				{Math.round(clamped)}
+			</span>
+		</div>
+
+		{#if showLabel && label}
+			<span class="text-muted-foreground text-xs font-semibold uppercase">{label}</span>
+		{/if}
+	</HoverCard.Trigger>
+
+	<HoverCard.Content side="top" align="end" sideOffset={8} class="w-60 p-5">
+		<div class="text-popover-foreground text-base font-bold uppercase">
+			Group {label} <span class="text-muted-foreground">(N={total})</span>
+		</div>
+		<dl class="text-muted-foreground mt-3 space-y-2">
+			<div class="flex items-center justify-between text-base font-semibold">
+				<dt>Agree</dt>
+				<dd class="tabular-nums">{pct(agrees)}%</dd>
+			</div>
+			<div class="flex items-center justify-between text-base font-semibold">
+				<dt>Disagree</dt>
+				<dd class="tabular-nums">{pct(disagrees)}%</dd>
+			</div>
+			<div class="flex items-center justify-between text-base font-semibold">
+				<dt>Pass</dt>
+				<dd class="tabular-nums">{pct(passes)}%</dd>
+			</div>
+		</dl>
+	</HoverCard.Content>
+</HoverCard.Root>

--- a/ui/packages/comhairle/src/lib/components/polis-report/RowAccentStripe.svelte
+++ b/ui/packages/comhairle/src/lib/components/polis-report/RowAccentStripe.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+	interface Props {
+		/** Tailwind background-color class for the bar, e.g. "bg-primary". */
+		accent: string;
+	}
+
+	let { accent }: Props = $props();
+</script>
+
+<!-- Left accent stripe. Requires the parent row to have `group` + `relative`;
+     the bar grows from 1.5 → 2 when the row is hovered. -->
+<div
+	class={`absolute top-0 bottom-0 left-0 w-1.5 transition-all duration-150 group-hover:w-2 ${accent}`}
+></div>

--- a/ui/packages/comhairle/src/lib/components/polis-report/StatementRow.svelte
+++ b/ui/packages/comhairle/src/lib/components/polis-report/StatementRow.svelte
@@ -1,0 +1,139 @@
+<script lang="ts">
+	import type { ReportComment, ReportGroup } from '$lib/tools/polis/reportTypes';
+	import { computeGroupVotePercents, totalVotes } from '$lib/tools/polis/report';
+	import { User } from '@lucide/svelte';
+	import GroupCircle from './GroupCircle.svelte';
+	import RowAccentStripe from './RowAccentStripe.svelte';
+	import ThemePicker from './ThemePicker.svelte';
+
+	type Variant = 'consensus' | 'difference' | 'uncertainty' | 'neutral';
+
+	interface Props {
+		/** Accepted for call-site convenience; the "#" cell shows the Polis tid. */
+		index?: number;
+		comment: ReportComment;
+		groups: ReportGroup[];
+		variant?: Variant;
+		/** Drop passes from the agree% denominator (agrees/(agrees+disagrees)). */
+		excludePasses?: boolean;
+		picker?: {
+			availableThemes: string[];
+			onAddTheme: (theme: string) => void | Promise<void>;
+			onRemoveTheme: (theme: string) => void | Promise<void>;
+			disabled?: boolean;
+		};
+	}
+
+	let { comment, groups, variant = 'neutral', excludePasses = false, picker }: Props = $props();
+
+	const groupPcts = $derived(computeGroupVotePercents(comment, groups, { excludePasses }));
+	const count = $derived(totalVotes(comment));
+
+	// Per-variant metric shown in its own column (matches the Figma tables):
+	//   consensus  → lowest group agree% (MIN AGREE)
+	//   difference → max−min group agree% spread (DIFFERENCE, in pp)
+	//   otherwise  → total votes (COUNT)
+	const agreedPcts = $derived(groupPcts.map((g) => g.agreed));
+	const minAgree = $derived(agreedPcts.length ? Math.min(...agreedPcts) : 0);
+	const spread = $derived(
+		agreedPcts.length ? Math.max(...agreedPcts) - Math.min(...agreedPcts) : 0
+	);
+
+	const stripeClass = $derived(
+		variant === 'consensus'
+			? 'bg-primary'
+			: variant === 'difference'
+				? 'bg-destructive'
+				: 'bg-transparent'
+	);
+
+	// Seed/host-authored statements (is_seed) label as "You" (the host viewing
+	// this admin report authored them). Everyone else is "Participant" — the
+	// report payload has no author pid yet, so we can't show the real participant
+	// id. Seed author is assumed to be pid 0.
+	const isHostAuthored = $derived(!!comment.is_seed);
+</script>
+
+<!-- col-span-full + grid-cols-subgrid: the row spans every column of the owning
+     grid in StatementSection and adopts its exact tracks, so cells line up with the
+     header without this component knowing the column widths. -->
+<div
+	class="border-border group hover:bg-muted/40 relative col-span-full grid grid-cols-subgrid items-start border-b py-6 pr-4 pl-5 transition-colors duration-150"
+>
+	<RowAccentStripe accent={stripeClass} />
+
+	<!-- Polis statement id -->
+	<div class="text-muted-foreground pt-1 text-center text-sm tabular-nums">
+		{comment.tid}
+	</div>
+
+	<!-- Statement text + theme tags -->
+	<div class="min-w-0">
+		<p class="text-foreground text-lg leading-6 font-medium">{comment.text}</p>
+		<div class="mt-3">
+			{#if picker}
+				<ThemePicker
+					themes={comment.topics ?? []}
+					availableThemes={picker.availableThemes}
+					disabled={picker.disabled}
+					onAddTheme={picker.onAddTheme}
+					onRemoveTheme={picker.onRemoveTheme}
+				/>
+			{:else}
+				<div class="flex flex-wrap items-center gap-1.5">
+					{#each comment.topics ?? [] as topic (topic)}
+						<span
+							class="bg-muted text-foreground/80 inline-flex items-center rounded px-2 py-0.5 text-sm font-medium"
+						>
+							{topic}
+						</span>
+					{/each}
+				</div>
+			{/if}
+		</div>
+	</div>
+
+	<!-- Author -->
+	<div class="pt-1 text-right">
+		{#if isHostAuthored}
+			<span
+				class="bg-primary text-primary-foreground inline-flex items-center gap-1 rounded px-2 py-0.5 text-sm font-medium"
+			>
+				<User class="size-3.5" />You
+			</span>
+		{:else}
+			<span
+				class="bg-muted text-muted-foreground inline-flex items-center gap-1 rounded px-2 py-0.5 text-sm font-medium"
+			>
+				<User class="size-3.5" />Participant
+			</span>
+		{/if}
+	</div>
+
+	<!-- Per-variant metric -->
+	<div class="pt-1 text-center font-bold">
+		{#if variant === 'consensus'}
+			<span class="text-primary">{Math.round(minAgree)}%</span>
+		{:else if variant === 'difference'}
+			<span class="text-destructive">{Math.round(spread)}pp</span>
+		{:else}
+			<span class="text-foreground">{count}</span>
+		{/if}
+	</div>
+
+	<!-- Per-group agree rings. Arc reflects the toggled agree% (g.agreed); the
+	     tooltip uses raw group_votes counts for the honest full breakdown. -->
+	<div class="flex items-center gap-3 self-start pt-0.5">
+		{#each groupPcts as g (g.group_id)}
+			{@const gv = comment.group_votes.find((v) => v.group_id === g.group_id)}
+			<GroupCircle
+				label={g.label}
+				agreePct={g.agreed}
+				agrees={gv?.agrees ?? 0}
+				disagrees={gv?.disagrees ?? 0}
+				passes={gv?.passes ?? 0}
+				showLabel={false}
+			/>
+		{/each}
+	</div>
+</div>

--- a/ui/packages/comhairle/src/lib/components/polis-report/StatementSection.svelte
+++ b/ui/packages/comhairle/src/lib/components/polis-report/StatementSection.svelte
@@ -1,0 +1,186 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	import { ChevronDown } from '@lucide/svelte';
+	import ColumnFilterHeader from './ColumnFilterHeader.svelte';
+	import * as Card from '$lib/components/ui/card';
+
+	interface Props {
+		/** Optional id on the root section (scroll anchor for deep-links). */
+		id?: string;
+		title: string;
+		/** Trailing description text after the "N STATEMENTS" count, e.g. "with greater than 80%…". */
+		description: string;
+		/** Count shown as the coloured "N STATEMENTS" lead-in (main + low-quality). */
+		count?: number;
+		/** Accent colour for the count lead-in. */
+		countAccent?: 'consensus' | 'difference' | 'all';
+		/** Header label for the per-variant metric column, e.g. "Min Agree". */
+		metricLabel: string;
+		/** Number of opinion groups — sizes the trailing agree-rings column so the
+		    header grid and the (separate) row grids share identical column widths. */
+		groupCount?: number;
+		/** Full main-list count. When it exceeds what's rendered, show the expander. */
+		total?: number;
+		/** Rows shown while collapsed (parent does the slicing). */
+		collapsedCount?: number;
+		/** Bindable expand state — parent slices its list on this. */
+		expanded?: boolean;
+		/** How many low-quality rows are hidden. 0 → no low-quality reveal. */
+		lowQualityCount?: number;
+		/** Bindable — reveal the low-quality rows. */
+		showLowQuality?: boolean;
+		excludePasses?: boolean;
+		excludeHosts?: boolean;
+		onExcludePassesChange?: (next: boolean) => void;
+		onExcludeHostsChange?: (next: boolean) => void;
+		children: Snippet;
+		/** Optional action rendered on the title row, right-aligned (e.g. a Download button). */
+		headerAction?: Snippet;
+		/** Optional controls rendered between the description and the table (e.g. theme chips). */
+		toolbar?: Snippet;
+		/** Low-quality rows, rendered below the reveal toggle when expanded. */
+		lowQuality?: Snippet;
+	}
+
+	let {
+		id,
+		title,
+		description,
+		count,
+		countAccent = 'all',
+		metricLabel,
+		total,
+		collapsedCount = 5,
+		groupCount = 0,
+		expanded = $bindable(false),
+		lowQualityCount = 0,
+		showLowQuality = $bindable(false),
+		excludePasses = $bindable(false),
+		excludeHosts = $bindable(false),
+		onExcludePassesChange,
+		onExcludeHostsChange,
+		children,
+		headerAction,
+		toolbar,
+		lowQuality
+	}: Props = $props();
+
+	const showExpander = $derived(total !== undefined && total > collapsedCount);
+
+	// One real grid, defined here on the table wrapper; the header and every row are
+	// `subgrid`s that adopt these exact tracks (see StatementRow). That's why columns
+	// line up without any hand-tuned fr ratios: there's a single source of truth.
+	//
+	//   #        → auto: hugs the tid/"#" width
+	//   Statement→ minmax(12rem,1fr): eats all leftover space (min 12rem so it never
+	//              collapses; below that the wrapper scrolls horizontally on mobile)
+	//   Author / metric / Agree%|rings → auto: each takes exactly the width its own
+	//              content needs, no more. Even column-gap comes from `gap-x-*`.
+	//
+	// groupCount is no longer needed to size the rings column — `auto` fits the
+	// circles for free — but stays in Props for call-site compatibility.
+	const insightsCols = 'auto minmax(12rem,1fr) auto auto auto';
+
+	const countAccentClass = $derived(
+		countAccent === 'consensus'
+			? 'text-primary'
+			: countAccent === 'difference'
+				? 'text-destructive'
+				: 'text-primary'
+	);
+</script>
+
+<section {id} class="flex scroll-mt-4 flex-col gap-4" style={`--insights-cols: ${insightsCols}`}>
+	<div class="flex items-center justify-between gap-4">
+		<h2 class="text-foreground text-lg leading-tight font-semibold">{title}</h2>
+		{#if headerAction}
+			<div class="shrink-0">{@render headerAction()}</div>
+		{/if}
+	</div>
+	<p class="text-foreground text-base font-medium">
+		{#if count !== undefined}<span class={`${countAccentClass} whitespace-nowrap`}
+				>{count} STATEMENTS</span
+			>&nbsp;{/if}{description}
+	</p>
+
+	{#if toolbar}
+		{@render toolbar()}
+	{/if}
+
+	<!-- overflow-visible (overrides Card's default overflow) so the sticky header
+	     can pin to the layout scroll container instead of being clipped. p-0 so the
+	     header/rows sit flush against the card edge. -->
+	<Card.Root
+		class="hover:border-muted-foreground/40 overflow-visible rounded-[20px] p-0 shadow-sm transition-colors duration-200"
+	>
+		<!-- The single owning grid: its columns are defined once here and every direct
+		     child (header, each row, the reveal buttons) spans all of them. Rows adopt
+		     these exact tracks via `subgrid`, so columns align with zero fr juggling.
+		     overflow-x-auto lets the table scroll sideways on a narrow panel instead of
+		     crushing columns; md:overflow-visible keeps desktop untouched so the sticky
+		     header still pins vertically. -->
+		<div
+			class="grid [grid-template-columns:var(--insights-cols)] gap-x-4 overflow-x-auto md:overflow-visible [&>*:last-child]:rounded-b-[20px]"
+		>
+			<div
+				class="bg-card text-foreground sticky top-0 z-10 col-span-full grid grid-cols-subgrid items-center rounded-t-[20px] py-3 pr-4 pl-5 text-sm font-semibold uppercase"
+			>
+				<div>#</div>
+				<div>Statement</div>
+				<ColumnFilterHeader
+					label="Author"
+					optionLabel="Include host statements"
+					checked={!excludeHosts}
+					onchange={(included) => {
+						excludeHosts = !included;
+						onExcludeHostsChange?.(excludeHosts);
+					}}
+				/>
+				<div class="text-center whitespace-nowrap">{metricLabel}</div>
+				<ColumnFilterHeader
+					label="Agree %"
+					optionLabel="Include passes"
+					align="right"
+					checked={!excludePasses}
+					onchange={(included) => {
+						excludePasses = !included;
+						onExcludePassesChange?.(excludePasses);
+					}}
+				/>
+			</div>
+
+			{@render children()}
+
+			{#if showExpander}
+				<button
+					type="button"
+					onclick={() => (expanded = !expanded)}
+					class="bg-muted/40 hover:bg-muted/70 text-foreground/70 col-span-full flex items-center justify-center gap-2 py-5 text-base font-normal transition-colors"
+				>
+					{expanded ? 'Show fewer statements' : `See all ${total} statements`}
+					<ChevronDown
+						class={`text-primary size-4 transition-transform ${expanded ? 'rotate-180' : ''}`}
+					/>
+				</button>
+			{/if}
+
+			{#if lowQualityCount > 0}
+				<button
+					type="button"
+					onclick={() => (showLowQuality = !showLowQuality)}
+					class="text-muted-foreground bg-muted/30 hover:bg-muted/50 col-span-full flex items-center justify-center gap-2 py-5 text-base transition-colors"
+				>
+					{showLowQuality
+						? 'Hide low data quality statements'
+						: `See ${lowQualityCount} statement${lowQualityCount === 1 ? '' : 's'} with low data quality`}
+					<ChevronDown
+						class={`size-4 transition-transform ${showLowQuality ? 'rotate-180' : ''}`}
+					/>
+				</button>
+				{#if showLowQuality && lowQuality}
+					{@render lowQuality()}
+				{/if}
+			{/if}
+		</div>
+	</Card.Root>
+</section>

--- a/ui/packages/comhairle/src/lib/components/polis-report/StatementSection.svelte
+++ b/ui/packages/comhairle/src/lib/components/polis-report/StatementSection.svelte
@@ -16,18 +16,18 @@
 		countAccent?: 'consensus' | 'difference' | 'all';
 		/** Header label for the per-variant metric column, e.g. "Min Agree". */
 		metricLabel: string;
-		/** Number of opinion groups — sizes the trailing agree-rings column so the
+		/** Number of opinion groups, sizing the trailing agree-rings column so the
 		    header grid and the (separate) row grids share identical column widths. */
 		groupCount?: number;
 		/** Full main-list count. When it exceeds what's rendered, show the expander. */
 		total?: number;
 		/** Rows shown while collapsed (parent does the slicing). */
 		collapsedCount?: number;
-		/** Bindable expand state — parent slices its list on this. */
+		/** Bindable expand state; parent slices its list on this. */
 		expanded?: boolean;
 		/** How many low-quality rows are hidden. 0 → no low-quality reveal. */
 		lowQualityCount?: number;
-		/** Bindable — reveal the low-quality rows. */
+		/** Bindable; reveal the low-quality rows. */
 		showLowQuality?: boolean;
 		excludePasses?: boolean;
 		excludeHosts?: boolean;
@@ -77,8 +77,8 @@
 	//   Author / metric / Agree%|rings → auto: each takes exactly the width its own
 	//              content needs, no more. Even column-gap comes from `gap-x-*`.
 	//
-	// groupCount is no longer needed to size the rings column — `auto` fits the
-	// circles for free — but stays in Props for call-site compatibility.
+	// groupCount is no longer needed to size the rings column (`auto` fits the
+	// circles for free), but stays in Props for call-site compatibility.
 	const insightsCols = 'auto minmax(12rem,1fr) auto auto auto';
 
 	const countAccentClass = $derived(

--- a/ui/packages/comhairle/src/lib/components/polis-report/ThemeBar.svelte
+++ b/ui/packages/comhairle/src/lib/components/polis-report/ThemeBar.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+	import { ArrowRight } from '@lucide/svelte';
+	import type { ThemeSummary } from '$lib/tools/polis/reportTypes';
+
+	interface Props {
+		summary: ThemeSummary;
+		/** Statement count of the largest theme — the bar's full-scale reference. */
+		barMax: number;
+		onclick?: () => void;
+	}
+
+	let { summary, barMax, onclick }: Props = $props();
+
+	// Bar length ranks this theme against the largest theme (100% = the top theme),
+	// per the "very simple, based on manually added themes" spec. Theme counts don't
+	// sum to totalStatements (a statement can carry many themes), so share-of-total
+	// would be a meaningless denominator. No controversy signal here.
+	const pct = $derived(barMax > 0 ? (summary.statementCount / barMax) * 100 : 0);
+</script>
+
+<div
+	class="border-border group hover:bg-muted/40 grid grid-cols-[10rem_3rem_1fr_2.5rem] items-center gap-6 border-b px-2 py-4 transition-colors duration-150"
+>
+	<div class="text-foreground truncate text-base font-bold">{summary.theme}</div>
+	<div class="text-foreground text-center text-base font-bold tabular-nums">
+		{summary.statementCount}
+	</div>
+	<div class="bg-muted h-2 w-full rounded-full">
+		<div class="bg-primary h-full rounded-full" style={`width:${pct}%`}></div>
+	</div>
+	<button
+		type="button"
+		{onclick}
+		aria-label={`Open ${summary.theme}`}
+		class="bg-muted text-primary group-hover:bg-primary/15 flex size-8 shrink-0 cursor-pointer items-center justify-center justify-self-end rounded-full transition-all duration-150 hover:scale-110 active:scale-95"
+	>
+		<ArrowRight class="size-4" />
+	</button>
+</div>

--- a/ui/packages/comhairle/src/lib/components/polis-report/ThemeChip.svelte
+++ b/ui/packages/comhairle/src/lib/components/polis-report/ThemeChip.svelte
@@ -9,7 +9,7 @@
 		 * primary fill when selected and the subtle secondary surface when idle.
 		 */
 		variant?: 'default' | 'primary';
-		onclick?: () => void;
+		onclick: () => void;
 	}
 
 	let { label, selected, variant = 'default', onclick }: Props = $props();

--- a/ui/packages/comhairle/src/lib/components/polis-report/ThemeChip.svelte
+++ b/ui/packages/comhairle/src/lib/components/polis-report/ThemeChip.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+	/** Pill-shaped selectable theme chip used by the Theme Explorer. */
+	interface Props {
+		label: string;
+		selected: boolean;
+		/**
+		 * Colour scheme — both variants use the comhairle primary accent. `default`
+		 * renders primary text on a neutral muted surface; `primary` uses the solid
+		 * primary fill when selected and the subtle secondary surface when idle.
+		 */
+		variant?: 'default' | 'primary';
+		onclick?: () => void;
+	}
+
+	let { label, selected, variant = 'default', onclick }: Props = $props();
+
+	const palette = {
+		default: {
+			on: 'bg-primary text-primary-foreground hover:bg-primary/90',
+			off: 'bg-muted text-primary hover:bg-muted-foreground/15'
+		},
+		primary: {
+			on: 'bg-primary text-primary-foreground hover:bg-primary/90',
+			off: 'bg-secondary text-primary hover:bg-secondary/80'
+		}
+	};
+</script>
+
+<button
+	type="button"
+	{onclick}
+	class={`cursor-pointer rounded-[30px] px-3 py-2 text-lg leading-6 font-medium transition-all duration-150 hover:scale-[1.05] hover:shadow-sm active:scale-[0.96] ${
+		selected ? palette[variant].on : palette[variant].off
+	}`}
+>
+	{label}
+</button>

--- a/ui/packages/comhairle/src/lib/components/polis-report/ThemePicker.svelte
+++ b/ui/packages/comhairle/src/lib/components/polis-report/ThemePicker.svelte
@@ -7,7 +7,13 @@
 	 * The component is dumb — the parent owns the source of truth and the
 	 * persistence call. We just emit per-theme add/remove events that map 1:1
 	 * onto the comhairle /themes endpoints.
+	 *
+	 * The dropdown is a shadcn `Popover`, which portals its content to the body
+	 * and handles collision/flip via Floating UI. That's why the ancestor `Card`
+	 * / scroll container overflow doesn't clip it, with no manual positioning.
 	 */
+	import * as Popover from '$lib/components/ui/popover';
+
 	interface Props {
 		/** Themes currently assigned to this statement. */
 		themes: string[];
@@ -21,40 +27,9 @@
 
 	let { themes, availableThemes, disabled = false, onAddTheme, onRemoveTheme }: Props = $props();
 
-	let open = $state(false);
 	let newDraft = $state('');
-	let containerEl: HTMLDivElement | undefined = $state();
-	let dropdownEl: HTMLDivElement | undefined = $state();
-	let dropdownPos = $state<{ top: number; left: number } | null>(null);
 
 	const themeSet = $derived(new Set(themes));
-
-	function toggleOpen() {
-		if (disabled) return;
-		open = !open;
-		if (open) reposition();
-	}
-
-	/**
-	 * Dropdown uses `position: fixed` to escape ancestor `overflow: hidden`
-	 * (e.g. the Card wrapping the statements list). So we have to position it
-	 * manually from the trigger's bbox, and re-position on scroll/resize.
-	 *
-	 * When there isn't room below the trigger (statement near the bottom of the
-	 * viewport), flip the menu above it so it never gets clipped off-screen.
-	 */
-	function reposition() {
-		if (!containerEl) return;
-		const rect = containerEl.getBoundingClientRect();
-		const gap = 4;
-		const menuHeight = dropdownEl?.offsetHeight ?? 260;
-		const spaceBelow = window.innerHeight - rect.bottom;
-		const top =
-			spaceBelow < menuHeight + gap && rect.top > spaceBelow
-				? Math.max(gap, rect.top - menuHeight - gap)
-				: rect.bottom + gap;
-		dropdownPos = { top, left: rect.left };
-	}
 
 	function applyToggle(theme: string) {
 		if (themeSet.has(theme)) {
@@ -75,33 +50,9 @@
 		onAddTheme?.(t);
 		newDraft = '';
 	}
-
-	// Once the menu is in the DOM we know its real height, so re-measure to
-	// decide whether it should flip above the trigger.
-	$effect(() => {
-		if (open && dropdownEl) reposition();
-	});
-
-	// Close on outside click + reposition on scroll/resize while open.
-	$effect(() => {
-		if (!open) return;
-		function onDocClick(e: MouseEvent) {
-			if (containerEl && !containerEl.contains(e.target as Node)) {
-				open = false;
-			}
-		}
-		document.addEventListener('mousedown', onDocClick);
-		window.addEventListener('scroll', reposition, true);
-		window.addEventListener('resize', reposition);
-		return () => {
-			document.removeEventListener('mousedown', onDocClick);
-			window.removeEventListener('scroll', reposition, true);
-			window.removeEventListener('resize', reposition);
-		};
-	});
 </script>
 
-<div class="relative inline-flex flex-wrap items-center gap-2" bind:this={containerEl}>
+<div class="inline-flex flex-wrap items-center gap-2">
 	{#each themes as t (t)}
 		<span
 			class="group/chip bg-muted text-foreground inline-flex items-center gap-1 rounded-[3px] px-[5px] py-[3px] text-base font-medium"
@@ -121,52 +72,44 @@
 	{/each}
 
 	{#if !disabled}
-		<button
-			type="button"
-			onclick={toggleOpen}
-			class="text-primary bg-primary/10 hover:bg-primary/20 inline-flex items-center rounded-[3px] px-[5px] py-0.5 text-base font-medium"
-		>
-			Add new+
-		</button>
-	{/if}
-
-	{#if open && dropdownPos}
-		<div
-			bind:this={dropdownEl}
-			style:top="{dropdownPos.top}px"
-			style:left="{dropdownPos.left}px"
-			class="border-border bg-popover text-popover-foreground fixed z-50 w-80 overflow-hidden rounded-lg border shadow-lg"
-		>
-			{#each availableThemes as t (t)}
-				{@const checked = themeSet.has(t)}
-				<button
-					type="button"
-					onclick={() => applyToggle(t)}
-					class="hover:bg-muted/60 border-border flex w-full items-center justify-between gap-2 border-b px-4 py-3 text-left text-base last:border-b-0"
-				>
-					<span>#{t}</span>
-					{#if checked}
-						<span class="text-primary text-lg">✓</span>
-					{/if}
-				</button>
-			{/each}
-			<div class="border-border flex items-center gap-2 border-t p-2.5">
-				<input
-					type="text"
-					bind:value={newDraft}
-					onkeydown={(e) => e.key === 'Enter' && applyAdd()}
-					placeholder="Add new…"
-					class="border-border focus:ring-primary/40 min-w-0 flex-1 rounded-md border px-3 py-2 text-base focus:ring-2 focus:outline-none"
-				/>
-				<button
-					type="button"
-					onclick={applyAdd}
-					disabled={!newDraft.trim()}
-					class="bg-primary text-primary-foreground rounded-md px-4 py-2 text-base font-medium disabled:opacity-40"
-				>
-					Add
-				</button>
-			</div>
-		</div>
+		<Popover.Root>
+			<Popover.Trigger
+				class="text-primary bg-primary/10 hover:bg-primary/20 inline-flex items-center rounded-[3px] px-[5px] py-0.5 text-base font-medium"
+			>
+				Add new+
+			</Popover.Trigger>
+			<Popover.Content align="start" class="w-80 overflow-hidden p-0 shadow-lg">
+				{#each availableThemes as t (t)}
+					{@const checked = themeSet.has(t)}
+					<button
+						type="button"
+						onclick={() => applyToggle(t)}
+						class="hover:bg-muted/60 border-border flex w-full items-center justify-between gap-2 border-b px-4 py-3 text-left text-base last:border-b-0"
+					>
+						<span>#{t}</span>
+						{#if checked}
+							<span class="text-primary text-lg">✓</span>
+						{/if}
+					</button>
+				{/each}
+				<div class="border-border flex items-center gap-2 border-t p-2.5">
+					<input
+						type="text"
+						bind:value={newDraft}
+						onkeydown={(e) => e.key === 'Enter' && applyAdd()}
+						placeholder="Add new…"
+						class="border-border focus:ring-primary/40 min-w-0 flex-1 rounded-md border px-3 py-2 text-base focus:ring-2 focus:outline-none"
+					/>
+					<button
+						type="button"
+						onclick={applyAdd}
+						disabled={!newDraft.trim()}
+						class="bg-primary text-primary-foreground rounded-md px-4 py-2 text-base font-medium disabled:opacity-40"
+					>
+						Add
+					</button>
+				</div>
+			</Popover.Content>
+		</Popover.Root>
 	{/if}
 </div>

--- a/ui/packages/comhairle/src/lib/components/polis-report/ThemePicker.svelte
+++ b/ui/packages/comhairle/src/lib/components/polis-report/ThemePicker.svelte
@@ -1,0 +1,172 @@
+<script lang="ts">
+	/**
+	 * Inline theme chip + dropdown picker. Renders the current themes on a
+	 * statement; clicking opens a dropdown of themes already used elsewhere
+	 * on this conversation, with toggle checkmarks and an "Add new" affordance.
+	 *
+	 * The component is dumb — the parent owns the source of truth and the
+	 * persistence call. We just emit per-theme add/remove events that map 1:1
+	 * onto the comhairle /themes endpoints.
+	 */
+	interface Props {
+		/** Themes currently assigned to this statement. */
+		themes: string[];
+		/** Every theme already used on this conversation (for the dropdown). */
+		availableThemes: string[];
+		/** Disabled when there's no aux row to write to. */
+		disabled?: boolean;
+		onAddTheme?: (theme: string) => void | Promise<void>;
+		onRemoveTheme?: (theme: string) => void | Promise<void>;
+	}
+
+	let { themes, availableThemes, disabled = false, onAddTheme, onRemoveTheme }: Props = $props();
+
+	let open = $state(false);
+	let newDraft = $state('');
+	let containerEl: HTMLDivElement | undefined = $state();
+	let dropdownEl: HTMLDivElement | undefined = $state();
+	let dropdownPos = $state<{ top: number; left: number } | null>(null);
+
+	const themeSet = $derived(new Set(themes));
+
+	function toggleOpen() {
+		if (disabled) return;
+		open = !open;
+		if (open) reposition();
+	}
+
+	/**
+	 * Dropdown uses `position: fixed` to escape ancestor `overflow: hidden`
+	 * (e.g. the Card wrapping the statements list). So we have to position it
+	 * manually from the trigger's bbox, and re-position on scroll/resize.
+	 *
+	 * When there isn't room below the trigger (statement near the bottom of the
+	 * viewport), flip the menu above it so it never gets clipped off-screen.
+	 */
+	function reposition() {
+		if (!containerEl) return;
+		const rect = containerEl.getBoundingClientRect();
+		const gap = 4;
+		const menuHeight = dropdownEl?.offsetHeight ?? 260;
+		const spaceBelow = window.innerHeight - rect.bottom;
+		const top =
+			spaceBelow < menuHeight + gap && rect.top > spaceBelow
+				? Math.max(gap, rect.top - menuHeight - gap)
+				: rect.bottom + gap;
+		dropdownPos = { top, left: rect.left };
+	}
+
+	function applyToggle(theme: string) {
+		if (themeSet.has(theme)) {
+			onRemoveTheme?.(theme);
+		} else {
+			onAddTheme?.(theme);
+		}
+	}
+
+	function applyRemove(theme: string) {
+		if (disabled) return;
+		onRemoveTheme?.(theme);
+	}
+
+	function applyAdd() {
+		const t = newDraft.trim();
+		if (!t || themeSet.has(t)) return;
+		onAddTheme?.(t);
+		newDraft = '';
+	}
+
+	// Once the menu is in the DOM we know its real height, so re-measure to
+	// decide whether it should flip above the trigger.
+	$effect(() => {
+		if (open && dropdownEl) reposition();
+	});
+
+	// Close on outside click + reposition on scroll/resize while open.
+	$effect(() => {
+		if (!open) return;
+		function onDocClick(e: MouseEvent) {
+			if (containerEl && !containerEl.contains(e.target as Node)) {
+				open = false;
+			}
+		}
+		document.addEventListener('mousedown', onDocClick);
+		window.addEventListener('scroll', reposition, true);
+		window.addEventListener('resize', reposition);
+		return () => {
+			document.removeEventListener('mousedown', onDocClick);
+			window.removeEventListener('scroll', reposition, true);
+			window.removeEventListener('resize', reposition);
+		};
+	});
+</script>
+
+<div class="relative inline-flex flex-wrap items-center gap-2" bind:this={containerEl}>
+	{#each themes as t (t)}
+		<span
+			class="group/chip bg-muted text-foreground inline-flex items-center gap-1 rounded-[3px] px-[5px] py-[3px] text-base font-medium"
+		>
+			{t}
+			{#if !disabled}
+				<button
+					type="button"
+					onclick={() => applyRemove(t)}
+					aria-label={`Remove theme ${t}`}
+					class="hover:text-destructive text-foreground/40 hidden leading-none group-hover/chip:inline"
+				>
+					×
+				</button>
+			{/if}
+		</span>
+	{/each}
+
+	{#if !disabled}
+		<button
+			type="button"
+			onclick={toggleOpen}
+			class="text-primary bg-primary/10 hover:bg-primary/20 inline-flex items-center rounded-[3px] px-[5px] py-0.5 text-base font-medium"
+		>
+			Add new+
+		</button>
+	{/if}
+
+	{#if open && dropdownPos}
+		<div
+			bind:this={dropdownEl}
+			style:top="{dropdownPos.top}px"
+			style:left="{dropdownPos.left}px"
+			class="border-border bg-popover text-popover-foreground fixed z-50 w-80 overflow-hidden rounded-lg border shadow-lg"
+		>
+			{#each availableThemes as t (t)}
+				{@const checked = themeSet.has(t)}
+				<button
+					type="button"
+					onclick={() => applyToggle(t)}
+					class="hover:bg-muted/60 border-border flex w-full items-center justify-between gap-2 border-b px-4 py-3 text-left text-base last:border-b-0"
+				>
+					<span>#{t}</span>
+					{#if checked}
+						<span class="text-primary text-lg">✓</span>
+					{/if}
+				</button>
+			{/each}
+			<div class="border-border flex items-center gap-2 border-t p-2.5">
+				<input
+					type="text"
+					bind:value={newDraft}
+					onkeydown={(e) => e.key === 'Enter' && applyAdd()}
+					placeholder="Add new…"
+					class="border-border focus:ring-primary/40 min-w-0 flex-1 rounded-md border px-3 py-2 text-base focus:ring-2 focus:outline-none"
+				/>
+				<button
+					type="button"
+					onclick={applyAdd}
+					disabled={!newDraft.trim()}
+					class="bg-primary text-primary-foreground rounded-md px-4 py-2 text-base font-medium disabled:opacity-40"
+				>
+					Add
+				</button>
+			</div>
+		</div>
+	{/if}
+</div>

--- a/ui/packages/comhairle/src/lib/tools/polis/PolisInsights.svelte
+++ b/ui/packages/comhairle/src/lib/tools/polis/PolisInsights.svelte
@@ -1,0 +1,608 @@
+<script lang="ts">
+	import type {
+		ReportComment,
+		PolisReportData,
+		ThemeSummary
+	} from '$lib/tools/polis/reportTypes';
+	import type { PolisStatementAux } from '@crownshy/api-client/api';
+	import { apiClient } from '@crownshy/api-client/client';
+	import {
+		getEngagementStats,
+		getConsensusStatements,
+		getDifferenceStatements,
+		themeControversy,
+		classifyStatement,
+		isLowQuality,
+		totalVotes,
+		consensusDirection,
+		groupLabel
+	} from '$lib/tools/polis/report';
+	import { notifications } from '$lib/notifications.svelte';
+	import StatementRow from '$lib/components/polis-report/StatementRow.svelte';
+	import StatementSection from '$lib/components/polis-report/StatementSection.svelte';
+	import ThemeBar from '$lib/components/polis-report/ThemeBar.svelte';
+	import ThemeChip from '$lib/components/polis-report/ThemeChip.svelte';
+	import * as Card from '$lib/components/ui/card';
+	import { Button } from '$lib/components/ui/button';
+	import { Download, ChevronDown } from '@lucide/svelte';
+	import { onMount, tick } from 'svelte';
+	import { page } from '$app/state';
+	import { replaceState, invalidate } from '$app/navigation';
+
+	const ALL_STATEMENTS_ID = 'all-statements';
+
+	let {
+		workflowStepId,
+		reportData,
+		statementAux
+	}: {
+		workflowStepId: string;
+		reportData: PolisReportData | null;
+		statementAux: PolisStatementAux[];
+	} = $props();
+
+	// Local mutable aux map (keyed by Polis tid) so picker edits re-render without
+	// waiting for the invalidated load to round-trip. Re-seeded whenever the
+	// `statementAux` prop changes (e.g. after an invalidate or slug change).
+	let auxByTid = $state<Record<number, PolisStatementAux>>({});
+	$effect(() => {
+		const map: Record<number, PolisStatementAux> = {};
+		for (const a of statementAux) map[a.polis_statement_id] = a;
+		auxByTid = map;
+	});
+
+	/**
+	 * Overlay aux.themes onto each comment so the existing utils (which read
+	 * `comment.topics`) get aux-sourced themes for free. Themes are human-authored
+	 * today and live only in aux; Polis carries none, so `comment.topics` is empty
+	 * until a future source populates it. Comments with no aux row keep that empty
+	 * `topics` and simply contribute no themes. Works on a cloned copy so the
+	 * `reportData` prop is never mutated in place across reruns.
+	 */
+	const report = $derived.by<PolisReportData | null>(() => {
+		if (!reportData) return null;
+		return {
+			...reportData,
+			comments: reportData.comments.map((c) => {
+				const aux = auxByTid[c.tid];
+				return aux ? { ...c, topics: aux.themes } : c;
+			})
+		};
+	});
+
+	const stats = $derived(report ? getEngagementStats(report) : null);
+	// Theme roll-up over ALL tagged statements (aux), not just the Polis report
+	// set. Controversy needs vote data (only the report carries), so themes on
+	// non-report statements fall back to 'low'.
+	const themes = $derived.by<ThemeSummary[]>(() => {
+		const counts = new Map<string, number>();
+		for (const row of Object.values(auxByTid)) {
+			for (const t of row.themes) counts.set(t, (counts.get(t) ?? 0) + 1);
+		}
+		return [...counts.entries()]
+			.map(([theme, statementCount]) => ({
+				theme,
+				statementCount,
+				controversy: report ? themeControversy(theme, report) : ('low' as const)
+			}))
+			.sort((a, b) => b.statementCount - a.statementCount);
+	});
+	// Bars rank against the biggest theme (themes is sorted count-desc).
+	const maxThemeCount = $derived(themes[0]?.statementCount ?? 0);
+
+	// --- Section filter state (Consensus / Difference) ---
+	let consensusExcludeHosts = $state(false);
+	let consensusExcludePasses = $state(false);
+	let differencesExcludeHosts = $state(false);
+	let differencesExcludePasses = $state(false);
+
+	// Collapse long lists to a preview; "See all" expands in place.
+	const COLLAPSED_ROWS = 5;
+	let consensusExpanded = $state(false);
+	let differencesExpanded = $state(false);
+	let showAllThemes = $state(false);
+
+	// Low-quality rows (any group < 10 votes) are hidden by default in every table
+	// but stay in the counts; each table reveals its own set.
+	let consensusShowLow = $state(false);
+	let differencesShowLow = $state(false);
+
+	const consensus = $derived(
+		report ? getConsensusStatements(report, { excludePasses: consensusExcludePasses }) : []
+	);
+	const differences = $derived(
+		report ? getDifferenceStatements(report, { excludePasses: differencesExcludePasses }) : []
+	);
+
+	const filterHosts = (list: ReportComment[], excludeHosts: boolean) =>
+		excludeHosts ? list.filter((c) => !c.is_seed) : list;
+
+	const consensusFiltered = $derived(filterHosts(consensus, consensusExcludeHosts));
+	const differencesFiltered = $derived(filterHosts(differences, differencesExcludeHosts));
+
+	// Split each list into trustworthy rows (shown) and low-quality rows (behind a
+	// reveal). Both halves stay counted in the section total.
+	const consensusMain = $derived(consensusFiltered.filter((c) => !isLowQuality(c)));
+	const consensusLow = $derived(consensusFiltered.filter((c) => isLowQuality(c)));
+	const differencesMain = $derived(differencesFiltered.filter((c) => !isLowQuality(c)));
+	const differencesLow = $derived(differencesFiltered.filter((c) => isLowQuality(c)));
+
+	/** All themes used anywhere on this conversation — powers the picker dropdown. */
+	const availableThemes = $derived.by(() => {
+		const set = new Set<string>();
+		for (const row of Object.values(auxByTid)) {
+			for (const t of row.themes) set.add(t);
+		}
+		return [...set].sort();
+	});
+
+	// --- All Statements: theme filter state ---
+	// Multi-select theme filter (OR/union). Seeded from ?theme=a,b so the view is
+	// deep-linkable/shareable.
+	let selectedThemes = $state<string[]>(
+		(page.url.searchParams.get('theme') ?? '')
+			.split(',')
+			.map((s) => s.trim())
+			.filter(Boolean)
+	);
+	let explorerExcludePasses = $state(false);
+	let explorerExcludeHosts = $state(false);
+
+	const explorerStatements = $derived.by(() => {
+		if (!report) return [] as ReportComment[];
+		let list: ReportComment[] = [...report.comments];
+		if (explorerExcludeHosts) list = list.filter((c) => !c.is_seed);
+		// OR: keep statements matching ANY selected theme.
+		if (selectedThemes.length > 0) {
+			list = list.filter((c) => selectedThemes.some((t) => c.topics?.includes(t)));
+		}
+		return list.sort((a, b) => totalVotes(b) - totalVotes(a));
+	});
+
+	// "All Statements" shows everything by default (it's last, so length doesn't
+	// disrupt) but the reveal is still reversible. Low-quality rows split out as in
+	// the other tables.
+	let explorerExpanded = $state(true);
+	let showLowQuality = $state(false);
+	const explorerMain = $derived(explorerStatements.filter((c) => !isLowQuality(c)));
+	const explorerLowQuality = $derived(explorerStatements.filter((c) => isLowQuality(c)));
+	const explorerTotal = $derived(explorerMain.length + explorerLowQuality.length);
+
+	/** Set the theme filter and mirror it into ?theme=a,b (shallow — no history spam). */
+	function setThemes(next: string[]) {
+		selectedThemes = next;
+		const url = new URL(page.url);
+		if (next.length) url.searchParams.set('theme', next.join(','));
+		else url.searchParams.delete('theme');
+		replaceState(url, {});
+	}
+
+	/** Chip bar: add/remove one theme from the OR-combined filter. */
+	function toggleTheme(theme: string) {
+		setThemes(
+			selectedThemes.includes(theme)
+				? selectedThemes.filter((t) => t !== theme)
+				: [...selectedThemes, theme]
+		);
+	}
+
+	/** Themes card: replace the filter with just this theme and scroll to the table. */
+	async function focusTheme(theme: string) {
+		setThemes([theme]);
+		await tick();
+		document
+			.getElementById(ALL_STATEMENTS_ID)
+			?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+	}
+
+	// Arriving via a ?theme= deep-link: jump to the (already filtered) table.
+	onMount(() => {
+		if (selectedThemes.length) {
+			document.getElementById(ALL_STATEMENTS_ID)?.scrollIntoView({ block: 'start' });
+		}
+	});
+
+	/** Shared theme-picker wiring for a row (disabled until the aux row exists). */
+	function pickerFor(tid: number) {
+		return {
+			availableThemes,
+			disabled: !auxByTid[tid],
+			onAddTheme: (theme: string) => addThemeFor(tid, theme),
+			onRemoveTheme: (theme: string) => removeThemeFor(tid, theme)
+		};
+	}
+
+	/**
+	 * Persist a picker edit. Optimistic + roll-back on failure, then invalidate so
+	 * the parent load re-seeds `statementAux`. No aux row means the statement hasn't
+	 * been backfilled yet — the picker is disabled for those, so this only fires
+	 * for taggable rows.
+	 */
+	async function addThemeFor(tid: number, theme: string) {
+		const row = auxByTid[tid];
+		if (!row || row.themes.includes(theme)) return;
+		const prevThemes = row.themes;
+		auxByTid = { ...auxByTid, [tid]: { ...row, themes: [...prevThemes, theme] } };
+		try {
+			const updated = await apiClient.PolisAddStatementAuxTheme(
+				{ theme },
+				{ params: { id: row.id } }
+			);
+			auxByTid = { ...auxByTid, [tid]: updated };
+			await invalidate('polis:statement-aux');
+		} catch (e) {
+			console.error('PolisAddStatementAuxTheme failed', e);
+			auxByTid = { ...auxByTid, [tid]: { ...row, themes: prevThemes } };
+			notifications.send({ priority: 'ERROR', message: 'Failed to add theme' });
+		}
+	}
+
+	async function removeThemeFor(tid: number, theme: string) {
+		const row = auxByTid[tid];
+		if (!row || !row.themes.includes(theme)) return;
+		const prevThemes = row.themes;
+		auxByTid = {
+			...auxByTid,
+			[tid]: { ...row, themes: prevThemes.filter((t) => t !== theme) }
+		};
+		try {
+			const updated = await apiClient.PolisRemoveStatementAuxTheme(
+				{ theme },
+				{ params: { id: row.id } }
+			);
+			auxByTid = { ...auxByTid, [tid]: updated };
+			await invalidate('polis:statement-aux');
+		} catch (e) {
+			console.error('PolisRemoveStatementAuxTheme failed', e);
+			auxByTid = { ...auxByTid, [tid]: { ...row, themes: prevThemes } };
+			notifications.send({ priority: 'ERROR', message: 'Failed to remove theme' });
+		}
+	}
+
+	// --- CSV export (inlined; one row per comment, columns match the UI) ---
+	/** Wrap a value for CSV: quote, double internal quotes, normalize newlines. */
+	function csvField(value: unknown): string {
+		if (value === null || value === undefined) return '';
+		const s = String(value).replace(/\r\n|\r/g, '\n');
+		return `"${s.replace(/"/g, '""')}"`;
+	}
+
+	/** Sorted union of every theme appearing on any statement in the report. */
+	function collectThemes(comments: ReportComment[]): string[] {
+		const set = new Set<string>();
+		for (const c of comments) {
+			for (const t of c.topics ?? []) set.add(t);
+		}
+		return [...set].sort();
+	}
+
+	function buildStatementsCsv(
+		data: PolisReportData,
+		auxMap: Record<number, PolisStatementAux>
+	): string {
+		const themeCols = collectThemes(data.comments);
+		const groupIds = data.groups.map((g) => g.group_id).sort((a, b) => a - b);
+
+		const header: string[] = [
+			'user_id',
+			'agrees',
+			'disagrees',
+			'passes',
+			'total_votes',
+			...themeCols.map((t) => `theme: ${t}`),
+			'consensus',
+			'statement_text'
+		];
+		for (const gid of groupIds) {
+			const label = groupLabel(gid);
+			header.push(
+				`group_${label}_agrees`,
+				`group_${label}_disagrees`,
+				`group_${label}_passes`
+			);
+		}
+		header.push('moderation_status', 'is_seed');
+
+		const lines = [header.map(csvField).join(',')];
+
+		for (const c of data.comments) {
+			const aux = auxMap[c.tid];
+			const dir = consensusDirection(c, data.groups);
+			const consensusLabel = dir === '+' ? 'True +' : dir === '-' ? 'True −' : '';
+			const topicSet = new Set(c.topics ?? []);
+
+			const row: unknown[] = [
+				aux?.user_id ?? '',
+				c.overall_votes.agrees,
+				c.overall_votes.disagrees,
+				c.overall_votes.passes,
+				totalVotes(c),
+				...themeCols.map((t) => (topicSet.has(t) ? 'true' : 'false')),
+				consensusLabel,
+				c.text
+			];
+
+			for (const gid of groupIds) {
+				const gv = c.group_votes.find((v) => v.group_id === gid);
+				row.push(gv?.agrees ?? 0, gv?.disagrees ?? 0, gv?.passes ?? 0);
+			}
+
+			row.push(
+				aux?.moderation_status ?? '',
+				(c.is_seed ?? aux?.is_seed ?? false) ? 'true' : 'false'
+			);
+
+			lines.push(row.map(csvField).join(','));
+		}
+
+		return lines.join('\n');
+	}
+
+	function downloadCsv(filename: string, csv: string): void {
+		const blob = new Blob([csv], { type: 'text/csv;charset=utf-8' });
+		const url = URL.createObjectURL(blob);
+		const a = document.createElement('a');
+		a.href = url;
+		a.download = filename;
+		document.body.appendChild(a);
+		a.click();
+		a.remove();
+		URL.revokeObjectURL(url);
+	}
+
+	function handleDownloadCsv() {
+		if (!report) return;
+		const csv = buildStatementsCsv(report, auxByTid);
+		const ts = new Date().toISOString().slice(0, 10);
+		downloadCsv(`polis-statements-${ts}.csv`, csv);
+	}
+</script>
+
+{#if !report || !stats}
+	<div class="text-muted-foreground p-8 text-base">
+		No report data yet — participants need to vote first.
+	</div>
+{:else}
+	<div class="flex flex-col gap-10 pb-8">
+		<!-- ===== Top stats ===== -->
+		<div class="flex flex-wrap items-end justify-between gap-4">
+			<div class="flex flex-wrap gap-6">
+				{#each [{ label: 'Total Statements', value: stats.totalStatements }, { label: 'Themes', value: themes.length }, { label: 'Areas of Consensus', value: consensus.length }] as s (s.label)}
+					<div class="flex flex-col gap-1">
+						<span class="text-foreground text-2xl font-bold tabular-nums"
+							>{s.value}</span
+						>
+						<span class="text-muted-foreground text-sm">{s.label}</span>
+					</div>
+				{/each}
+			</div>
+			<Button onclick={handleDownloadCsv} class="w-full sm:w-auto">
+				<Download class="size-4" />
+				Download CSV
+			</Button>
+		</div>
+
+		<!-- ===== Themes card ===== -->
+		<Card.Root
+			class="hover:border-muted-foreground/40 rounded-[20px] p-0 shadow-sm transition-colors duration-200"
+		>
+			<header class="flex items-start justify-between gap-4 px-8 pt-8">
+				<div>
+					<h2 class="text-foreground text-lg font-semibold">Themes</h2>
+					<p class="text-foreground/70 mt-2 text-base font-medium">
+						Click a theme to see all of the statements associated with it.
+					</p>
+				</div>
+			</header>
+
+			<div class="px-8 pt-6 pb-2">
+				<div
+					class="text-foreground grid grid-cols-[10rem_3rem_1fr_2.5rem] items-center gap-6 px-2 py-2 text-sm font-semibold uppercase"
+				>
+					<div>Theme</div>
+					<div class="text-right">Count</div>
+					<div></div>
+					<div></div>
+				</div>
+				{#if themes.length === 0}
+					<p class="text-muted-foreground py-6 text-base italic">
+						No themes have been generated yet for this conversation.
+					</p>
+				{:else}
+					{#each showAllThemes ? themes : themes.slice(0, COLLAPSED_ROWS) as t (t.theme)}
+						<ThemeBar
+							summary={t}
+							barMax={maxThemeCount}
+							onclick={() => focusTheme(t.theme)}
+						/>
+					{/each}
+					{#if themes.length > COLLAPSED_ROWS}
+						<button
+							type="button"
+							onclick={() => (showAllThemes = !showAllThemes)}
+							class="text-foreground/70 hover:text-foreground flex w-full items-center justify-center gap-2 py-4 text-base transition-colors"
+						>
+							{showAllThemes
+								? 'Show fewer themes'
+								: `See all ${themes.length} themes`}
+							<ChevronDown
+								class={`text-primary size-4 transition-transform ${showAllThemes ? 'rotate-180' : ''}`}
+							/>
+						</button>
+					{/if}
+				{/if}
+			</div>
+		</Card.Root>
+
+		<!-- ===== Areas of Consensus ===== -->
+		<StatementSection
+			title="Areas of Consensus"
+			count={consensusFiltered.length}
+			countAccent="consensus"
+			description="with greater than 80% agreement across all groups."
+			metricLabel="Min Agree"
+			groupCount={report.groups.length}
+			total={consensusMain.length}
+			collapsedCount={COLLAPSED_ROWS}
+			lowQualityCount={consensusLow.length}
+			bind:expanded={consensusExpanded}
+			bind:showLowQuality={consensusShowLow}
+			bind:excludeHosts={consensusExcludeHosts}
+			bind:excludePasses={consensusExcludePasses}
+		>
+			{#if consensusMain.length === 0}
+				<p class="text-muted-foreground col-span-full px-4 py-6 text-base italic">
+					No consensus statements yet.
+				</p>
+			{:else}
+				{#each consensusExpanded ? consensusMain : consensusMain.slice(0, COLLAPSED_ROWS) as c, i (c.tid)}
+					<StatementRow
+						index={i + 1}
+						comment={c}
+						groups={report.groups}
+						variant="consensus"
+						excludePasses={consensusExcludePasses}
+						picker={pickerFor(c.tid)}
+					/>
+				{/each}
+			{/if}
+
+			{#snippet lowQuality()}
+				{#each consensusLow as c, i (c.tid)}
+					<StatementRow
+						index={i + 1}
+						comment={c}
+						groups={report.groups}
+						variant="consensus"
+						excludePasses={consensusExcludePasses}
+						picker={pickerFor(c.tid)}
+					/>
+				{/each}
+			{/snippet}
+		</StatementSection>
+
+		<!-- ===== Areas of Difference ===== -->
+		<StatementSection
+			title="Areas of Difference"
+			count={differencesFiltered.length}
+			countAccent="difference"
+			description="with greater than 30% difference across the groups."
+			metricLabel="Difference"
+			groupCount={report.groups.length}
+			total={differencesMain.length}
+			collapsedCount={COLLAPSED_ROWS}
+			lowQualityCount={differencesLow.length}
+			bind:expanded={differencesExpanded}
+			bind:showLowQuality={differencesShowLow}
+			bind:excludeHosts={differencesExcludeHosts}
+			bind:excludePasses={differencesExcludePasses}
+		>
+			{#if differencesMain.length === 0}
+				<p class="text-muted-foreground col-span-full px-4 py-6 text-base italic">
+					No clear differences yet.
+				</p>
+			{:else}
+				{#each differencesExpanded ? differencesMain : differencesMain.slice(0, COLLAPSED_ROWS) as c, i (c.tid)}
+					<StatementRow
+						index={i + 1}
+						comment={c}
+						groups={report.groups}
+						variant="difference"
+						excludePasses={differencesExcludePasses}
+						picker={pickerFor(c.tid)}
+					/>
+				{/each}
+			{/if}
+
+			{#snippet lowQuality()}
+				{#each differencesLow as c, i (c.tid)}
+					<StatementRow
+						index={i + 1}
+						comment={c}
+						groups={report.groups}
+						variant="difference"
+						excludePasses={differencesExcludePasses}
+						picker={pickerFor(c.tid)}
+					/>
+				{/each}
+			{/snippet}
+		</StatementSection>
+
+		<!-- Areas of Uncertainty is deferred. Ships as Consensus + Difference only. -->
+
+		<!-- ===== All Statements ===== -->
+		<StatementSection
+			id={ALL_STATEMENTS_ID}
+			title="All Statements"
+			count={explorerTotal}
+			countAccent="all"
+			description="in total. Use labels below to filter by theme."
+			metricLabel="Count"
+			groupCount={report.groups.length}
+			total={explorerMain.length}
+			collapsedCount={COLLAPSED_ROWS}
+			lowQualityCount={explorerLowQuality.length}
+			bind:expanded={explorerExpanded}
+			bind:showLowQuality
+			bind:excludeHosts={explorerExcludeHosts}
+			bind:excludePasses={explorerExcludePasses}
+		>
+			{#snippet headerAction()}
+				<Button size="sm" onclick={handleDownloadCsv}>
+					<Download class="size-4" />
+					Download CSV
+				</Button>
+			{/snippet}
+
+			{#snippet toolbar()}
+				<div class="flex flex-wrap gap-2">
+					{#each themes as t (t.theme)}
+						<ThemeChip
+							label={t.theme}
+							variant="primary"
+							selected={selectedThemes.includes(t.theme)}
+							onclick={() => toggleTheme(t.theme)}
+						/>
+					{/each}
+					{#if themes.length === 0}
+						<span class="text-muted-foreground text-sm italic">No themes yet.</span>
+					{/if}
+				</div>
+			{/snippet}
+
+			{#if explorerMain.length === 0}
+				<p class="text-muted-foreground col-span-full px-4 py-6 text-base italic">
+					No statements match the current filters.
+				</p>
+			{:else}
+				{#each explorerExpanded ? explorerMain : explorerMain.slice(0, COLLAPSED_ROWS) as c, i (c.tid)}
+					<StatementRow
+						index={i + 1}
+						comment={c}
+						groups={report.groups}
+						variant={classifyStatement(c, report.groups, {
+							excludePasses: explorerExcludePasses
+						})}
+						excludePasses={explorerExcludePasses}
+						picker={pickerFor(c.tid)}
+					/>
+				{/each}
+			{/if}
+
+			{#snippet lowQuality()}
+				{#each explorerLowQuality as c, i (c.tid)}
+					<StatementRow
+						index={i + 1}
+						comment={c}
+						groups={report.groups}
+						variant={classifyStatement(c, report.groups, {
+							excludePasses: explorerExcludePasses
+						})}
+						excludePasses={explorerExcludePasses}
+						picker={pickerFor(c.tid)}
+					/>
+				{/each}
+			{/snippet}
+		</StatementSection>
+	</div>
+{/if}

--- a/ui/packages/comhairle/src/lib/tools/polis/PolisInsights.svelte
+++ b/ui/packages/comhairle/src/lib/tools/polis/PolisInsights.svelte
@@ -41,6 +41,9 @@
 		statementAux: PolisStatementAux[];
 	} = $props();
 
+	// "aux" = PolisStatementAux: our supplementary per-statement record (themes,
+	// moderation status/reason, step id, seed flag) that Polis itself doesn't store.
+	//
 	// Local mutable aux map (keyed by Polis tid) so picker edits re-render without
 	// waiting for the invalidated load to round-trip. Re-seeded whenever the
 	// `statementAux` prop changes (e.g. after an invalidate or slug change).

--- a/ui/packages/comhairle/src/lib/tools/polis/report.ts
+++ b/ui/packages/comhairle/src/lib/tools/polis/report.ts
@@ -1,0 +1,248 @@
+import type {
+	GroupVotePercent,
+	PolisReportData,
+	ReportComment,
+	ReportGroup,
+	ThemeControversy,
+	ThemeSummary
+} from './reportTypes';
+
+/** A-Z label for a group_id (0 -> "A"). */
+export function groupLabel(groupId: number): string {
+	return String.fromCharCode(65 + groupId);
+}
+
+/**
+ * Thresholds for the Insights consensus/difference labels. Defined in the
+ * ticket (286), tunable here. Not Polis concepts - our own classification.
+ */
+export const CONSENSUS_AGREE = 80; // all groups agree% >= this -> consensus (+)
+export const CONSENSUS_DISAGREE = 20; // all groups agree% < this -> consensus (-)
+export const DIFFERENCE_SPREAD = 30; // max-min agree% > this -> difference
+
+/**
+ * Per-group vote percentages for a single comment.
+ *
+ * Percentages are taken over the votes cast on THIS statement, not the
+ * group's total membership. With `excludePasses`, the denominator drops
+ * passes too - agree% becomes agrees / (agrees + disagrees).
+ */
+export function computeGroupVotePercents(
+	comment: ReportComment,
+	groups: ReportGroup[],
+	{ excludePasses = false }: { excludePasses?: boolean } = {}
+): GroupVotePercent[] {
+	return comment.group_votes.map((gv) => {
+		const group = groups.find((g) => g.group_id === gv.group_id);
+		const totalMembers = group ? group.total_members : gv.agrees + gv.disagrees + gv.passes;
+		const totalVoted = gv.agrees + gv.disagrees + gv.passes;
+		const denom = excludePasses ? gv.agrees + gv.disagrees : totalVoted;
+		const pct = (n: number) => (denom > 0 ? (n / denom) * 100 : 0);
+		return {
+			group_id: gv.group_id,
+			label: groupLabel(gv.group_id),
+			totalMembers,
+			totalVoted,
+			agreed: pct(gv.agrees),
+			disagreed: pct(gv.disagrees),
+			passed: excludePasses ? 0 : pct(gv.passes)
+		};
+	});
+}
+
+/** Top-line stats across the conversation. */
+export function getEngagementStats(data: PolisReportData) {
+	const totalParticipants = data.groups.reduce((s, g) => s + g.total_members, 0);
+	const totalGroups = data.groups.length;
+	const totalStatements = data.comments.length;
+	const totalVotesCast = data.comments.reduce(
+		(s, c) => s + c.overall_votes.agrees + c.overall_votes.disagrees + c.overall_votes.passes,
+		0
+	);
+	return { totalParticipants, totalGroups, totalStatements, totalVotes: totalVotesCast };
+}
+
+/** Vote total for a single comment (a + d + p). */
+export function totalVotes(c: ReportComment): number {
+	return c.overall_votes.agrees + c.overall_votes.disagrees + c.overall_votes.passes;
+}
+
+/** Fewest votes any single group cast on a comment (a + d + p per group). */
+export function minGroupVotes(c: ReportComment): number {
+	if (c.group_votes.length === 0) return 0;
+	return Math.min(...c.group_votes.map((gv) => gv.agrees + gv.disagrees + gv.passes));
+}
+
+/**
+ * "Low data quality" threshold - a per-group minimum. See CONTEXT.md. A
+ * statement is low quality when ANY group cast fewer than this many votes on
+ * it, because every Insights table compares group agree%s and a barely-voted
+ * group yields a meaningless percentage.
+ */
+export const LOW_QUALITY_MIN_GROUP_VOTES = 10;
+
+/** True when any group has fewer than LOW_QUALITY_MIN_GROUP_VOTES on the comment. */
+export function isLowQuality(c: ReportComment): boolean {
+	return minGroupVotes(c) < LOW_QUALITY_MIN_GROUP_VOTES;
+}
+
+/**
+ * Single classification driving the left color sliver, so the same statement
+ * shows the same stripe in every table. Consensus and difference are mutually
+ * exclusive by their own math (a row can't be all-same-side AND spread > 30).
+ */
+export function classifyStatement(
+	c: ReportComment,
+	groups: ReportGroup[],
+	{ excludePasses = false }: { excludePasses?: boolean } = {}
+): 'consensus' | 'difference' | 'neutral' {
+	if (consensusDirection(c, groups, { excludePasses }) !== null) return 'consensus';
+	const agreed = computeGroupVotePercents(c, groups, { excludePasses }).map((p) => p.agreed);
+	const spread = agreed.length ? Math.max(...agreed) - Math.min(...agreed) : 0;
+	return spread > DIFFERENCE_SPREAD ? 'difference' : 'neutral';
+}
+
+/** Filter helpers shared by the three areas-of-* lists. */
+function withMinVotes(comments: ReportComment[], minVotes: number) {
+	return comments.filter((c) => totalVotes(c) >= minVotes);
+}
+
+/**
+ * Consensus direction for a statement, or null if it isn't a consensus.
+ *   '+' -> every group agrees (agree% >= CONSENSUS_AGREE)
+ *   '-' -> every group disagrees (agree% < CONSENSUS_DISAGREE)
+ */
+export function consensusDirection(
+	comment: ReportComment,
+	groups: ReportGroup[],
+	{ excludePasses = false }: { excludePasses?: boolean } = {}
+): '+' | '-' | null {
+	const agreed = computeGroupVotePercents(comment, groups, { excludePasses }).map(
+		(p) => p.agreed
+	);
+	if (agreed.length === 0) return null;
+	if (agreed.every((a) => a >= CONSENSUS_AGREE)) return '+';
+	if (agreed.every((a) => a < CONSENSUS_DISAGREE)) return '-';
+	return null;
+}
+
+/**
+ * Areas of consensus: ALL groups land on the same side - either all agree
+ * (agree% >= 80) or all disagree (agree% < 20). See CONTEXT.md / ticket 286.
+ */
+export function getConsensusStatements(
+	data: PolisReportData,
+	{ minVotes = 5, excludePasses = false }: { minVotes?: number; excludePasses?: boolean } = {}
+): ReportComment[] {
+	return withMinVotes(data.comments, minVotes)
+		.filter((c) => consensusDirection(c, data.groups, { excludePasses }) !== null)
+		.sort((a, b) => (b.group_informed_consensus ?? 0) - (a.group_informed_consensus ?? 0));
+}
+
+/**
+ * Areas of difference: the largest agree% gap between any two groups exceeds
+ * the threshold (30 by default). With >2 groups this is max(agree%) -
+ * min(agree%), i.e. ONE diverging pair is enough. Sorted by spread, desc.
+ */
+export function getDifferenceStatements(
+	data: PolisReportData,
+	{
+		threshold = DIFFERENCE_SPREAD,
+		minVotes = 5,
+		excludePasses = false
+	}: {
+		threshold?: number;
+		minVotes?: number;
+		excludePasses?: boolean;
+	} = {}
+): ReportComment[] {
+	return withMinVotes(data.comments, minVotes)
+		.map((c) => {
+			const pcts = computeGroupVotePercents(c, data.groups, { excludePasses }).map(
+				(p) => p.agreed
+			);
+			const spread = pcts.length ? Math.max(...pcts) - Math.min(...pcts) : 0;
+			return { c, spread };
+		})
+		.filter(({ spread }) => spread > threshold)
+		.sort((a, b) => b.spread - a.spread)
+		.map(({ c }) => c);
+}
+
+/**
+ * Areas of uncertainty: pass% significantly higher than the average pass
+ * rate across all comments. Default = pass% >= avg + stdev (or >= 30%).
+ */
+export function getUncertaintyStatements(
+	data: PolisReportData,
+	{ minVotes = 5 }: { minVotes?: number } = {}
+): ReportComment[] {
+	const filtered = withMinVotes(data.comments, minVotes);
+	if (filtered.length === 0) return [];
+
+	const passPcts = filtered.map((c) => {
+		const t = totalVotes(c);
+		return t === 0 ? 0 : (c.overall_votes.passes / t) * 100;
+	});
+	const avg = passPcts.reduce((s, x) => s + x, 0) / passPcts.length;
+	const variance = passPcts.reduce((s, x) => s + (x - avg) ** 2, 0) / passPcts.length;
+	const stdev = Math.sqrt(variance);
+	const cutoff = Math.max(avg + stdev, 30);
+
+	return filtered
+		.map((c, i) => ({ c, pct: passPcts[i] }))
+		.filter(({ pct }) => pct >= cutoff)
+		.sort((a, b) => b.pct - a.pct)
+		.map(({ c }) => c);
+}
+
+/** Aggregate topic counts across all comments. */
+export function getThemeCounts(data: PolisReportData): { theme: string; count: number }[] {
+	const counts = new Map<string, number>();
+	for (const c of data.comments) {
+		for (const t of c.topics ?? []) counts.set(t, (counts.get(t) ?? 0) + 1);
+	}
+	return [...counts.entries()]
+		.map(([theme, count]) => ({ theme, count }))
+		.sort((a, b) => b.count - a.count);
+}
+
+/**
+ * Per-statement group-agree spread = max(agree%) - min(agree%) across groups.
+ * Returns 0 when the statement has fewer than 2 groups voting.
+ */
+function statementSpread(comment: ReportComment, groups: ReportGroup[]): number {
+	const agreed = computeGroupVotePercents(comment, groups).map((p) => p.agreed);
+	if (agreed.length < 2) return 0;
+	return Math.max(...agreed) - Math.min(...agreed);
+}
+
+/**
+ * Controversy classification for a theme. See CONTEXT.md -> "Controversy".
+ * Average per-statement group-agree spread, bucketed:
+ *   <15 -> low, 15-30 -> moderate, >30 -> high.
+ */
+export function themeControversy(theme: string, data: PolisReportData): ThemeControversy {
+	const tagged = data.comments.filter((c) => c.topics?.includes(theme));
+	if (tagged.length === 0) return 'low';
+	const spreads = tagged.map((c) => statementSpread(c, data.groups));
+	const avg = spreads.reduce((s, x) => s + x, 0) / spreads.length;
+	if (avg > 30) return 'high';
+	if (avg >= 15) return 'moderate';
+	return 'low';
+}
+
+/** Theme roll-ups for the Themes card: statement count + controversy bucket. */
+export function getThemeSummaries(data: PolisReportData): ThemeSummary[] {
+	return getThemeCounts(data).map(({ theme, count }) => ({
+		theme,
+		statementCount: count,
+		controversy: themeControversy(theme, data)
+	}));
+}
+
+/** Overall agree% for one comment (denominator = total votes). */
+export function overallAgreePct(c: ReportComment): number {
+	const t = totalVotes(c);
+	return t === 0 ? 0 : (c.overall_votes.agrees / t) * 100;
+}

--- a/ui/packages/comhairle/src/lib/tools/polis/report.ts
+++ b/ui/packages/comhairle/src/lib/tools/polis/report.ts
@@ -36,16 +36,18 @@ export function computeGroupVotePercents(
 		const group = groups.find((g) => g.group_id === gv.group_id);
 		const totalMembers = group ? group.total_members : gv.agrees + gv.disagrees + gv.passes;
 		const totalVoted = gv.agrees + gv.disagrees + gv.passes;
-		const denom = excludePasses ? gv.agrees + gv.disagrees : totalVoted;
-		const pct = (n: number) => (denom > 0 ? (n / denom) * 100 : 0);
+		const denominator = excludePasses ? gv.agrees + gv.disagrees : totalVoted;
+		// Share of `denominator` a given vote count represents, as a 0-100 percentage.
+		const percentOf = (voteCount: number) =>
+			denominator > 0 ? (voteCount / denominator) * 100 : 0;
 		return {
 			group_id: gv.group_id,
 			label: groupLabel(gv.group_id),
 			totalMembers,
 			totalVoted,
-			agreed: pct(gv.agrees),
-			disagreed: pct(gv.disagrees),
-			passed: excludePasses ? 0 : pct(gv.passes)
+			agreed: percentOf(gv.agrees),
+			disagreed: percentOf(gv.disagrees),
+			passed: excludePasses ? 0 : percentOf(gv.passes)
 		};
 	});
 }
@@ -158,10 +160,12 @@ export function getDifferenceStatements(
 ): ReportComment[] {
 	return withMinVotes(data.comments, minVotes)
 		.map((c) => {
-			const pcts = computeGroupVotePercents(c, data.groups, { excludePasses }).map(
+			const agreePercents = computeGroupVotePercents(c, data.groups, { excludePasses }).map(
 				(p) => p.agreed
 			);
-			const spread = pcts.length ? Math.max(...pcts) - Math.min(...pcts) : 0;
+			const spread = agreePercents.length
+				? Math.max(...agreePercents) - Math.min(...agreePercents)
+				: 0;
 			return { c, spread };
 		})
 		.filter(({ spread }) => spread > threshold)
@@ -180,19 +184,19 @@ export function getUncertaintyStatements(
 	const filtered = withMinVotes(data.comments, minVotes);
 	if (filtered.length === 0) return [];
 
-	const passPcts = filtered.map((c) => {
+	const passPercents = filtered.map((c) => {
 		const t = totalVotes(c);
 		return t === 0 ? 0 : (c.overall_votes.passes / t) * 100;
 	});
-	const avg = passPcts.reduce((s, x) => s + x, 0) / passPcts.length;
-	const variance = passPcts.reduce((s, x) => s + (x - avg) ** 2, 0) / passPcts.length;
+	const avg = passPercents.reduce((s, x) => s + x, 0) / passPercents.length;
+	const variance = passPercents.reduce((s, x) => s + (x - avg) ** 2, 0) / passPercents.length;
 	const stdev = Math.sqrt(variance);
 	const cutoff = Math.max(avg + stdev, 30);
 
 	return filtered
-		.map((c, i) => ({ c, pct: passPcts[i] }))
-		.filter(({ pct }) => pct >= cutoff)
-		.sort((a, b) => b.pct - a.pct)
+		.map((c, i) => ({ c, passPercent: passPercents[i] }))
+		.filter(({ passPercent }) => passPercent >= cutoff)
+		.sort((a, b) => b.passPercent - a.passPercent)
 		.map(({ c }) => c);
 }
 

--- a/ui/packages/comhairle/src/lib/tools/polis/reportTypes.ts
+++ b/ui/packages/comhairle/src/lib/tools/polis/reportTypes.ts
@@ -1,69 +1,60 @@
 /**
  * Polis report data shapes.
  *
- * Mirrors the comhairle backend `WikiPollReport` returned by
- * `GET /tools/polis/report_data?workflow_step_id=...` (the generated
- * `WikiPollReport` type from `@crownshy/api-client`). `topics`/`subtopics`
- * are a client-side overlay from `polis_statement_aux.themes` and are not on
- * the backend payload — see PolisInsights.svelte.
+ * The wire types are the single source of truth in the generated
+ * `@crownshy/api-client` (`WikiPollReport` and friends) — this module does NOT
+ * re-declare them, it only re-exports them under the names this feature uses
+ * and adds what the client can't know about:
+ *   - `topics`/`subtopics`: a client-side overlay tagged from
+ *     `polis_statement_aux.themes`; the backend payload carries neither.
+ *   - view models computed in `report.ts` (`GroupVotePercent`) and the Themes
+ *     card roll-ups (`ThemeControversy`, `ThemeSummary`).
+ * See PolisInsights.svelte and CONTEXT.md.
  */
 
-export interface VoteCounts {
-	agrees: number;
-	disagrees: number;
-	passes: number;
-}
+import type {
+	CommentReportData,
+	GroupReportData,
+	ParticipantReportData
+} from '@crownshy/api-client/api';
 
-export interface GroupVote {
-	group_id: number;
-	agrees: number;
-	disagrees: number;
-	passes: number;
-}
+// Generated wire types, aliased to the names this feature already uses so
+// consumers get the client's types without importing the client directly.
+export type {
+	VoteCounts,
+	GroupVoteCounts as GroupVote,
+	RepresentativeComment,
+	PcaPosition,
+	ParticipantReportData as ReportParticipant
+} from '@crownshy/api-client/api';
 
-export interface ReportComment {
-	tid: number;
-	text: string;
-	overall_votes: VoteCounts;
-	group_votes: GroupVote[];
-	group_informed_consensus: number;
-	divisiveness: number;
-	is_seed?: boolean;
-	/** Theme tags overlaid from polis_statement_aux.themes (not from the backend). */
+export type ReportGroup = GroupReportData;
+
+/**
+ * A report comment plus the client-only theme overlay. `topics`/`subtopics`
+ * are tagged from `polis_statement_aux.themes` after load; the backend payload
+ * (`CommentReportData`) carries neither.
+ */
+export type ReportComment = CommentReportData & {
 	topics?: string[];
 	subtopics?: string[];
-}
+};
 
-export interface RepresentativeComment {
-	tid: number;
-	text: string;
-}
-
-export interface ReportGroup {
-	group_id: number;
-	representative_comments: RepresentativeComment[];
-	members: number[];
-	total_members: number;
-}
-
-export interface PcaPosition {
-	x: number;
-	y: number;
-}
-
-export interface ReportParticipant {
-	pid: number;
-	group_id: number;
-	pca_position: PcaPosition | null;
-}
-
+/**
+ * `WikiPollReport` with the client-side theme overlay applied to its comments.
+ *
+ * Spelled out from the generated element types rather than
+ * `Omit<WikiPollReport, 'comments'>`: the client's `.passthrough()` adds a
+ * `[k: string]: unknown` index signature, which makes `Omit` collapse the
+ * remaining props to `unknown`.
+ */
 export interface PolisReportData {
 	comments: ReportComment[];
-	groups: ReportGroup[];
-	participants: ReportParticipant[];
+	groups: GroupReportData[];
+	participants: ParticipantReportData[];
 }
 
-/** Per-group vote percentage breakdown for one comment. */
+/** Per-group vote percentage breakdown for one comment. Computed in report.ts. */
 export interface GroupVotePercent {
 	group_id: number;
 	label: string;

--- a/ui/packages/comhairle/src/lib/tools/polis/reportTypes.ts
+++ b/ui/packages/comhairle/src/lib/tools/polis/reportTypes.ts
@@ -1,0 +1,91 @@
+/**
+ * Polis report data shapes.
+ *
+ * Mirrors the comhairle backend `WikiPollReport` returned by
+ * `GET /tools/polis/report_data?workflow_step_id=...` (the generated
+ * `WikiPollReport` type from `@crownshy/api-client`). `topics`/`subtopics`
+ * are a client-side overlay from `polis_statement_aux.themes` and are not on
+ * the backend payload — see PolisInsights.svelte.
+ */
+
+export interface VoteCounts {
+	agrees: number;
+	disagrees: number;
+	passes: number;
+}
+
+export interface GroupVote {
+	group_id: number;
+	agrees: number;
+	disagrees: number;
+	passes: number;
+}
+
+export interface ReportComment {
+	tid: number;
+	text: string;
+	overall_votes: VoteCounts;
+	group_votes: GroupVote[];
+	group_informed_consensus: number;
+	divisiveness: number;
+	is_seed?: boolean;
+	/** Theme tags overlaid from polis_statement_aux.themes (not from the backend). */
+	topics?: string[];
+	subtopics?: string[];
+}
+
+export interface RepresentativeComment {
+	tid: number;
+	text: string;
+}
+
+export interface ReportGroup {
+	group_id: number;
+	representative_comments: RepresentativeComment[];
+	members: number[];
+	total_members: number;
+}
+
+export interface PcaPosition {
+	x: number;
+	y: number;
+}
+
+export interface ReportParticipant {
+	pid: number;
+	group_id: number;
+	pca_position: PcaPosition | null;
+}
+
+export interface PolisReportData {
+	comments: ReportComment[];
+	groups: ReportGroup[];
+	participants: ReportParticipant[];
+}
+
+/** Per-group vote percentage breakdown for one comment. */
+export interface GroupVotePercent {
+	group_id: number;
+	label: string;
+	totalMembers: number;
+	totalVoted: number;
+	agreed: number;
+	disagreed: number;
+	passed: number;
+}
+
+/**
+ * Roll-up for one theme as shown in the Themes card on the Insights page.
+ *
+ * `controversy` is defined in CONTEXT.md and computed in `themeControversy()`
+ * - it is our own classification, not from Polis/T3C. `subtopics` is left
+ * empty until a T3C-shaped source provides them.
+ */
+export type ThemeControversy = 'low' | 'moderate' | 'high';
+
+export interface ThemeSummary {
+	theme: string;
+	statementCount: number;
+	controversy: ThemeControversy;
+	subtopics?: string[];
+}

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/+layout.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/+layout.svelte
@@ -189,7 +189,7 @@
 	</div>
 {/if}
 
-<div class="bg-muted grow px-4 py-8 sm:px-8 sm:pb-12 md:py-10 lg:px-16 lg:pb-18">
+<div class="bg-muted pt-2pb-8 grow px-4 sm:px-8 sm:pb-12 md:py-8 lg:px-16">
 	<div class="mx-auto h-full w-full max-w-[1200px]">
 		{@render children()}
 	</div>

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/+layout.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/+layout.svelte
@@ -189,7 +189,7 @@
 	</div>
 {/if}
 
-<div class="bg-muted pt-2pb-8 grow px-4 sm:px-8 sm:pb-12 md:py-8 lg:px-16">
+<div class="bg-muted grow px-4 pt-2 pb-8 sm:px-8 sm:pb-12 md:py-8 lg:px-16">
 	<div class="mx-auto h-full w-full max-w-[1200px]">
 		{@render children()}
 	</div>

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/design/step/[step_id]/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/design/step/[step_id]/+page.svelte
@@ -2,6 +2,7 @@
 	import LearnManage from '$lib/tools/learn/LearnManage.svelte';
 	import PolisManage from '$lib/tools/polis/PolisManage.svelte';
 	import PolisModeration from '$lib/tools/polis/PolisModeration.svelte';
+	import PolisInsights from '$lib/tools/polis/PolisInsights.svelte';
 	import CommonStepConfig from '$lib/components/CommonStepConfig/CommonStepConfig.svelte';
 	import HeyFormManage from '$lib/tools/heyform/HeyFormManage.svelte';
 	import ThinkingSpaceManage from '$lib/tools/thinking_space/ThinkingSpaceManage.svelte';
@@ -106,8 +107,12 @@
 	/>
 {:else if step && isPolis && subtab === 'moderation'}
 	<PolisModeration workflowStepId={step.id} statements={data.statementAux ?? []} />
-{:else if isPolis && subtab === 'insights'}
-	<div class="text-muted-foreground py-12 text-center text-sm">Insights view coming soon.</div>
+{:else if step && isPolis && subtab === 'insights'}
+	<PolisInsights
+		workflowStepId={step.id}
+		reportData={data.reportData ?? null}
+		statementAux={data.statementAux ?? []}
+	/>
 {/if}
 
 {#if subtab === 'setup' && toolConfig?.type === 'heyform'}

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/design/step/[step_id]/+page.ts
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/design/step/[step_id]/+page.ts
@@ -1,4 +1,5 @@
 import type { PolisStatementAux } from '@crownshy/api-client/api';
+import type { PolisReportData } from '$lib/tools/polis/reportTypes';
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async (event) => {
@@ -7,8 +8,10 @@ export const load: PageLoad = async (event) => {
 
 	// Polis Moderation/Insights subtabs read the statement_aux table for this
 	// step. Declared here so the tabs can invalidate just this after
-	// sync/moderate/seed, and so both subtabs share one fetch.
+	// sync/moderate/seed, and so both subtabs share one fetch. `polis:report`
+	// is a separate key for the Insights vote/report export.
 	event.depends('polis:statement-aux');
+	event.depends('polis:report');
 
 	const step = workflowSteps?.find((s) => s.id === step_id);
 	const toolConfig = step
@@ -18,6 +21,7 @@ export const load: PageLoad = async (event) => {
 		: null;
 
 	let statementAux: PolisStatementAux[] = [];
+	let reportData: PolisReportData | null = null;
 	if (toolConfig?.type === 'polis') {
 		try {
 			statementAux = await api.PolisListStatementAux({
@@ -26,7 +30,16 @@ export const load: PageLoad = async (event) => {
 		} catch (e) {
 			console.error('Failed to load Polis statement aux', e);
 		}
+		try {
+			// Typed as WikiPollReport by the client; structurally PolisReportData.
+			// Fails (→ null) when the poll has no votes yet.
+			reportData = (await api.PolisGetReportData({
+				queries: { workflow_step_id: step_id }
+			})) as unknown as PolisReportData;
+		} catch (e) {
+			console.error('Failed to load Polis report data', e);
+		}
 	}
 
-	return { step_id, conversation, workflows, workflowSteps, statementAux };
+	return { step_id, conversation, workflows, workflowSteps, statementAux, reportData };
 };

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/design/step/[step_id]/+page.ts
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/design/step/[step_id]/+page.ts
@@ -31,11 +31,12 @@ export const load: PageLoad = async (event) => {
 			console.error('Failed to load Polis statement aux', e);
 		}
 		try {
-			// Typed as WikiPollReport by the client; structurally PolisReportData.
-			// Fails (→ null) when the poll has no votes yet.
-			reportData = (await api.PolisGetReportData({
+			// PolisReportData is WikiPollReport (the client's return type) plus the
+			// client-only theme overlay, so this assigns without a cast. Fails
+			// (→ null) when the poll has no votes yet.
+			reportData = await api.PolisGetReportData({
 				queries: { workflow_step_id: step_id }
-			})) as unknown as PolisReportData;
+			});
 		} catch (e) {
 			console.error('Failed to load Polis report data', e);
 		}


### PR DESCRIPTION
Second UI PR. Adds the native **Insights** tab: the per-step Polis report showing where opinions cluster, what people agree and disagree on, and how statements group by theme. Uses the typed `report_data` endpoint from PR 0.

## What changed

- **Analytics core** (`report.ts`, `reportTypes.ts`): ported from civic_os. Consensus (all groups agree >80% or <20%), difference (group agree gap >30pts), theme controversy (low <15, moderate 15–30, high >30), low data quality (any group <10 votes). Pure functions, thresholds as tunable constants.
- **`reportTypes.ts`**: re-exports the wire types from `@crownshy/api-client` instead of re-declaring them. Only adds what the client can't know (see Decisions).
- **`PolisInsights.svelte`**: stats row, Themes card, three sections (Consensus, Difference, All Statements). Theme filter chips with `?theme=` deep-linking, per-column filters (include hosts, include passes), low-quality reveal, CSV export, per-row theme picker.
- **9 reskinned components** in `lib/components/polis-report/`: StatementRow, StatementSection, ThemeBar, ThemeChip, GroupCircle, ColumnFilterHeader, FilterToggle, RowAccentStripe, ThemePicker.
- **`+page.ts`**: loads `report_data` for Polis steps under a `polis:report` depends key. Returns null when the poll has no votes yet. Assigns the client's return type directly, no cast.

## Decisions

Need help with this: **Report types reuse the typed client, they don't duplicate it.** `reportTypes.ts` re-exports `WikiPollReport` and its friends from `@crownshy/api-client` under the names this feature uses, and only adds:
- `topics`/`subtopics`, a client-side overlay from `polis_statement_aux.themes` (the backend payload has neither).
- view models computed here: `GroupVotePercent`, `ThemeControversy`, `ThemeSummary`.

Why this matters: the first cut hand-copied the wire shapes as parallel interfaces. That forced an `as unknown as PolisReportData` cast in the loader (the two type trees weren't the same identity), and the copy had already drifted from the source (it wrongly made `group_informed_consensus`/`divisiveness` required and `is_seed` optional). Deriving from the client removes the drift and drops the cast.

One gotcha, documented in-file: `PolisReportData` lists its three fields explicitly instead of `Omit<WikiPollReport, 'comments'>`, because the client's zod `.passthrough()` adds a `[k: string]: unknown` index signature that makes `Omit` collapse the other props to `unknown`.

(A second, older copy of these types lives at `lib/types/report.ts` for the public `waves/report` feature. It predates this branch. Worth unifying the same way later, kept out of scope here.)

**Other:**
- Themes are human authored and live in `polis_statement_aux.themes`. The view overlays them onto a cloned copy, so loaded `reportData` is never mutated. Theme edits go through the api client, then invalidate `polis:statement-aux`.
- Theme tokens only, no hardcoded colours. No success/warning token exists, so consensus green maps to `--primary` and low-quality amber maps to `text-muted-foreground`. GroupCircle agree scale: `text-destructive` (<33), `text-muted-foreground` (33–66), `text-primary` (>66).
- Uncertainty section deferred. CSV helper, stat row, and meter bar inlined since comhairle has no equivalents.

## Testing

- Not yet driven end to end (needs a launched poll with votes across 2+ groups).
- `svelte-check` clean on the touched files. The only remaining errors nearby are pre-existing `step`-undefined warnings in a sibling `+page.svelte` this PR doesn't touch.

<img width="1483" height="884" alt="image" src="https://github.com/user-attachments/assets/230ded1f-9a36-4db8-a925-fe8a2f4215ca" />
<img width="1462" height="879" alt="image" src="https://github.com/user-attachments/assets/c08d346e-a61f-475e-b7af-9a0e38a5235e" />