### PR TITLE
Server-render read-only rich text

### DIFF
--- a/ui/packages/comhairle/package.json
+++ b/ui/packages/comhairle/package.json
@@ -105,6 +105,7 @@
 		"@tiptap/markdown": "^3.11.0",
 		"@tiptap/pm": "^3.11.0",
 		"@tiptap/starter-kit": "^3.11.0",
+		"@tiptap/static-renderer": "^3.28.0",
 		"@zodios/core": "^10.9.6",
 		"carta-md": "^4.9.0",
 		"carta-plugin-video": "^2.1.0",

--- a/ui/packages/comhairle/src/lib/components/RichTextEditor/ContentRenderer/ContentRenderer.svelte
+++ b/ui/packages/comhairle/src/lib/components/RichTextEditor/ContentRenderer/ContentRenderer.svelte
@@ -1,25 +1,16 @@
 <script lang="ts">
-	import { onMount, onDestroy, untrack } from 'svelte';
-	import { Editor } from '@tiptap/core';
-	import { detectContentType } from '$lib/utils/contentDetection';
-	import { getBaseExtensions, getEditorProps } from '../editorConfig';
-	import { SourceDocument } from '../extensions/sourceDocument';
+	import { renderRichTextToHtml } from '$lib/utils/renderRichText';
+	import { EDITOR_HTML_ATTRIBUTES } from '../editorConfig';
+	import { cn } from '$lib/utils';
 	import type { ComhairleDocument } from '@crownshy/api-client/api';
 	import PdfDocumentDialog from '$lib/components/PdfViewer/PdfDocumentDialog.svelte';
 	import '../editor-content.css';
-
-	function buildDocMap(docs: ComhairleDocument[]) {
-		const map: Record<string, { name: string; size: number }> = {};
-		for (const doc of docs) {
-			map[doc.id] = { name: doc.name, size: doc.size };
-		}
-		return map;
-	}
 
 	type Props = {
 		content?: string;
 		class?: string;
 		minimal?: boolean;
+		/** Documents referenced by source-document badges, for filename and download link. */
 		availableDocuments?: ComhairleDocument[];
 		conversationId?: string;
 	};
@@ -32,9 +23,14 @@
 		conversationId = ''
 	}: Props = $props();
 
-	let editorElement = $state<HTMLElement>();
-	let editor = $state<Editor>();
-	let lastDocMapKey = $state('');
+	// $derived (not onMount + an editor instance) so the content is present in the SSR
+	// markup. This used to mount a headless Tiptap editor on the client, which meant every
+	// call site painted blank until hydration, and blanked again on each remount.
+	let html = $derived(
+		renderRichTextToHtml(content, { documents: availableDocuments, conversationId })
+	);
+
+	let contentElement = $state<HTMLElement>();
 
 	let previewDialog = $state<{
 		open: boolean;
@@ -80,94 +76,31 @@
 		previewDialog = { open: true, kind, src: href, name: doc.name, downloadHref: href };
 	}
 
-	function createRenderer() {
-		untrack(() => {
-			if (editor) {
-				editor.destroy();
-				editor = undefined;
-			}
-		});
-		if (!editorElement) return;
-
-		try {
-			const currentContent = untrack(() => content);
-			const detected = detectContentType(currentContent);
-			const docMap = untrack(() => buildDocMap(availableDocuments));
-			lastDocMapKey = JSON.stringify({
-				docMap,
-				conversationId: untrack(() => conversationId)
-			});
-
-			editor = new Editor({
-				element: editorElement,
-				extensions: [
-					...getBaseExtensions({ mode: 'renderer' }).filter(
-						(ext) => ext.name !== 'sourceDocument'
-					),
-					SourceDocument.configure({ documents: docMap, conversationId })
-				],
-				content: detected.content,
-				contentType: detected.type,
-				editable: false,
-				editorProps: minimal ? {} : getEditorProps()
-			});
-		} catch (error) {
-			console.error('[ContentRenderer] Failed to initialize:', error);
-		}
-	}
-
-	onMount(() => {
-		createRenderer();
-	});
-
+	// Delegated rather than an inline onclick: the badges come from {@html}, and putting a
+	// handler on the static wrapper would trip the a11y interactive-element rules.
 	$effect(() => {
-		if (editor && content !== undefined) {
-			try {
-				const detected = detectContentType(content);
-
-				editor.commands.setContent(detected.content, {
-					contentType: detected.type,
-					emitUpdate: false
-				});
-			} catch (error) {
-				console.error('[ContentRenderer] Failed to update content:', error);
-			}
-		}
-	});
-
-	// When availableDocuments / conversationId change (e.g. async fetch resolves),
-	// recreate the editor so SourceDocument nodes re-render with correct name/size/href.
-	// (Tiptap extension options are captured at construction; setContent on identical
-	// docs won't redraw atom nodeViews.)
-	$effect(() => {
-		const docMap = buildDocMap(availableDocuments);
-		const newKey = JSON.stringify({ docMap, conversationId });
-		if (newKey !== lastDocMapKey && editorElement) {
-			createRenderer();
-		}
-	});
-
-	// Delegated click handling for source-document badges rendered by Tiptap.
-	$effect(() => {
-		const el = editorElement;
+		const el = contentElement;
 		if (!el) return;
 		el.addEventListener('click', handleContentClick);
 		return () => el.removeEventListener('click', handleContentClick);
 	});
