### PR TITLE
596 search pagination reset

### DIFF
--- a/ui/packages/comhairle/src/routes/(public)/conversations/utils.ts
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/utils.ts
@@ -39,12 +39,13 @@ export const getSearch = (url: URL): string => {
 
 export const setSearch = (_url: URL, search: string): URL => {
 	const url = new URL(_url);
+	url.searchParams.delete('page');
 	if (search) {
 		url.searchParams.set('search', search);
-		setPage(url, 0)
+		setPage(url, 0);
 	} else {
 		url.searchParams.delete('search');
-		setPage(url, 0)
+		setPage(url, 0);
 	}
 	return url;
 };


### PR DESCRIPTION
Actions:

+ reset pagination when user begins a new search

Motivation:

+ fix bug where user would be stuck on wrong page after searching