### PR TITLE
Admin: normalize page padding + shared PageHeader

### DIFF
--- a/ui/packages/comhairle/src/lib/components/ConversationTabs.svelte
+++ b/ui/packages/comhairle/src/lib/components/ConversationTabs.svelte
@@ -19,7 +19,9 @@
 	class="border-border bg-background scrollbar-none flex w-full overflow-x-auto border-b"
 	aria-label="Conversation sections"
 >
-	<ul class="flex min-w-full items-center px-5">
+	<!-- First tab bleeds left into the gutter ([&>li:first-child]:-ml-4 cancels the
+		 link's px-4) so its label aligns to the shared gutter column. -->
+	<ul class="pl-gutter flex min-w-full items-center pr-5 [&>li:first-child]:-ml-4">
 		{#each conversationSections as section (section.path)}
 			{@const active = isActive(section.path, page.url.pathname)}
 			{@const disabled = section.requiresLive && !conversationIsLive}

--- a/ui/packages/comhairle/src/lib/components/EventStrip.svelte
+++ b/ui/packages/comhairle/src/lib/components/EventStrip.svelte
@@ -25,9 +25,11 @@
 	aria-label="Events"
 >
 	<ul
-		class="flex min-w-max items-center gap-x-1.5 gap-y-0.5 px-5 py-1 sm:w-full sm:min-w-0 sm:flex-wrap"
+		class="pl-gutter flex min-w-max items-center gap-x-1.5 gap-y-0.5 py-1 pr-5 sm:w-full sm:min-w-0 sm:flex-wrap"
 	>
-		<li>
+		<!-- First item bleeds left into the gutter (-ml-3.5 cancels its own px-3.5)
+			 so the "All events" icon aligns to the shared gutter column. -->
+		<li class="-ml-3.5">
 			<a
 				href={basePath}
 				class="text-foreground inline-flex h-9 items-center gap-1.5 px-3.5 text-sm font-medium whitespace-nowrap transition-opacity"

--- a/ui/packages/comhairle/src/lib/components/PageHeader.svelte
+++ b/ui/packages/comhairle/src/lib/components/PageHeader.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	type Props = {
+		/** Page title, rendered as the page's single h1. */
+		title: string;
+		/** Optional supporting line shown beneath the title. */
+		description?: string;
+		/** Optional controls aligned to the right of the title row (e.g. a template picker). */
+		actions?: Snippet;
+	};
+
+	let { title, description, actions }: Props = $props();
+</script>
+
+<!-- Shared heading block for admin pages: fixes the title/description sizes and the
+	 spacing beneath the header so every route reads as one system. Top spacing comes
+	 from the surrounding content wrapper, not from here, so pages stay vertically aligned. -->
+<div class="mb-8 flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+	<div class="flex flex-col gap-1">
+		<h1 class="text-2xl font-bold">{title}</h1>
+		{#if description}
+			<p class="text-muted-foreground text-base">{description}</p>
+		{/if}
+	</div>
+	{#if actions}
+		<div class="shrink-0">
+			{@render actions()}
+		</div>
+	{/if}
+</div>

--- a/ui/packages/comhairle/src/lib/components/WorkflowStepStrip.svelte
+++ b/ui/packages/comhairle/src/lib/components/WorkflowStepStrip.svelte
@@ -29,9 +29,11 @@
 	aria-label="Workflow steps"
 >
 	<ul
-		class="flex min-w-max items-center gap-x-1.5 gap-y-0.5 px-5 py-1 sm:w-full sm:min-w-0 sm:flex-wrap"
+		class="pl-gutter flex min-w-max items-center gap-x-1.5 gap-y-0.5 py-1 pr-5 sm:w-full sm:min-w-0 sm:flex-wrap"
 	>
-		<li>
+		<!-- First item bleeds left into the gutter (-ml-3.5 cancels its own px-3.5)
+			 so the "Design" icon aligns to the shared gutter column. -->
+		<li class="-ml-3.5">
 			<a
 				href={basePath}
 				class="text-foreground inline-flex h-9 items-center gap-1.5 px-3.5 text-sm font-medium whitespace-nowrap transition-opacity"

--- a/ui/packages/comhairle/src/lib/styles/comhairle-themes.css
+++ b/ui/packages/comhairle/src/lib/styles/comhairle-themes.css
@@ -486,12 +486,30 @@
 
 @theme {
 	--breakpoint-navbar: 900px;
+
+	/* Shared left inset for every admin page section (title row, tabs, sub-strips,
+	   page content). One knob to align + retune them all: `pl-gutter`, `md:pl-gutter`, etc.
+	   Tailwind v4 exposes this on every spacing utility from the `--spacing-*` namespace. */
+	--spacing-gutter: 2.75rem; /* 44px */
+
+	/* Breathing room above admin page content (below the fixed tab header). `pt-page-top`. */
+	--spacing-page-top: 2rem; /* 32px */
+
 	--radius: 0.5rem;
 	--radius-xs: calc(0.5rem - 6px);
 	--radius-sm: calc(0.5rem - 4px);
 	--radius-md: calc(0.5rem - 2px);
 	--radius-lg: 0.5rem;
 	--radius-xl: calc(0.5rem + 4px);
+}
+
+/* The gutter is a real CSS variable, so every `*-gutter` utility (tabs, sub-strips,
+   page content, banner) tracks it live. Shrink it on phones (< sm) so content isn't
+   over-inset on narrow screens; sections stay aligned because they all read this one var. */
+@media (width < 40rem) {
+	:root {
+		--spacing-gutter: 1.25rem; /* 20px on phones (44px from sm up) */
+	}
 }
 
 @theme inline {

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/+layout.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/+layout.svelte
@@ -39,7 +39,7 @@
 
 <!-- Row 1: conversation title + launch controls -->
 <div
-	class="border-border bg-background flex w-full shrink-0 items-center justify-between border-b py-2 pr-3 pl-14 md:px-6"
+	class="border-border bg-background md:pl-gutter flex w-full shrink-0 items-center justify-between border-b py-2 pr-3 pl-14 md:pr-6"
 >
 	<h1
 		class="text-primary max-w-[22ch] truncate text-lg leading-7 font-semibold sm:max-w-[40ch]"
@@ -195,7 +195,7 @@
 	{/if}
 
 	{#if conversation.isComplete}
-		<div class="border-destructive/20 bg-destructive/10 border-b px-5 py-2">
+		<div class="border-destructive/20 bg-destructive/10 pl-gutter border-b py-2 pr-5">
 			<p class="text-destructive text-sm">This conversation has closed</p>
 		</div>
 	{/if}
@@ -206,8 +206,10 @@
 		{@render children()}
 	</div>
 {:else}
-	<div class="bg-muted grow px-4 pt-2 pb-8 sm:px-8 sm:pb-12 md:py-8 lg:px-16">
-		<div class="mx-auto h-full w-full max-w-[1200px]">
+	<!-- Mobile: symmetric `px-gutter` so content is evenly inset. Larger screens keep the
+		 left gutter for tab alignment and widen the right margin. Top is token-driven. -->
+	<div class="bg-muted pt-page-top px-gutter grow pb-8 sm:pr-8 sm:pb-12 lg:pr-16">
+		<div class="h-full w-full max-w-[1200px]">
 			{@render children()}
 		</div>
 	</div>

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/configure/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/configure/+page.svelte
@@ -10,6 +10,7 @@
 	import { zodClient } from 'sveltekit-superforms/adapters';
 	import { conversationConfigSchema } from './schema';
 	import TeamManager from '$lib/components/TeamManager.svelte';
+	import PageHeader from '$lib/components/PageHeader.svelte';
 	import TranslatableField from '$lib/components/Translation/TranslatableField.svelte';
 	import { autoTranslateNewLanguage } from '$lib/components/Translation/translationUtils';
 	import { LanguageSelector } from '$lib/components/ui/language-selector';
@@ -308,14 +309,9 @@
 	<title>{pageTitle} - Comhairle Admin</title>
 </svelte:head>
 
-<h1 class="mb-4 text-3xl font-bold">Configure</h1>
+<PageHeader title="Configure" description="Personal details and general information." />
 
-<div class="flex flex-col gap-4">
-	<h2 class="text-card-foreground text-xl font-semibold">Conversation configuration</h2>
-	<p class="text-muted-foreground text-sm">Personal details and general information.</p>
-</div>
-
-<form method="POST" onsubmit={updateConversation} class="mt-8 flex flex-col" use:enhance>
+<form method="POST" onsubmit={updateConversation} class="flex flex-col" use:enhance>
 	<!-- Title -->
 	<div
 		class="border-border flex flex-col gap-4 border-t py-6 lg:flex-row lg:items-start lg:gap-6"

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/design/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/design/+page.svelte
@@ -239,14 +239,15 @@
 <!-- Full-bleed surface; the design tab has no page padding. overflow-hidden makes this
 	 an independent scroll boundary so the list can't push the sidebar-inset past the
 	 viewport. Only the inner column scrolls. -->
-<div class="bg-muted flex min-h-0 w-full flex-1 overflow-hidden px-2">
+<div class="bg-muted flex min-h-0 w-full flex-1 overflow-hidden">
 	<div bind:this={boardEl} class="min-h-0 flex-1 overflow-auto">
-		<div class="mx-auto flex w-full max-w-5xl flex-col gap-4 py-6">
+		<!-- Same gutter column + top spacing as every other admin page; symmetric inset on mobile. -->
+		<div class="px-gutter pt-page-top flex w-full max-w-5xl flex-col gap-4 pb-8">
 			<!-- Toolbar -->
 			<div class="flex shrink-0 flex-col items-center justify-between gap-2 sm:flex-row">
 				<div class="flex flex-col">
 					<h1 class="self-start text-2xl font-bold sm:self-auto">Process steps</h1>
-					<p class="text-muted-foreground text-sm">
+					<p class="text-muted-foreground text-base">
 						Design and configure your engagement, one step at a time.
 					</p>
 				</div>

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/events/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/events/+page.svelte
@@ -3,6 +3,7 @@
 	import { Plus } from 'lucide-svelte';
 	import * as Card from '$lib/components/ui/card';
 	import EventCard from '$lib/components/EventCard.svelte';
+	import PageHeader from '$lib/components/PageHeader.svelte';
 
 	let { data } = $props();
 	let conversation = $derived(data.conversation);
@@ -15,22 +16,29 @@
 	<title>{pageTitle} - Comhairle Admin</title>
 </svelte:head>
 
-<h1 class="mt-8 mb-4 text-3xl font-bold sm:mt-10">Events</h1>
+<PageHeader title="Events" description="Use this space to manage your conversation's events." />
 
-<p class="text-muted-foreground mb-10 text-base font-medium">
-	Use this space to manage your conversation's events.
-</p>
+<div class="flex max-w-[700px] flex-col gap-6">
+	{#if events.length === 0}
+		<div
+			class="border-border bg-card text-muted-foreground flex flex-col items-center justify-center gap-3 rounded-xl border border-dashed p-12 text-center"
+		>
+			<p class="text-base">No events yet. Add your first event to get started.</p>
+			<Button variant="default" href={`/admin/conversations/${conversation.id}/events/new`}>
+				<Plus class="h-4 w-4" /> Add event
+			</Button>
+		</div>
+	{:else}
+		{#each events as event (event.id)}
+			<Card.Root class="overflow-hidden rounded-3xl pb-0 shadow-sm">
+				<EventCard {event} conversationId={conversation.id} />
+			</Card.Root>
+		{/each}
 
-<div class="mx-auto flex max-w-[700px] flex-col gap-6">
-	{#each events as event (event.id)}
-		<Card.Root class="overflow-hidden rounded-3xl pb-0 shadow-sm">
-			<EventCard {event} conversationId={conversation.id} />
-		</Card.Root>
-	{/each}
-
-	<div class="flex justify-center pt-6">
-		<Button variant="default" href={`/admin/conversations/${conversation.id}/events/new`}>
-			<Plus class="h-4 w-4" /> Add event
-		</Button>
-	</div>
+		<div class="flex justify-center pt-6">
+			<Button variant="default" href={`/admin/conversations/${conversation.id}/events/new`}>
+				<Plus class="h-4 w-4" /> Add event
+			</Button>
+		</div>
+	{/if}
 </div>

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/invites/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/invites/+page.svelte
@@ -2,6 +2,7 @@
 	import { invalidateAll } from '$app/navigation';
 	import { page } from '$app/state';
 	import Button from '$lib/components/ui/button/button.svelte';
+	import PageHeader from '$lib/components/PageHeader.svelte';
 
 	import EmailInviteForm from '$lib/components/ui/email-invites/EmailInviteForm.svelte';
 	import InviteLabelDialog from '$lib/components/InviteLabelDialog.svelte';
@@ -93,7 +94,7 @@
 	/>
 {/snippet}
 
-<h1 class="mb-4 text-3xl font-bold">Recruit</h1>
+<PageHeader title="Recruit" />
 
 {#if activeTab === 'email'}
 	<EmailInviteForm conversationId={conversation.id} onDone={emailInvitesSubmitted} />

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/knowledge-base/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/knowledge-base/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { ComhairleDocument, ConversationWithTranslations } from '@crownshy/api-client/api';
+	import PageHeader from '$lib/components/PageHeader.svelte';
 	import FileUpload from '$lib/components/KnowledgeBase/FileUpload.svelte';
 	import ParsedFileList from '$lib/components/KnowledgeBase/ParsedFileList.svelte';
 	import ParsingFileList from '$lib/components/KnowledgeBase/ParsingFileList.svelte';
@@ -31,9 +32,10 @@
 	<title>Knowledge Base - Comhairle Admin</title>
 </svelte:head>
 
-<h1 class="mb-4 text-3xl font-bold">Knowledge Base</h1>
-
-<p class="mb-10">Use this space to manage your conversation's knowledge base</p>
+<PageHeader
+	title="Knowledge Base"
+	description="Use this space to manage your conversation's knowledge base"
+/>
 <p>
 	The knowledge base is a set of documents that you can use to provide users information about the
 	topic at hand. They are used for a variety of tasks including influcencing the helper bot and

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/moderate/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/moderate/+page.svelte
@@ -2,6 +2,7 @@
 	import { BookOpen, ListChecks, MessagesSquare, Video } from 'lucide-svelte';
 	import * as Card from '$lib/components/ui/card';
 	import { Button } from '$lib/components/ui/button';
+	import PageHeader from '$lib/components/PageHeader.svelte';
 	import type { ToolConfig, WorkflowStepWithTranslations } from '@crownshy/api-client/api';
 
 	let { data } = $props();
@@ -16,9 +17,7 @@
 	<title>Moderate Conversation - Comhairle Admin</title>
 </svelte:head>
 
-<h1 class="mb-4 text-3xl font-bold">Moderate</h1>
-
-<p class="mb-10">Use this space to moderate the conversation</p>
+<PageHeader title="Moderate" description="Use this space to moderate the conversation" />
 
 <div class="mb-5 flex flex-col gap-y-5">
 	{#each workflowSteps as step (step.id)}

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/monitor/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/monitor/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import PageHeader from '$lib/components/PageHeader.svelte';
 	import DailyStatsChart from '$lib/components/DailyStatsChart.svelte';
 	import StatsBar from '$lib/components/StatsBar.svelte';
 	import StatProgressIndicator from '$lib/components/StatProgressIndicator.svelte';
@@ -41,12 +42,10 @@
 	<title>Monitor Conversation - Comhairle Admin</title>
 </svelte:head>
 
-<h1 class="mb-4 text-3xl font-bold">Monitor</h1>
-
-<p class="mb-10">
-	See how your conversation is working, monitor recruitment and user progress and check out your
-	reach
-</p>
+<PageHeader
+	title="Monitor"
+	description="See how your conversation is working, monitor recruitment and user progress and check out your reach"
+/>
 
 <h2 class="my-10 text-2xl">Overview</h2>
 <StatsBar {stats} />

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/notifications/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/notifications/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import NotificationForm from '$lib/components/NotificationForm.svelte';
+	import PageHeader from '$lib/components/PageHeader.svelte';
 	import type { PageData } from './$types';
 
 	let { data } = $props() as { data: PageData };
@@ -10,11 +11,9 @@
 	<title>Manage Notifications - Comhairle Admin</title>
 </svelte:head>
 
-<h1 class="mb-4 text-3xl font-bold">Notify</h1>
-
-<p class="mb-10">
-	Send notifications to all participants in this conversation. Notifications will be delivered to
-	all users who have participated in workflows within this conversation.
-</p>
+<PageHeader
+	title="Notify"
+	description="Send notifications to all participants in this conversation. Notifications will be delivered to all users who have participated in workflows within this conversation."
+/>
 
 <NotificationForm conversationId={conversation.id} />

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/report/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/report/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import Button from '$lib/components/ui/button/button.svelte';
+	import PageHeader from '$lib/components/PageHeader.svelte';
 	import { buttonVariants } from '$lib/components/ui/button/index.js';
 	import * as Card from '$lib/components/ui/card/index.js';
 	import * as Dialog from '$lib/components/ui/dialog';
@@ -72,9 +73,7 @@
 	<title>Conversation Report - Comhairle Admin</title>
 </svelte:head>
 
-<h1 class="mb-4 text-3xl font-bold">Report</h1>
-
-<p class="mb-10">Use this space to edit the report for this conversation</p>
+<PageHeader title="Report" description="Use this space to edit the report for this conversation" />
 
 <div class="flex flex-col gap-4">
 	<div class="flex w-full flex-row items-center justify-end gap-2">


### PR DESCRIPTION
Normalize layout across the admin so every page shares one gutter/alignment system.

## Changes
- Introduce a shared **`PageHeader`** component and adopt it across the admin section pages
  (Configure, Design, Events, Invites, Knowledge base, Moderate, Monitor, Notifications, Report).
- Standardize page padding to a common gutter, aligned with the tab strips
  (`ConversationTabs`, `WorkflowStepStrip`, `EventStrip`) and a gutter token in the theme CSS.

## Notes
- Stacked on top of  #649 . Base is that branch; it retargets to `staging`
  automatically once 649 merges.