-
-	onDestroy(() => {
-		if (editor) {
-			editor.destroy();
-		}
-	});
 </script>
 
-<div
-	class="content-renderer {className}"
-	class:content-renderer--minimal={minimal}
-	bind:this={editorElement}
->
-	<!-- Tiptap editor renders here -->
+<div class="content-renderer {className}" class:content-renderer--minimal={minimal}>
+	<!-- `.tiptap` carries all of editor-content.css, and the prose classes are what the editor
+		applied through editorProps. Both are reproduced here so rendered content keeps the
+		typography it had when a live editor was drawing it. -->
+	<div
+		bind:this={contentElement}
+		class={cn('tiptap', !minimal && EDITOR_HTML_ATTRIBUTES.editor.class)}
+	>
+		<!-- Safe because `html` is not author-supplied markup: renderRichTextToHtml builds it by
+			walking a ProseMirror document, so only nodes and marks in our schema can emit tags and
+			anything else survives as escaped text. Feeding it raw markup (via a markdown-to-HTML
+			library, say) would make this a real XSS hole. renderRichText.test.ts pins that down. -->
+		<!-- eslint-disable-next-line svelte/no-at-html-tags -->
+		{@html html}
+	</div>
 </div>
 
 <PdfDocumentDialog

--- a/ui/packages/comhairle/src/lib/components/RichTextEditor/ContentRenderer/contentRendererSsr.test.ts
+++ b/ui/packages/comhairle/src/lib/components/RichTextEditor/ContentRenderer/contentRendererSsr.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { render } from 'svelte/server';
+import ContentRenderer from './ContentRenderer.svelte';
+
+/**
+ * The regression this guards: ContentRenderer used to build its output in `onMount`, so
+ * server-rendered markup contained an empty div and the text only appeared after hydration.
+ * Rendering it through `svelte/server` here is the same path SvelteKit takes for SSR.
+ */
+describe('ContentRenderer server-side rendering', () => {
+	it('includes the content in server-rendered markup', () => {
+		const content = JSON.stringify({
+			type: 'doc',
+			content: [{ type: 'paragraph', content: [{ type: 'text', text: 'A new Survey Step' }] }]
+		});
+
+		const { body } = render(ContentRenderer, { props: { content } });
+
+		expect(body).toContain('A new Survey Step');
+	});
+
+	it('keeps the .tiptap wrapper that carries the content styling', () => {
+		const { body } = render(ContentRenderer, { props: { content: 'hello' } });
+		expect(body).toContain('tiptap');
+	});
+});

--- a/ui/packages/comhairle/src/lib/components/StepHeader.svelte
+++ b/ui/packages/comhairle/src/lib/components/StepHeader.svelte
@@ -101,9 +101,7 @@
 			<div
 				class={`prose-sm prose-p:text-sm   prose-li:text-sm text-muted-foreground mx-auto max-w-3xl text-center ${boldDescription ? '' : 'prose-p:text-muted-foreground prose-li:text-muted-foreground'}`}
 			>
