### PR TITLE
Admin: Workflow Design - change template dropdown

### DIFF
--- a/ui/packages/comhairle/src/lib/components/NewConversationButton.svelte
+++ b/ui/packages/comhairle/src/lib/components/NewConversationButton.svelte
@@ -1,32 +1,25 @@
 <script lang="ts">
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
-	import * as Dialog from '$lib/components/ui/dialog';
-	import * as Accordion from '$lib/components/ui/accordion';
-	import { buttonVariants, LoadingButton } from '$lib/components/ui/button';
+	import { buttonVariants } from '$lib/components/ui/button';
 	import LoadingOverlay from '$lib/components/LoadingOverlay.svelte';
 	import { Plus } from 'lucide-svelte';
 	import { goto } from '$app/navigation';
 	import { notifications } from '$lib/notifications.svelte';
 	import { manage_conversation_url } from '$lib/urls';
 	import { createConversation } from '$lib/createConversation';
-	import { conversationTemplates } from '$lib/conversation_templates';
 	import { justCreatedConversation } from '$lib/stores/justCreatedConversation.svelte';
-	import SelectableOptionRow from '$lib/components/SelectableOptionRow.svelte';
-	import TemplateIllustration from '$lib/components/TemplateIllustration.svelte';
+	import TemplatePickerDialog from '$lib/components/TemplatePickerDialog.svelte';
 	import { cn } from '$lib/utils';
 
-	let {
-		class: className = '',
-		label = 'New conversation',
-		labelClass = ''
-	}: { class?: string; label?: string; labelClass?: string } = $props();
+	type Props = {
+		class?: string;
+		label?: string;
+		labelClass?: string;
+	};
+	let { class: className = '', label = 'New conversation', labelClass = '' }: Props = $props();
 
 	let dialogOpen = $state(false);
 	let submitting = $state(false);
