### PR TITLE
Admin: nicer loading states & transitions

### DIFF
--- a/ui/packages/comhairle/src/lib/components/LoadingOverlay.svelte
+++ b/ui/packages/comhairle/src/lib/components/LoadingOverlay.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { untrack } from 'svelte';
 	import { Portal } from 'bits-ui';
 	import { Spinner } from '$lib/components/ui/spinner';
 
@@ -6,22 +7,46 @@
 	 * A full-screen, screen-level loading overlay for slow, deliberate actions (creating
 	 * a conversation, adding a workflow step) where a disabled button alone is too subtle.
 	 *
+	 * Anti-flicker: once shown it stays for at least {@link minVisibleMs}, so an action that
+	 * finishes almost instantly can't blink the overlay on and off.
+	 *
 	 * Portaled to `<body>` so no ancestor stacking context (e.g. the sidebar) can trap it,
 	 * and above dialogs/toasts so it reads as a single clear "working…" state.
 	 */
 	type Props = {
-		/** Whether the overlay is shown. */
+		/** Whether the underlying action is in progress. */
 		open: boolean;
 		/** Short status message shown next to the spinner, e.g. `"Adding step…"`. */
 		message: string;
+		/** Once shown, keep it visible at least this long (ms) so it never flickers. */
+		minVisibleMs?: number;
 	};
-	let { open, message }: Props = $props();
+	let { open, message, minVisibleMs = 500 }: Props = $props();
+
+	let visible = $state(false);
+	// Plain (non-reactive) so reading it inside the effect doesn't re-trigger the effect.
+	let shownAt = 0;
+
+	$effect(() => {
+		// Track only `open` (and `minVisibleMs`). `visible` is read via `untrack` so setting
+		// it here never re-runs this effect and resets the hide timer.
+		if (open) {
+			visible = true;
+			shownAt = Date.now();
+			return;
+		}
+
+		if (!untrack(() => visible)) return; // never showed: nothing to hide
+		const remaining = Math.max(0, minVisibleMs - (Date.now() - shownAt));
+		const hideTimer = setTimeout(() => (visible = false), remaining);
+		return () => clearTimeout(hideTimer);
+	});
 </script>
 