-				{#key description}
-					<ContentRenderer content={description} {availableDocuments} {conversationId} />
-				{/key}
+				<ContentRenderer content={description} {availableDocuments} {conversationId} />
 			</div>
 		{/if}
 	</div>

--- a/ui/packages/comhairle/src/lib/styles/comhairle-themes.css
+++ b/ui/packages/comhairle/src/lib/styles/comhairle-themes.css
@@ -294,6 +294,8 @@
 	--chat-text: var(--foreground);
 	--chat-text-muted: var(--chat-neutral);
 	--chat-bubble: var(--card);
+
+	--admin-background: #111827;
 }
 
 [data-theme='waves']

--- a/ui/packages/comhairle/src/lib/tools/learn/LearnUI.svelte
+++ b/ui/packages/comhairle/src/lib/tools/learn/LearnUI.svelte
@@ -113,9 +113,7 @@
 		<LearnArticleSkeleton />
 	{:else if content}
 		<article class="prose mx-auto w-full grow overflow-y-auto">
-			{#key content}
-				<ContentRenderer {content} {availableDocuments} conversationId={conversation?.id} />
-			{/key}
+			<ContentRenderer {content} {availableDocuments} conversationId={conversation?.id} />
 		</article>
 	{:else}
 		<h1>Sorry this page is currently not avaliable in this language</h1>

--- a/ui/packages/comhairle/src/lib/tools/learn/LearnUI.svelte
+++ b/ui/packages/comhairle/src/lib/tools/learn/LearnUI.svelte
@@ -15,6 +15,7 @@
 	import LearnTutor from './LearnTutor.svelte';
 	import LearnArticleSkeleton from './LearnArticleSkeleton.svelte';
 	import { apiClient } from '@crownshy/api-client/client';
+	import { delayedFlag } from '$lib/utils/delayedFlag.svelte';
 
 	let {
 		pages,
@@ -37,15 +38,12 @@
 	);
 
 	let availableDocuments = $state<ComhairleDocument[]>([]);
-	let documentsLoading = $state(true);
 
 	$effect(() => {
 		if (!conversation?.id) {
 			availableDocuments = [];
-			documentsLoading = false;
 			return;
 		}
-		documentsLoading = true;
 		apiClient
 			.ListDocuments({ params: { conversation_id: conversation.id } })
 			.then((docs) => {
@@ -53,9 +51,6 @@
 			})
 			.catch(() => {
 				availableDocuments = [];
-			})
-			.finally(() => {
-				documentsLoading = false;
 			});
 	});
 
@@ -84,8 +79,20 @@
 		});
 	}
 
