### PR TITLE
Add "unsaved changes" guard to prevent losing edits on the Learn Edit

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -316,6 +316,24 @@ migrate them.
     If you genuinely can't express it as a `$derived` (rare), that's the signal to stop
     and rethink the data flow, not to reach for `$effect`.
 
+- **Reach for `onMount` when the setup runs once and doesn't track reactive state.** Both
+  are Svelte 5 (`onMount` / `onDestroy` are still first-class), so this is a readability
+  call, not a legacy one. `onMount` says "wire this up once, on mount, and tear it down on
+  unmount"; `$effect` says "this re-runs whenever its dependencies change". Use that to
+  signal intent:
+    - **One-time, non-reactive setup → `onMount`.** Attaching a `window`/`document` event
+      listener, kicking off a one-shot subscription, an imperative third-party init. Return
+      a cleanup function for the teardown. A reader doesn't have to hunt for what makes it
+      re-run, because nothing does.
+    - **Setup that must re-run when reactive state changes → `$effect`.** The effect body
+      reads runes state and needs to re-subscribe / re-measure / re-sync when it changes.
+      Here the re-run is the point.
+    - Rule of thumb: if the body reads no reactive state (or only reads it lazily inside a
+      callback that fires later, like an event handler), it isn't tracking anything, so
+      `onMount` states the intent more honestly than an `$effect` that never re-runs. See
+      `unsavedChangesGuard.svelte.ts` for the pattern (listener wired once; the dirty check
+      runs at event time via a getter).
+
 ### SvelteKit
 
 - Use `depends()` in `load` functions to declare explicit cache keys for invalidation.

--- a/ui/packages/comhairle/src/lib/components/Translation/TranslatableField.svelte
+++ b/ui/packages/comhairle/src/lib/components/Translation/TranslatableField.svelte
@@ -214,18 +214,16 @@
 				</button>
 			</Dialog.Header>
 			<div class="max-h-[calc(90vh-120px)] overflow-y-auto">
