### PR TITLE
Extract shared tab-strip components + section skeletons

### DIFF
--- a/ui/packages/comhairle/src/lib/components/EventStrip.svelte
+++ b/ui/packages/comhairle/src/lib/components/EventStrip.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { page } from '$app/state';
 	import { CalendarDays, Plus } from 'lucide-svelte';
+	import TabStripShell from '$lib/components/TabStripShell.svelte';
 	import type { LocalizedEventDto } from '@crownshy/api-client/api';
 
 	let {
@@ -20,61 +21,45 @@
 	}
 </script>
 
-<nav
-	class="border-border bg-muted/50 scrollbar-none w-full overflow-x-auto border-b"
-	aria-label="Events"
->
-	<ul
-		class="pl-gutter flex min-w-max items-center gap-x-1.5 gap-y-0.5 py-1 pr-5 sm:w-full sm:min-w-0 sm:flex-wrap"
-	>
-		<!-- First item bleeds left into the gutter (-ml-3.5 cancels its own px-3.5)
-			 so the "All events" icon aligns to the shared gutter column. -->
-		<li class="-ml-3.5">
-			<a
-				href={basePath}
-				class="text-foreground inline-flex h-9 items-center gap-1.5 px-3.5 text-sm font-medium whitespace-nowrap transition-opacity"
-				class:text-primary={manageActive}
-				class:opacity-70={!manageActive}
-				class:hover:opacity-100={!manageActive}
-				aria-current={manageActive ? 'page' : undefined}
-			>
-				<CalendarDays class="size-4" />
-				All events
-			</a>
-		</li>
-		{#each events as event (event.id)}
-			{@const active = isEventActive(event.id, page.url.pathname)}
-			<li>
-				<a
-					href={`${basePath}/${event.id}`}
-					title={event.name || 'Unnamed event'}
-					class="text-foreground inline-flex h-9 max-w-[220px] items-center px-3.5 text-sm font-medium transition-opacity"
-					class:text-primary={active}
-					class:opacity-70={!active}
-					class:hover:opacity-100={!active}
-					aria-current={active ? 'page' : undefined}
-				>
-					<span class="truncate">{event.name || 'Unnamed event'}</span>
-				</a>
-			</li>
-		{/each}
+<TabStripShell ariaLabel="Events">
+	<!-- First item bleeds left into the gutter (-ml-3.5 cancels its own px-3.5)
+		 so the "All events" icon aligns to the shared gutter column. -->
+	<li class="-ml-3.5">
+		<a
+			href={basePath}
+			class="text-foreground inline-flex h-9 items-center gap-1.5 px-3.5 text-sm font-medium whitespace-nowrap transition-opacity"
+			class:text-primary={manageActive}
+			class:opacity-70={!manageActive}
+			class:hover:opacity-100={!manageActive}
+			aria-current={manageActive ? 'page' : undefined}
+		>
+			<CalendarDays class="size-4" />
+			All events
+		</a>
+	</li>
+	{#each events as event (event.id)}
+		{@const active = isEventActive(event.id, page.url.pathname)}
 		<li>
 			<a
-				href={newPath}
-				class="text-foreground/40 hover:text-foreground inline-flex h-9 items-center gap-1 px-3.5 text-sm font-medium whitespace-nowrap"
+				href={`${basePath}/${event.id}`}
+				title={event.name || 'Unnamed event'}
+				class="text-foreground inline-flex h-9 max-w-[220px] items-center px-3.5 text-sm font-medium transition-opacity"
+				class:text-primary={active}
+				class:opacity-70={!active}
+				class:hover:opacity-100={!active}
+				aria-current={active ? 'page' : undefined}
 			>
-				<Plus class="size-4" />
-				Add event
+				<span class="truncate">{event.name || 'Unnamed event'}</span>
 			</a>
 		</li>
-	</ul>
-</nav>
-
-<style>
-	.scrollbar-none {
-		scrollbar-width: none;
-	}
-	.scrollbar-none::-webkit-scrollbar {
-		display: none;
-	}
-</style>
+	{/each}
+	<li>
+		<a
+			href={newPath}
+			class="text-foreground/40 hover:text-foreground inline-flex h-9 items-center gap-1 px-3.5 text-sm font-medium whitespace-nowrap"
+		>
+			<Plus class="size-4" />
+			Add event
+		</a>
+	</li>
+</TabStripShell>

--- a/ui/packages/comhairle/src/lib/components/SubTabStrip.svelte
+++ b/ui/packages/comhairle/src/lib/components/SubTabStrip.svelte
@@ -3,15 +3,20 @@
 
 	type Item = { label: string; value: string };
 
-	let {
-		items,
-		paramName = 'subtab',
-		defaultValue
-	}: {
+	type Props = {
 		items: Item[];
 		paramName?: string;
 		defaultValue?: string;
-	} = $props();
+		/**
+		 * Which layout row this strip sits in, which sets its background tone:
+		 * - `'secondary'` (default) = the deepest sub-tab strip → `bg-accent`.
+		 * - `'primary'` = a section's sole strip directly under the section tabs
+		 *   (e.g. Recruit/invites) → `bg-secondary`.
+		 */
+		tone?: 'primary' | 'secondary';
+	};
+
+	let { items, paramName = 'subtab', defaultValue, tone = 'secondary' }: Props = $props();
 
 	let currentValue = $derived(
 		page.url.searchParams.get(paramName) ?? defaultValue ?? items[0]?.value
@@ -25,7 +30,9 @@
 </script>
 
 <nav
-	class="border-border bg-primary/5 scrollbar-none flex w-full overflow-x-auto border-b"
+	class="border-border scrollbar-none flex w-full overflow-x-auto border-b {tone === 'primary'
+		? 'bg-secondary'
+		: 'bg-accent'}"
 	aria-label="Sub sections"
 >
 	<ul class="flex min-w-full items-center gap-1.5 px-5">

--- a/ui/packages/comhairle/src/lib/components/TabStripShell.svelte
+++ b/ui/packages/comhairle/src/lib/components/TabStripShell.svelte
@@ -1,0 +1,40 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+
+	type Props = {
+		/** Accessible label for the strip's `<nav>` (omit for decorative/skeleton strips). */
+		ariaLabel?: string;
+		/** Hide from the accessibility tree (used by the loading skeleton). */
+		ariaHidden?: boolean;
+		/** The strip's `<li>` items, rendered inside the shared `<ul>`. */
+		children: Snippet;
+	};
+
+	let { ariaLabel, ariaHidden = false, children }: Props = $props();
+</script>
+
+<!-- Shared shell for the conversation layout's "Row 2" primary strip (section sub-tabs,
+	 workflow steps, events). Owns the row's chrome — background, bottom border, gutter
+	 alignment, horizontal scroll, wrap behaviour — so every strip and its loading skeleton
+	 stay pixel-identical. `bg-secondary` is the Row 2 tone (Row 1 is `bg-background`, the
+	 Row 3 sub-strip is `bg-accent`). -->
+<nav
+	class="border-border bg-secondary scrollbar-none w-full overflow-x-auto border-b"
+	aria-label={ariaLabel}
+	aria-hidden={ariaHidden || undefined}
+>
+	<ul
+		class="pl-gutter flex min-w-max items-center gap-x-1.5 gap-y-0.5 py-1 pr-5 sm:w-full sm:min-w-0 sm:flex-wrap"
+	>
+		{@render children()}
+	</ul>
+</nav>
+
+<style>
+	.scrollbar-none {
+		scrollbar-width: none;
+	}
+	.scrollbar-none::-webkit-scrollbar {
+		display: none;
+	}
+</style>

--- a/ui/packages/comhairle/src/lib/components/TabStripSkeleton.svelte
+++ b/ui/packages/comhairle/src/lib/components/TabStripSkeleton.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+	import { Skeleton } from '$lib/components/ui/skeleton';
+	import TabStripShell from '$lib/components/TabStripShell.svelte';
+
+	type Props = {
+		/**
+		 * Render a leading icon + label placeholder, matching strips whose first item is an
+		 * icon tab (design's "Design", events' "All events"). Configure's plain sub-tabs omit it.
+		 */
+		leadingIcon?: boolean;
+		/**
+		 * Approximate widths (in `rem`) of the placeholder tab labels, in display order.
+		 * The count and widths are cosmetic; they only shape the loading row.
+		 */
+		widths?: number[];
+	};
+
+	// Defaults roughly match the Configure sub-tabs (Details / Content / Access / Team).
+	let { leadingIcon = false, widths = [3.5, 4, 3, 2.75] }: Props = $props();
+</script>
+
+<!-- Placeholder for the injected "Row 2" primary strip: reserves the row's height so a
+	 refresh doesn't shift the layout. Reuses TabStripShell to stay pixel-identical to the
+	 real strips. -->
+<TabStripShell ariaHidden>
+	{#if leadingIcon}
+		<!-- Leading icon tab (bleeds into the gutter like the real strips' first item). -->
+		<li class="-ml-3.5 flex h-9 items-center gap-1.5 px-3.5">
+			<Skeleton class="bg-primary/15 size-4 rounded" />
+			<Skeleton class="bg-primary/15 h-4 w-14 rounded-md" />
+		</li>
+	{/if}
+	{#each widths as width, i (i)}
+		<!-- Without a leading icon, the first pill bleeds into the gutter (-ml-3.5 cancels
+			 its own px-3.5) to align with the real strip's first tab. Tinted with the brand
+			 color so the shimmer reads against the secondary strip instead of gray-on-gray. -->
+		<li class="flex h-9 items-center px-3.5" class:-ml-3.5={!leadingIcon && i === 0}>
+			<Skeleton class="bg-primary/15 h-4 rounded-md" style="width: {width}rem" />
+		</li>
+	{/each}
+</TabStripShell>

--- a/ui/packages/comhairle/src/lib/components/WorkflowStepStrip.svelte
+++ b/ui/packages/comhairle/src/lib/components/WorkflowStepStrip.svelte
@@ -2,6 +2,7 @@
 	import { page } from '$app/state';
 	import { Plus, Settings2 } from 'lucide-svelte';
 	import { Skeleton } from '$lib/components/ui/skeleton';
+	import TabStripShell from '$lib/components/TabStripShell.svelte';
 	import type { WorkflowStepWithTranslations } from '@crownshy/api-client/api';
 
 	let {
@@ -24,70 +25,54 @@
 	}
 </script>
 
-<nav
-	class="border-border bg-muted/50 scrollbar-none w-full overflow-x-auto border-b"
-	aria-label="Workflow steps"
->
-	<ul
-		class="pl-gutter flex min-w-max items-center gap-x-1.5 gap-y-0.5 py-1 pr-5 sm:w-full sm:min-w-0 sm:flex-wrap"
-	>
-		<!-- First item bleeds left into the gutter (-ml-3.5 cancels its own px-3.5)
-			 so the "Design" icon aligns to the shared gutter column. -->
-		<li class="-ml-3.5">
-			<a
-				href={basePath}
-				class="text-foreground inline-flex h-9 items-center gap-1.5 px-3.5 text-sm font-medium whitespace-nowrap transition-opacity"
-				class:text-primary={manageActive}
-				class:opacity-70={!manageActive}
-				class:hover:opacity-100={!manageActive}
-				aria-current={manageActive ? 'page' : undefined}
-			>
-				<Settings2 class="size-4" />
-				Design
-			</a>
-		</li>
-		{#if loading}
-			{#each Array(3) as _, i (i)}
-				<li class="px-3.5 py-1.5">
-					<Skeleton class="h-5 w-24" />
-				</li>
-			{/each}
-		{:else}
-			{#each orderedSteps as step (step.id)}
-				{@const active = isStepActive(step.id, page.url.pathname)}
-				<li>
-					<a
-						href={`${basePath}/step/${step.id}`}
-						title={step.name || 'Unnamed step'}
-						class="text-foreground inline-flex h-9 max-w-[220px] items-center px-3.5 text-sm font-medium transition-opacity"
-						class:text-primary={active}
-						class:opacity-70={!active}
-						class:hover:opacity-100={!active}
-						aria-current={active ? 'page' : undefined}
-					>
-						<span class="truncate">{step.name || 'Unnamed step'}</span>
-					</a>
-				</li>
-			{/each}
-			<li>
-				<button
-					type="button"
-					onclick={onAddStep}
-					class="text-foreground/40 hover:text-foreground inline-flex h-9 items-center gap-1 px-3.5 text-sm font-medium whitespace-nowrap"
-				>
-					<Plus class="size-4" />
-					Add step
-				</button>
+<TabStripShell ariaLabel="Workflow steps">
+	<!-- First item bleeds left into the gutter (-ml-3.5 cancels its own px-3.5)
+		 so the "Design" icon aligns to the shared gutter column. -->
+	<li class="-ml-3.5">
+		<a
+			href={basePath}
+			class="text-foreground inline-flex h-9 items-center gap-1.5 px-3.5 text-sm font-medium whitespace-nowrap transition-opacity"
+			class:text-primary={manageActive}
+			class:opacity-70={!manageActive}
+			class:hover:opacity-100={!manageActive}
+			aria-current={manageActive ? 'page' : undefined}
+		>
+			<Settings2 class="size-4" />
+			Design
+		</a>
+	</li>
+	{#if loading}
+		{#each Array(3) as _, i (i)}
+			<li class="px-3.5 py-1.5">
+				<Skeleton class="h-5 w-24" />
 			</li>
-		{/if}
-	</ul>
-</nav>
-
-<style>
-	.scrollbar-none {
-		scrollbar-width: none;
-	}
-	.scrollbar-none::-webkit-scrollbar {
-		display: none;
-	}
-</style>
+		{/each}
+	{:else}
+		{#each orderedSteps as step (step.id)}
+			{@const active = isStepActive(step.id, page.url.pathname)}
+			<li>
+				<a
+					href={`${basePath}/step/${step.id}`}
+					title={step.name || 'Unnamed step'}
+					class="text-foreground inline-flex h-9 max-w-[220px] items-center px-3.5 text-sm font-medium transition-opacity"
+					class:text-primary={active}
+					class:opacity-70={!active}
+					class:hover:opacity-100={!active}
+					aria-current={active ? 'page' : undefined}
+				>
+					<span class="truncate">{step.name || 'Unnamed step'}</span>
+				</a>
+			</li>
+		{/each}
+		<li>
+			<button
+				type="button"
+				onclick={onAddStep}
+				class="text-foreground/40 hover:text-foreground inline-flex h-9 items-center gap-1 px-3.5 text-sm font-medium whitespace-nowrap"
+			>
+				<Plus class="size-4" />
+				Add step
+			</button>
+		</li>
+	{/if}
+</TabStripShell>

--- a/ui/packages/comhairle/src/lib/styles/comhairle-themes.css
+++ b/ui/packages/comhairle/src/lib/styles/comhairle-themes.css
@@ -171,7 +171,7 @@
 	--muted: #f3f4f6;
 	--muted-foreground: #6b7280;
 	--subtle-foreground: #9ca3af;
-	--accent: #f3f4f6;
+	--accent: #ebf1ff;
 	--accent-foreground: #111827;
 	--destructive: #dc2626;
 	--destructive-foreground: #fef2f2;

--- a/ui/packages/comhairle/src/lib/utils/conversationTabStrip.test.ts
+++ b/ui/packages/comhairle/src/lib/utils/conversationTabStrip.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { conversationPrimaryStripSkeleton } from './conversationTabStrip';
+
+const id = '29a4318b-4b91-4852-bb81-992c35d29b96';
+const base = `/admin/conversations/${id}`;
+
+describe('conversationPrimaryStripSkeleton', () => {
+	it('returns a skeleton shape for sections that inject a primary strip', () => {
+		expect(conversationPrimaryStripSkeleton(`${base}/configure`, id)).toEqual({
+			leadingIcon: false,
+			widths: [3.5, 4, 3, 2.75]
+		});
+		expect(conversationPrimaryStripSkeleton(`${base}/design`, id)?.leadingIcon).toBe(true);
+		expect(conversationPrimaryStripSkeleton(`${base}/events`, id)?.leadingIcon).toBe(true);
+		expect(conversationPrimaryStripSkeleton(`${base}/invites`, id)).not.toBeNull();
+	});
+
+	it('resolves nested routes to their section skeleton', () => {
+		expect(conversationPrimaryStripSkeleton(`${base}/design/step/abc`, id)?.leadingIcon).toBe(
+			true
+		);
+		expect(
+			conversationPrimaryStripSkeleton(`${base}/events/some-event-id`, id)?.leadingIcon
+		).toBe(true);
+	});
+
+	it('ignores a trailing slash', () => {
+		expect(conversationPrimaryStripSkeleton(`${base}/configure/`, id)).not.toBeNull();
+	});
+
+	it('returns null for sections without a primary strip', () => {
+		expect(conversationPrimaryStripSkeleton(`${base}/knowledge-base`, id)).toBeNull();
+		expect(conversationPrimaryStripSkeleton(`${base}/monitor`, id)).toBeNull();
+		expect(conversationPrimaryStripSkeleton(`${base}/report`, id)).toBeNull();
+		expect(conversationPrimaryStripSkeleton(base, id)).toBeNull();
+	});
+
+	it('returns null for unrelated paths or a mismatched conversation id', () => {
+		expect(conversationPrimaryStripSkeleton('/admin/dashboard', id)).toBeNull();
+		expect(
+			conversationPrimaryStripSkeleton(`/admin/conversations/other-id/configure`, id)
+		).toBeNull();
+	});
+
+	it('does not match a section that only shares a prefix', () => {
+		expect(conversationPrimaryStripSkeleton(`${base}/designs`, id)).toBeNull();
+		expect(conversationPrimaryStripSkeleton(`${base}/configure-extra`, id)).toBeNull();
+	});
+});

--- a/ui/packages/comhairle/src/lib/utils/conversationTabStrip.ts
+++ b/ui/packages/comhairle/src/lib/utils/conversationTabStrip.ts
@@ -1,0 +1,49 @@
+/**
+ * Shape of the placeholder skeleton for a conversation section's primary sub-tab strip.
+ * Cosmetic only: it mimics the real strip closely enough to reserve its height and avoid
+ * a layout shift while the strip mounts.
+ */
+export type TabStripSkeletonShape = {
+	/**
+	 * Whether the strip's first item leads with an icon + short label (e.g. design's
+	 * "Design" tab, events' "All events" tab). Configure's plain sub-tabs do not.
+	 */
+	leadingIcon: boolean;
+	/** Placeholder label widths (in `rem`), in display order, for the tab/name pills. */
+	widths: number[];
+};
+
+/**
+ * Per-section skeletons for the "Row 3" primary strip. The strip is injected by a child
+ * `$effect` (see {@link CONVERSATION_TAB_EXTRAS_CTX}), which never runs during SSR and only
+ * fires after the client mounts, so on a hard refresh the row is briefly empty. The layout
+ * reserves it with one of these skeletons for the sections that populate it.
+ *
+ * Keyed by the section segment right after `/admin/conversations/<id>/`. Widths roughly
+ * match each real strip: Configure's four sub-tabs; design/events lead with an icon tab
+ * followed by a few variable-width step/event names.
+ */
+const SECTION_STRIP_SKELETONS: Record<string, TabStripSkeletonShape> = {
+	configure: { leadingIcon: false, widths: [3.5, 4, 3, 2.75] },
+	design: { leadingIcon: true, widths: [6, 4.5, 7, 5, 5.5] },
+	events: { leadingIcon: true, widths: [6, 4.5, 5.5, 5] },
+	invites: { leadingIcon: false, widths: [4, 5] }
+};
+
+/**
+ * The placeholder skeleton shape for the given conversation-admin route's primary sub-tab
+ * strip, or `null` if the route has no such strip (so the layout renders nothing).
+ *
+ * @param pathname - The current `page.url.pathname` (no query string).
+ * @param conversationId - The active conversation's id, forming the route base.
+ */
+export function conversationPrimaryStripSkeleton(
+	pathname: string,
+	conversationId: string
+): TabStripSkeletonShape | null {
+	const base = `/admin/conversations/${conversationId}`;
+	if (pathname !== base && !pathname.startsWith(`${base}/`)) return null;
+	const rest = pathname.slice(base.length).replace(/^\/+/, '');
+	const section = rest.split('/')[0];
+	return SECTION_STRIP_SKELETONS[section] ?? null;
+}

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/+layout.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/+layout.svelte
@@ -7,10 +7,12 @@
 	import LaunchConversationModal from '$lib/components/LaunchConversationModal.svelte';
 	import EndConversationModal from '$lib/components/EndConversationModal.svelte';
 	import ConversationTabs from '$lib/components/ConversationTabs.svelte';
+	import TabStripSkeleton from '$lib/components/TabStripSkeleton.svelte';
 	import {
 		CONVERSATION_TAB_EXTRAS_CTX,
 		type ConversationTabExtras
 	} from '$lib/conversationTabExtras';
+	import { conversationPrimaryStripSkeleton } from '$lib/utils/conversationTabStrip';
 	import { getTextInLocale } from '$lib/components/Translation/translationUtils';
 
 	let { data, children } = $props();
@@ -34,6 +36,12 @@
 	// /design/step/* — keeps the padded, max-width reading column.
 	let isDesignBoard = $derived(
 		page.url.pathname.replace(/\/+$/, '') === `/admin/conversations/${conversation.id}/design`
+	);
+
+	// Reserve the injected primary strip's row with a matching skeleton (null = no strip on this
+	// route) so a hard refresh doesn't shift the layout. See conversationPrimaryStripSkeleton for why.
+	let primaryStripSkeleton = $derived(
+		conversationPrimaryStripSkeleton(page.url.pathname, conversation.id)
 	);
 </script>
 
@@ -189,6 +197,11 @@
 	<!-- Row 3+ : section-specific sub-strips injected via context (e.g. workflow steps, sub-tabs) -->
 	{#if tabExtras.primary}
 		{@render tabExtras.primary()}
+	{:else if primaryStripSkeleton}
+		<TabStripSkeleton
+			leadingIcon={primaryStripSkeleton.leadingIcon}
+			widths={primaryStripSkeleton.widths}
+		/>
 	{/if}
 	{#if tabExtras.secondary}
 		{@render tabExtras.secondary()}

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/configure/ConfigureTabStrip.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/configure/ConfigureTabStrip.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { page } from '$app/state';
 	import { SvelteURLSearchParams } from 'svelte/reactivity';
+	import TabStripShell from '$lib/components/TabStripShell.svelte';
 
 	/** One selectable sub-tab of the Configure page. `id` is the `?tab=` value. */
 	export type ConfigureTab = { id: string; label: string };
@@ -23,39 +24,23 @@
 	}
 </script>
 
-<nav
-	class="border-border bg-muted/50 scrollbar-none w-full overflow-x-auto border-b"
-	aria-label="Configure sections"
->
-	<ul
-		class="pl-gutter flex min-w-max items-center gap-x-1.5 gap-y-0.5 py-1 pr-5 sm:w-full sm:min-w-0 sm:flex-wrap"
-	>
-		{#each tabs as tab, i (tab.id)}
-			{@const active = activeTab === tab.id}
-			<!-- First item bleeds left into the gutter (-ml-3.5 cancels its own px-3.5)
-				 so it aligns to the shared gutter column, matching WorkflowStepStrip. -->
-			<li class={i === 0 ? '-ml-3.5' : undefined}>
-				<a
-					href={hrefFor(tab.id)}
-					data-sveltekit-noscroll
-					class="text-foreground inline-flex h-9 items-center px-3.5 text-sm font-medium whitespace-nowrap transition-opacity"
-					class:text-primary={active}
-					class:opacity-70={!active}
-					class:hover:opacity-100={!active}
-					aria-current={active ? 'page' : undefined}
-				>
-					{tab.label}
-				</a>
-			</li>
-		{/each}
-	</ul>
-</nav>
-
-<style>
-	.scrollbar-none {
-		scrollbar-width: none;
-	}
-	.scrollbar-none::-webkit-scrollbar {
-		display: none;
-	}
-</style>
+<TabStripShell ariaLabel="Configure sections">
+	{#each tabs as tab, i (tab.id)}
+		{@const active = activeTab === tab.id}
+		<!-- First item bleeds left into the gutter (-ml-3.5 cancels its own px-3.5)
+			 so it aligns to the shared gutter column, matching WorkflowStepStrip. -->
+		<li class={i === 0 ? '-ml-3.5' : undefined}>
+			<a
+				href={hrefFor(tab.id)}
+				data-sveltekit-noscroll
+				class="text-foreground inline-flex h-9 items-center px-3.5 text-sm font-medium whitespace-nowrap transition-opacity"
+				class:text-primary={active}
+				class:opacity-70={!active}
+				class:hover:opacity-100={!active}
+				aria-current={active ? 'page' : undefined}
+			>
+				{tab.label}
+			</a>
+		</li>
+	{/each}
+</TabStripShell>

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/design/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/design/+page.svelte
@@ -6,6 +6,7 @@
 	import { notifications } from '$lib/notifications.svelte.js';
 	import { saveTranslation } from '$lib/components/Translation/translationUtils';
 	import DraggableList from '$lib/components/DraggableList.svelte';
+	import StepListSkeleton from './StepListSkeleton.svelte';
 	import { Button } from '$lib/components/ui/button';
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
 	import * as AlertDialog from '$lib/components/ui/alert-dialog';
@@ -34,12 +35,16 @@
 	let workflow = $derived(data.workflows[0]);
 	let workflowSteps = $derived<WorkflowStepWithTranslations[] | undefined>(data.workflowSteps);
 
-	let reorderedSteps = $state<WorkflowStepWithTranslations[]>([]);
-	$effect(() => {
-		reorderedSteps = workflowSteps
-			? [...workflowSteps].sort((a, b) => a.stepOrder - b.stepOrder)
-			: [];
-	});
+	// `undefined` = steps not loaded yet (show a skeleton); `[]` = genuinely no steps.
+	let loadingSteps = $derived(workflowSteps === undefined);
+
+	// Writable derived: seeds from the loaded steps and re-seeds whenever they change (e.g.
+	// after `invalidate`), while a drag/reorder can still assign to it locally in between.
+	// Using $derived (not $state + $effect) means SSR renders the real order too, so a slow
+	// client no longer flashes the empty state before hydration. (See CLAUDE.md.)
+	let reorderedSteps = $derived(
+		workflowSteps ? [...workflowSteps].sort((a, b) => a.stepOrder - b.stepOrder) : []
+	);
 
 	// --- Ephemeral UI state ---
 	let editingId = $state<string | null>(null);
@@ -268,7 +273,9 @@
 				</DropdownMenu.Root>
 			</div>
 
-			{#if reorderedSteps.length === 0}
+			{#if loadingSteps}
+				<StepListSkeleton />
+			{:else if reorderedSteps.length === 0}
 				<div
 					class="border-border bg-card text-muted-foreground flex flex-col items-center justify-center gap-3 rounded-xl border border-dashed p-12 text-center"
 				>

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/design/StepListSkeleton.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/design/StepListSkeleton.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+	import { Skeleton } from '$lib/components/ui/skeleton';
+
+	type Props = {
+		/** How many placeholder step cards to render. */
+		count?: number;
+	};
+
+	let { count = 3 }: Props = $props();
+</script>
+
+<!-- Loading placeholder for the process-steps list. Mirrors the real step card
+	 (grip, numbered badge, name + type lines, actions) so the list doesn't shift
+	 when the steps arrive. -->
+<div class="flex flex-col gap-2.5" aria-hidden="true">
+	{#each Array(count) as _, i (i)}
+		<!-- Brand-tinted shimmer so it reads against the card instead of gray-on-gray. -->
+		<div class="border-border bg-card flex items-center gap-4 rounded-xl border p-4">
+			<Skeleton class="bg-primary/10 size-5 shrink-0 rounded" />
+			<Skeleton class="bg-primary/20 size-6 shrink-0 rounded-lg" />
+			<div class="flex min-w-0 flex-1 flex-col gap-2">
+				<Skeleton class="bg-primary/15 h-5 w-48 max-w-full rounded-md" />
+				<Skeleton class="bg-primary/10 h-4 w-24 rounded-md" />
+			</div>
+			<Skeleton class="bg-primary/10 size-9 shrink-0 rounded-md" />
+		</div>
+	{/each}
+</div>

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/invites/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/invites/+page.svelte
@@ -85,6 +85,7 @@
 
 {#snippet inviteSubtabStripSnippet()}
 	<SubTabStrip
+		tone="primary"
 		items={[
 			{ label: 'Email', value: 'email' },
 			{ label: 'Open Links', value: 'open-links' },


### PR DESCRIPTION
Additive groundwork for the tab-strip refactor: shared components + loading skeletons. No
behavioral change to how strips are populated yet that lands in #654.

## Changes
- Extract **`TabStripShell`** (shared row/scroll/alignment shell) and adopt it in
  `WorkflowStepStrip`, `EventStrip`, `SubTabStrip`, `ConfigureTabStrip`.
- Add **`TabStripSkeleton`** + `StepListSkeleton`, and a `conversationTabStrip` util (with unit
  tests) that reserves each section strip's row so a hard refresh / section switch doesn't shift
  the layout.

## Notes
- Stacked on #651. Purely additive shared components. sets up #654.