-	/** True while SvelteKit is routing OR documents for embeds are still being fetched. */
-	let showSkeleton = $derived(!!navigating.to || documentsLoading);
+	/** True while SvelteKit is routing to another step. Gates the controls, which shouldn't be
+	 * clickable mid-navigation. */
+	let isNavigating = $derived(!!navigating.to);
+
+	/**
+	 * Skeleton only, so a step hop that resolves quickly never renders one and can't flash.
+	 * See delayedFlag for the reasoning.
+	 *
+	 * Deliberately not gated on the document fetch, unlike before: the article server-renders
+	 * now, and withholding it for a client-only fetch would blank content that is already on
+	 * screen. A source-document badge instead renders its placeholder label and upgrades in
+	 * place when the fetch lands, which is a far smaller change than hiding the whole article.
+	 */
+	let showSkeleton = delayedFlag(() => isNavigating, 150);
 
 	$effect(() => {
 		if (onNextAction) {
@@ -109,7 +116,7 @@
 	{/if}
 
 	<!-- Article content: own loading state (route navigation / content not ready) -->
-	{#if showSkeleton}
+	{#if showSkeleton.current}
 		<LearnArticleSkeleton />
 	{:else if content}
 		<article class="prose mx-auto w-full grow overflow-y-auto">
@@ -124,19 +131,21 @@
 			<LearnTutor
 				conversationId={conversation.id}
 				pageTitle={pageHeading}
-				loading={showSkeleton}
+				loading={showSkeleton.current}
 			/>
 		</div>
 	{/if}
 
 	{#if currentPageNo == pages.length - 1}
-		<Button class="mx-auto mt-10" onclick={onDone} disabled={showSkeleton || isSubmitting}>
+		<!-- Disabling tracks isNavigating, not the delayed flag: a control that stays live for
+			150ms into a navigation could fire twice. -->
+		<Button class="mx-auto mt-10" onclick={onDone} disabled={isNavigating || isSubmitting}>
 			{#if isSubmitting}
 				<Spinner class="mr-2 size-4" />
 			{/if}
 			{m.continue_()}
 		</Button>
 	{:else}
-		<Button class="mx-auto mt-10" onclick={nextPage} disabled={showSkeleton}>{m.next()}</Button>
+		<Button class="mx-auto mt-10" onclick={nextPage} disabled={isNavigating}>{m.next()}</Button>
 	{/if}
 </div>

--- a/ui/packages/comhairle/src/lib/utils/renderRichText.test.ts
+++ b/ui/packages/comhairle/src/lib/utils/renderRichText.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { renderRichTextToHtml } from './renderRichText';
+import type { ComhairleDocument } from '@crownshy/api-client/api';
+
+/**
+ * These run under vitest's default `node` environment with no DOM, which is the
+ * point: it's the same condition as SSR, so a regression back to a DOM-dependent
+ * renderer fails here rather than silently blanking the first paint.
+ */
+describe('renderRichTextToHtml', () => {
+	const paragraph = (text: string) =>
+		JSON.stringify({
+			type: 'doc',
+			content: [{ type: 'paragraph', content: [{ type: 'text', text }] }]
+		});
+
+	it('renders ProseMirror JSON', () => {
+		expect(renderRichTextToHtml(paragraph('A new Survey Step'))).toBe(
+			'<p>A new Survey Step</p>'
+		);
+	});
+
+	it('renders marks within JSON', () => {
+		const content = JSON.stringify({
+			type: 'doc',
+			content: [
+				{
+					type: 'paragraph',
+					content: [
+						{ type: 'text', text: 'a ' },
+						{ type: 'text', marks: [{ type: 'bold' }], text: 'bold' },
+						{ type: 'text', text: ' word' }
+					]
+				}
+			]
+		});
+		expect(renderRichTextToHtml(content)).toBe('<p>a <strong>bold</strong> word</p>');
+	});
+
+	it('renders markdown', () => {
+		expect(renderRichTextToHtml('# Title\n\nsome *text*')).toBe(
+			'<h1>Title</h1><p>some <em>text</em></p>'
+		);
+	});
+
+	it('treats a plain string as markdown', () => {
+		expect(renderRichTextToHtml('New Survey Step')).toBe('<p>New Survey Step</p>');
+	});
+
+	it.each([null, undefined, '', '   '])('returns empty string for %p', (content) => {
+		expect(renderRichTextToHtml(content)).toBe('');
+	});
+
+	it('escapes raw HTML embedded in markdown rather than passing it through', () => {
+		const html = renderRichTextToHtml('hello <img src=x onerror=alert(1)>');
+		expect(html).not.toContain('<img');
+		expect(html).toContain('&lt;img');
+	});
+
+	it('escapes raw HTML embedded in a JSON text node', () => {
+		const html = renderRichTextToHtml(paragraph('<script>alert(1)</script>'));
+		expect(html).not.toContain('<script>');
+		expect(html).toContain('&lt;script&gt;');
+	});
+
+	it('falls back to a generic label for a badge whose document is not loaded yet', () => {
+		const content = JSON.stringify({
+			type: 'doc',
+			content: [{ type: 'sourceDocument', attrs: { documentId: 'doc-1' } }]
+		});
+		const html = renderRichTextToHtml(content, { conversationId: 'conv-1' });
+		expect(html).toContain('Source document');
+	});
+
+	it('renders a badge with the real filename and download link once documents are known', () => {
+		const content = JSON.stringify({
+			type: 'doc',
+			content: [{ type: 'sourceDocument', attrs: { documentId: 'doc-1' } }]
+		});
+		const documents = [
+			{ id: 'doc-1', name: 'budget.pdf', size: 2048 }
+		] as unknown as ComhairleDocument[];
+
+		const html = renderRichTextToHtml(content, { documents, conversationId: 'conv-1' });
+
+		expect(html).toContain('budget.pdf');
+		expect(html).toContain('/api/conversation/conv-1/documents/doc-1/download');
+		expect(html).toContain('data-document-id="doc-1"');
+	});
+
+	it('returns empty string for malformed content instead of throwing', () => {
+		expect(renderRichTextToHtml('{"type":"doc","content":[{"type":"nope"}]}')).toBe('');
+	});
+});

--- a/ui/packages/comhairle/src/lib/utils/renderRichText.ts
+++ b/ui/packages/comhairle/src/lib/utils/renderRichText.ts
@@ -1,0 +1,76 @@
+import type { AnyExtension, JSONContent } from '@tiptap/core';
+import { MarkdownManager } from '@tiptap/markdown';
+import { renderToHTMLString } from '@tiptap/static-renderer/pm/html-string';
+import { getBaseExtensions } from '$lib/components/RichTextEditor/editorConfig';
+import { SourceDocument } from '$lib/components/RichTextEditor/extensions/sourceDocument';
+import { CONTENT_TYPES } from '$lib/components/RichTextEditor/types';
+import { detectContentType } from './contentDetection';
+import type { ComhairleDocument } from '@crownshy/api-client/api';
+
+/**
+ * Documents referenced by `sourceDocument` nodes, so a badge can render its real
+ * filename and download link. Content with no badges renders fine without these.
+ */
+export type RenderRichTextOptions = {
+	documents?: ComhairleDocument[];
+	conversationId?: string;
+};
+
+function buildExtensions(
+	documents: ComhairleDocument[],
+	conversationId: string
+): AnyExtension[] {
+	const documentsById: Record<string, { name: string; size: number }> = {};
+	for (const document of documents) {
+		documentsById[document.id] = { name: document.name, size: document.size };
+	}
+
+	// SourceDocument reads its options inside renderHTML, so it has to be reconfigured
+	// (not just re-run) whenever the document set changes.
+	return [
+		...getBaseExtensions({ mode: 'renderer' }).filter((ext) => ext.name !== 'sourceDocument'),
+		SourceDocument.configure({ documents: documentsById, conversationId })
+	];
+}
+
+/**
+ * Renders stored rich-text (ProseMirror JSON, or Markdown/plain text) to an HTML string.
+ *
+ * This exists so read-only content can be server-rendered. The obvious alternative,
+ * `generateHTML` from `@tiptap/core`, calls into ProseMirror's `DOMSerializer` and throws
+ * `window is not defined` under SSR; `@tiptap/static-renderer` walks the node tree instead
+ * and needs no DOM.
+ *
+ * Markdown is parsed into a ProseMirror document rather than handed to a markdown-to-HTML
+ * library because the schema is what makes this safe to feed to `{@html}`: unknown tags in
+ * the source survive as escaped text, so admin-authored content can't inject markup.
+ *
+ * @param content - stored content: ProseMirror JSON, Markdown, or plain text
+ * @param options - documents and conversation id used to render source-document badges
+ * @returns an HTML string, or `''` for empty or unrenderable content
+ */
+export function renderRichTextToHtml(
+	content: string | null | undefined,
+	options: RenderRichTextOptions = {}
+): string {
+	const { documents = [], conversationId = '' } = options;
+
+	const detected = detectContentType(content);
+	if (!detected.content) return '';
+
+	const extensions = buildExtensions(documents, conversationId);
+
+	try {
+		const document =
+			detected.type === CONTENT_TYPES.JSON
+				? (detected.content as JSONContent)
+				: (new MarkdownManager({ extensions }).parse(
+						String(detected.content)
+					) as JSONContent);
+
+		return renderToHTMLString({ content: document, extensions });
+	} catch (error) {
+		console.error('[renderRichTextToHtml] Failed to render content:', error);
+		return '';
+	}
+}

--- a/ui/packages/comhairle/src/lib/utils/renderRichText.ts
+++ b/ui/packages/comhairle/src/lib/utils/renderRichText.ts
@@ -16,10 +16,7 @@ export type RenderRichTextOptions = {
 	conversationId?: string;
 };
 
-function buildExtensions(
-	documents: ComhairleDocument[],
-	conversationId: string
-): AnyExtension[] {
+function buildExtensions(documents: ComhairleDocument[], conversationId: string): AnyExtension[] {
 	const documentsById: Record<string, { name: string; size: number }> = {};
 	for (const document of documents) {
 		documentsById[document.id] = { name: document.name, size: document.size };

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/workflow/[workflow_id]/s/[workflow_step_id]/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/workflow/[workflow_id]/s/[workflow_step_id]/+page.svelte
@@ -19,6 +19,7 @@
 	import { thank_you_page, next_workflow_step_url, workflow_step_url } from '$lib/urls';
 	import { page, navigating } from '$app/state';
 	import LearnArticleSkeleton from '$lib/tools/learn/LearnArticleSkeleton.svelte';
+	import { delayedFlag } from '$lib/utils/delayedFlag.svelte';
 	import LearnTutorSkeleton from '$lib/tools/learn/LearnTutorSkeleton.svelte';
 	import type { ComhairleDocument } from '@crownshy/api-client/api';
 
@@ -120,6 +121,13 @@
 		if (!target) return undefined;
 		return conversation.isLive ? target.toolConfig?.type : target.previewToolConfig?.type;
 	});
+
+	/**
+	 * A step hop that resolves quickly never trips this, so the header and body skeletons stay
+	 * hidden and the page just swaps content. Only a genuinely slow load shows them, where the
+	 * feedback is worth having. See delayedFlag for the reasoning.
+	 */
+	let showNavigationSkeleton = delayedFlag(() => navigating.to !== null, 150);
 
 	let prevStepHref = $derived.by(() => {
 		const viewedIdx = sortedSteps.findIndex((ws) => ws.id === workflowStep.id);
@@ -247,7 +255,7 @@
 		</div>
 
 		<div class="mt-2 w-full md:mt-6 md:px-0">
-			{#if navigating.to}
+			{#if showNavigationSkeleton.current}
 				<StepHeaderSkeleton />
 			{:else}
 				<StepHeader
@@ -283,7 +291,7 @@
 					</Button>
 				{/if}
 				<div class="mb-10 w-full grow">
-					{#if navigating.to}
+					{#if showNavigationSkeleton.current}
 						{#if navigatingToToolType === HeyForm.TOOL_NAME}
 							<HeyForm.UserUISkeleton />
 						{:else}

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -97,6 +97,9 @@ importers:
       '@tiptap/starter-kit':
         specifier: ^3.11.0
         version: 3.20.0
+      '@tiptap/static-renderer':
+        specifier: ^3.28.0
+        version: 3.28.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@zodios/core':
         specifier: ^10.9.6
         version: 10.9.6(axios@1.13.5)(zod@3.25.76)
@@ -1682,8 +1685,15 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
+  '@thisux/sveltednd@0.0.12':
+    resolution: {integrity: sha512-9edVcakYkoCzU6pNIwmJ6Cf+9anECod26Ue/rL3Ssf5LyuLaBLXtBx4H4U8YwQCkwtMeSGFf0OsiMpPpFjvCcg==}
+    peerDependencies:
+      svelte: ^5.0.0
+
   '@thisux/sveltednd@0.0.14':
     resolution: {integrity: sha512-Vbq69SU3HUomPg6oCXtb89OG89hka0YIkdaErYibn3waK7tYE66IcQxD/Fzg8YNW3EVsXoA9kc7kW5EUBCSQGg==}
+    peerDependencies:
+      svelte: ^5.0.0
 
   '@thisux/sveltednd@0.0.17':
     resolution: {integrity: sha512-lRninjw439phhA8xAHqCpMAX0hnwFMdbXW4M0XJgAdnGxeum+QsLiIC4P3HnkNXAygsVKUqxRcbS84CxDZ9hPw==}
@@ -1856,6 +1866,14 @@ packages:
 
   '@tiptap/starter-kit@3.20.0':
     resolution: {integrity: sha512-W4+1re35pDNY/7rpXVg+OKo/Fa4Gfrn08Bq3E3fzlJw6gjE3tYU8dY9x9vC2rK9pd9NOp7Af11qCFDaWpohXkw==}
+
+  '@tiptap/static-renderer@3.28.0':
+    resolution: {integrity: sha512-3S32+vv4/xoGQdgrnr/Uq8qILeH1IXtUOhyrUSfCh65HDdck1IfoK9V/vPsChHIbxI2dCE1VFWFvIk+m9Y7eYg==}
+    peerDependencies:
+      '@tiptap/core': 3.28.0
+      '@tiptap/pm': 3.28.0
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
 
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
@@ -6099,11 +6117,18 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.0
 
-  '@thisux/sveltednd@0.0.14': {}
+  '@thisux/sveltednd@0.0.12(svelte@5.53.3)':
+    dependencies:
+      svelte: 5.53.3
+
+  '@thisux/sveltednd@0.0.14(svelte@5.53.3)':
+    dependencies:
+      '@thisux/sveltednd': 0.0.12(svelte@5.53.3)
+      svelte: 5.53.3
 
   '@thisux/sveltednd@0.0.17(svelte@5.53.3)':
     dependencies:
-      '@thisux/sveltednd': 0.0.14
+      '@thisux/sveltednd': 0.0.14(svelte@5.53.3)
       svelte: 5.53.3
 
   '@thisux/sveltednd@0.0.18(svelte@5.53.3)':
@@ -6287,6 +6312,13 @@ snapshots:
       '@tiptap/extension-underline': 3.20.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))
       '@tiptap/extensions': 3.20.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0)
       '@tiptap/pm': 3.20.0
+
+  '@tiptap/static-renderer@3.28.0(@tiptap/core@3.20.0(@tiptap/pm@3.20.0))(@tiptap/pm@3.20.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@tiptap/core': 3.20.0(@tiptap/pm@3.20.0)
+      '@tiptap/pm': 3.20.0
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
   '@types/aria-query@5.0.4': {}
 


### PR DESCRIPTION
Problem

`ContentRenderer` built its output inside `onMount` by constructing a headless Tiptap
`Editor`. Nothing it rendered reached the SSR markup, so every read-only piece of rich
text (step descriptions, Learn articles, FAQ, privacy, thank-you) painted blank until
the JS bundle loaded and hydrated, then again on every remount. On a throttled
connection the step description visibly arrived late, after the title beside it.

Rendering the old component through `svelte/server` returns an empty shell:

 `<div class="content-renderer svelte-1472d5b"></div>`

Learn had a second, independent cause: its skeleton was gated on `documentsLoading`,
which starts `true` and is only cleared by a client-side `ListDocuments` call. Effects
do not run during SSR, so Learn was server-rendering a skeleton every time.

### Changes

- New `renderRichText.ts`: a pure helper that turns stored content (ProseMirror JSON,
  Markdown, or plain text) into an HTML string with no DOM.
- `ContentRenderer` derives that string instead of owning an editor instance. No
  `onMount`, no teardown, no rebuild when documents arrive.
- Dropped the `{#key}` wrappers in `StepHeader` and `LearnUI` that existed only because
  the editor could not update in place, removing a remount per navigation.
- Learn no longer withholds the article for the document fetch, and its skeleton now
  goes through `delayedFlag` so a fast step hop cannot flash one.
- Same `delayedFlag` treatment for the workflow step header and body skeletons.

### New dependency

`@tiptap/static-renderer` (3.28.0, matching the existing v3 line). `generateHTML` from
`@tiptap/core` looked like it would avoid this, but it calls into ProseMirror's
`DOMSerializer` and throws `window is not defined` under SSR. The static renderer walks
the node tree instead.

### Security note for review

Markdown is parsed into a ProseMirror document rather than handed to a
markdown-to-HTML library. That matters, because the output is fed to `{@html}`: going
through the schema means only known nodes and marks can emit tags, and anything else
survives as escaped text. Using `marked` here (already a dependency) would have passed
raw HTML straight through and turned admin-authored content into an injection vector.
`renderRichText.test.ts` pins the escaping down in both the JSON and Markdown paths.
The `{@html}` carries an eslint disable with that reasoning inline.

### Behaviour change worth a look

A Learn page containing source-document badges now shows the article immediately with a
placeholder "Source document" label, which upgrades to the real filename once
`ListDocuments` resolves. Previously the whole article stayed hidden until then. Showing
content immediately seems like the better trade, but it is a visible change.

### Follow-up, not in this PR

`availableDocuments` is still fetched in a client-side `$effect` on the step page and in
`LearnUI`. Hoisting it into the layout `load` with a `depends()` key would let badges
server-render with real filenames and remove the placeholder hop.