### PR TITLE
Configure page: sub-tabs + labelled fields with autosave

### DIFF
--- a/documentation/adr/0004-configure-page-fully-autosave.md
+++ b/documentation/adr/0004-configure-page-fully-autosave.md
@@ -1,0 +1,67 @@
+# ADR-0004: The Configure page is fully autosave (no explicit Save button)
+
+**Status:** accepted
+**Date:** 2026-07-17
+
+## Context
+
+The conversation admin **Configure** page
+([configure/+page.svelte](../../ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/configure/+page.svelte))
+was one long `superForm` with a single **Save Changes** button at the bottom. We split it into
+sub-tabs (Details / Content / Access / Team) so switching between groups of settings doesn't mean
+scrolling a long page. That raised the question of where the Save button should go now that its
+fields are spread across tabs.
+
+Auditing what actually persisted how made the answer obvious: **almost everything on the page
+already autosaved, and the Save button only uniquely mattered for six toggles.**
+
+- Every `TranslatableField` (Title, Short description, Description, and the rich fields: Privacy
+  policy, Short privacy policy, FAQs, Thank-you message, Call to action) autosaves on a 1s debounce
+  straight to the API once it is `textContent`-backed
+  ([TranslatableField.svelte](../../ui/packages/comhairle/src/lib/components/Translation/TranslatableField.svelte)).
+  Title / Short description / Description are always `textContent`-backed (`Translation3` in the
+  api-client schema); the nullable rich fields create-then-autosave on first edit.
+- **Language options** and the **Banner image** already saved immediately through their own handlers.
+- Only the six **Access** toggles (`isPublic`, `isInviteOnly`, `autoLogin`, `enableQaChatBot`,
+  `enableSignupPrompts`, `showThankYouPageAnnonInstructions`) relied solely on the Save button.
+
+So the single "Save Changes" button was actively misleading: it read as "save the whole page" while
+~90% of the page had already saved itself seconds earlier, and clicking it merely re-sent those
+fields redundantly (via a different snake-cased `UpdateConversation` path).
+
+## Decision
+
+**Make the whole Configure page uniformly autosave and remove the Save button.**
+
+- The six toggles gain per-change autosave, mirroring the existing Banner / Language handlers: five
+  go through `UpdateConversation({ [field]: value })` and `autoLogin` through
+  `UpdateConversationWorkflow({ auto_login })`, each wrapped in `tryCatchAsync`, followed by
+  `invalidate('conversation:meta')` and a "Setting updated" toast. On failure the optimistic switch
+  state is reverted and an error toast is shown.
+- The `updateConversation` submit handler, the `<form>` submit, and the Save button are removed.
+  `superForm` is kept only for field binding and inline validation display, not for submission.
+
+The `UpdateConversation` route already accepts partial updates (the page had long called it with
+tiny payloads like `{ image }` and `{ primary_locale, supported_languages }`), so no backend or
+api-client change was needed — this is purely a client-side save-model change.
+
+## Considered options
+
+- **Keep one global Save button** (rejected): least change, but preserves the deception — the button
+  only ever mattered for the toggles while everything else autosaved.
+- **Per-tab Save buttons** (rejected): only the Access tab has any button-only fields, so this
+  produces a lone, asymmetric Save on one tab out of four.
+- **Full autosave, no button** (chosen): uniform behaviour, removes the misleading affordance, and
+  makes tab-switching inherently safe — there is never a pending edit to lose.
+
+## Consequences
+
+- **No explicit Save affordance on an admin form.** A future reader may expect one; this ADR is the
+  answer to "why is there no Save button here?". Autosave is now the page's contract.
+- **Toggle feedback is a toast for now; an inline per-toggle "Saving → Saved" indicator is the
+  intended follow-up.** English-only fields show no autosave badge (the `TranslatableField` badge
+  only renders when other languages exist), so toggles use a toast as their confirmation. The
+  preferred end state is a quiet inline indicator per toggle row (like `TranslatableField`'s), which
+  is left as a `// TODO` at the toggle handler.
+- **A toast fires per toggle change.** Flipping several switches in quick succession stacks toasts;
+  acceptable on this page, and superseded once the inline indicator lands.

--- a/ui/packages/comhairle/src/lib/components/Translation/TranslatableField.svelte
+++ b/ui/packages/comhairle/src/lib/components/Translation/TranslatableField.svelte
@@ -36,6 +36,12 @@
 		dialogMinHeight?: string;
 		dialogTitle?: string;
 		inputProps?: Record<string, any>;
+		/**
+		 * Optional guard run against the primary-locale value before autosaving. Return `false`
+		 * to skip the save (e.g. the value fails validation, such as a required field left blank).
+		 * Omit it and every change autosaves, which is correct for optional fields.
+		 */
+		canSave?: (value: string) => boolean;
 		translation?: TranslationData;
 		initialContents?: Record<string, string>;
 		initialStatuses?: Record<string, TranslationStatus>;
@@ -64,6 +70,7 @@
 		dialogMinHeight = '200px',
 		dialogTitle = 'Content Translation',
 		inputProps = {},
+		canSave,
 		translation,
 		initialContents,
 		initialStatuses,
@@ -90,6 +97,12 @@
 	}
 
 	const debouncedSaveInline = useDebounce(async (content: string) => {
+		// Never persist a value the parent has rejected (e.g. a required field cleared to blank).
+		// The debounce fires with the latest content, so a value typed then cleared is dropped here.
+		if (canSave && !canSave(content)) {
+			setSaveStatus('idle');
+			return;
+		}
 		if (isTextContentMode && textContentId) {
 			const id = textContentId;
 			setSaveStatus('saving');
@@ -156,7 +169,9 @@
 	}
 
 	function saveInlinePrimary(content: string) {
-		if (isTextContentMode) setSaveStatus('saving');
+		// Still reset the debounce timer on every keystroke, but don't show "Saving" for a value
+		// that the guard below will drop; the debounced callback repeats the check before saving.
+		if (isTextContentMode && (!canSave || canSave(content))) setSaveStatus('saving');
 		debouncedSaveInline(content);
 	}
 

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/configure/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/configure/+page.svelte
@@ -12,7 +12,9 @@
 	import { conversationConfigSchema } from './schema';
 	import TeamManager from '$lib/components/TeamManager.svelte';
 	import PageHeader from '$lib/components/PageHeader.svelte';
+	import * as Tooltip from '$lib/components/ui/tooltip';
 	import ConfigureTabStrip, { type ConfigureTab } from './ConfigureTabStrip.svelte';
+	import CollapsibleRichField from './CollapsibleRichField.svelte';
 	import {
 		CONVERSATION_TAB_EXTRAS_CTX,
 		type ConversationTabExtras
@@ -26,12 +28,11 @@
 		WorkflowDto
 	} from '@crownshy/api-client/api';
 	import { camelToSentenceCase, camelToSnakeCase } from '$lib/utils/casingUtils';
-	import { Image as ImageIcon } from 'lucide-svelte';
+	import { Image as ImageIcon, ArrowUpRight, HelpCircle } from 'lucide-svelte';
 	import MediaLibraryDialog, {
 		addToCache
 	} from '$lib/components/Media/MediaLibraryDialog.svelte';
 	import MediaUpload from '$lib/components/Media/MediaUpload.svelte';
-	import Label from '$lib/components/ui/label/label.svelte';
 	import { tryCatchAsync } from '$lib/utils/errorHandling';
 
 	let {
@@ -69,6 +70,10 @@
 	};
 	let activeTab = $derived(page.url.searchParams.get('tab') ?? tabs[0].id);
 	let header = $derived(tabHeaders[activeTab] ?? tabHeaders.details);
+
+	// Base for the "See where" links: the participant preview always renders in preview mode,
+	// so each field can deep-link to the exact surface it appears on (privacy, faq, thank-you…).
+	let previewBase = $derived(`/conversations/${conversation.id}/preview`);
 
 	// Inject the full-bleed sub-tab strip into "Row 3" of the conversation layout,
 	// the same slot the workflow step strip uses. Cleared on unmount.
@@ -262,6 +267,13 @@
 
 	let { form } = conversationForm;
 
+	// Gate the inline autosave for required text fields: TranslatableField saves on every change,
+	// so without this an empty title/description would persist even while the form shows its
+	// "required" error. Optional fields get no guard and keep autosaving blank values.
+	function requiredFieldValidator(field: 'title' | 'shortDescription' | 'description') {
+		return (value: string) => conversationConfigSchema.shape[field].safeParse(value).success;
+	}
+
 	// Access toggles autosave on change (the page has no Save button — see ADR-0004).
 	// `$form.<field>` is updated optimistically by `bind:checked`; on failure we revert it.
 	// TODO: replace the per-toggle toast with a quiet inline "Saving → Saved" indicator per
@@ -345,6 +357,61 @@
 	<ConfigureTabStrip {tabs} />
 {/snippet}
 
+<!-- "See where" deep-link to the live participant preview surface this field appears on. Opens
+	 in a new tab; skipped when a field has no distinct participant surface (e.g. Language). -->
+{#snippet seeWhere(previewHref: string)}
+	{#if previewHref}
+		<a
+			href={previewHref}
+			target="_blank"
+			rel="noopener"
+			class="text-primary mt-1.5 inline-flex items-center gap-1 text-sm hover:underline"
+		>
+			See where
+			<ArrowUpRight class="size-3.5" />
+		</a>
+	{/if}
+{/snippet}
+
+<!-- Left-column label for a form field. `label` stays a <Form.Label> so it keeps its `for`
+	 association with the control. What the field does lives in the field's placeholder; this
+	 column just carries the label and a "See where" link to the surface it appears on. -->
+{#snippet fieldLabel(label: string, previewHref: string = '')}
+	<div class="lg:w-50 lg:shrink-0 lg:pt-2">
+		<Form.Label class="text-sm font-semibold">{label}</Form.Label>
+		{@render seeWhere(previewHref)}
+	</div>
+{/snippet}
+
+<!-- Same, for rows whose control isn't a Form.Field (Banner, Language), so there's no label to
+	 associate. -->
+{#snippet plainLabel(label: string, description: string = '', previewHref: string = '')}
+	<div class="lg:w-50 lg:shrink-0 lg:pt-2">
+		<p class="text-sm font-semibold">{label}</p>
+		{#if description}
+			<p class="text-muted-foreground mt-1 text-sm">{description}</p>
+		{/if}
+		{@render seeWhere(previewHref)}
+	</div>
+{/snippet}
+
+<!-- Small info affordance for Access toggles: a "?" that reveals a fuller plain-language
+	 explanation of what the setting does for participants. -->
+{#snippet infoTip(text: string)}
+	<Tooltip.Provider delayDuration={150}>
+		<Tooltip.Root>
+			<Tooltip.Trigger
+				type="button"
+				class="text-muted-foreground hover:text-foreground"
+				aria-label="More information"
+			>
+				<HelpCircle class="size-4" />
+			</Tooltip.Trigger>
+			<Tooltip.Content class="max-w-xs text-sm">{text}</Tooltip.Content>
+		</Tooltip.Root>
+	</Tooltip.Provider>
+{/snippet}
+
 <PageHeader title={header.title} description={header.description} />
 
 <!-- One superForm still backs every field (its inline validation + $form binding); there is
@@ -358,13 +425,12 @@
 			<Form.Field form={conversationForm} name="title" class="contents">
 				<Form.Control>
 					{#snippet children({ props })}
-						<Form.Label class="text-sm font-semibold lg:w-50 lg:shrink-0 lg:pt-2"
-							>Title</Form.Label
-						>
+						{@render fieldLabel('Title', previewBase)}
 						<div class="flex-1" id="conversation-title-field">
 							<TranslatableField
 								value={$form.title}
 								onValueChange={(v) => ($form.title = v)}
+								canSave={requiredFieldValidator('title')}
 								translation={conversation.translations?.title}
 								primaryLocale={primaryLanguage}
 								{supportedLanguages}
@@ -384,18 +450,17 @@
 			<Form.Field form={conversationForm} name="shortDescription" class="contents">
 				<Form.Control>
 					{#snippet children({ props })}
-						<Form.Label class="text-sm font-semibold lg:w-50 lg:shrink-0 lg:pt-2"
-							>Short description</Form.Label
-						>
+						{@render fieldLabel('Short description', previewBase)}
 						<div class="flex-1">
 							<TranslatableField
 								value={$form.shortDescription}
 								onValueChange={(v) => ($form.shortDescription = v)}
+								canSave={requiredFieldValidator('shortDescription')}
 								translation={conversation.translations?.shortDescription}
 								primaryLocale={primaryLanguage}
 								{supportedLanguages}
 								inputType="textarea"
-								placeholder="A short description for this conversation."
+								placeholder="A one-line summary, shown under the title on the landing page and on conversation cards in listings."
 								inputProps={props}
 							/>
 							<Form.FieldErrors />
@@ -412,18 +477,17 @@
 			<Form.Field form={conversationForm} name="description" class="contents">
 				<Form.Control>
 					{#snippet children({ props })}
-						<Form.Label class="text-sm font-semibold lg:w-50 lg:shrink-0 lg:pt-2"
-							>Description</Form.Label
-						>
+						{@render fieldLabel('Description', previewBase)}
 						<div class="flex-1">
 							<TranslatableField
 								value={$form.description}
 								onValueChange={(v) => ($form.description = v)}
+								canSave={requiredFieldValidator('description')}
 								translation={conversation.translations?.description}
 								primaryLocale={primaryLanguage}
 								{supportedLanguages}
 								inputType="textarea"
-								placeholder="Introduce people to what is being discussed and outline the actions that might be taken as a result of the conversation."
+								placeholder="Introduce people to what is being discussed and outline the actions that might be taken as a result of the conversation. A fuller introduction, shown beside the banner image on the landing and invitation pages."
 								inputProps={props}
 							/>
 							<Form.FieldErrors />
@@ -437,7 +501,10 @@
 		<div
 			class="border-border flex flex-col gap-4 border-t py-6 lg:flex-row lg:items-start lg:gap-6"
 		>
-			<p class="text-sm font-semibold lg:w-50 lg:shrink-0 lg:pt-2">Language options</p>
+			{@render plainLabel(
+				'Language options',
+				'The primary language plus any others you support. Adding a language lets you translate the other fields into it.'
+			)}
 			<div class="max-w-md flex-1">
 				<LanguageSelector
 					bind:primaryLanguage
@@ -453,9 +520,11 @@
 			class="border-border flex flex-col gap-4 border-t py-6 lg:flex-row lg:items-start lg:gap-6"
 		>
 			<div class="contents">
-				<Label class="text-sm font-semibold lg:w-50 lg:shrink-0 lg:pt-2"
-					>Banner image URL</Label
-				>
+				{@render plainLabel(
+					'Banner image',
+					'Shown beside the description on the landing and invitation pages.',
+					previewBase
+				)}
 				<div class="align-start flex w-full flex-col gap-4">
 					<div class="flex flex-1 gap-4">
 						<MediaLibraryDialog
@@ -505,27 +574,32 @@
 			<Form.Field form={conversationForm} name="privacyPolicy" class="contents">
 				<Form.Control>
 					{#snippet children({ props })}
-						<Form.Label class="text-sm font-semibold lg:w-50 lg:shrink-0 lg:pt-2"
-							>Privacy Policy</Form.Label
-						>
+						{@render fieldLabel('Privacy Policy', `${previewBase}/privacy`)}
 						<div class="flex-1">
-							<TranslatableField
-								value={$form.privacyPolicy || null}
-								onValueChange={(v) => ($form.privacyPolicy = v)}
-								translation={conversation.translations?.privacyPolicy ?? undefined}
-								editorType="rich"
-								onSaveSource={(content: string) =>
-									handleInitOptionalTranslationField(
-										content,
-										'privacyPolicy',
-										'rich',
-										true
-									)}
-								primaryLocale={primaryLanguage}
-								{supportedLanguages}
-								inputProps={props}
-							/>
-							<Form.FieldErrors />
+							<CollapsibleRichField
+								label="Privacy policy"
+								content={$form.privacyPolicy}
+							>
+								<TranslatableField
+									value={$form.privacyPolicy || null}
+									onValueChange={(v) => ($form.privacyPolicy = v)}
+									translation={conversation.translations?.privacyPolicy ??
+										undefined}
+									editorType="rich"
+									placeholder="The full policy, shown on the Privacy Policy page and the 'Find out more' panel. Leave blank to use Comhairle's default."
+									onSaveSource={(content: string) =>
+										handleInitOptionalTranslationField(
+											content,
+											'privacyPolicy',
+											'rich',
+											true
+										)}
+									primaryLocale={primaryLanguage}
+									{supportedLanguages}
+									inputProps={props}
+								/>
+								<Form.FieldErrors />
+							</CollapsibleRichField>
 						</div>
 					{/snippet}
 				</Form.Control>
@@ -539,28 +613,32 @@
 			<Form.Field form={conversationForm} name="shortPrivacyPolicy" class="contents">
 				<Form.Control>
 					{#snippet children({ props })}
-						<Form.Label class="text-sm font-semibold lg:w-50 lg:shrink-0 lg:pt-2"
-							>Short Privacy Policy</Form.Label
-						>
+						{@render fieldLabel('Short Privacy Policy', previewBase)}
 						<div class="flex-1">
-							<TranslatableField
-								value={$form.shortPrivacyPolicy || null}
-								onValueChange={(v) => ($form.shortPrivacyPolicy = v)}
-								translation={conversation.translations?.shortPrivacyPolicy ??
-									undefined}
-								editorType="rich"
-								onSaveSource={(content: string) =>
-									handleInitOptionalTranslationField(
-										content,
-										'shortPrivacyPolicy',
-										'rich',
-										true
-									)}
-								primaryLocale={primaryLanguage}
-								{supportedLanguages}
-								inputProps={props}
-							/>
-							<Form.FieldErrors />
+							<CollapsibleRichField
+								label="Short privacy policy"
+								content={$form.shortPrivacyPolicy}
+							>
+								<TranslatableField
+									value={$form.shortPrivacyPolicy || null}
+									onValueChange={(v) => ($form.shortPrivacyPolicy = v)}
+									translation={conversation.translations?.shortPrivacyPolicy ??
+										undefined}
+									editorType="rich"
+									placeholder="Shown in the consent dialog participants accept before joining. Leave blank to use Comhairle's default."
+									onSaveSource={(content: string) =>
+										handleInitOptionalTranslationField(
+											content,
+											'shortPrivacyPolicy',
+											'rich',
+											true
+										)}
+									primaryLocale={primaryLanguage}
+									{supportedLanguages}
+									inputProps={props}
+								/>
+								<Form.FieldErrors />
+							</CollapsibleRichField>
 						</div>
 					{/snippet}
 				</Form.Control>
@@ -574,22 +652,23 @@
 			<Form.Field form={conversationForm} name="faqs" class="contents">
 				<Form.Control>
 					{#snippet children({ props })}
-						<Form.Label class="text-sm font-semibold lg:w-50 lg:shrink-0 lg:pt-2"
-							>FAQs</Form.Label
-						>
+						{@render fieldLabel('FAQs', `${previewBase}/faq`)}
 						<div class="flex-1">
-							<TranslatableField
-								value={$form.faqs || null}
-								onValueChange={(v) => ($form.faqs = v)}
-								translation={conversation.translations?.faqs ?? undefined}
-								editorType="rich"
-								onSaveSource={(content: string) =>
-									handleInitOptionalTranslationField(content, 'faqs')}
-								primaryLocale={primaryLanguage}
-								{supportedLanguages}
-								inputProps={props}
-							/>
-							<Form.FieldErrors />
+							<CollapsibleRichField label="FAQs" content={$form.faqs}>
+								<TranslatableField
+									value={$form.faqs || null}
+									onValueChange={(v) => ($form.faqs = v)}
+									translation={conversation.translations?.faqs ?? undefined}
+									editorType="rich"
+									placeholder="Shown on the FAQ page and the 'Find out more' panel. Leave blank to use Comhairle's default FAQs."
+									onSaveSource={(content: string) =>
+										handleInitOptionalTranslationField(content, 'faqs')}
+									primaryLocale={primaryLanguage}
+									{supportedLanguages}
+									inputProps={props}
+								/>
+								<Form.FieldErrors />
+							</CollapsibleRichField>
 						</div>
 					{/snippet}
 				</Form.Control>
@@ -603,23 +682,33 @@
 			<Form.Field form={conversationForm} name="thankYouMessage" class="contents">
 				<Form.Control>
 					{#snippet children({ props })}
-						<Form.Label class="text-sm font-semibold lg:w-50 lg:shrink-0 lg:pt-2"
-							>Thank you message</Form.Label
-						>
+						{@render fieldLabel(
+							'Thank you message',
+							`${previewBase}/workflow/${workflow.id}/thank_you`
+						)}
 						<div class="flex-1">
-							<TranslatableField
-								value={$form.thankYouMessage || null}
-								onValueChange={(v) => ($form.thankYouMessage = v)}
-								translation={conversation.translations?.thankYouMessage ??
-									undefined}
-								editorType="rich"
-								onSaveSource={(content: string) =>
-									handleInitOptionalTranslationField(content, 'thankYouMessage')}
-								primaryLocale={primaryLanguage}
-								{supportedLanguages}
-								inputProps={props}
-							/>
-							<Form.FieldErrors />
+							<CollapsibleRichField
+								label="Thank you message"
+								content={$form.thankYouMessage}
+							>
+								<TranslatableField
+									value={$form.thankYouMessage || null}
+									onValueChange={(v) => ($form.thankYouMessage = v)}
+									translation={conversation.translations?.thankYouMessage ??
+										undefined}
+									editorType="rich"
+									placeholder="Shown on the thank-you page after someone finishes. Leave blank for the default 'Thank you for participating' message."
+									onSaveSource={(content: string) =>
+										handleInitOptionalTranslationField(
+											content,
+											'thankYouMessage'
+										)}
+									primaryLocale={primaryLanguage}
+									{supportedLanguages}
+									inputProps={props}
+								/>
+								<Form.FieldErrors />
+							</CollapsibleRichField>
 						</div>
 					{/snippet}
 				</Form.Control>
@@ -633,14 +722,13 @@
 			<Form.Field form={conversationForm} name="callToAction" class="contents">
 				<Form.Control>
 					{#snippet children({ props })}
-						<Form.Label class="text-sm font-semibold lg:w-50 lg:shrink-0 lg:pt-2"
-							>Call to action</Form.Label
-						>
+						{@render fieldLabel('Call to action', previewBase)}
 						<div class="flex-1">
 							<TranslatableField
 								value={$form.callToAction || null}
 								onValueChange={(v) => ($form.callToAction = v)}
 								translation={conversation.translations?.callToAction ?? undefined}
+								placeholder="The label on the main join button. Leave blank for 'Join the conversation'."
 								onSaveSource={(content: string) =>
 									handleInitOptionalTranslationField(
 										content,
@@ -671,11 +759,16 @@
 						{#snippet children({ props })}
 							<div class="flex items-center justify-between gap-4">
 								<div class="flex flex-col gap-1">
-									<Form.Label class="text-sm font-medium"
-										>Show conversation publicly</Form.Label
-									>
+									<div class="flex items-center gap-1.5">
+										<Form.Label class="text-sm font-medium"
+											>Show conversation publicly</Form.Label
+										>
+										{@render infoTip(
+											'When this conversation is launched, anyone (even without an account) can open its documents and data. Off means only you, collaborators, and participants can.'
+										)}
+									</div>
 									<p class="text-muted-foreground text-sm">
-										Allow export of personal data and backups.
+										Let anyone view this conversation's data once it's launched.
 									</p>
 								</div>
 								<Switch
@@ -694,9 +787,14 @@
 						{#snippet children({ props })}
 							<div class="flex items-center justify-between gap-4">
 								<div class="flex flex-col gap-1">
-									<Form.Label class="text-sm font-medium"
-										>Only allow participation by invite</Form.Label
-									>
+									<div class="flex items-center gap-1.5">
+										<Form.Label class="text-sm font-medium"
+											>Only allow participation by invite</Form.Label
+										>
+										{@render infoTip(
+											'Only people you invite can take part. With this off, anyone with the link can participate.'
+										)}
+									</div>
 									<p class="text-muted-foreground text-sm">
 										Admins can invite and manage members.
 									</p>
@@ -718,9 +816,14 @@
 						{#snippet children({ props })}
 							<div class="flex items-center justify-between gap-4">
 								<div class="flex flex-col gap-1">
-									<Form.Label class="text-sm font-medium"
-										>Automatically log in with an anonymous account</Form.Label
-									>
+									<div class="flex items-center gap-1.5">
+										<Form.Label class="text-sm font-medium"
+											>Automatically log in with an anonymous account</Form.Label
+										>
+										{@render infoTip(
+											'Visitors who are not signed in get a temporary anonymous account automatically, so they can take part without registering. They can upgrade to a real account later.'
+										)}
+									</div>
 									<p class="text-muted-foreground text-sm">
 										Creates a temporary account for unauthenticated users.
 									</p>
@@ -741,9 +844,14 @@
 						{#snippet children({ props })}
 							<div class="flex items-center justify-between gap-4">
 								<div class="flex flex-col gap-1">
-									<Form.Label class="text-sm font-medium"
-										>Show Learning Assistant</Form.Label
-									>
+									<div class="flex items-center gap-1.5">
+										<Form.Label class="text-sm font-medium"
+											>Show Learning Assistant</Form.Label
+										>
+										{@render infoTip(
+											"Shows a Q&A 'Learning Assistant' that answers participants' questions from the conversation's knowledge base. Set it up on the Knowledge Base page."
+										)}
+									</div>
 									<p class="text-muted-foreground text-sm">
 										Display a Q&A Learning Assistant on the conversation.<br />
 										{#if !conversation.isLive}
@@ -772,9 +880,14 @@
 						{#snippet children({ props })}
 							<div class="flex items-center justify-between gap-4">
 								<div class="flex flex-col gap-1">
-									<Form.Label class="text-sm font-medium"
-										>Enable signup prompts</Form.Label
-									>
+									<div class="flex items-center gap-1.5">
+										<Form.Label class="text-sm font-medium"
+											>Enable signup prompts</Form.Label
+										>
+										{@render infoTip(
+											'Shows prompts encouraging participants to create an account on the thank-you page after they finish.'
+										)}
+									</div>
 									<p class="text-muted-foreground text-sm">
 										Toggle whether to display signup prompts on thank you page.
 									</p>
@@ -796,9 +909,14 @@
 						{#snippet children({ props })}
 							<div class="flex items-center justify-between gap-4">
 								<div class="flex flex-col gap-1">
-									<Form.Label class="text-sm font-medium"
-										>Show thank you page anonymous instructions</Form.Label
-									>
+									<div class="flex items-center gap-1.5">
+										<Form.Label class="text-sm font-medium"
+											>Show thank you page anonymous instructions</Form.Label
+										>
+										{@render infoTip(
+											'On the thank-you page, shows anonymous participants their temporary ID and how to log back in later to see the results.'
+										)}
+									</div>
 									<p class="text-muted-foreground text-sm">
 										Display instructions for anonymous users on the thank you
 										page.

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/configure/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/configure/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
+	import { onMount, getContext } from 'svelte';
+	import { page } from '$app/state';
 	import { Switch } from '$lib/components/ui/switch';
 	import * as Form from '$lib/components/ui/form/';
 	import { notifications } from '$lib/notifications.svelte';
@@ -11,6 +12,11 @@
 	import { conversationConfigSchema } from './schema';
 	import TeamManager from '$lib/components/TeamManager.svelte';
 	import PageHeader from '$lib/components/PageHeader.svelte';
+	import ConfigureTabStrip, { type ConfigureTab } from './ConfigureTabStrip.svelte';
+	import {
+		CONVERSATION_TAB_EXTRAS_CTX,
+		type ConversationTabExtras
+	} from '$lib/conversationTabExtras';
 	import TranslatableField from '$lib/components/Translation/TranslatableField.svelte';
 	import { autoTranslateNewLanguage } from '$lib/components/Translation/translationUtils';
 	import { LanguageSelector } from '$lib/components/ui/language-selector';
@@ -19,7 +25,7 @@
 		MediaDto,
 		WorkflowDto
 	} from '@crownshy/api-client/api';
-	import { camelToSentenceCase, camelToSnakeCase, snakeCaseKeys } from '$lib/utils/casingUtils';
+	import { camelToSentenceCase, camelToSnakeCase } from '$lib/utils/casingUtils';
 	import { Image as ImageIcon } from 'lucide-svelte';
 	import MediaLibraryDialog, {
 		addToCache
@@ -44,6 +50,36 @@
 	let primaryLanguage = $state(data.conversation.primaryLocale ?? 'en');
 	let supportedLanguages = $state(data.conversation.supportedLanguages ?? ['en']);
 	let pageTitle = $derived(`Configure ${conversation.title}`);
+
+	// Sub-tabs. `id` is the `?tab=` value; the first entry is the default when absent.
+	const tabs: ConfigureTab[] = [
+		{ id: 'details', label: 'Details' },
+		{ id: 'content', label: 'Content' },
+		{ id: 'access', label: 'Access' },
+		{ id: 'team', label: 'Team' }
+	];
+	const tabHeaders: Record<string, { title: string; description: string }> = {
+		details: { title: 'Details', description: 'Title, description, language and banner.' },
+		content: {
+			title: 'Content',
+			description: 'Participant-facing copy shown throughout the conversation.'
+		},
+		access: { title: 'Access', description: 'Visibility, invites and participation.' },
+		team: { title: 'Team', description: 'Manage collaborators.' }
+	};
+	let activeTab = $derived(page.url.searchParams.get('tab') ?? tabs[0].id);
+	let header = $derived(tabHeaders[activeTab] ?? tabHeaders.details);
+
+	// Inject the full-bleed sub-tab strip into "Row 3" of the conversation layout,
+	// the same slot the workflow step strip uses. Cleared on unmount.
+	const tabExtras = getContext<ConversationTabExtras>(CONVERSATION_TAB_EXTRAS_CTX);
+	$effect(() => {
+		if (!tabExtras) return;
+		tabExtras.primary = configureStripSnippet;
+		return () => {
+			tabExtras.primary = null;
+		};
+	});
 
 	// When we land here straight after creating this conversation, focus and select the
 	// auto-generated "Untitled …" title so it's obvious this is a brand-new conversation
@@ -179,8 +215,7 @@
 		{
 			validators: zodClient(conversationConfigSchema),
 			taintedMessage: false,
-			validationMethod: 'oninput',
-			onSubmit: updateConversation
+			validationMethod: 'oninput'
 		}
 	);
 
@@ -225,55 +260,52 @@
 		}
 	}
 
-	let { form, enhance, validateForm, submitting, tainted } = conversationForm;
+	let { form } = conversationForm;
 
-	async function updateConversation() {
-		const result = await validateForm({ update: true });
+	// Access toggles autosave on change (the page has no Save button — see ADR-0004).
+	// `$form.<field>` is updated optimistically by `bind:checked`; on failure we revert it.
+	// TODO: replace the per-toggle toast with a quiet inline "Saving → Saved" indicator per
+	// row (like TranslatableField's), which is the intended end state for toggle feedback.
+	type ConversationToggle =
+		| 'isPublic'
+		| 'isInviteOnly'
+		| 'enableQaChatBot'
+		| 'enableSignupPrompts'
+		| 'showThankYouPageAnnonInstructions';
 
-		if (!result.valid) return;
-
-		try {
-			const {
-				title: _title /* eslint-disable-line @typescript-eslint/no-unused-vars */,
-				shortDescription:
-					_short_description /* eslint-disable-line @typescript-eslint/no-unused-vars */,
-				description:
-					_description /* eslint-disable-line @typescript-eslint/no-unused-vars */,
-				privacyPolicy:
-					_privacyPolicy /* eslint-disable-line @typescript-eslint/no-unused-vars */,
-				shortPrivacyPolicy:
-					_shortPrivacyPolicy /* eslint-disable-line @typescript-eslint/no-unused-vars */,
-				faqs: _faqs /* eslint-disable-line @typescript-eslint/no-unused-vars */,
-				thankYouMessage:
-					_thankYouMessage /* eslint-disable-line @typescript-eslint/no-unused-vars */,
-				callToAction:
-					_callToAction /* eslint-disable-line @typescript-eslint/no-unused-vars */,
-				autoLogin: _auto_login /* eslint-disable-line @typescript-eslint/no-unused-vars */,
-				...conversationData
-			} = result.data;
-
-			// Convert to snake case for update params
-			const conversationSnakeCase = snakeCaseKeys(conversationData);
-
-			await apiClient.UpdateConversation(
-				{
-					...conversationSnakeCase,
-					primary_locale: primaryLanguage,
-					supported_languages: supportedLanguages
-				},
+	async function saveConversationToggle(field: ConversationToggle, value: boolean) {
+		const res = await tryCatchAsync(() =>
+			apiClient.UpdateConversation(
+				{ [camelToSnakeCase(field)]: value },
 				{ params: { conversation_id: conversation.id } }
-			);
-
-			await apiClient.UpdateConversationWorkflow(
-				{ auto_login: result.data.autoLogin },
-				{ params: { conversation_id: conversation.id, workflow_id: workflow.id } }
-			);
-
-			await invalidateAll();
-			notifications.send({ message: 'Updated conversation', priority: 'INFO' });
-		} catch (e) {
-			notifications.send({ message: 'Failed to save changes', priority: 'ERROR' });
+			)
+		);
+		if (res.err !== null) {
+			console.error(res.err);
+			$form[field] = !value;
+			notifications.send({ message: 'Failed to update setting', priority: 'ERROR' });
+			return;
 		}
+		notifications.send({ message: 'Setting updated', priority: 'INFO' });
+		await invalidate('conversation:meta');
+	}
+
+	// `autoLogin` lives on the workflow, not the conversation, so it saves via its own route.
+	async function saveAutoLogin(value: boolean) {
+		const res = await tryCatchAsync(() =>
+			apiClient.UpdateConversationWorkflow(
+				{ auto_login: value },
+				{ params: { conversation_id: conversation.id, workflow_id: workflow.id } }
+			)
+		);
+		if (res.err !== null) {
+			console.error(res.err);
+			$form.autoLogin = !value;
+			notifications.send({ message: 'Failed to update setting', priority: 'ERROR' });
+			return;
+		}
+		notifications.send({ message: 'Setting updated', priority: 'INFO' });
+		await invalidate('conversation:meta');
 	}
 
 	async function updateConversationMedia(media: MediaDto, field: string) {
@@ -309,457 +341,496 @@
 	<title>{pageTitle} - Comhairle Admin</title>
 </svelte:head>
 
-<PageHeader title="Configure" description="Personal details and general information." />
+{#snippet configureStripSnippet()}
+	<ConfigureTabStrip {tabs} />
+{/snippet}
 
-<form method="POST" onsubmit={updateConversation} class="flex flex-col" use:enhance>
-	<!-- Title -->
-	<div
-		class="border-border flex flex-col gap-4 border-t py-6 lg:flex-row lg:items-start lg:gap-6"
-	>
-		<Form.Field form={conversationForm} name="title" class="contents">
-			<Form.Control>
-				{#snippet children({ props })}
-					<Form.Label class="text-sm font-semibold lg:w-50 lg:shrink-0 lg:pt-2"
-						>Title</Form.Label
-					>
-					<div class="flex-1" id="conversation-title-field">
-						<TranslatableField
-							value={$form.title}
-							onValueChange={(v) => ($form.title = v)}
-							translation={conversation.translations?.title}
-							primaryLocale={primaryLanguage}
-							{supportedLanguages}
-							inputProps={props}
-						/>
-						<Form.FieldErrors />
-					</div>
-				{/snippet}
-			</Form.Control>
-		</Form.Field>
-	</div>
+<PageHeader title={header.title} description={header.description} />
 
-	<!-- Short Description -->
-	<div
-		class="border-border flex flex-col gap-4 border-t py-6 lg:flex-row lg:items-start lg:gap-6"
-	>
-		<Form.Field form={conversationForm} name="shortDescription" class="contents">
-			<Form.Control>
-				{#snippet children({ props })}
-					<Form.Label class="text-sm font-semibold lg:w-50 lg:shrink-0 lg:pt-2"
-						>Short description</Form.Label
-					>
-					<div class="flex-1">
-						<TranslatableField
-							value={$form.shortDescription}
-							onValueChange={(v) => ($form.shortDescription = v)}
-							translation={conversation.translations?.shortDescription}
-							primaryLocale={primaryLanguage}
-							{supportedLanguages}
-							inputType="textarea"
-							placeholder="A short description for this conversation."
-							inputProps={props}
-						/>
-						<Form.FieldErrors />
-					</div>
-				{/snippet}
-			</Form.Control>
-		</Form.Field>
-	</div>
-
-	<!-- Description -->
-	<div
-		class="border-border flex flex-col gap-4 border-t py-6 lg:flex-row lg:items-start lg:gap-6"
-	>
-		<Form.Field form={conversationForm} name="description" class="contents">
-			<Form.Control>
-				{#snippet children({ props })}
-					<Form.Label class="text-sm font-semibold lg:w-50 lg:shrink-0 lg:pt-2"
-						>Description</Form.Label
-					>
-					<div class="flex-1">
-						<TranslatableField
-							value={$form.description}
-							onValueChange={(v) => ($form.description = v)}
-							translation={conversation.translations?.description}
-							primaryLocale={primaryLanguage}
-							{supportedLanguages}
-							inputType="textarea"
-							placeholder="Introduce people to what is being discussed and outline the actions that might be taken as a result of the conversation."
-							inputProps={props}
-						/>
-						<Form.FieldErrors />
-					</div>
-				{/snippet}
-			</Form.Control>
-		</Form.Field>
-	</div>
-
-	<!-- Language options -->
-	<div
-		class="border-border flex flex-col gap-4 border-t py-6 lg:flex-row lg:items-start lg:gap-6"
-	>
-		<p class="text-sm font-semibold lg:w-50 lg:shrink-0 lg:pt-2">Language options</p>
-		<div class="max-w-md flex-1">
-			<LanguageSelector
-				bind:primaryLanguage
-				bind:supportedLanguages
-				onPrimaryChange={handlePrimaryLanguageChange}
-				onSupportedChange={handleSupportedLanguagesChange}
-			/>
-		</div>
-	</div>
-
-	<!-- Banner Image URL -->
-	<div
-		class="border-border flex flex-col gap-4 border-t py-6 lg:flex-row lg:items-start lg:gap-6"
-	>
-		<div class="contents">
-			<Label class="text-sm font-semibold lg:w-50 lg:shrink-0 lg:pt-2">Banner image URL</Label
-			>
-			<div class="align-start flex w-full flex-col gap-4">
-				<div class="flex flex-1 gap-4">
-					<MediaLibraryDialog
-						onconfirm={(media) => {
-							updateConversationMedia(media, 'image');
-						}}
-					/>
-					<MediaUpload
-						clientSide
-						size="sm"
-						oncomplete={(media) => {
-							if (!media.length) return;
-							updateConversationMedia(media[0], 'image');
-							for (const m of media) {
-								addToCache(m);
-							}
-						}}
-					/>
-				</div>
-				{#if imageMedia}
-					<div class="h-70 w-auto">
-						<img
-							src={imageMedia.url}
-							alt="Conversation"
-							class="h-full w-auto object-contain"
-						/>
-					</div>
-				{:else}
-					<div class="relative h-40 w-fit rounded-3xl bg-white/60">
-						<ImageIcon class="h-full w-auto" />
-						<span
-							class="absolute top-1/2 left-1/2 z-10 -translate-1/2 text-center text-xl font-bold text-gray-600"
-							>Awaiting image</span
+<!-- One superForm still backs every field (its inline validation + $form binding); there is
+	 no submit — every field autosaves (see ADR-0004), so this is a plain container. -->
+<div class="flex flex-col">
+	{#if activeTab === 'details'}
+		<!-- Title -->
+		<div
+			class="border-border flex flex-col gap-4 border-t py-6 lg:flex-row lg:items-start lg:gap-6"
+		>
+			<Form.Field form={conversationForm} name="title" class="contents">
+				<Form.Control>
+					{#snippet children({ props })}
+						<Form.Label class="text-sm font-semibold lg:w-50 lg:shrink-0 lg:pt-2"
+							>Title</Form.Label
 						>
-					</div>
-				{/if}
+						<div class="flex-1" id="conversation-title-field">
+							<TranslatableField
+								value={$form.title}
+								onValueChange={(v) => ($form.title = v)}
+								translation={conversation.translations?.title}
+								primaryLocale={primaryLanguage}
+								{supportedLanguages}
+								inputProps={props}
+							/>
+							<Form.FieldErrors />
+						</div>
+					{/snippet}
+				</Form.Control>
+			</Form.Field>
+		</div>
+
+		<!-- Short Description -->
+		<div
+			class="border-border flex flex-col gap-4 border-t py-6 lg:flex-row lg:items-start lg:gap-6"
+		>
+			<Form.Field form={conversationForm} name="shortDescription" class="contents">
+				<Form.Control>
+					{#snippet children({ props })}
+						<Form.Label class="text-sm font-semibold lg:w-50 lg:shrink-0 lg:pt-2"
+							>Short description</Form.Label
+						>
+						<div class="flex-1">
+							<TranslatableField
+								value={$form.shortDescription}
+								onValueChange={(v) => ($form.shortDescription = v)}
+								translation={conversation.translations?.shortDescription}
+								primaryLocale={primaryLanguage}
+								{supportedLanguages}
+								inputType="textarea"
+								placeholder="A short description for this conversation."
+								inputProps={props}
+							/>
+							<Form.FieldErrors />
+						</div>
+					{/snippet}
+				</Form.Control>
+			</Form.Field>
+		</div>
+
+		<!-- Description -->
+		<div
+			class="border-border flex flex-col gap-4 border-t py-6 lg:flex-row lg:items-start lg:gap-6"
+		>
+			<Form.Field form={conversationForm} name="description" class="contents">
+				<Form.Control>
+					{#snippet children({ props })}
+						<Form.Label class="text-sm font-semibold lg:w-50 lg:shrink-0 lg:pt-2"
+							>Description</Form.Label
+						>
+						<div class="flex-1">
+							<TranslatableField
+								value={$form.description}
+								onValueChange={(v) => ($form.description = v)}
+								translation={conversation.translations?.description}
+								primaryLocale={primaryLanguage}
+								{supportedLanguages}
+								inputType="textarea"
+								placeholder="Introduce people to what is being discussed and outline the actions that might be taken as a result of the conversation."
+								inputProps={props}
+							/>
+							<Form.FieldErrors />
+						</div>
+					{/snippet}
+				</Form.Control>
+			</Form.Field>
+		</div>
+
+		<!-- Language options -->
+		<div
+			class="border-border flex flex-col gap-4 border-t py-6 lg:flex-row lg:items-start lg:gap-6"
+		>
+			<p class="text-sm font-semibold lg:w-50 lg:shrink-0 lg:pt-2">Language options</p>
+			<div class="max-w-md flex-1">
+				<LanguageSelector
+					bind:primaryLanguage
+					bind:supportedLanguages
+					onPrimaryChange={handlePrimaryLanguageChange}
+					onSupportedChange={handleSupportedLanguagesChange}
+				/>
 			</div>
 		</div>
-	</div>
 
-	<!-- Privacy policy -->
-	<div
-		class="border-border flex flex-col gap-4 border-t py-6 lg:flex-row lg:items-start lg:gap-6"
-	>
-		<Form.Field form={conversationForm} name="privacyPolicy" class="contents">
-			<Form.Control>
-				{#snippet children({ props })}
-					<Form.Label class="text-sm font-semibold lg:w-50 lg:shrink-0 lg:pt-2"
-						>Privacy Policy</Form.Label
-					>
-					<div class="flex-1">
-						<TranslatableField
-							value={$form.privacyPolicy || null}
-							onValueChange={(v) => ($form.privacyPolicy = v)}
-							translation={conversation.translations?.privacyPolicy ?? undefined}
-							editorType="rich"
-							onSaveSource={(content: string) =>
-								handleInitOptionalTranslationField(
-									content,
-									'privacyPolicy',
-									'rich',
-									true
-								)}
-							primaryLocale={primaryLanguage}
-							{supportedLanguages}
-							inputProps={props}
+		<!-- Banner Image URL -->
+		<div
+			class="border-border flex flex-col gap-4 border-t py-6 lg:flex-row lg:items-start lg:gap-6"
+		>
+			<div class="contents">
+				<Label class="text-sm font-semibold lg:w-50 lg:shrink-0 lg:pt-2"
+					>Banner image URL</Label
+				>
+				<div class="align-start flex w-full flex-col gap-4">
+					<div class="flex flex-1 gap-4">
+						<MediaLibraryDialog
+							onconfirm={(media) => {
+								updateConversationMedia(media, 'image');
+							}}
 						/>
-						<Form.FieldErrors />
-					</div>
-				{/snippet}
-			</Form.Control>
-		</Form.Field>
-	</div>
-
-	<!-- Short privacy policy -->
-	<div
-		class="border-border flex flex-col gap-4 border-t py-6 lg:flex-row lg:items-start lg:gap-6"
-	>
-		<Form.Field form={conversationForm} name="shortPrivacyPolicy" class="contents">
-			<Form.Control>
-				{#snippet children({ props })}
-					<Form.Label class="text-sm font-semibold lg:w-50 lg:shrink-0 lg:pt-2"
-						>Short Privacy Policy</Form.Label
-					>
-					<div class="flex-1">
-						<TranslatableField
-							value={$form.shortPrivacyPolicy || null}
-							onValueChange={(v) => ($form.shortPrivacyPolicy = v)}
-							translation={conversation.translations?.shortPrivacyPolicy ?? undefined}
-							editorType="rich"
-							onSaveSource={(content: string) =>
-								handleInitOptionalTranslationField(
-									content,
-									'shortPrivacyPolicy',
-									'rich',
-									true
-								)}
-							primaryLocale={primaryLanguage}
-							{supportedLanguages}
-							inputProps={props}
+						<MediaUpload
+							clientSide
+							size="sm"
+							oncomplete={(media) => {
+								if (!media.length) return;
+								updateConversationMedia(media[0], 'image');
+								for (const m of media) {
+									addToCache(m);
+								}
+							}}
 						/>
-						<Form.FieldErrors />
 					</div>
-				{/snippet}
-			</Form.Control>
-		</Form.Field>
-	</div>
-
-	<!-- FAQs -->
-	<div
-		class="border-border flex flex-col gap-4 border-t py-6 lg:flex-row lg:items-start lg:gap-6"
-	>
-		<Form.Field form={conversationForm} name="faqs" class="contents">
-			<Form.Control>
-				{#snippet children({ props })}
-					<Form.Label class="text-sm font-semibold lg:w-50 lg:shrink-0 lg:pt-2"
-						>FAQs</Form.Label
-					>
-					<div class="flex-1">
-						<TranslatableField
-							value={$form.faqs || null}
-							onValueChange={(v) => ($form.faqs = v)}
-							translation={conversation.translations?.faqs ?? undefined}
-							editorType="rich"
-							onSaveSource={(content: string) =>
-								handleInitOptionalTranslationField(content, 'faqs')}
-							primaryLocale={primaryLanguage}
-							{supportedLanguages}
-							inputProps={props}
-						/>
-						<Form.FieldErrors />
-					</div>
-				{/snippet}
-			</Form.Control>
-		</Form.Field>
-	</div>
-
-	<!-- Thank you message -->
-	<div
-		class="border-border flex flex-col gap-4 border-t py-6 lg:flex-row lg:items-start lg:gap-6"
-	>
-		<Form.Field form={conversationForm} name="thankYouMessage" class="contents">
-			<Form.Control>
-				{#snippet children({ props })}
-					<Form.Label class="text-sm font-semibold lg:w-50 lg:shrink-0 lg:pt-2"
-						>Thank you message</Form.Label
-					>
-					<div class="flex-1">
-						<TranslatableField
-							value={$form.thankYouMessage || null}
-							onValueChange={(v) => ($form.thankYouMessage = v)}
-							translation={conversation.translations?.thankYouMessage ?? undefined}
-							editorType="rich"
-							onSaveSource={(content: string) =>
-								handleInitOptionalTranslationField(content, 'thankYouMessage')}
-							primaryLocale={primaryLanguage}
-							{supportedLanguages}
-							inputProps={props}
-						/>
-						<Form.FieldErrors />
-					</div>
-				{/snippet}
-			</Form.Control>
-		</Form.Field>
-	</div>
-
-	<!-- Call to action -->
-	<div
-		class="border-border flex flex-col gap-4 border-t py-6 lg:flex-row lg:items-start lg:gap-6"
-	>
-		<Form.Field form={conversationForm} name="callToAction" class="contents">
-			<Form.Control>
-				{#snippet children({ props })}
-					<Form.Label class="text-sm font-semibold lg:w-50 lg:shrink-0 lg:pt-2"
-						>Call to action</Form.Label
-					>
-					<div class="flex-1">
-						<TranslatableField
-							value={$form.callToAction || null}
-							onValueChange={(v) => ($form.callToAction = v)}
-							translation={conversation.translations?.callToAction ?? undefined}
-							onSaveSource={(content: string) =>
-								handleInitOptionalTranslationField(
-									content,
-									'callToAction',
-									'plain'
-								)}
-							primaryLocale={primaryLanguage}
-							{supportedLanguages}
-							inputProps={props}
-						/>
-						<Form.FieldErrors />
-					</div>
-				{/snippet}
-			</Form.Control>
-		</Form.Field>
-	</div>
-
-	<!-- Access / Other configuration -->
-	<div
-		class="border-border flex flex-col gap-4 border-t py-6 lg:flex-row lg:items-start lg:gap-6"
-	>
-		<p class="text-sm font-semibold lg:w-50 lg:shrink-0 lg:pt-2">Other configuration</p>
-		<div class="flex flex-1 flex-col gap-6">
-			<Form.Field form={conversationForm} name="isPublic">
-				<Form.Control>
-					{#snippet children({ props })}
-						<div class="flex items-center justify-between gap-4">
-							<div class="flex flex-col gap-1">
-								<Form.Label class="text-sm font-medium"
-									>Show conversation publicly</Form.Label
-								>
-								<p class="text-muted-foreground text-sm">
-									Allow export of personal data and backups.
-								</p>
-							</div>
-							<Switch {...props} bind:checked={$form.isPublic} />
-						</div>
-					{/snippet}
-				</Form.Control>
-				<Form.FieldErrors />
-			</Form.Field>
-
-			<Form.Field form={conversationForm} name="isInviteOnly">
-				<Form.Control>
-					{#snippet children({ props })}
-						<div class="flex items-center justify-between gap-4">
-							<div class="flex flex-col gap-1">
-								<Form.Label class="text-sm font-medium"
-									>Only allow participation by invite</Form.Label
-								>
-								<p class="text-muted-foreground text-sm">
-									Admins can invite and manage members.
-								</p>
-							</div>
-							<Switch {...props} bind:checked={$form.isInviteOnly} />
-						</div>
-					{/snippet}
-				</Form.Control>
-				<Form.FieldErrors />
-			</Form.Field>
-
-			<Form.Field form={conversationForm} name="autoLogin">
-				<Form.Control>
-					{#snippet children({ props })}
-						<div class="flex items-center justify-between gap-4">
-							<div class="flex flex-col gap-1">
-								<Form.Label class="text-sm font-medium"
-									>Automatically log in with an anonymous account</Form.Label
-								>
-								<p class="text-muted-foreground text-sm">
-									Creates a temporary account for unauthenticated users.
-								</p>
-							</div>
-							<Switch {...props} bind:checked={$form.autoLogin} />
-						</div>
-					{/snippet}
-				</Form.Control>
-				<Form.FieldErrors />
-			</Form.Field>
-
-			<Form.Field form={conversationForm} name="enableQaChatBot">
-				<Form.Control>
-					{#snippet children({ props })}
-						<div class="flex items-center justify-between gap-4">
-							<div class="flex flex-col gap-1">
-								<Form.Label class="text-sm font-medium"
-									>Show Learning Assistant</Form.Label
-								>
-								<p class="text-muted-foreground text-sm">
-									Display a Q&A Learning Assistant on the conversation.<br />
-									{#if !conversation.isLive}
-										(Configure Learning Assistant on the
-										<a
-											href={`/admin/conversations/${conversation.id}/knowledge-base`}
-											class="underline">Knowledge Base page</a
-										>)
-									{/if}
-								</p>
-							</div>
-							<Switch {...props} bind:checked={$form.enableQaChatBot} />
-						</div>
-					{/snippet}
-				</Form.Control>
-				<Form.FieldErrors />
-			</Form.Field>
-
-			<Form.Field form={conversationForm} name="enableSignupPrompts">
-				<Form.Control>
-					{#snippet children({ props })}
-						<div class="flex items-center justify-between gap-4">
-							<div class="flex flex-col gap-1">
-								<Form.Label class="text-sm font-medium"
-									>Enable signup prompts</Form.Label
-								>
-								<p class="text-muted-foreground text-sm">
-									Toggle whether to display signup prompts on thank you page.
-								</p>
-							</div>
-							<Switch {...props} bind:checked={$form.enableSignupPrompts} />
-						</div>
-					{/snippet}
-				</Form.Control>
-				<Form.FieldErrors />
-			</Form.Field>
-
-			<Form.Field form={conversationForm} name="showThankYouPageAnnonInstructions">
-				<Form.Control>
-					{#snippet children({ props })}
-						<div class="flex items-center justify-between gap-4">
-							<div class="flex flex-col gap-1">
-								<Form.Label class="text-sm font-medium"
-									>Show thank you page anonymous instructions</Form.Label
-								>
-								<p class="text-muted-foreground text-sm">
-									Display instructions for anonymous users on the thank you page.
-								</p>
-							</div>
-							<Switch
-								{...props}
-								bind:checked={$form.showThankYouPageAnnonInstructions}
+					{#if imageMedia}
+						<div class="h-70 w-auto">
+							<img
+								src={imageMedia.url}
+								alt="Conversation"
+								class="h-full w-auto object-contain"
 							/>
 						</div>
+					{:else}
+						<div class="relative h-40 w-fit rounded-3xl bg-white/60">
+							<ImageIcon class="h-full w-auto" />
+							<span
+								class="absolute top-1/2 left-1/2 z-10 -translate-1/2 text-center text-xl font-bold text-gray-600"
+								>Awaiting image</span
+							>
+						</div>
+					{/if}
+				</div>
+			</div>
+		</div>
+	{/if}
+
+	{#if activeTab === 'content'}
+		<!-- Privacy policy -->
+		<div
+			class="border-border flex flex-col gap-4 border-t py-6 lg:flex-row lg:items-start lg:gap-6"
+		>
+			<Form.Field form={conversationForm} name="privacyPolicy" class="contents">
+				<Form.Control>
+					{#snippet children({ props })}
+						<Form.Label class="text-sm font-semibold lg:w-50 lg:shrink-0 lg:pt-2"
+							>Privacy Policy</Form.Label
+						>
+						<div class="flex-1">
+							<TranslatableField
+								value={$form.privacyPolicy || null}
+								onValueChange={(v) => ($form.privacyPolicy = v)}
+								translation={conversation.translations?.privacyPolicy ?? undefined}
+								editorType="rich"
+								onSaveSource={(content: string) =>
+									handleInitOptionalTranslationField(
+										content,
+										'privacyPolicy',
+										'rich',
+										true
+									)}
+								primaryLocale={primaryLanguage}
+								{supportedLanguages}
+								inputProps={props}
+							/>
+							<Form.FieldErrors />
+						</div>
 					{/snippet}
 				</Form.Control>
-				<Form.FieldErrors />
 			</Form.Field>
 		</div>
-	</div>
 
-	<!-- Collaborators -->
-	<div
-		class="border-border flex flex-col gap-4 border-t py-6 lg:flex-row lg:items-start lg:gap-6"
-	>
-		<p class="text-sm font-semibold lg:w-50 lg:shrink-0 lg:pt-2">Collaborators</p>
-		<div class="flex-1">
-			<TeamManager />
+		<!-- Short privacy policy -->
+		<div
+			class="border-border flex flex-col gap-4 border-t py-6 lg:flex-row lg:items-start lg:gap-6"
+		>
+			<Form.Field form={conversationForm} name="shortPrivacyPolicy" class="contents">
+				<Form.Control>
+					{#snippet children({ props })}
+						<Form.Label class="text-sm font-semibold lg:w-50 lg:shrink-0 lg:pt-2"
+							>Short Privacy Policy</Form.Label
+						>
+						<div class="flex-1">
+							<TranslatableField
+								value={$form.shortPrivacyPolicy || null}
+								onValueChange={(v) => ($form.shortPrivacyPolicy = v)}
+								translation={conversation.translations?.shortPrivacyPolicy ??
+									undefined}
+								editorType="rich"
+								onSaveSource={(content: string) =>
+									handleInitOptionalTranslationField(
+										content,
+										'shortPrivacyPolicy',
+										'rich',
+										true
+									)}
+								primaryLocale={primaryLanguage}
+								{supportedLanguages}
+								inputProps={props}
+							/>
+							<Form.FieldErrors />
+						</div>
+					{/snippet}
+				</Form.Control>
+			</Form.Field>
 		</div>
-	</div>
 
-	<!-- Save Button -->
-	<div class="border-border flex justify-center border-t py-6">
-		<Form.Button variant="default" class="px-12" disabled={$submitting || !$tainted}>
-			Save Changes
-		</Form.Button>
-	</div>
-</form>
+		<!-- FAQs -->
+		<div
+			class="border-border flex flex-col gap-4 border-t py-6 lg:flex-row lg:items-start lg:gap-6"
+		>
+			<Form.Field form={conversationForm} name="faqs" class="contents">
+				<Form.Control>
+					{#snippet children({ props })}
+						<Form.Label class="text-sm font-semibold lg:w-50 lg:shrink-0 lg:pt-2"
+							>FAQs</Form.Label
+						>
+						<div class="flex-1">
+							<TranslatableField
+								value={$form.faqs || null}
+								onValueChange={(v) => ($form.faqs = v)}
+								translation={conversation.translations?.faqs ?? undefined}
+								editorType="rich"
+								onSaveSource={(content: string) =>
+									handleInitOptionalTranslationField(content, 'faqs')}
+								primaryLocale={primaryLanguage}
+								{supportedLanguages}
+								inputProps={props}
+							/>
+							<Form.FieldErrors />
+						</div>
+					{/snippet}
+				</Form.Control>
+			</Form.Field>
+		</div>
+
+		<!-- Thank you message -->
+		<div
+			class="border-border flex flex-col gap-4 border-t py-6 lg:flex-row lg:items-start lg:gap-6"
+		>
+			<Form.Field form={conversationForm} name="thankYouMessage" class="contents">
+				<Form.Control>
+					{#snippet children({ props })}
+						<Form.Label class="text-sm font-semibold lg:w-50 lg:shrink-0 lg:pt-2"
+							>Thank you message</Form.Label
+						>
+						<div class="flex-1">
+							<TranslatableField
+								value={$form.thankYouMessage || null}
+								onValueChange={(v) => ($form.thankYouMessage = v)}
+								translation={conversation.translations?.thankYouMessage ??
+									undefined}
+								editorType="rich"
+								onSaveSource={(content: string) =>
+									handleInitOptionalTranslationField(content, 'thankYouMessage')}
+								primaryLocale={primaryLanguage}
+								{supportedLanguages}
+								inputProps={props}
+							/>
+							<Form.FieldErrors />
+						</div>
+					{/snippet}
+				</Form.Control>
+			</Form.Field>
+		</div>
+
+		<!-- Call to action -->
+		<div
+			class="border-border flex flex-col gap-4 border-t py-6 lg:flex-row lg:items-start lg:gap-6"
+		>
+			<Form.Field form={conversationForm} name="callToAction" class="contents">
+				<Form.Control>
+					{#snippet children({ props })}
+						<Form.Label class="text-sm font-semibold lg:w-50 lg:shrink-0 lg:pt-2"
+							>Call to action</Form.Label
+						>
+						<div class="flex-1">
+							<TranslatableField
+								value={$form.callToAction || null}
+								onValueChange={(v) => ($form.callToAction = v)}
+								translation={conversation.translations?.callToAction ?? undefined}
+								onSaveSource={(content: string) =>
+									handleInitOptionalTranslationField(
+										content,
+										'callToAction',
+										'plain'
+									)}
+								primaryLocale={primaryLanguage}
+								{supportedLanguages}
+								inputProps={props}
+							/>
+							<Form.FieldErrors />
+						</div>
+					{/snippet}
+				</Form.Control>
+			</Form.Field>
+		</div>
+	{/if}
+
+	{#if activeTab === 'access'}
+		<!-- Access / Other configuration -->
+		<div
+			class="border-border flex flex-col gap-4 border-t py-6 lg:flex-row lg:items-start lg:gap-6"
+		>
+			<p class="text-sm font-semibold lg:w-50 lg:shrink-0 lg:pt-2">Other configuration</p>
+			<div class="flex flex-1 flex-col gap-6">
+				<Form.Field form={conversationForm} name="isPublic">
+					<Form.Control>
+						{#snippet children({ props })}
+							<div class="flex items-center justify-between gap-4">
+								<div class="flex flex-col gap-1">
+									<Form.Label class="text-sm font-medium"
+										>Show conversation publicly</Form.Label
+									>
+									<p class="text-muted-foreground text-sm">
+										Allow export of personal data and backups.
+									</p>
+								</div>
+								<Switch
+									{...props}
+									bind:checked={$form.isPublic}
+									onCheckedChange={(v) => saveConversationToggle('isPublic', v)}
+								/>
+							</div>
+						{/snippet}
+					</Form.Control>
+					<Form.FieldErrors />
+				</Form.Field>
+
+				<Form.Field form={conversationForm} name="isInviteOnly">
+					<Form.Control>
+						{#snippet children({ props })}
+							<div class="flex items-center justify-between gap-4">
+								<div class="flex flex-col gap-1">
+									<Form.Label class="text-sm font-medium"
+										>Only allow participation by invite</Form.Label
+									>
+									<p class="text-muted-foreground text-sm">
+										Admins can invite and manage members.
+									</p>
+								</div>
+								<Switch
+									{...props}
+									bind:checked={$form.isInviteOnly}
+									onCheckedChange={(v) =>
+										saveConversationToggle('isInviteOnly', v)}
+								/>
+							</div>
+						{/snippet}
+					</Form.Control>
+					<Form.FieldErrors />
+				</Form.Field>
+
+				<Form.Field form={conversationForm} name="autoLogin">
+					<Form.Control>
+						{#snippet children({ props })}
+							<div class="flex items-center justify-between gap-4">
+								<div class="flex flex-col gap-1">
+									<Form.Label class="text-sm font-medium"
+										>Automatically log in with an anonymous account</Form.Label
+									>
+									<p class="text-muted-foreground text-sm">
+										Creates a temporary account for unauthenticated users.
+									</p>
+								</div>
+								<Switch
+									{...props}
+									bind:checked={$form.autoLogin}
+									onCheckedChange={(v) => saveAutoLogin(v)}
+								/>
+							</div>
+						{/snippet}
+					</Form.Control>
+					<Form.FieldErrors />
+				</Form.Field>
+
+				<Form.Field form={conversationForm} name="enableQaChatBot">
+					<Form.Control>
+						{#snippet children({ props })}
+							<div class="flex items-center justify-between gap-4">
+								<div class="flex flex-col gap-1">
+									<Form.Label class="text-sm font-medium"
+										>Show Learning Assistant</Form.Label
+									>
+									<p class="text-muted-foreground text-sm">
+										Display a Q&A Learning Assistant on the conversation.<br />
+										{#if !conversation.isLive}
+											(Configure Learning Assistant on the
+											<a
+												href={`/admin/conversations/${conversation.id}/knowledge-base`}
+												class="underline">Knowledge Base page</a
+											>)
+										{/if}
+									</p>
+								</div>
+								<Switch
+									{...props}
+									bind:checked={$form.enableQaChatBot}
+									onCheckedChange={(v) =>
+										saveConversationToggle('enableQaChatBot', v)}
+								/>
+							</div>
+						{/snippet}
+					</Form.Control>
+					<Form.FieldErrors />
+				</Form.Field>
+
+				<Form.Field form={conversationForm} name="enableSignupPrompts">
+					<Form.Control>
+						{#snippet children({ props })}
+							<div class="flex items-center justify-between gap-4">
+								<div class="flex flex-col gap-1">
+									<Form.Label class="text-sm font-medium"
+										>Enable signup prompts</Form.Label
+									>
+									<p class="text-muted-foreground text-sm">
+										Toggle whether to display signup prompts on thank you page.
+									</p>
+								</div>
+								<Switch
+									{...props}
+									bind:checked={$form.enableSignupPrompts}
+									onCheckedChange={(v) =>
+										saveConversationToggle('enableSignupPrompts', v)}
+								/>
+							</div>
+						{/snippet}
+					</Form.Control>
+					<Form.FieldErrors />
+				</Form.Field>
+
+				<Form.Field form={conversationForm} name="showThankYouPageAnnonInstructions">
+					<Form.Control>
+						{#snippet children({ props })}
+							<div class="flex items-center justify-between gap-4">
+								<div class="flex flex-col gap-1">
+									<Form.Label class="text-sm font-medium"
+										>Show thank you page anonymous instructions</Form.Label
+									>
+									<p class="text-muted-foreground text-sm">
+										Display instructions for anonymous users on the thank you
+										page.
+									</p>
+								</div>
+								<Switch
+									{...props}
+									bind:checked={$form.showThankYouPageAnnonInstructions}
+									onCheckedChange={(v) =>
+										saveConversationToggle(
+											'showThankYouPageAnnonInstructions',
+											v
+										)}
+								/>
+							</div>
+						{/snippet}
+					</Form.Control>
+					<Form.FieldErrors />
+				</Form.Field>
+			</div>
+		</div>
+	{/if}
+
+	{#if activeTab === 'team'}
+		<!-- Collaborators -->
+		<div
+			class="border-border flex flex-col gap-4 border-t py-6 lg:flex-row lg:items-start lg:gap-6"
+		>
+			<p class="text-sm font-semibold lg:w-50 lg:shrink-0 lg:pt-2">Collaborators</p>
+			<div class="flex-1">
+				<TeamManager />
+			</div>
+		</div>
+	{/if}
+</div>

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/configure/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/configure/+page.svelte
@@ -12,9 +12,10 @@
 	import { conversationConfigSchema } from './schema';
 	import TeamManager from '$lib/components/TeamManager.svelte';
 	import PageHeader from '$lib/components/PageHeader.svelte';
-	import * as Tooltip from '$lib/components/ui/tooltip';
+	import * as HoverCard from '$lib/components/ui/hover-card';
 	import ConfigureTabStrip, { type ConfigureTab } from './ConfigureTabStrip.svelte';
 	import CollapsibleRichField from './CollapsibleRichField.svelte';
+	import ExampleDialog from './ExampleDialog.svelte';
 	import {
 		CONVERSATION_TAB_EXTRAS_CTX,
 		type ConversationTabExtras
@@ -28,7 +29,7 @@
 		WorkflowDto
 	} from '@crownshy/api-client/api';
 	import { camelToSentenceCase, camelToSnakeCase } from '$lib/utils/casingUtils';
-	import { Image as ImageIcon, ArrowUpRight, HelpCircle } from 'lucide-svelte';
+	import { Image as ImageIcon, Info } from 'lucide-svelte';
 	import MediaLibraryDialog, {
 		addToCache
 	} from '$lib/components/Media/MediaLibraryDialog.svelte';
@@ -71,9 +72,35 @@
 	let activeTab = $derived(page.url.searchParams.get('tab') ?? tabs[0].id);
 	let header = $derived(tabHeaders[activeTab] ?? tabHeaders.details);
 
-	// Base for the "See where" links: the participant preview always renders in preview mode,
-	// so each field can deep-link to the exact surface it appears on (privacy, faq, thank-you…).
-	let previewBase = $derived(`/conversations/${conversation.id}/preview`);
+	// "See example" opens a modal with a static screenshot of where the field appears for
+	// participants. Images are hand-maintained assets under static/examples/; a missing one
+	// falls back to "Example coming soon" (see ExampleDialog).
+	const examples: Record<string, { title: string; src: string }> = {
+		title: { title: 'Title', src: '/examples/title.png' },
+		shortDescription: { title: 'Short description', src: '/examples/short-description.png' },
+		description: { title: 'Description', src: '/examples/description.png' },
+		banner: { title: 'Banner image', src: '/examples/banner.png' },
+		privacyPolicy: { title: 'Privacy Policy', src: '/examples/privacy-policy.png' },
+		shortPrivacyPolicy: {
+			title: 'Short Privacy Policy',
+			src: '/examples/short-privacy-policy.png'
+		},
+		faqs: { title: 'FAQs', src: '/examples/faqs.png' },
+		thankYouMessage: { title: 'Thank you message', src: '/examples/thank-you.png' },
+		callToAction: { title: 'Call to action', src: '/examples/call-to-action.png' }
+	};
+	let exampleKey = $state<string | null>(null);
+	let exampleOpen = $state(false);
+	let exampleEntry = $derived(exampleKey ? examples[exampleKey] : null);
+
+	function openExample(key: string) {
+		exampleKey = key;
+		exampleOpen = true;
+	}
+
+	// The rich Content fields behave as an accordion: at most one is expanded at a time.
+	// Holds the field name of the open one, or null when all are collapsed.
+	let openContentField = $state<string | null>(null);
 
 	// Inject the full-bleed sub-tab strip into "Row 3" of the conversation layout,
 	// the same slot the workflow step strip uses. Cleared on unmount.
@@ -357,59 +384,58 @@
 	<ConfigureTabStrip {tabs} />
 {/snippet}
 
-<!-- "See where" deep-link to the live participant preview surface this field appears on. Opens
-	 in a new tab; skipped when a field has no distinct participant surface (e.g. Language). -->
-{#snippet seeWhere(previewHref: string)}
-	{#if previewHref}
-		<a
-			href={previewHref}
-			target="_blank"
-			rel="noopener"
-			class="text-primary mt-1.5 inline-flex items-center gap-1 text-sm hover:underline"
+<!-- The (i) affordance: a hover card (bits-ui LinkPreview, via our HoverCard wrapper) that shows
+	 the field's description on hover, plus an optional "See example" button that opens the image
+	 modal. Keeping the heavy image behind an explicit click means an accidental hover only ever
+	 reveals a light text card. `exampleKey` indexes the examples map. -->
+{#snippet infoPreview(info: string, exampleKey: string = '')}
+	<HoverCard.Root openDelay={150} closeDelay={100}>
+		<HoverCard.Trigger
+			class="text-muted-foreground hover:text-foreground inline-flex cursor-help"
+			aria-label="More information"
 		>
-			See where
-			<ArrowUpRight class="size-3.5" />
-		</a>
-	{/if}
+			<Info class="size-4" />
+		</HoverCard.Trigger>
+		<HoverCard.Content class="w-72 text-sm" side="top" sideOffset={6}>
+			<p>{info}</p>
+			{#if exampleKey}
+				<button
+					type="button"
+					onclick={() => openExample(exampleKey)}
+					class="text-primary mt-3 inline-flex items-center gap-1 text-sm font-medium hover:underline"
+				>
+					<ImageIcon class="size-3.5" />
+					See example
+				</button>
+			{/if}
+		</HoverCard.Content>
+	</HoverCard.Root>
 {/snippet}
 
 <!-- Left-column label for a form field. `label` stays a <Form.Label> so it keeps its `for`
-	 association with the control. What the field does lives in the field's placeholder; this
-	 column just carries the label and a "See where" link to the surface it appears on. -->
-{#snippet fieldLabel(label: string, previewHref: string = '')}
+	 association with the control. The (i) beside it carries the description and the example. -->
+{#snippet fieldLabel(label: string, exampleKey: string = '', info: string = '')}
 	<div class="lg:w-50 lg:shrink-0 lg:pt-2">
-		<Form.Label class="text-sm font-semibold">{label}</Form.Label>
-		{@render seeWhere(previewHref)}
+		<div class="flex items-center gap-1.5">
+			<Form.Label class="text-sm font-semibold">{label}</Form.Label>
+			{#if info || exampleKey}
+				{@render infoPreview(info, exampleKey)}
+			{/if}
+		</div>
 	</div>
 {/snippet}
 
 <!-- Same, for rows whose control isn't a Form.Field (Banner, Language), so there's no label to
 	 associate. -->
-{#snippet plainLabel(label: string, description: string = '', previewHref: string = '')}
+{#snippet plainLabel(label: string, exampleKey: string = '', info: string = '')}
 	<div class="lg:w-50 lg:shrink-0 lg:pt-2">
-		<p class="text-sm font-semibold">{label}</p>
-		{#if description}
-			<p class="text-muted-foreground mt-1 text-sm">{description}</p>
-		{/if}
-		{@render seeWhere(previewHref)}
+		<div class="flex items-center gap-1.5">
+			<p class="text-sm font-semibold">{label}</p>
+			{#if info || exampleKey}
+				{@render infoPreview(info, exampleKey)}
+			{/if}
+		</div>
 	</div>
-{/snippet}
-
-<!-- Small info affordance for Access toggles: a "?" that reveals a fuller plain-language
-	 explanation of what the setting does for participants. -->
-{#snippet infoTip(text: string)}
-	<Tooltip.Provider delayDuration={150}>
-		<Tooltip.Root>
-			<Tooltip.Trigger
-				type="button"
-				class="text-muted-foreground hover:text-foreground"
-				aria-label="More information"
-			>
-				<HelpCircle class="size-4" />
-			</Tooltip.Trigger>
-			<Tooltip.Content class="max-w-xs text-sm">{text}</Tooltip.Content>
-		</Tooltip.Root>
-	</Tooltip.Provider>
 {/snippet}
 
 <PageHeader title={header.title} description={header.description} />
@@ -425,7 +451,11 @@
 			<Form.Field form={conversationForm} name="title" class="contents">
 				<Form.Control>
 					{#snippet children({ props })}
-						{@render fieldLabel('Title', previewBase)}
+						{@render fieldLabel(
+							'Title',
+							'title',
+							"The conversation's name. Shown as the heading participants see, and on listing cards, invitations, and the thank-you and report pages."
+						)}
 						<div class="flex-1" id="conversation-title-field">
 							<TranslatableField
 								value={$form.title}
@@ -450,7 +480,11 @@
 			<Form.Field form={conversationForm} name="shortDescription" class="contents">
 				<Form.Control>
 					{#snippet children({ props })}
-						{@render fieldLabel('Short description', previewBase)}
+						{@render fieldLabel(
+							'Short description',
+							'shortDescription',
+							'A one-line summary, shown under the title on the landing page and on conversation cards in listings.'
+						)}
 						<div class="flex-1">
 							<TranslatableField
 								value={$form.shortDescription}
@@ -477,7 +511,11 @@
 			<Form.Field form={conversationForm} name="description" class="contents">
 				<Form.Control>
 					{#snippet children({ props })}
-						{@render fieldLabel('Description', previewBase)}
+						{@render fieldLabel(
+							'Description',
+							'description',
+							'A fuller introduction, shown beside the banner image on the landing and invitation pages.'
+						)}
 						<div class="flex-1">
 							<TranslatableField
 								value={$form.description}
@@ -503,6 +541,7 @@
 		>
 			{@render plainLabel(
 				'Language options',
+				'',
 				'The primary language plus any others you support. Adding a language lets you translate the other fields into it.'
 			)}
 			<div class="max-w-md flex-1">
@@ -522,8 +561,8 @@
 			<div class="contents">
 				{@render plainLabel(
 					'Banner image',
-					'Shown beside the description on the landing and invitation pages.',
-					previewBase
+					'banner',
+					'Shown beside the description on the landing and invitation pages.'
 				)}
 				<div class="align-start flex w-full flex-col gap-4">
 					<div class="flex flex-1 gap-4">
@@ -574,11 +613,18 @@
 			<Form.Field form={conversationForm} name="privacyPolicy" class="contents">
 				<Form.Control>
 					{#snippet children({ props })}
-						{@render fieldLabel('Privacy Policy', `${previewBase}/privacy`)}
+						{@render fieldLabel(
+							'Privacy Policy',
+							'privacyPolicy',
+							"The full policy, shown on the Privacy Policy page and the 'Find out more' panel. Leave blank to use Comhairle's default."
+						)}
 						<div class="flex-1">
 							<CollapsibleRichField
 								label="Privacy policy"
 								content={$form.privacyPolicy}
+								open={openContentField === 'privacyPolicy'}
+								onOpenChange={(o) =>
+									(openContentField = o ? 'privacyPolicy' : null)}
 							>
 								<TranslatableField
 									value={$form.privacyPolicy || null}
@@ -613,11 +659,18 @@
 			<Form.Field form={conversationForm} name="shortPrivacyPolicy" class="contents">
 				<Form.Control>
 					{#snippet children({ props })}
-						{@render fieldLabel('Short Privacy Policy', previewBase)}
+						{@render fieldLabel(
+							'Short Privacy Policy',
+							'shortPrivacyPolicy',
+							"Shown in the consent dialog participants accept before joining. Leave blank to use Comhairle's default."
+						)}
 						<div class="flex-1">
 							<CollapsibleRichField
 								label="Short privacy policy"
 								content={$form.shortPrivacyPolicy}
+								open={openContentField === 'shortPrivacyPolicy'}
+								onOpenChange={(o) =>
+									(openContentField = o ? 'shortPrivacyPolicy' : null)}
 							>
 								<TranslatableField
 									value={$form.shortPrivacyPolicy || null}
@@ -652,9 +705,18 @@
 			<Form.Field form={conversationForm} name="faqs" class="contents">
 				<Form.Control>
 					{#snippet children({ props })}
-						{@render fieldLabel('FAQs', `${previewBase}/faq`)}
+						{@render fieldLabel(
+							'FAQs',
+							'faqs',
+							"Shown on the FAQ page and the 'Find out more' panel. Leave blank to use Comhairle's default FAQs."
+						)}
 						<div class="flex-1">
-							<CollapsibleRichField label="FAQs" content={$form.faqs}>
+							<CollapsibleRichField
+								label="FAQs"
+								content={$form.faqs}
+								open={openContentField === 'faqs'}
+								onOpenChange={(o) => (openContentField = o ? 'faqs' : null)}
+							>
 								<TranslatableField
 									value={$form.faqs || null}
 									onValueChange={(v) => ($form.faqs = v)}
@@ -684,12 +746,16 @@
 					{#snippet children({ props })}
 						{@render fieldLabel(
 							'Thank you message',
-							`${previewBase}/workflow/${workflow.id}/thank_you`
+							'thankYouMessage',
+							"Shown on the thank-you page after someone finishes. Leave blank for the default 'Thank you for participating' message."
 						)}
 						<div class="flex-1">
 							<CollapsibleRichField
 								label="Thank you message"
 								content={$form.thankYouMessage}
+								open={openContentField === 'thankYouMessage'}
+								onOpenChange={(o) =>
+									(openContentField = o ? 'thankYouMessage' : null)}
 							>
 								<TranslatableField
 									value={$form.thankYouMessage || null}
@@ -722,13 +788,16 @@
 			<Form.Field form={conversationForm} name="callToAction" class="contents">
 				<Form.Control>
 					{#snippet children({ props })}
-						{@render fieldLabel('Call to action', previewBase)}
+						{@render fieldLabel(
+							'Call to action',
+							'callToAction',
+							"The label on the main join button. Leave blank for 'Join the conversation'."
+						)}
 						<div class="flex-1">
 							<TranslatableField
 								value={$form.callToAction || null}
 								onValueChange={(v) => ($form.callToAction = v)}
 								translation={conversation.translations?.callToAction ?? undefined}
-								placeholder="The label on the main join button. Leave blank for 'Join the conversation'."
 								onSaveSource={(content: string) =>
 									handleInitOptionalTranslationField(
 										content,
@@ -763,7 +832,7 @@
 										<Form.Label class="text-sm font-medium"
 											>Show conversation publicly</Form.Label
 										>
-										{@render infoTip(
+										{@render infoPreview(
 											'When this conversation is launched, anyone (even without an account) can open its documents and data. Off means only you, collaborators, and participants can.'
 										)}
 									</div>
@@ -791,7 +860,7 @@
 										<Form.Label class="text-sm font-medium"
 											>Only allow participation by invite</Form.Label
 										>
-										{@render infoTip(
+										{@render infoPreview(
 											'Only people you invite can take part. With this off, anyone with the link can participate.'
 										)}
 									</div>
@@ -820,7 +889,7 @@
 										<Form.Label class="text-sm font-medium"
 											>Automatically log in with an anonymous account</Form.Label
 										>
-										{@render infoTip(
+										{@render infoPreview(
 											'Visitors who are not signed in get a temporary anonymous account automatically, so they can take part without registering. They can upgrade to a real account later.'
 										)}
 									</div>
@@ -848,7 +917,7 @@
 										<Form.Label class="text-sm font-medium"
 											>Show Learning Assistant</Form.Label
 										>
-										{@render infoTip(
+										{@render infoPreview(
 											"Shows a Q&A 'Learning Assistant' that answers participants' questions from the conversation's knowledge base. Set it up on the Knowledge Base page."
 										)}
 									</div>
@@ -884,7 +953,7 @@
 										<Form.Label class="text-sm font-medium"
 											>Enable signup prompts</Form.Label
 										>
-										{@render infoTip(
+										{@render infoPreview(
 											'Shows prompts encouraging participants to create an account on the thank-you page after they finish.'
 										)}
 									</div>
@@ -913,7 +982,7 @@
 										<Form.Label class="text-sm font-medium"
 											>Show thank you page anonymous instructions</Form.Label
 										>
-										{@render infoTip(
+										{@render infoPreview(
 											'On the thank-you page, shows anonymous participants their temporary ID and how to log back in later to see the results.'
 										)}
 									</div>
@@ -952,3 +1021,9 @@
 		</div>
 	{/if}
 </div>
+
+<ExampleDialog
+	bind:open={exampleOpen}
+	title={exampleEntry?.title ?? ''}
+	src={exampleEntry?.src ?? null}
+/>

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/configure/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/configure/+page.svelte
@@ -494,7 +494,7 @@
 								primaryLocale={primaryLanguage}
 								{supportedLanguages}
 								inputType="textarea"
-								placeholder="A one-line summary, shown under the title on the landing page and on conversation cards in listings."
+								placeholder="A short description for this conversation."
 								inputProps={props}
 							/>
 							<Form.FieldErrors />
@@ -525,7 +525,7 @@
 								primaryLocale={primaryLanguage}
 								{supportedLanguages}
 								inputType="textarea"
-								placeholder="Introduce people to what is being discussed and outline the actions that might be taken as a result of the conversation. A fuller introduction, shown beside the banner image on the landing and invitation pages."
+								placeholder="Introduce people to what is being discussed and outline the actions that might be taken as a result of the conversation."
 								inputProps={props}
 							/>
 							<Form.FieldErrors />

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/configure/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/configure/+page.svelte
@@ -76,10 +76,7 @@
 	// participants. Images are hand-maintained assets under static/examples/; a missing one
 	// falls back to "Example coming soon" (see ExampleDialog).
 	const examples: Record<string, { title: string; src: string }> = {
-		title: { title: 'Title', src: '/examples/title.png' },
 		shortDescription: { title: 'Short description', src: '/examples/short-description.png' },
-		description: { title: 'Description', src: '/examples/description.png' },
-		banner: { title: 'Banner image', src: '/examples/banner.png' },
 		privacyPolicy: { title: 'Privacy Policy', src: '/examples/privacy-policy.png' },
 		shortPrivacyPolicy: {
 			title: 'Short Privacy Policy',
@@ -453,7 +450,7 @@
 					{#snippet children({ props })}
 						{@render fieldLabel(
 							'Title',
-							'title',
+							'',
 							"The conversation's name. Shown as the heading participants see, and on listing cards, invitations, and the thank-you and report pages."
 						)}
 						<div class="flex-1" id="conversation-title-field">
@@ -513,7 +510,7 @@
 					{#snippet children({ props })}
 						{@render fieldLabel(
 							'Description',
-							'description',
+							'',
 							'A fuller introduction, shown beside the banner image on the landing and invitation pages.'
 						)}
 						<div class="flex-1">
@@ -561,7 +558,7 @@
 			<div class="contents">
 				{@render plainLabel(
 					'Banner image',
-					'banner',
+					'',
 					'Shown beside the description on the landing and invitation pages.'
 				)}
 				<div class="align-start flex w-full flex-col gap-4">

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/configure/CollapsibleRichField.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/configure/CollapsibleRichField.svelte
@@ -8,13 +8,15 @@
 		label: string;
 		/** Current primary-locale value, for the preview and the empty check. */
 		content: string | null | undefined;
+		/** Whether this field is expanded. Controlled by the parent so only one is open at a time. */
+		open: boolean;
+		/** Request to expand (true) or collapse (false) this field. */
+		onOpenChange: (open: boolean) => void;
 		/** The editor to reveal when expanded (a TranslatableField and its errors). */
 		children: Snippet;
 	};
 
-	let { label, content, children }: Props = $props();
-
-	let open = $state(false);
+	let { label, content, open, onOpenChange, children }: Props = $props();
 
 	// Rich text counts as empty when it's null/blank or just an empty paragraph, so a
 	// never-set field shows the "Add …" call to action rather than an empty preview card.
@@ -36,7 +38,7 @@
 			<button
 				type="button"
 				class="text-muted-foreground hover:text-foreground text-sm font-medium"
-				onclick={() => (open = false)}
+				onclick={() => onOpenChange(false)}
 			>
 				Done
 			</button>
@@ -45,8 +47,8 @@
 {:else if isEmpty}
 	<button
 		type="button"
-		onclick={() => (open = true)}
-		class="border-border text-muted-foreground hover:border-foreground/40 hover:text-foreground flex h-11 w-full items-center gap-2 rounded-lg border border-dashed px-4 text-sm"
+		onclick={() => onOpenChange(true)}
+		class="bg-card border-border text-muted-foreground hover:border-foreground/40 hover:text-foreground flex h-11 w-full items-center gap-2 rounded-lg border border-dashed px-4 text-sm"
 	>
 		<Plus class="size-4" />
 		Add {label.toLowerCase()}
@@ -54,7 +56,7 @@
 {:else}
 	<button
 		type="button"
-		onclick={() => (open = true)}
+		onclick={() => onOpenChange(true)}
 		class="bg-card border-border hover:border-primary/60 flex w-full flex-col gap-2 rounded-lg border p-4 text-left"
 	>
 		<div class="text-foreground line-clamp-3 w-full text-sm">

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/configure/CollapsibleRichField.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/configure/CollapsibleRichField.svelte
@@ -2,6 +2,7 @@
 	import type { Snippet } from 'svelte';
 	import { Plus, Pencil } from 'lucide-svelte';
 	import ContentRenderer from '$lib/components/RichTextEditor/ContentRenderer/ContentRenderer.svelte';
+	import { Button } from '$lib/components/ui/button';
 
 	type Props = {
 		/** Field name, used in the empty-state call to action ("Add privacy policy"). */
@@ -32,23 +33,17 @@
 </script>
 
 {#if open}
-	<div class="flex flex-col gap-2">
+	<div class="flex flex-col gap-1">
 		{@render children()}
 		<div>
-			<button
-				type="button"
-				class="text-muted-foreground hover:text-foreground text-sm font-medium"
-				onclick={() => onOpenChange(false)}
-			>
-				Done
-			</button>
+			<Button variant="outline" onclick={() => onOpenChange(false)}>Done</Button>
 		</div>
 	</div>
 {:else if isEmpty}
 	<button
 		type="button"
 		onclick={() => onOpenChange(true)}
-		class="bg-card border-border text-muted-foreground hover:border-foreground/40 hover:text-foreground flex h-11 w-full items-center gap-2 rounded-lg border border-dashed px-4 text-sm"
+		class="bg-card border-border text-muted-foreground hover:border-foreground/40 hover:text-foreground flex h-11 w-full items-center gap-2 rounded-lg border border-dashed px-4 text-left text-sm"
 	>
 		<Plus class="size-4" />
 		Add {label.toLowerCase()}

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/configure/CollapsibleRichField.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/configure/CollapsibleRichField.svelte
@@ -1,0 +1,68 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	import { Plus, Pencil } from 'lucide-svelte';
+	import ContentRenderer from '$lib/components/RichTextEditor/ContentRenderer/ContentRenderer.svelte';
+
+	type Props = {
+		/** Field name, used in the empty-state call to action ("Add privacy policy"). */
+		label: string;
+		/** Current primary-locale value, for the preview and the empty check. */
+		content: string | null | undefined;
+		/** The editor to reveal when expanded (a TranslatableField and its errors). */
+		children: Snippet;
+	};
+
+	let { label, content, children }: Props = $props();
+
+	let open = $state(false);
+
+	// Rich text counts as empty when it's null/blank or just an empty paragraph, so a
+	// never-set field shows the "Add …" call to action rather than an empty preview card.
+	let isEmpty = $derived.by(() => {
+		const raw = (content ?? '').trim();
+		if (!raw) return true;
+		const withoutTags = raw
+			.replace(/<[^>]*>/g, '')
+			.replace(/&nbsp;/g, '')
+			.trim();
+		return withoutTags.length === 0;
+	});
+</script>
+
+{#if open}
+	<div class="flex flex-col gap-2">
+		{@render children()}
+		<div>
+			<button
+				type="button"
+				class="text-muted-foreground hover:text-foreground text-sm font-medium"
+				onclick={() => (open = false)}
+			>
+				Done
+			</button>
+		</div>
+	</div>
+{:else if isEmpty}
+	<button
+		type="button"
+		onclick={() => (open = true)}
+		class="border-border text-muted-foreground hover:border-foreground/40 hover:text-foreground flex h-11 w-full items-center gap-2 rounded-lg border border-dashed px-4 text-sm"
+	>
+		<Plus class="size-4" />
+		Add {label.toLowerCase()}
+	</button>
+{:else}
+	<button
+		type="button"
+		onclick={() => (open = true)}
+		class="bg-card border-border hover:border-primary/60 flex w-full flex-col gap-2 rounded-lg border p-4 text-left"
+	>
+		<div class="text-foreground line-clamp-3 w-full text-sm">
+			<ContentRenderer content={content ?? ''} minimal />
+		</div>
+		<span class="text-primary inline-flex items-center gap-1 text-sm font-medium">
+			<Pencil class="size-3.5" />
+			Edit
+		</span>
+	</button>
+{/if}

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/configure/ConfigureTabStrip.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/configure/ConfigureTabStrip.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+	import { page } from '$app/state';
+	import { SvelteURLSearchParams } from 'svelte/reactivity';
+
+	/** One selectable sub-tab of the Configure page. `id` is the `?tab=` value. */
+	export type ConfigureTab = { id: string; label: string };
+
+	type Props = {
+		/** Tabs to render, in display order. First tab is the default when `?tab=` is absent. */
+		tabs: ConfigureTab[];
+	};
+
+	let { tabs }: Props = $props();
+
+	let activeTab = $derived(page.url.searchParams.get('tab') ?? tabs[0]?.id);
+
+	// Preserve the rest of the URL, just swap `?tab=`. `noscroll` (below) keeps the
+	// scroll position so switching tabs never jumps the page.
+	function hrefFor(tabId: string): string {
+		const params = new SvelteURLSearchParams(page.url.searchParams);
+		params.set('tab', tabId);
+		return `${page.url.pathname}?${params.toString()}`;
+	}
+</script>
+
+<nav
+	class="border-border bg-muted/50 scrollbar-none w-full overflow-x-auto border-b"
+	aria-label="Configure sections"
+>
+	<ul
+		class="pl-gutter flex min-w-max items-center gap-x-1.5 gap-y-0.5 py-1 pr-5 sm:w-full sm:min-w-0 sm:flex-wrap"
+	>
+		{#each tabs as tab, i (tab.id)}
+			{@const active = activeTab === tab.id}
+			<!-- First item bleeds left into the gutter (-ml-3.5 cancels its own px-3.5)
+				 so it aligns to the shared gutter column, matching WorkflowStepStrip. -->
+			<li class={i === 0 ? '-ml-3.5' : undefined}>
+				<a
+					href={hrefFor(tab.id)}
+					data-sveltekit-noscroll
+					class="text-foreground inline-flex h-9 items-center px-3.5 text-sm font-medium whitespace-nowrap transition-opacity"
+					class:text-primary={active}
+					class:opacity-70={!active}
+					class:hover:opacity-100={!active}
+					aria-current={active ? 'page' : undefined}
+				>
+					{tab.label}
+				</a>
+			</li>
+		{/each}
+	</ul>
+</nav>
+
+<style>
+	.scrollbar-none {
+		scrollbar-width: none;
+	}
+	.scrollbar-none::-webkit-scrollbar {
+		display: none;
+	}
+</style>

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/configure/ExampleDialog.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/configure/ExampleDialog.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+	import * as Dialog from '$lib/components/ui/dialog';
+
+	type Props = {
+		/** Whether the dialog is open (two-way). */
+		open: boolean;
+		/** Field name, shown as the dialog title. */
+		title: string;
+		/** Static example image path (e.g. /examples/privacy-policy.png), or null. */
+		src: string | null;
+	};
+
+	let { open = $bindable(), title, src }: Props = $props();
+
+	// Writable-derived: recomputes to `false` whenever `src` changes (so switching fields
+	// clears a prior error), but the img `onerror` handler can still flip it to `true`.
+	let failed = $derived.by(() => {
+		void src;
+		return false;
+	});
+</script>
+
+<Dialog.Root bind:open>
+	<Dialog.Content class="max-w-3xl">
+		<Dialog.Header>
+			<Dialog.Title>{title}</Dialog.Title>
+			<Dialog.Description>Where this appears for participants.</Dialog.Description>
+		</Dialog.Header>
+		{#if src && !failed}
+			<img
+				{src}
+				alt={`Example of ${title}`}
+				class="border-border w-full rounded-lg border"
+				onerror={() => (failed = true)}
+			/>
+		{:else}
+			<div
+				class="border-border text-muted-foreground flex h-48 items-center justify-center rounded-lg border border-dashed text-sm"
+			>
+				Example coming soon.
+			</div>
+		{/if}
+	</Dialog.Content>
+</Dialog.Root>

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/design/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/design/+page.svelte
@@ -401,7 +401,7 @@
 												target="_blank"
 												class="flex w-full items-center gap-2"
 											>
-												<Info class="size-4" /> Step info
+												<Info class="size-4" /> Learn more
 											</a>
 										</DropdownMenu.Item>
 										<DropdownMenu.Separator />


### PR DESCRIPTION
Rework the Configure page into labelled, autosaving sub-tabs. (Combines the "add tabs" and
"label the fields" branches, both are the Configure page.)

## Changes
- Split Configure into **Details / Content / Access / Team** sub-tabs (`ConfigureTabStrip`),
  with **full inline autosave** no submit button (see `documentation/adr/0004-configure-page-fully-autosave.md`).
- Replace the old "See where" preview links with **hover-card info tips** plus a
  **"See example" image modal** (`ExampleDialog`).
- Add a validation guard so required fields don't autosave an invalid/empty value.
- Refine rich-text field placeholders/styling (`CollapsibleRichField`, `TranslatableField`).

## Notes
- Stacked on #650 . Spans two internal branches (`admin-add-tabs-to-configure-page` +
  `add-labels-to-fields-in-configure-page`) which aren't opened as separate PRs.