-	let selectedKey = $state(conversationTemplates[0].key);
-	const selected = $derived(
-		conversationTemplates.find((t) => t.key === selectedKey) ?? conversationTemplates[0]
-	);
 
 	async function create(templateKey?: string) {
 		if (submitting) return;
@@ -60,91 +53,11 @@
 	</DropdownMenu.Content>
 </DropdownMenu.Root>
 
-<Dialog.Root bind:open={dialogOpen}>
-	<Dialog.Content
-		class="flex max-h-[90vh] w-full max-w-5xl flex-col gap-6 overflow-hidden sm:max-w-5xl"
-	>
-		<Dialog.Header>
-			<Dialog.Title class="text-center text-2xl font-semibold">Choose a template</Dialog.Title
-			>
-			<Dialog.Description class="text-center">
-				Select a workflow template from the options below. You will have the opportunity to
-				customise the workflow in the next step.
-			</Dialog.Description>
-		</Dialog.Header>
-
-		<div class="flex min-h-0 flex-1 items-start gap-6 overflow-hidden">
-			<!-- Left: selectable template list -->
-			<div
-				class="flex w-96 shrink-0 flex-col gap-3 self-stretch overflow-y-auto pr-4 [scrollbar-gutter:stable]"
-			>
-				{#each conversationTemplates as template (template.key)}
-					<SelectableOptionRow
-						selected={selectedKey === template.key}
-						name={template.name}
-						description={template.description}
-						onSelect={() => (selectedKey = template.key)}
-					/>
-				{/each}
-			</div>
-
-			<!-- Right: selected template detail -->
-			<div
-				class="bg-card flex min-h-0 flex-1 flex-col gap-4 self-stretch overflow-y-auto rounded-xl p-6"
-			>
-				<div class="flex items-center justify-between gap-2">
-					<h3 class="text-card-foreground text-base font-bold">{selected.name}</h3>
-					<div class="flex max-w-80 flex-wrap justify-end gap-2">
-						{#each selected.badges as badge (badge.label)}
-							{@const Icon = badge.icon}
-							<span
-								class={cn(
-									'text-foreground inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium',
-									badge.class
-								)}
-							>
-								<Icon class="size-4 shrink-0" />
-								{badge.label}
-							</span>
-						{/each}
-					</div>
-				</div>
-
-				<TemplateIllustration templateKey={selected.key} />
-
-				<div class="flex flex-col gap-1">
-					<h4 class="text-card-foreground text-sm font-bold">Workflow steps</h4>
-					<Accordion.Root type="single">
-						{#each selected.displaySteps as displayStep, i (displayStep.label)}
-							<Accordion.Item value={`step-${i}`}>
-								<Accordion.Trigger class="text-foreground text-sm font-medium">
-									Step {i + 1}: {displayStep.label}
-								</Accordion.Trigger>
-								<Accordion.Content class="text-muted-foreground text-sm">
-									{displayStep.description}
-								</Accordion.Content>
-							</Accordion.Item>
-						{/each}
-					</Accordion.Root>
-				</div>
-			</div>
-		</div>
-
-		<Dialog.Footer>
-			<Dialog.Close class={buttonVariants({ variant: 'outline', size: 'sm' })}
-				>Close</Dialog.Close
-			>
-			<LoadingButton
-				variant="default"
-				size="sm"
-				loading={submitting}
-				onclick={() => create(selected.key)}
-			>
-				Get started
-			</LoadingButton>
-		</Dialog.Footer>
-	</Dialog.Content>
-</Dialog.Root>
+<TemplatePickerDialog
+	bind:open={dialogOpen}
+	{submitting}
+	onConfirm={(template) => create(template.key)}
+/>
 
 <!-- Immediate, screen-level feedback while the conversation is being created (covers
 	both "Start from blank", where the dropdown has already closed, and a template). -->

--- a/ui/packages/comhairle/src/lib/components/TemplatePickerDialog.svelte
+++ b/ui/packages/comhairle/src/lib/components/TemplatePickerDialog.svelte
@@ -1,0 +1,118 @@
+<script lang="ts">
+	import * as Dialog from '$lib/components/ui/dialog';
+	import * as Accordion from '$lib/components/ui/accordion';
+	import { buttonVariants, LoadingButton } from '$lib/components/ui/button';
+	import { conversationTemplates, type ConversationTemplate } from '$lib/conversation_templates';
+	import SelectableOptionRow from '$lib/components/SelectableOptionRow.svelte';
+	import TemplateIllustration from '$lib/components/TemplateIllustration.svelte';
+	import { cn } from '$lib/utils';
+
+	type Props = {
+		/** Two-way bound so either side can close the dialog. */
+		open: boolean;
+		/** Puts the confirm button in its pending state and blocks re-submits. */
+		submitting?: boolean;
+		/** Guidance under the title. Differs by caller: creating vs re-templating. */
+		description?: string;
+		/** Label for the confirm button (e.g. "Get started", "Choose template"). */
+		confirmLabel?: string;
+		/** Receives the template the user settled on. The caller decides what to do with it. */
+		onConfirm: (template: ConversationTemplate) => void;
+	};
+
+	let {
+		open = $bindable(),
+		submitting = false,
+		description = 'Select a workflow template from the options below. You will have the opportunity to customise the workflow in the next step.',
+		confirmLabel = 'Get started',
+		onConfirm
+	}: Props = $props();
+
+	let selectedKey = $state(conversationTemplates[0].key);
+	const selected = $derived(
+		conversationTemplates.find((t) => t.key === selectedKey) ?? conversationTemplates[0]
+	);
+</script>
+
+<Dialog.Root bind:open>
+	<Dialog.Content
+		class="flex max-h-[90vh] w-full max-w-5xl flex-col gap-6 overflow-hidden sm:max-w-5xl"
+	>
+		<Dialog.Header>
+			<Dialog.Title class="text-center text-2xl font-semibold">Choose a template</Dialog.Title
+			>
+			<Dialog.Description class="text-center">{description}</Dialog.Description>
+		</Dialog.Header>
+
+		<div class="flex min-h-0 flex-1 items-start gap-6 overflow-hidden">
+			<!-- Left: selectable template list -->
+			<div
+				class="flex w-96 shrink-0 flex-col gap-3 self-stretch overflow-y-auto pr-4 [scrollbar-gutter:stable]"
+			>
+				{#each conversationTemplates as template (template.key)}
+					<SelectableOptionRow
+						selected={selectedKey === template.key}
+						name={template.name}
+						description={template.description}
+						onSelect={() => (selectedKey = template.key)}
+					/>
+				{/each}
+			</div>
+
+			<!-- Right: selected template detail -->
+			<div
+				class="bg-card flex min-h-0 flex-1 flex-col gap-4 self-stretch overflow-y-auto rounded-xl p-6"
+			>
+				<div class="flex items-center justify-between gap-2">
+					<h3 class="text-card-foreground text-base font-bold">{selected.name}</h3>
+					<div class="flex max-w-80 flex-wrap justify-end gap-2">
+						{#each selected.badges as badge (badge.label)}
+							{@const Icon = badge.icon}
+							<span
+								class={cn(
+									'text-foreground inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-medium',
+									badge.class
+								)}
+							>
+								<Icon class="size-4 shrink-0" />
+								{badge.label}
+							</span>
+						{/each}
+					</div>
+				</div>
+
+				<TemplateIllustration templateKey={selected.key} />
+
+				<div class="flex flex-col gap-1">
+					<h4 class="text-card-foreground text-sm font-bold">Workflow steps</h4>
+					<Accordion.Root type="single">
+						{#each selected.displaySteps as displayStep, i (displayStep.label)}
+							<Accordion.Item value={`step-${i}`}>
+								<Accordion.Trigger class="text-foreground text-sm font-medium">
+									Step {i + 1}: {displayStep.label}
+								</Accordion.Trigger>
+								<Accordion.Content class="text-muted-foreground text-sm">
+									{displayStep.description}
+								</Accordion.Content>
+							</Accordion.Item>
+						{/each}
+					</Accordion.Root>
+				</div>
+			</div>
+		</div>
+
+		<Dialog.Footer>
+			<Dialog.Close class={buttonVariants({ variant: 'outline', size: 'sm' })}
+				>Close</Dialog.Close
+			>
+			<LoadingButton
+				variant="default"
+				size="sm"
+				loading={submitting}
+				onclick={() => onConfirm(selected)}
+			>
+				{confirmLabel}
+			</LoadingButton>
+		</Dialog.Footer>
+	</Dialog.Content>
+</Dialog.Root>

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/design/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/design/+page.svelte
@@ -11,7 +11,8 @@
 	import * as DropdownMenu from '$lib/components/ui/dropdown-menu';
 	import * as AlertDialog from '$lib/components/ui/alert-dialog';
 	import { toolMeta, toolInfoUrl } from '$lib/tool_meta';
-	import { workflow_templates } from '$lib/workflow_templates.js';
+	import type { ConversationTemplate } from '$lib/conversation_templates';
+	import TemplatePickerDialog from '$lib/components/TemplatePickerDialog.svelte';
 	import { addStepDialog } from '$lib/stores/addStepDialog.svelte';
 	import { newStepHighlight } from '$lib/stores/newStepHighlight.svelte';
 	import { moveItem } from '$lib/utils/reorder';
@@ -56,29 +57,41 @@
 	}
 
 	// --- Templates (re-seed the whole workflow) ---
-	// Keys map to the step arrays in workflow_templates. The workflow doesn't persist
-	// which template it came from, so the chip label is session-local (resets on reload).
-	const TEMPLATES = [
-		{ key: 'empty', label: 'Blank' },
-		{ key: 'learn_polis', label: 'Learn + Wiki Poll' },
-		{ key: 'learn_survey', label: 'Learn + Survey' },
-		{ key: 'learn_survey_polis', label: 'Learn + Survey + Wiki Poll' }
-	];
-	let currentTemplateLabel = $state('Blank');
-	let pendingTemplate = $state<{ key: string; label: string } | null>(null);
+	// The workflow doesn't persist which template it came from, and steps drift once
+	// the admin edits them, so the trigger reads "Choose from templates" rather than
+	// naming a current template it can't actually know.
+	type TemplateChoice = { kind: 'blank' } | { kind: 'template'; template: ConversationTemplate };
+
+	let templatePickerOpen = $state(false);
+	let pendingChoice = $state<TemplateChoice | null>(null);
 	let templateDialogOpen = $state(false);
 	let applyingTemplate = $state(false);
 
-	function chooseTemplate(t: { key: string; label: string }) {
-		pendingTemplate = t;
-		templateDialogOpen = true;
+	let pendingLabel = $derived(
+		pendingChoice?.kind === 'template' ? pendingChoice.template.name : 'Blank'
+	);
+
+	/**
+	 * Stage a choice. An empty workflow has nothing to destroy, so it skips straight
+	 * past the replace-warning instead of asking about steps that don't exist.
+	 */
+	function chooseTemplate(choice: TemplateChoice) {
+		pendingChoice = choice;
+		templatePickerOpen = false;
+		if (reorderedSteps.length === 0) {
+			applyTemplate();
+		} else {
+			templateDialogOpen = true;
+		}
 	}
 
 	async function applyTemplate() {
-		const t = pendingTemplate;
-		if (!t) return;
+		const choice = pendingChoice;
+		if (!choice) return;
 		applyingTemplate = true;
-		const steps = workflow_templates[t.key as keyof typeof workflow_templates] ?? [];
+		// Templates may also declare creationEvents, but those belong to conversation
+		// creation; re-templating an existing conversation only touches its steps.
+		const steps = choice.kind === 'blank' ? [] : choice.template.creationSteps;
 		try {
 			// Replace the workflow: delete every existing step, then create the template's.
 			for (const s of reorderedSteps) {
@@ -110,7 +123,6 @@
 				);
 			}
 			await invalidate('conversation:workflow');
-			currentTemplateLabel = t.label;
 			notifications.send({ priority: 'INFO', message: 'Template applied' });
 		} catch (e) {
 			console.error(e);
@@ -118,7 +130,7 @@
 			await invalidate('conversation:workflow');
 		} finally {
 			applyingTemplate = false;
-			pendingTemplate = null;
+			pendingChoice = null;
 			templateDialogOpen = false;
 		}
 	}
@@ -260,15 +272,16 @@
 					<DropdownMenu.Trigger
 						class="bg-card border-primary text-primary flex h-8 shrink-0 items-center gap-2 self-end rounded-full border px-3 py-4 text-sm font-medium shadow-sm sm:self-auto"
 					>
-						Template: {currentTemplateLabel}
+						Choose from templates
 						<ChevronDown class="size-3" />
 					</DropdownMenu.Trigger>
-					<DropdownMenu.Content align="end">
-						{#each TEMPLATES as t (t.key)}
-							<DropdownMenu.Item onSelect={() => chooseTemplate(t)}>
-								{t.label}
-							</DropdownMenu.Item>
-						{/each}
+					<DropdownMenu.Content align="end" class="w-56">
+						<DropdownMenu.Item onSelect={() => chooseTemplate({ kind: 'blank' })}>
+							Start from blank
+						</DropdownMenu.Item>
+						<DropdownMenu.Item onSelect={() => (templatePickerOpen = true)}>
+							Choose from templates
+						</DropdownMenu.Item>
 					</DropdownMenu.Content>
 				</DropdownMenu.Root>
 			</div>
@@ -436,10 +449,18 @@
 	</div>
 </div>
 
+<TemplatePickerDialog
+	bind:open={templatePickerOpen}
+	submitting={applyingTemplate}
+	description="Select a workflow template from the options below. Applying it replaces the steps this conversation has now."
+	confirmLabel="Apply template"
+	onConfirm={(template) => chooseTemplate({ kind: 'template', template })}
+/>
+
 <AlertDialog.Root bind:open={templateDialogOpen}>
 	<AlertDialog.Content>
 		<AlertDialog.Header>
-			<AlertDialog.Title>Apply the “{pendingTemplate?.label}” template?</AlertDialog.Title>
+			<AlertDialog.Title>Apply the “{pendingLabel}” template?</AlertDialog.Title>
 			<AlertDialog.Description>
 				This replaces the entire workflow. Every current step, its configuration and any
 				collected data will be permanently deleted and cannot be recovered.


### PR DESCRIPTION
Discussed this with Shu in the morning

Actions:
+ create TemplatePickerDialog.svelte with template selection UI extracted from NewConversationButton
+ add Props type with open (bindable), submitting, description, confirmLabel, and onConfirm callback
+ make description and confirmLabel configurable to support both creation and re-templating contexts
+ refactor NewConversationButton to use TemplatePickerDialog component with onConfirm callback


<img width="583" height="263" alt="image" src="https://github.com/user-attachments/assets/d6eed448-0796-4667-89e2-c24c218ab05a" />