-				{#if dialogOpen}
-					<TranslationEditor
-						{source}
-						{primaryLocale}
-						{supportedLanguages}
-						{editorType}
-						minHeight={dialogMinHeight}
-						initialTargetLang={clickedLang}
-						{availableDocuments}
-						{conversationId}
-					/>
-				{/if}
+				<TranslationEditor
+					{source}
+					{primaryLocale}
+					{supportedLanguages}
+					{editorType}
+					minHeight={dialogMinHeight}
+					initialTargetLang={clickedLang}
+					{availableDocuments}
+					{conversationId}
+				/>
 			</div>
 		</Dialog.Content>
 	</Dialog.Root>

--- a/ui/packages/comhairle/src/lib/components/Translation/translationSource.svelte.ts
+++ b/ui/packages/comhairle/src/lib/components/Translation/translationSource.svelte.ts
@@ -72,6 +72,14 @@ export function createTextContentSource(options: TextContentSourceOptions): Tran
 	let savedResetTimer: ReturnType<typeof setTimeout> | undefined;
 	const activeSaves = new Set<Promise<unknown>>();
 
+	// Flip to "saving" the instant an edit is queued (not just when the debounced request fires), so the
+	// indicator reflects "unsaved changes" during the debounce window and an unsaved-changes guard can
+	// see it. Mirrors what the learn Pages controller does.
+	function markSaving() {
+		clearTimeout(savedResetTimer);
+		saveState = 'saving';
+	}
+
 	function runSave(fn: () => Promise<void>): Promise<void> {
 		clearTimeout(savedResetTimer);
 		saveState = 'saving';
@@ -206,11 +214,13 @@ export function createTextContentSource(options: TextContentSourceOptions): Tran
 		saveSource(content: string) {
 			onEdit?.(content);
 			overlay = { ...overlay, [getPrimaryLocale()]: content };
+			markSaving();
 			debouncedSaveSource(content);
 		},
 
 		saveTarget(locale: string, content: string) {
 			overlay = { ...overlay, [locale]: content };
+			markSaving();
 			debouncedSaveTarget(locale, content);
 		},
 

--- a/ui/packages/comhairle/src/lib/components/Translation/translationUtils.ts
+++ b/ui/packages/comhairle/src/lib/components/Translation/translationUtils.ts
@@ -56,6 +56,14 @@ export interface TranslationSource {
 	flush(): Promise<void>;
 }
 
+/**
+ * True while a source still has an edit in flight (or a failed save), i.e. there are unsaved changes.
+ * Handy for an unsaved-changes guard: `guardUnsavedChanges(() => sources.some(hasUnsavedChanges))`.
+ */
+export function hasUnsavedChanges(source: TranslationSource): boolean {
+	return source.saveState === 'saving' || source.saveState === 'error';
+}
+
 export function getTextInLocale(
 	translation: Translation | Translation2 | undefined,
 	locale: string,

--- a/ui/packages/comhairle/src/lib/tools/learn/LearnManage.svelte
+++ b/ui/packages/comhairle/src/lib/tools/learn/LearnManage.svelte
@@ -21,6 +21,7 @@
 		WorkflowStepWithTranslationsAndTool
 	} from '$lib/tools/types';
 	import * as Tooltip from '$lib/components/ui/tooltip';
+	import { guardUnsavedChanges } from '$lib/utils/unsavedChangesGuard.svelte';
 
 	interface Props {
 		conversationId: string;
@@ -52,6 +53,10 @@
 		getPrimaryLocale: () => primaryLocale,
 		getSupportedLanguages: () => supportedLanguages
 	});
+
+	// Warn on refresh / navigate-away while a page edit hasn't finished saving. `areDirty` stays true
+	// until a save succeeds (and after a failed save), so this covers the mid-save refresh case.
+	guardUnsavedChanges(() => pages.areDirty);
 
 	type SaveToServerOptions = { invalidate?: boolean };
 	async function save(

--- a/ui/packages/comhairle/src/lib/utils/unsavedChangesGuard.svelte.ts
+++ b/ui/packages/comhairle/src/lib/utils/unsavedChangesGuard.svelte.ts
@@ -1,15 +1,18 @@
 import { beforeNavigate } from '$app/navigation';
+import { onMount } from 'svelte';
 
 /**
  * Warn before leaving the page while there are unsaved changes, e.g. a refresh mid-save on the learn
  * step. Covers a full-page refresh / tab close / external navigation (via the browser's native
  * prompt) and in-app SvelteKit navigation.
  *
- * Call during component initialisation (it uses `$effect` and `beforeNavigate`) and pass a getter
+ * Call during component initialisation (it uses `onMount` and `beforeNavigate`) and pass a getter
  * for the "dirty" condition, e.g. `guardUnsavedChanges(() => pages.areDirty)`.
  */
 export function guardUnsavedChanges(hasUnsavedChanges: () => boolean) {
-	$effect(() => {
+	// onMount (not $effect): the listener is wired up once and never depends on reactive state. The
+	// dirty check runs at event time via the getter, so there is nothing to re-run on state change.
+	onMount(() => {
 		function handleBeforeUnload(event: BeforeUnloadEvent) {
 			if (!hasUnsavedChanges()) return;
 			// Triggering the native "you have unsaved changes" prompt: modern browsers key off

--- a/ui/packages/comhairle/src/lib/utils/unsavedChangesGuard.svelte.ts
+++ b/ui/packages/comhairle/src/lib/utils/unsavedChangesGuard.svelte.ts
@@ -1,0 +1,31 @@
+import { beforeNavigate } from '$app/navigation';
+
+/**
+ * Warn before leaving the page while there are unsaved changes, e.g. a refresh mid-save on the learn
+ * step. Covers a full-page refresh / tab close / external navigation (via the browser's native
+ * prompt) and in-app SvelteKit navigation.
+ *
+ * Call during component initialisation (it uses `$effect` and `beforeNavigate`) and pass a getter
+ * for the "dirty" condition, e.g. `guardUnsavedChanges(() => pages.areDirty)`.
+ */
+export function guardUnsavedChanges(hasUnsavedChanges: () => boolean) {
+	$effect(() => {
+		function handleBeforeUnload(event: BeforeUnloadEvent) {
+			if (!hasUnsavedChanges()) return;
+			// Triggering the native "you have unsaved changes" prompt: modern browsers key off
+			// preventDefault(); older ones need returnValue set. The message itself is not customisable.
+			event.preventDefault();
+			event.returnValue = '';
+		}
+		window.addEventListener('beforeunload', handleBeforeUnload);
+		return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+	});
+
+	beforeNavigate((navigation) => {
+		// A full-page unload already gets the native prompt above, so only guard in-app navigation here.
+		if (navigation.willUnload || !hasUnsavedChanges()) return;
+		if (!confirm('Your changes are still saving. Leave without waiting for them to save?')) {
+			navigation.cancel();
+		}
+	});
+}

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/configure/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/configure/+page.svelte
@@ -18,6 +18,8 @@
 	import ExampleDialog from './ExampleDialog.svelte';
 	import TranslatableField from '$lib/components/Translation/TranslatableField.svelte';
 	import { createTextContentSource } from '$lib/components/Translation/translationSource.svelte';
+	import { hasUnsavedChanges } from '$lib/components/Translation/translationUtils';
+	import { guardUnsavedChanges } from '$lib/utils/unsavedChangesGuard.svelte';
 	import { autoTranslateNewLanguage } from '$lib/components/Translation/translationUtils';
 	import { LanguageSelector } from '$lib/components/ui/language-selector';
 	import type {
@@ -322,6 +324,19 @@
 	const callToActionSource = fieldSource('callToAction', (content) =>
 		handleInitOptionalTranslationField(content, 'callToAction', 'plain')
 	);
+
+	// Warn on refresh / navigate-away while any field is still autosaving.
+	const fieldSources = [
+		titleSource,
+		shortDescriptionSource,
+		descriptionSource,
+		privacyPolicySource,
+		shortPrivacyPolicySource,
+		faqsSource,
+		thankYouMessageSource,
+		callToActionSource
+	];
+	guardUnsavedChanges(() => fieldSources.some(hasUnsavedChanges));
 
 	// Access toggles autosave on change (the page has no Save button — see ADR-0004).
 	// `$form.<field>` is updated optimistically by `bind:checked`; on failure we revert it.

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/events/[event_id]/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/events/[event_id]/+page.svelte
@@ -6,6 +6,8 @@
 	import * as Select from '$lib/components/ui/select';
 	import TranslatableField from '$lib/components/Translation/TranslatableField.svelte';
 	import { createTextContentSource } from '$lib/components/Translation/translationSource.svelte';
+	import { hasUnsavedChanges } from '$lib/components/Translation/translationUtils';
+	import { guardUnsavedChanges } from '$lib/utils/unsavedChangesGuard.svelte';
 	import Combobox from '$lib/components/ui/combobox/combobox.svelte';
 	import Input from '$lib/components/ui/input/input.svelte';
 	import { TimeRangePicker } from '$lib/components/ui/time-picker';
@@ -113,6 +115,9 @@
 		getPrimaryFallback: () => $form.description ?? '',
 		onEdit: (content) => ($form.description = content)
 	});
+
+	// Warn on refresh / navigate-away while a field is still autosaving.
+	guardUnsavedChanges(() => [nameSource, descriptionSource].some(hasUnsavedChanges));
 
 	function convertTimeToSelectedZone(date: string, time: string, timeZone: string) {
 		const localTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;


### PR DESCRIPTION
Add "unsaved changes" guard to prevent losing edits


Builds on top of the translatable field refactor in #675 



https://github.com/user-attachments/assets/f1b0e939-e1a9-41a6-8f30-d5a4693731ee