-{#if open}
+{#if visible}
 	<Portal>
 		<div
-			class="bg-background/70 fixed inset-0 z-[100] flex items-center justify-center backdrop-blur-sm"
+			class="bg-background/70 fixed inset-0 z-100 flex items-center justify-center backdrop-blur-sm"
 			role="status"
 			aria-live="polite"
 		>

--- a/ui/packages/comhairle/src/lib/components/LoadingOverlay.svelte
+++ b/ui/packages/comhairle/src/lib/components/LoadingOverlay.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+	import { Portal } from 'bits-ui';
+	import { Spinner } from '$lib/components/ui/spinner';
+
+	/**
+	 * A full-screen, screen-level loading overlay for slow, deliberate actions (creating
+	 * a conversation, adding a workflow step) where a disabled button alone is too subtle.
+	 *
+	 * Portaled to `<body>` so no ancestor stacking context (e.g. the sidebar) can trap it,
+	 * and above dialogs/toasts so it reads as a single clear "working…" state.
+	 */
+	type Props = {
+		/** Whether the overlay is shown. */
+		open: boolean;
+		/** Short status message shown next to the spinner, e.g. `"Adding step…"`. */
+		message: string;
+	};
+	let { open, message }: Props = $props();
+</script>
+
+{#if open}
+	<Portal>
+		<div
+			class="bg-background/70 fixed inset-0 z-[100] flex items-center justify-center backdrop-blur-sm"
+			role="status"
+			aria-live="polite"
+		>
+			<div
+				class="bg-card border-border flex items-center gap-3 rounded-xl border px-5 py-4 shadow-lg"
+			>
+				<Spinner class="text-primary size-5" />
+				<span class="text-foreground text-base font-medium">{message}</span>
+			</div>
+		</div>
+	</Portal>
+{/if}

--- a/ui/packages/comhairle/src/lib/components/NewConversationButton.svelte
+++ b/ui/packages/comhairle/src/lib/components/NewConversationButton.svelte
@@ -2,9 +2,8 @@
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
 	import * as Dialog from '$lib/components/ui/dialog';
 	import * as Accordion from '$lib/components/ui/accordion';
-	import { Portal } from 'bits-ui';
 	import { buttonVariants, LoadingButton } from '$lib/components/ui/button';
-	import { Spinner } from '$lib/components/ui/spinner';
+	import LoadingOverlay from '$lib/components/LoadingOverlay.svelte';
 	import { Plus } from 'lucide-svelte';
 	import { goto } from '$app/navigation';
 	import { notifications } from '$lib/notifications.svelte';
@@ -179,23 +178,5 @@
 </Dialog.Root>
 
 <!-- Immediate, screen-level feedback while the conversation is being created (covers
-	both "Start from blank", where the dropdown has already closed, and a template).
-	Portaled to <body> so no sidebar stacking context can trap it below the page. -->
-{#if submitting}
-	<Portal>
-		<div
-			class="bg-background/70 fixed inset-0 z-[100] flex items-center justify-center backdrop-blur-sm"
-			role="status"
-			aria-live="polite"
-		>
-			<div
-				class="bg-card border-border flex items-center gap-3 rounded-xl border px-5 py-4 shadow-lg"
-			>
-				<Spinner class="text-primary size-5" />
-				<span class="text-foreground text-base font-medium"
-					>Creating your conversation…</span
-				>
-			</div>
-		</div>
-	</Portal>
-{/if}
+	both "Start from blank", where the dropdown has already closed, and a template). -->
+<LoadingOverlay open={submitting} message="Creating your conversation…" />

--- a/ui/packages/comhairle/src/lib/components/NewConversationButton.svelte
+++ b/ui/packages/comhairle/src/lib/components/NewConversationButton.svelte
@@ -2,13 +2,16 @@
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
 	import * as Dialog from '$lib/components/ui/dialog';
 	import * as Accordion from '$lib/components/ui/accordion';
-	import { buttonVariants } from '$lib/components/ui/button';
+	import { Portal } from 'bits-ui';
+	import { buttonVariants, LoadingButton } from '$lib/components/ui/button';
+	import { Spinner } from '$lib/components/ui/spinner';
 	import { Plus } from 'lucide-svelte';
 	import { goto } from '$app/navigation';
 	import { notifications } from '$lib/notifications.svelte';
 	import { manage_conversation_url } from '$lib/urls';
 	import { createConversation } from '$lib/createConversation';
 	import { conversationTemplates } from '$lib/conversation_templates';
+	import { justCreatedConversation } from '$lib/stores/justCreatedConversation.svelte';
 	import SelectableOptionRow from '$lib/components/SelectableOptionRow.svelte';
 	import { cn } from '$lib/utils';
 
@@ -30,6 +33,8 @@
 		submitting = true;
 		try {
 			const conversation = await createConversation(templateKey ? { templateKey } : {});
+			// Flag it so the configure page it lands on makes its newness obvious.
+			justCreatedConversation.flag(conversation.id);
 			notifications.addFlash({ message: 'Conversation created' });
 			dialogOpen = false;
 			await goto(manage_conversation_url(conversation.id), { invalidateAll: true });
@@ -70,7 +75,9 @@
 
 		<div class="flex min-h-0 flex-1 items-start gap-6 overflow-hidden">
 			<!-- Left: selectable template list -->
-			<div class="flex w-96 shrink-0 flex-col gap-3 self-stretch overflow-y-auto pr-1">
+			<div
+				class="flex w-96 shrink-0 flex-col gap-3 self-stretch overflow-y-auto pr-4 [scrollbar-gutter:stable]"
+			>
 				{#each conversationTemplates as template (template.key)}
 					<SelectableOptionRow
 						selected={selectedKey === template.key}
@@ -159,14 +166,36 @@
 			<Dialog.Close class={buttonVariants({ variant: 'outline', size: 'sm' })}
 				>Close</Dialog.Close
 			>
-			<button
-				type="button"
-				disabled={submitting}
+			<LoadingButton
+				variant="default"
+				size="sm"
+				loading={submitting}
 				onclick={() => create(selected.key)}
-				class={buttonVariants({ variant: 'default', size: 'sm' })}
 			>
 				Get started
-			</button>
+			</LoadingButton>
 		</Dialog.Footer>
 	</Dialog.Content>
 </Dialog.Root>
+
+<!-- Immediate, screen-level feedback while the conversation is being created (covers
+	both "Start from blank", where the dropdown has already closed, and a template).
+	Portaled to <body> so no sidebar stacking context can trap it below the page. -->
+{#if submitting}
+	<Portal>
+		<div
+			class="bg-background/70 fixed inset-0 z-[100] flex items-center justify-center backdrop-blur-sm"
+			role="status"
+			aria-live="polite"
+		>
+			<div
+				class="bg-card border-border flex items-center gap-3 rounded-xl border px-5 py-4 shadow-lg"
+			>
+				<Spinner class="text-primary size-5" />
+				<span class="text-foreground text-base font-medium"
+					>Creating your conversation…</span
+				>
+			</div>
+		</div>
+	</Portal>
+{/if}

--- a/ui/packages/comhairle/src/lib/stores/justCreatedConversation.svelte.ts
+++ b/ui/packages/comhairle/src/lib/stores/justCreatedConversation.svelte.ts
@@ -1,0 +1,25 @@
+/**
+ * Cross-navigation signal naming a conversation that was just created, so the page it
+ * lands on can make its newness obvious (focus + select the auto-generated title, ready
+ * to rename) instead of looking identical to the conversation the user came from.
+ *
+ * {@link import('$lib/components/NewConversationButton.svelte')} flags the new id here
+ * right before navigating; the configure page reads it on mount, acts if it matches its
+ * own conversation, then clears it so a later manual visit does not re-trigger.
+ */
+let id = $state<string | null>(null);
+
+export const justCreatedConversation = {
+	/** The id of the just-created conversation, or `null` when nothing is pending. */
+	get id() {
+		return id;
+	},
+	/** Flag a freshly-created conversation for its landing page to acknowledge. */
+	flag(conversationId: string) {
+		id = conversationId;
+	},
+	/** Clear the flag once the landing page has acknowledged it. */
+	clear() {
+		id = null;
+	}
+};

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/configure/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/configure/+page.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
+	import { onMount } from 'svelte';
 	import { Switch } from '$lib/components/ui/switch';
 	import * as Form from '$lib/components/ui/form/';
 	import { notifications } from '$lib/notifications.svelte';
 	import { apiClient } from '@crownshy/api-client/client';
 	import { invalidate, invalidateAll } from '$app/navigation';
+	import { justCreatedConversation } from '$lib/stores/justCreatedConversation.svelte';
 	import { superForm } from 'sveltekit-superforms';
 	import { zodClient } from 'sveltekit-superforms/adapters';
 	import { conversationConfigSchema } from './schema';
@@ -41,6 +43,22 @@
 	let primaryLanguage = $state(data.conversation.primaryLocale ?? 'en');
 	let supportedLanguages = $state(data.conversation.supportedLanguages ?? ['en']);
 	let pageTitle = $derived(`Configure ${conversation.title}`);
+
+	// When we land here straight after creating this conversation, focus and select the
+	// auto-generated "Untitled …" title so it's obvious this is a brand-new conversation
+	// ready to be named, rather than looking identical to the one the user came from.
+	onMount(() => {
+		if (justCreatedConversation.id !== conversation.id) return;
+		justCreatedConversation.clear();
+		// Defer a frame so the title field is mounted and populated before we select it.
+		requestAnimationFrame(() => {
+			const input = document.querySelector<HTMLInputElement>(
+				'#conversation-title-field input'
+			);
+			input?.focus();
+			input?.select();
+		});
+	});
 
 	$effect(() => {
 		primaryLanguage = data.conversation.primaryLocale ?? 'en';
@@ -308,7 +326,7 @@
 					<Form.Label class="text-sm font-semibold lg:w-50 lg:shrink-0 lg:pt-2"
 						>Title</Form.Label
 					>
-					<div class="flex-1">
+					<div class="flex-1" id="conversation-title-field">
 						<TranslatableField
 							value={$form.title}
 							onValueChange={(v) => ($form.title = v)}

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/design/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/design/+page.svelte
@@ -14,6 +14,7 @@
 	import { addStepDialog } from '$lib/stores/addStepDialog.svelte';
 	import { newStepHighlight } from '$lib/stores/newStepHighlight.svelte';
 	import { moveItem } from '$lib/utils/reorder';
+	import { cn } from '$lib/utils';
 	import {
 		Pencil,
 		Trash2,
@@ -202,18 +203,30 @@
 		}
 	}
 
-	// --- Scroll a step just created via the AddStepDialog into view (dialog owned by the layout) ---
+	// --- Scroll a step just created via the AddStepDialog into view and briefly highlight
+	//     it, so it's clear which card is the one just added (the dialog is owned by the
+	//     layout, so it hands the new id over via `newStepHighlight`). ---
+	let highlightedStepId = $state<string | null>(null);
+	// Plain handle so the highlight's own timer isn't torn down when this effect re-runs
+	// after we clear `newStepHighlight` below.
+	let highlightTimer: ReturnType<typeof setTimeout> | undefined;
+
 	$effect(() => {
 		const pending = newStepHighlight.id;
 		if (!pending) return;
 		// Wait until the invalidated steps actually include the new one.
 		if (!reorderedSteps.some((s) => s.id === pending)) return;
 		newStepHighlight.clear();
+		highlightedStepId = pending;
 		tick().then(() => {
 			boardEl
 				?.querySelector(`[data-step-id="${pending}"]`)
 				?.scrollIntoView({ behavior: 'smooth', block: 'center' });
 		});
+		clearTimeout(highlightTimer);
+		highlightTimer = setTimeout(() => {
+			if (highlightedStepId === pending) highlightedStepId = null;
+		}, 2500);
 	});
 
 	let pageTitle = $derived(`Design ${conversation.title}`);
@@ -282,7 +295,11 @@
 						     its clicks win. Pointer cursor + hover lift read as clickable. -->
 						<div
 							data-step-id={step.id}
-							class="bg-card group hover:border-primary/50 border-border relative flex cursor-pointer items-center gap-4 rounded-xl border p-4 transition-all hover:shadow-md"
+							class={cn(
+								'bg-card group hover:border-primary/50 border-border relative flex cursor-pointer items-center gap-4 rounded-xl border p-4 transition-all hover:shadow-md',
+								highlightedStepId === step.id &&
+									'ring-primary ring-offset-muted ring-2 ring-offset-2'
+							)}
 						>
 							<!-- Drag handle. The whole card is draggable; this grip is the
 							     affordance that signals it. Sits above the stretched link. -->

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/design/AddStepDialog.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/design/AddStepDialog.svelte
@@ -3,6 +3,7 @@
 	import { resolve } from '$app/paths';
 	import { buttonVariants, LoadingButton } from '$lib/components/ui/button';
 	import SelectableOptionRow from '$lib/components/SelectableOptionRow.svelte';
+	import LoadingOverlay from '$lib/components/LoadingOverlay.svelte';
 	import { PALETTE_TOOLS, isEventPaletteItem, type CreationKey } from '$lib/tool_meta';
 	import { BookOpen, ExternalLink, Check } from 'lucide-svelte';
 
@@ -183,3 +184,7 @@
 		</Dialog.Footer>
 	</Dialog.Content>
 </Dialog.Root>
+
+<!-- The dialog stays open while the step is created, so a button spinner alone is easy to
+	miss (Polis/HeyForm can take a few seconds). Mirror the create-conversation overlay. -->
+<LoadingOverlay open={adding} message="Adding step…" />

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/design/AddStepDialog.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/design/AddStepDialog.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import * as Dialog from '$lib/components/ui/dialog';
 	import { resolve } from '$app/paths';
-	import { buttonVariants } from '$lib/components/ui/button';
+	import { buttonVariants, LoadingButton } from '$lib/components/ui/button';
 	import SelectableOptionRow from '$lib/components/SelectableOptionRow.svelte';
 	import { PALETTE_TOOLS, isEventPaletteItem, type CreationKey } from '$lib/tool_meta';
 	import { BookOpen, ExternalLink, Check } from 'lucide-svelte';
@@ -45,7 +45,9 @@
 
 		<div class="flex min-h-0 flex-1 items-start gap-6 overflow-hidden">
 			<!-- Left: selectable step-type list -->
-			<div class="flex w-96 shrink-0 flex-col gap-3 self-stretch overflow-y-auto pr-1">
+			<div
+				class="flex w-96 shrink-0 flex-col gap-3 self-stretch overflow-y-auto pr-4 [scrollbar-gutter:stable]"
+			>
 				{#each PALETTE_TOOLS as tool (tool.type)}
 					<SelectableOptionRow
 						selected={selectedType === tool.type}
@@ -168,15 +170,15 @@
 				<Dialog.Close class={buttonVariants({ variant: 'outline', size: 'sm' })}>
 					Cancel
 				</Dialog.Close>
-				<button
-					type="button"
-					disabled={adding}
+				<LoadingButton
+					variant="default"
+					size="sm"
+					loading={adding}
 					onclick={() =>
 						isEventPaletteItem(selected) ? onAddEvent() : onAdd(selected.creationKey)}
-					class={buttonVariants({ variant: 'default', size: 'sm' })}
 				>
 					+ Add this step
-				</button>
+				</LoadingButton>
 			</div>
 		</Dialog.Footer>
 	</Dialog.Content>


### PR DESCRIPTION
Loading/transition polish across the admin creation flows.

## Changes
- Extract a reusable **`LoadingOverlay`** (with an anti-flicker delay) and reuse it in
  `NewConversationButton` and `AddStepDialog`.
- Add loading states + focus management to the conversation- and step-creation flows.
- Add a highlight animation for newly created steps.
- Fix `Sonner` toast `z-index` so toasts layer above overlays.
- Tidy tool-metadata copy and add the video-conference event entry.

## Notes
- First (bottom) PR in a 6-PR stack; targets `staging` directly.
