### PR TITLE
Add delayedFlag utility to prevent skeleton flashing on fast navigation

### DIFF
--- a/ui/packages/comhairle/src/lib/utils/delayedFlag.svelte.ts
+++ b/ui/packages/comhairle/src/lib/utils/delayedFlag.svelte.ts
@@ -1,0 +1,31 @@
+/**
+ * A boolean that mirrors `source` but only flips to `true` after `source` has
+ * stayed truthy for `delayMs`. Flipping back to `false` is immediate.
+ *
+ * The point is loading skeletons: a navigation that resolves faster than
+ * `delayMs` never trips the flag, so its skeleton is never rendered and can't
+ * flash. A genuinely slow load still trips it and shows the skeleton, where the
+ * feedback is wanted. Must be called during component init (it owns an `$effect`).
+ *
+ * @param source - getter for the underlying flag (e.g. `() => switchingSection`)
+ * @param delayMs - how long `source` must stay truthy before the flag flips
+ * @returns an object whose `current` getter is the delayed flag
+ */
+export function delayedFlag(source: () => boolean, delayMs = 150) {
+	let value = $state(false);
+
+	$effect(() => {
+		if (!source()) {
+			value = false;
+			return;
+		}
+		const timer = setTimeout(() => (value = true), delayMs);
+		return () => clearTimeout(timer);
+	});
+
+	return {
+		get current() {
+			return value;
+		}
+	};
+}

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/+layout.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/+layout.svelte
@@ -17,6 +17,7 @@
 	import { EVENT_SUBTABS } from './events/[event_id]/tabs';
 	import { addStepDialog } from '$lib/stores/addStepDialog.svelte';
 	import { conversationPrimaryStripSkeleton } from '$lib/utils/conversationTabStrip';
+	import { delayedFlag } from '$lib/utils/delayedFlag.svelte';
 	import { getTextInLocale } from '$lib/components/Translation/translationUtils';
 
 	let { data, children } = $props();
@@ -104,8 +105,14 @@
 		!!navigating.to && sectionKey(navigating.to.url.pathname) !== sectionKey(page.url.pathname)
 	);
 
+	// A fast switch (Configure/Setup, a nearby step) resolves in well under 150ms; painting the
+	// skeleton for those few frames only reads as a flash. Delay the swap so quick loads keep the
+	// current strip + content visible until the destination is ready, and only genuinely slow loads
+	// (where the feedback is wanted) ever show the skeleton. Hiding is immediate, so nothing lingers.
+	let showSwitchingSkeleton = delayedFlag(() => switchingSection, 150);
+
 	// While switching, reserve the *destination's* strip and content skeletons so the whole
-	// content region flips to a loading state the instant the tab is clicked.
+	// content region flips to a loading state once the switch has run long enough to warrant it.
 	let effectivePathname = $derived(navigating.to?.url.pathname ?? page.url.pathname);
 
 	// Reserve the injected primary strip's row with a matching skeleton (null = no strip on this
@@ -265,9 +272,9 @@
 	<ConversationTabs conversationId={conversation.id} conversationIsLive={conversation.isLive} />
 
 	<!-- Row 3+ : section sub-strips, all server-rendered here from loaded data / static lists
-		 (keyed off the pathname), never injected from a child `$effect`. While switching sections
-		 we ignore them and show the destination's reserved skeleton instead. -->
-	{#if switchingSection}
+		 (keyed off the pathname), never injected from a child `$effect`. Once a switch has run long
+		 enough to warrant the skeleton we ignore them and show the destination's reserved one. -->
+	{#if showSwitchingSkeleton.current}
 		{#if primaryStripSkeleton}
 			<TabStripSkeleton
 				leadingIcon={primaryStripSkeleton.leadingIcon}
@@ -293,7 +300,7 @@
 		/>
 	{/if}
 	<!-- Row 4: only the event-detail sub-tabs live here now. -->
-	{#if isEventDetailPage && !switchingSection}
+	{#if isEventDetailPage && !showSwitchingSkeleton.current}
 		<SubTabStrip items={EVENT_SUBTABS} defaultValue="details" />
 	{/if}
 
@@ -306,7 +313,7 @@
 
 {#if isDesignBoard}
 	<div class="bg-card flex min-h-0 grow flex-col overflow-hidden">
-		{#if switchingSection}
+		{#if showSwitchingSkeleton.current}
 			<div class="pt-page-top px-gutter">
 				<div class="w-full max-w-[1200px]">
 					<TabContentSkeleton />
@@ -319,7 +326,7 @@
 {:else if isStepPage}
 	<!-- The step layout renders Row 4 + its own padded column; while switching in, stand in with
 		 the same padded skeleton so the region doesn't collapse before the step load resolves. -->
-	{#if switchingSection}
+	{#if showSwitchingSkeleton.current}
 		<div class="bg-muted pt-page-top px-gutter grow pb-8 sm:pr-8 sm:pb-12 lg:pr-16">
 			<div class="h-full w-full max-w-[1200px]">
 				<TabContentSkeleton />
@@ -333,7 +340,7 @@
 		 left gutter for tab alignment and widen the right margin. Top is token-driven. -->
 	<div class="bg-muted pt-page-top px-gutter grow pb-8 sm:pr-8 sm:pb-12 lg:pr-16">
 		<div class="h-full w-full max-w-[1200px]">
-			{#if switchingSection}
+			{#if showSwitchingSkeleton.current}
 				<TabContentSkeleton />
 			{:else}
 				{@render children()}


### PR DESCRIPTION
Actions:
+ create delayedFlag.svelte.ts utility that delays boolean flag flip to true by configurable ms
+ replace switchingSection with showSwitchingSkeleton using delayedFlag with 150ms delay
+ update all skeleton conditionals to use showSwitchingSkeleton.current instead of switchingSection
+ add comments explaining fast navigation (<150ms) keeps current content visible while slow loads show skeleton

Motivation:
+ prevent loading skeleton flash on quick