### PR TITLE
Add style guide + contributor docs + agents file

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,65 @@
+# AGENTS.md
+
+Entry point for LLM agents (and a decent orientation for humans too). This file is
+intentionally thin: it points you at the canonical docs and lists the few things you must
+not get wrong. **Read the linked docs before writing code.**
+
+## What this repo is
+
+Comhairle is a platform for consultation and deliberation at scale. Admins (policy
+makers) create Conversations that route participants (citizens, stakeholders) through a
+sequence of engagement tools. Full domain glossary: **[CONTEXT.md](CONTEXT.md)**.
+
+Monorepo layout:
+
+- `api/` — Rust API server (axum, SQLX, sea-query, Postgres).
+- `data_model/` — the unified Rust data model ("grammar of participation").
+- `adaptors/` — per-tool adaptors (setup, data extraction, login) for the open-source
+  tools we integrate.
+- `ui/packages/comhairle/` — the SvelteKit frontend (Svelte 5 runes, shadcn-svelte,
+  Tailwind v4). This pnpm workspace is where most frontend paths in the docs are rooted.
+
+## Read these before you work
+
+- **[STYLE_GUIDE.md](STYLE_GUIDE.md)** — how we build: general principles, Rust, and the
+  full frontend working agreement. Read the relevant section before writing code in that
+  layer.
+- **[CONTEXT.md](CONTEXT.md)** — domain language. Use these terms exactly; they are load
+  bearing (e.g. `Insights` is per-Step, `Report` is conversation-level).
+- **[documentation/adr/](documentation/adr)** — architectural decisions and their
+  rationale. Check here before reversing a design choice.
+
+## Commands (run from `ui/packages/comhairle`)
+
+- `pnpm test:unit` — Vitest unit tests.
+- `pnpm check` — svelte-check (types).
+- `pnpm lint` — `prettier --check` + eslint.
+- `pnpm prettier --write <files>` — format only the files you touched. **Do not** run the
+  repo-wide `pnpm format`; it reformats hundreds of unrelated files and buries your diff.
+
+## Non-negotiables
+
+The short list. Full rationale for each is in [STYLE_GUIDE.md](STYLE_GUIDE.md).
+
+- **Do not `git commit`.** Leave changes for the human to review and commit.
+- **Svelte 5 runes only** (`$state` / `$derived` / `$props`). No `export let`, `$:`,
+  `$$props`. Never use `$effect` to mirror one piece of state from another; a writable
+  `$derived` is the fix.
+- **`tryCatchAsync`** for errors, and **never destructure its `Result`** (breaks TS
+  narrowing). Branch on `.err`.
+- **Colocate by default.** Route-local components live next to the route; promote to
+  `src/lib/components/**` only when reused. `src/lib/components/ui/**` is shadcn only.
+- **Reuse before you build.** Check `src/lib/components`, `.../ui`, and `src/lib/utils`
+  first. Reach for an existing dep over bespoke code.
+- **`text-base` is the floor** for content text. Tailwind utilities inline, flat shadcn
+  tokens (`bg-card`, `text-muted-foreground`).
+- **No em dashes** anywhere in code or prose.
+- Before finishing: `pnpm test:unit` and `pnpm check` pass; no `: any` where a real type
+  fits; no stray `console.*`.
+
+## Keeping these docs current
+
+When the same review feedback comes up a **second** time, add it to
+[STYLE_GUIDE.md](STYLE_GUIDE.md). When a decision reverses or introduces a non-obvious
+constraint, write an ADR in [documentation/adr/](documentation/adr). When a domain term
+gets coined or redefined, update [CONTEXT.md](CONTEXT.md).

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,114 @@
+# Comhairle
+
+Comhairle is a platform for consultation and deliberation at scale. Admins (policy makers) create Conversations that route participants (citizens, stakeholders) through a sequence of engagement tools.
+
+## Language
+
+**Conversation**:
+A single consultation/deliberation instance that participants take part in and admins configure. Created in a draft state (`is_live: false`) and later launched.
+_Avoid_: Topic (used loosely in the UI/design), consultation
+
+**Workflow**:
+The ordered sequence of Steps a Conversation routes participants through. Every Conversation has exactly one active Workflow.
+
+**Step**:
+A single stage in a Workflow, backed by one engagement tool (learn/onboarding, survey, Pol.is poll, prioritisation, etc.).
+
+**Design board**:
+The primary editing surface of a Conversation's Workflow, on the `…/design` route. A horizontal, left-to-right sequence of Step cards with a persistent left **Tool palette**. Historically labelled "Manage"; the tab is now labelled **Design**.
+_Avoid_: Manage (old label), canvas.
+
+**Tool palette**:
+The persistent left rail on the Design board listing the addable engagement tools. Hovering a tool reveals an **Add** action that eagerly appends a Step; hovering a tool's name shows a tooltip (title, one-line description, "Learn more" → Tools Guide in a new tab). Replaces the old modal (`ToolSelectionModal`). Each tool has an internal key (used to build `tool_setup`) distinct from its **display name** shown to admins (e.g. key `Polis` → "Wiki Poll (Pol.is)", `Learn` → "Rich content page", `Prioritization` → "Prioritisation tool", `Thinking Space` → "Thinking space").
+_Avoid_: Tool selection modal (being removed).
+
+**Estimated time**:
+A per-Step duration in minutes shown as a card pill when the board's "Estimated time" toggle is on. Distinct from the typical-duration ranges described narratively in the Tools Guide.
+_Status_: Not backed yet — displayed from a hardcoded per-tool default for now; a real editable `estimated_minutes` (nullable) column is deferred pending the same team decision as [[data-protocol]] (flagged on the PR).
+
+**Tools Guide**:
+The admin reference pages at `/admin/info/tools/<key>`, one long-form editorial page per tool (sections: What you need to know, How it works, Mostly used in, Data collection and analysis, A typical participant experience, How to set this up, The open source tool we use). Opened in a new tab from a tool's "Learn more" link.
+
+**Workflow template**:
+A named, pre-defined set of Steps used to seed a new Conversation's Workflow at creation time. Applied once at creation; the resulting Workflow is then freely editable. A template has *display* content (name, description, badges, preview, step list shown on its card) that is distinct from its *creation* steps (the real `tool_setup` configs instantiated on "Get started"). Display content may reference steps whose backing tool does not yet exist (e.g. "Online video conference"); such steps are shown but not instantiated. Template content is provisional pending product decisions.
+_Avoid_: Preset
+_Note_: Templates are no longer create-time-only. The design board's "Template" dropdown re-applies a template to an existing Workflow: it **destructively replaces** the whole Workflow (deletes every Step + its data, then creates the template's Steps) behind an "are you sure" confirmation. This reverses ADR-0002's create-time-only stance (see the amendment there). The Workflow still does not persist which template was applied, so the chip label is session-local (resets to "Blank" on reload).
+
+**Start from blank**:
+Creating a Conversation immediately (with an auto-generated title and an empty Workflow), then editing it on the configure tab. Create-then-edit, not fill-then-create.
+_Avoid_: Empty workflow (that's the underlying template key)
+
+**Data protocol**:
+A per-Step declaration of who may see the data participants produce in that Step. Canonical four-level ladder, least-to-most open: **Confidential** (no one) → **Restricted** (organiser only) → **Collaborative** (organiser + other participants) → **Open** (everyone).
+_Avoid_: Private/Limited (stale Learn-guide wording for Confidential/Restricted), "data sharing", "data policy".
+_Status_: Only Confidential and Restricted are backed today — they map onto the existing `request_user_share_permission` boolean (`false`→Confidential, `true`→Restricted). Collaborative and Open appear in the UI for design fidelity but are disabled pending a team decision on introducing a real `data_protocol` enum column (flagged as an open question on the PR).
+
+### Polis admin (Discuss step)
+
+The custom admin UI for a Pol.is Step, replacing the old Setup **iframe**. Its glossary and analytics are **adopted from the civic_os admin** (`bloom/civic_os/packages/admin`), taken as the source of truth because the equivalent surfaces were built out there first. Terms below carry civic_os's meaning unless noted. Canonical Polis-step subtabs: **`Configure · Setup · Moderation · Insights`** (civic_os's "Participants" tab is dropped — see Insights/Report and the Participants note).
+
+**Moderation**:
+The Polis statement-review subtab — sync statements from Polis, add/seed statements, CSV import, and accept/reject each with status filter chips (`all · seeded · accepted · pending · rejected`). Backed by the `polis_statement_aux` table. Supersedes the design's "Statements" label and the two dead entries in today's step editor (the `Statements` "coming soon" placeholder and the never-rendered `Moderate` subtab).
+_Avoid_: Statements (design label), Moderate (old dead tab).
+
+**Insights**:
+A **per-Step report** — the read-only analytics surface for a single Step, shown as a subtab in that Step's editor. For Polis: Themes, Areas of Consensus, Areas of Difference computed over the Polis `report_data` export (ported from civic_os's `report.ts` pure functions). Insights is a general per-Step-report pattern: each Step type that supports reporting (Polis, Thinking Space, HeyForm, …; not Learn) gets its own Insights subtab.
+_Avoid_: Report (that's the conversation-level tab — a different, global concept).
+
+**Report**:
+The **conversation-level, global** reporting tab in the top nav (`Configure · Workflow · Knowledge base · Events · Recruit · Monitor · Notify · Report`). Aggregates across the whole Conversation. Distinct from a Step's **Insights** subtab.
+_Avoid_: Insights (that's per-Step).
+
+**Participants** (Polis admin):
+_Out of scope / deferred._ civic_os has a Participants tab (demographics + recruitment goals, tied to its "questions attached" model), but comhairle has no equivalent concept and no top-level Participants tab. Not built as part of the Polis admin; revisited later as a separate effort (possibly HeyForm-adjacent) once its home is decided.
+_Avoid_: reusing civic_os's demographics Participants inside a Polis subtab.
+
+**Setup**:
+The Polis-step subtab replacing the old admin **iframe**: native controls for the Polis conversation config plus comhairle display flags. Two write paths — (1) **Polis-proxied** config (`is_active` = "conversation is open", `topic`, `description`, `strict_moderation` = "no comments without approval") goes through the `PolisUpdateConfig` route (widened `UpdatePollRequest` + server-side admin `login()` + `update_poll()`); (2) **comhairle `tool_config`** display flags (`required_votes`, `show_remaining_statements`, `label_seeds_as_conversation_starter`) via `UpdateConversationWorkflowStep`. No client-side Polis auth. The Polis-proxied fields are **also mirrored into `tool_config`** (they are fields on `PolisToolConfig`) so the form can pre-fill — Polis has no read path (see ADR-0003 amendment). Saving a config field writes Polis first, then the mirror. Seed authoring lives in the **Moderation** subtab, not Setup.
+_Note_: `is_active` (Polis "open/closed") is **plumbed but not surfaced** in the Setup UI — participant access in comhairle is governed by conversation launch + the Workflow, not a per-Polis toggle, so exposing it would be redundant. The field stays on `PolisToolConfig`/`PolisUpdateConfig` (defaulted active) for future use.
+_Status_: The design's "Participants can see the **visualization**" checkbox is **deferred** — the custom participant embed (`PolisEmbed.svelte`) renders no opinion-map, so the flag would control nothing. Building a participant PCA/opinion-map component (data via `get_math_pca`/`report_data`) is a separate follow-up, bundled with retiring the `PolisReport.svelte` iframe.
+
+**Preview poll / Live poll**:
+A Polis Step is backed by **two** separate Pol.is conversations: a **preview** poll (used while the Conversation is a draft — admin-only, for previewing and staging seeds) and a **live** poll (created at **launch**, where participants actually vote). The step editor targets the right one via `conversation.isLive` (`tool_config` = live, `preview_tool_config` = preview). Real participant voting is **post-launch only**.
+_Status_: `launch` creates a fresh live poll and migrates only seed **text** (`post_seed_comment`) — it does **not** carry over aux metadata (`moderation_status`, `themes`), so pre-launch moderation/theming does not survive launch. It also does not yet filter rejected seeds (`// TODO: filter seed statements`). Both are follow-up backend fixes, not part of the tab UI work.
+
+**Seed statement**:
+A statement authored by the moderator (not a participant) to spark discussion, `is_seed: true`. Posted server-side to the active Polis poll (preview while draft, live after launch) via a new backend seed route wrapping `post_seed_comment`, then surfaced locally after sync. Distinct from `moderation_status`.
+_Avoid_: Seeded status (it's a boolean flag, not a moderation status).
+
+**Polis statement aux**:
+Comhairle's `polis_statement_aux` sidecar table, one row per Polis statement, holding admin-only metadata Polis doesn't store: `moderation_status`, human-authored `themes`, `is_seed`, `moderation_reason`, `visible_statement_when_submitted`. Populated by sync.
+
+**Moderation status**:
+The three-value review state of a statement: `accepted · pending · rejected` (enum `ModerationStatus`). Not the same as `is_seed`.
+
+**Theme**:
+A human-authored topic tag string in `polis_statement_aux.themes: string[]`, added via the admin ThemePicker. Polis has no theme concept; sync never imports one. (Future: T3C may write machine themes into the same store.)
+
+**Controversy**:
+A per-Theme classification `low | moderate | high`, from the average per-statement group-agree spread across that theme's statements. Buckets: `<15` low, `15–30` moderate, `>30` high (tunable in `report.ts`; civic_os marks the exact cuts "to confirm").
+
+**Area of Consensus**:
+A statement where every group agrees ≥ 80% (consensus `+`) or every group < 20% (consensus `−`). Thresholds `CONSENSUS_AGREE`/`CONSENSUS_DISAGREE`.
+
+**Area of Difference**:
+A statement where the agree% gap between the most- and least-agreeing groups exceeds 30 points. One diverging pair is enough.
+
+**Low data quality**:
+A statement where any group has < 10 total votes on it (`min per-group votes < 10`), making its group %s untrustworthy. Hidden by default across the Insights tables but still counted; revealable.
+
+### Reporting
+
+**Report component**:
+The primitive of the reporting system: a self-contained, configurable widget fed by (usually) one tool's insight data, e.g. an "Areas of Agreement" list, an engagement stat card, a Prioritisation ranking, a beeswarm chart. The unit that gets built once per tool and reused. **Report views are compositions of report components** filtered by audience + timing; the components are the thing you design, the views are arrangements.
+_Avoid_: widget, block, card (too generic).
+_Status_: Partially skeletoned. Each tool folder already exports an (unused) `ReportUI` slot; only Polis has real components (`components/polis-report/**` + `tools/polis/report.ts`). An older parallel set (`components/report/**` + `utils/report.ts`) feeds only the `/waves` mock.
+
+**Report view**:
+A composition of report components. There are exactly four, each a different audience × timing × scope arrangement over the shared per-tool components:
+1. **Insights** — admin, live, per-tool/Step. A "summary of raw data": current responses + realtime insights; helps spot missing voices. (Already exists for Polis.)
+2. **In-progress feedback** — participant, live, per-tool/Step; appears **as a Step in the participant journey**. The only view that shows **individual** data (the participant's own response) alongside the aggregate from others.
+3. **Presentation mode** — public room screen, live, per-tool; a looping, simplified, low-interaction "highlights" display for a live audience. Either cycles all tools or shows one picked tool.
+4. **End of engagement report** — participant + public, final (frozen snapshot), conversation-level cross-tool; **human-authored**: auto-generated insights that an editor curates in a rich-text (TipTap) document, pulling component blocks in.
+_Avoid_: report type, report page, Monitor (the ops/funnel tab is a separate concern, not one of the four).
+_Note_: Views 1–3 are system-defined compositions over one per-tool live insight producer; view 4 freezes that output and wraps it in author-edited prose.

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -1,0 +1,334 @@
+# CrownShy Style Guide
+
+## Introduction
+
+This guide outlines agreed-upon principles for how we should both write and maintain
+code at CrownShy. It exists to help new engineers (and LLM agents) get up to speed
+faster, provides a common set of standards to uphold in PR reviews, and reduces the
+low-level decisions that slow us down.
+
+This is a living document and does **not** exist as a hard set of rules. Anyone on the
+team can propose a change to add new conventions or change existing ones. Please keep it
+up to date so we have a single source of truth.
+
+**This guide covers:**
+
+- General principles (language-agnostic)
+- Rust (backend)
+- JavaScript + Svelte (frontend)
+
+**How to use it:**
+
+- Reference it when you're unsure how to approach something.
+- Link to it in PR comments instead of re-explaining the same feedback.
+- Treat it as a starting point, not a rulebook, and use personal judgement when
+  circumstances demand it.
+- **When the same feedback comes up a second time in review, add it here.** The trigger
+  for a new entry is not "is this important" but "have we now said this twice". That keeps
+  the guide grounded in real friction rather than speculation.
+
+Related docs: domain language lives in [CONTEXT.md](CONTEXT.md); past architectural
+decisions in [documentation/adr](documentation/adr); the agent entry point is
+[AGENTS.md](AGENTS.md).
+
+### A note on LLM-generated code
+
+Using LLMs in development is not discouraged at CrownShy. However, LLM-generated code
+comes with problems worth naming: models are trained to produce working code, not code
+that fits your codebase's conventions. Generated code is often terse, inconsistently
+named, and written without awareness of the patterns we've established here.
+
+The consequence is that copy-pasting LLM output directly into the codebase is an
+antipattern. It shifts the burden of review onto your colleagues.
+
+Instead, treat generated code the way you'd treat code lifted from Stack Overflow or an
+unfamiliar source: read it, understand it, and rewrite it in the style outlined in this
+document. If you wouldn't submit code as-is without an LLM having written it, you
+shouldn't submit it because an LLM wrote it either. The bar is the same.
+
+## General Principles
+
+These apply regardless of language or layer.
+
+### Clarity
+
+Write code for the person reading it next, not the person writing it now. A solution
+that is slightly longer but immediately understandable is almost always better than a
+compact one that requires more decoding.
+
+**Things that reduce clarity and should be avoided:**
+
+#### Nested ternary operators
+
+These are harder to read and reason about than an `else if` block. "Ternary" also means
+three, and should be made up of three parts: a condition, the snippet to run if the
+condition is met, and the fallback. It is meant to be shorthand for a simple if/else
+block, not a longer if / else if / else if / else chain. If a code block contains
+multiple conditions, `else if` blocks are much easier to reason about.
+
+#### Abbreviations in variable names
+
+In general, longer variable names are much clearer for developers reading the code than
+abbreviations. Prefer full words: `conversation` not `conv`, `moderationStatus` not
+`modStatus`, `index` not `idx`, `denominator` not `denom`. Widely understood initialisms
+(`url`, `id`, `api`, `html`) are fine. An exception is closures and callback functions
+where the abbreviation is clear from the variable the closure is tied to.
+
+Define domain jargon at first use. Project-specific shorthands (`aux` for
+`PolisStatementAux`, `tid` for a Polis statement id) are invisible to a reviewer who
+doesn't live in that subsystem. Drop a one-line `//` gloss the first time one appears in
+a file, or prefer the spelled-out name.
+
+#### Deep nesting
+
+Deeply indented code is hard to follow, so keep nesting shallow:
+
+- If a block nests more than about four levels deep, pull the inner work out into its own
+  well-named function.
+- Prefer **guard clauses (early returns)** over wrapping the body in an `if`.
+- **Invert** to handle the negative and error cases first, so the rest of the function
+  reads as a straight, uninterrupted run of the successful path.
+
+## Rust (backend)
+
+Conventions for `api/`, `data_model/`, and `adaptors/`. See `api/src/tools.rs` for the
+house style, and use rustdoc (`///` on items, `//!` for module-level docs).
+
+_This section is a work in progress. Add conventions as they are agreed._
+
+### Name the update-payload method `to_values`
+
+In a model, the method that turns an update/insert struct into the
+`Vec<(SomeIden, SimpleExpr)>` of `(column, value)` pairs for a sea-query statement is
+called `to_values`. This is the established name across the models (`conversation`,
+`event`, `workflow_step`, `media`, and others), so reach for it rather than coining a
+per-model alternative. Reading it at a glance is easier when every model spells it the
+same way.
+
+## JavaScript + Svelte (frontend)
+
+The day-to-day working agreement for the SvelteKit app. The app lives in the pnpm
+workspace at **`ui/packages/comhairle`**; paths below are relative to that package unless
+noted. This is a **Svelte 5 runes** codebase.
+
+### Keep files small and single-purpose
+
+Route files (`+page.svelte`) are **composition roots**, not dumping grounds. If a page
+grows past ~300 lines it's a smell; past ~500 it's a bug in how it's split.
+
+- **Presentation** → `.svelte` components. **Colocate by default**: a component used by a
+  single route lives next to that route (e.g.
+  `conversations/[conversation_id]/design/AddStepDialog.svelte`), matching the existing
+  pattern (`media-library/DeleteDialog.svelte`, `events/[event_id]/AgendaEditor.svelte`).
+  Promote to `src/lib/components/**` only once a component is (or is clearly about to be)
+  reused across routes; `src/lib/components/ui/**` stays reserved for shadcn primitives.
+  Router-reserved filenames (`+page`, `+layout`, `+error`) are the only `.svelte` files a
+  route folder treats specially, so a plain colocated component is safe there.
+- **Reactive state / orchestration** → a `.svelte.ts` runes module (colocated next to its
+  feature, or under `src/lib/stores/**` / `src/lib/tools/**`). See
+  `notifications.svelte.ts` and `sidebarWidth.svelte.ts` for the pattern.
+- **Pure logic** (parse, format, match, transform, build-a-thing) → a plain `.ts` under
+  `src/lib/utils/**`, with a colocated `*.test.ts`.
+
+A `+page.svelte` should mostly _wire_ these together and branch between screens.
+
+#### Reporting work (upcoming)
+
+Report UI is being built out soon, across multiple tools (`thinking_space`, `polis`, and
+others). A couple of conventions to settle before that lands:
+
+- **Group report components under `report/`, not under each tool.** Rather than scatter
+  report UI as `components/tools/<tool>/report` (or `tools/<tool>/report`), group it under
+  `src/lib/components/report/<tool>` (e.g. `report/thinking_space`, `report/polis`), with
+  general-purpose report pieces sitting directly in `report/`. That keeps both the
+  tool-specific and the shared report components scoped to reporting in one place.
+  `src/lib/components/report/` already exists, and the flat `components/polis-report/`
+  would fold into `report/polis` under this scheme. **Status: proposed, still open for
+  discussion.**
+- **This lives in tension with colocate-by-default, and is resolved the usual way.** A
+  report component used by a single route still colocates next to that route; it graduates
+  to `components/report/**` once it is shared across routes or is clearly a general
+  reporting primitive.
+
+### Pure and testable by default
+
+- A pure helper takes its inputs as **arguments** and returns a value. It must not reach
+  into runes state, `page.url`, `sessionStorage`, or the DOM. Thread those in as params
+  instead, that's what makes it testable.
+- Colocate unit tests (`foo.ts` + `foo.test.ts`) and run `pnpm test:unit`. Vitest is set
+  up; `src/lib/utils/urlValidation.test.ts` is the reference style.
+- When extracting from a component, split the **pure core** from the **I/O shell**: the
+  pure, tested function behind a thin async that just loads data and calls it.
+
+### Reuse before you build
+
+Before hand-rolling UI or a helper, **check what already exists**: grep
+`src/lib/components`, `src/lib/components/ui` (shadcn-svelte primitives), and
+`src/lib/utils`.
+
+- Buttons → the shadcn `Button` (`$lib/components/ui/button`), incl. `href` links and
+  `loading-button` for pending states.
+- Dialogs, selects, tables, command palette, skeletons, sonner toasts all live in
+  `src/lib/components/ui/**`. Don't re-roll a shadcn primitive.
+- Class merging → `cn()` from `$lib/utils`. Never concatenate class strings by hand.
+- Icons → `lucide-svelte`. Don't inline bespoke SVGs for common glyphs.
+- Never hand-roll what a proven library already does: charts → LayerCake / layerchart /
+  `@carbon/charts-svelte`; rich text → TipTap / Carta; QR → `svelte-qrcode`;
+  drag-and-drop → the existing dnd deps. Add/use a dep before writing bespoke code.
+
+If you copy a block a second time, stop and extract it.
+
+### Naming
+
+- **Spell it out.** Prefer full words for variables, functions, props, and types (see
+  [Abbreviations in variable names](#abbreviations-in-variable-names) under General
+  Principles, which applies here too).
+- **Name the props type; don't inline the annotation.** Declare a `type Props = { … }`
+  (or `interface Props`) above the destructure and annotate with it, rather than inlining
+  a large object literal after `}:`.
+
+    ```svelte
+    <!-- WRONG: a big inline object literal buried in the destructure -->
+    let { row, selected, onToggle }: { row: Foo; selected: boolean; onToggle: () => void } =
+    	$props();
+
+    <!-- RIGHT: a named Props type, destructure stays scannable -->
+    type Props = {
+    	row: Foo;
+    	selected: boolean;
+    	onToggle: () => void;
+    };
+    let { row, selected, onToggle }: Props = $props();
+    ```
+
+- **Derive types; don't restate them.** Prefer extracting or deriving a type from its
+  source of truth over re-declaring a matching shape by hand: a hand-copied duplicate
+  drifts, and it moves errors to the wrong place. To type a value you pass into a
+  component, reach for `ComponentProps` so a change to the component's prop type lands as
+  an error _on the value_, not as an ambiguous "incorrect props" error down at the markup.
+
+    ```svelte
+    <script lang="ts">
+    	import type { ComponentProps } from 'svelte';
+    	import ComponentA from './ComponentA.svelte';
+
+    	// If ComponentA's `list` prop type changes, the error surfaces *here*, on the value…
+    	let list: ComponentProps<typeof ComponentA>['list'] = ['a', 'b', 'c'];
+    </script>
+
+    <!-- …not as a vague props error down here on the usage. -->
+    <ComponentA {list} />
+    ```
+
+### Imports
+
+- **`$lib` alias for cross-feature imports; relative paths for colocated files.** Reach
+  into shared code (`$lib/components/…`, `$lib/utils/…`) through the `$lib` alias rather
+  than long `../../..` chains. A component importing its own siblings (a colocated child,
+  its `*.svelte.ts`, its `*.test.ts`) uses a plain relative path (`./Child.svelte`). Rule
+  of thumb: crossing out of the current feature folder → `$lib`; staying inside it →
+  relative.
+- **Import ordering is not automated.** Prettier is our only formatter and it does not
+  reorder imports; there is no import-sort plugin in the toolchain today. Keep imports
+  tidy by hand (external packages, then `$lib`, then relative). **Open question: adopt a
+  prettier import-sort plugin so this stops being manual?**
+
+### Error handling
+
+- Prefer **`tryCatchAsync`** (`$lib/utils/errorHandling`) over raw `try/catch`.
+- **Never destructure its `Result`**, it breaks TypeScript's discriminated-union
+  narrowing. Keep the object and branch on `.err`:
+
+    ```ts
+    const res = await tryCatchAsync(() => apiClient.doThing());
+    if (res.err !== null) return handle(res.err);
+    use(res.ok);
+    ```
+
+- Client-side data goes through `apiClient` (`@crownshy/api-client/client`); server-side
+  loads use `tryFetch` from the same util.
+
+### Comments
+
+- Use **hoverable doc comments** on anything exported. Editors surface these on hover, so
+  they earn their keep; reserve plain `//` for short inline notes on a tricky line.
+    - **TypeScript** → TSDoc on functions, component props, and non-obvious types.
+      `errorHandling.ts` and `urlValidation.ts` show the house style (`@param`, a one-line
+      summary). Mind the delimiter: a doc comment must open with a two-star delimiter. A
+      single-star block comment looks the same in source but editors do NOT surface it on
+      hover, so a prop documented that way reads as undocumented at the call site. On any
+      exported item or interface member, use the two-star doc delimiter or nothing.
+    - **Rust** → rustdoc (`///` on items, `//!` for module-level docs), the same as the
+      rest of `api/`, `data_model/`, and `adaptors/`.
+- **Comment the _why_, not the _what_.** A comment earns its place only when it carries
+  something the reader can't recover from the code: a non-obvious reason, a footgun, a
+  constraint, a link to context. Delete comments that restate the line.
+    - Good: `// -ml-3.5 cancels its own px-3.5 so the icon aligns to the gutter column`.
+    - Good: `// $derived (not $state + $effect) so SSR renders the real order too`.
+    - Noise: `// derived value for the reordered steps` above `let reorderedSteps = $derived(...)`.
+- **State each rationale once.** If the same "why" is true in three files, explain it
+  fully in the canonical spot (usually the exported helper's TSDoc) and have the others
+  point to it by name rather than restating the paragraph.
+- **Density follows surface.** Exported functions, props, and non-obvious types get a
+  hoverable doc comment. Inside a function body, prefer self-explaining names and small
+  functions over inline narration.
+- No em dashes (or long dashes) in comments or prose. Use commas, parentheses, or a full
+  stop.
+
+### Styling
+
+- **Tailwind v4 utilities, inline.** No custom classes in `<style>` blocks: if you need
+  CSS, it's a utility. (Complex keyframe/`@container` work is the rare exception and must
+  be justified in a comment.)
+- **Never smaller than `text-base` for content.** `text-sm` only for small labels;
+  nothing below `text-sm`, ever. This is enforced on desktop.
+- Use the **flat shadcn design tokens** (`bg-card`, `text-muted-foreground`, …). When
+  translating from Figma, map its doubled token names to the flat token in markup.
+
+### Svelte (runes only)
+
+State is `$state` / `$derived` / `$props`, not the Svelte 4 style. Do not write
+`export let`, `$:` reactive statements, `$$props` / `$$restProps`, or default to writable
+stores for component state. If you see those in a file you're editing, they're legacy,
+migrate them.
+
+- **`$derived` is the default for computed state. `$effect` is a last resort.** If a value
+  is a function of other state (props from `load` included), it's a `$derived`. Reserve
+  `$effect` for true side effects that reach _outside_ the reactive graph: DOM
+  measurement, event listeners, subscriptions, logging, imperative third-party calls.
+- **Never use `$effect` to keep one piece of state in sync with another.** This is the
+  single most common runes mistake (and what LLMs emit by default), so call it out in
+  review. In Svelte 5 a `$derived` is _writable_: a local edit (e.g. a `bind:value` the
+  user types into) overrides it until a dependency changes, then it resyncs on its own.
+  That is exactly the "seed from a prop, re-seed on change" behaviour, with no effect:
+
+    ```svelte
+    <!-- WRONG: state mirrored from a prop via an effect (stale-value + extra-render footgun) -->
+    let topicInput = $state(topic);
+    $effect(() => {
+    	topicInput = topic;
+    });
+
+    <!-- RIGHT: a writable derived. bind:value still works; it resyncs when `topic` changes -->
+    let topicInput = $derived(topic);
+    ```
+
+    If you genuinely can't express it as a `$derived` (rare), that's the signal to stop
+    and rethink the data flow, not to reach for `$effect`.
+
+### SvelteKit
+
+- Use `depends()` in `load` functions to declare explicit cache keys for invalidation.
+- When sibling pages fetch the same resource, hoist the fetch to the nearest shared layout
+  `load` and read it via `await parent()` in children.
+
+### Before you finish
+
+- `pnpm test:unit` and `pnpm check` (svelte-check) pass.
+- Formatting is not optional, but **scope it to the files you touched**: run
+  `pnpm prettier --write <files>` (or `pnpm exec prettier --write $(git diff --name-only)`),
+  not the repo-wide `pnpm format`. A bare `pnpm format` reformats hundreds of unrelated
+  files and buries your real diff, drowning reviewers. Run `pnpm lint` (eslint) to check.
+- No `: any` where a real type fits; no stray `console.*` left in.
+- **Do not `git commit`.** Leave changes staged/unstaged for the human to review and
+  commit themselves.

--- a/documentation/adr/0002-eager-conversation-creation.md
+++ b/documentation/adr/0002-eager-conversation-creation.md
@@ -1,0 +1,38 @@
+# ADR-0002: Conversations are created eagerly, not after a form
+
+**Status:** accepted
+**Date:** 2026-07-06
+
+## Context
+
+The old "New conversation" flow was *fill-then-create*: a full-page form ([/admin/conversations/new](../../ui/packages/comhairle/src/routes/(admin)/admin/conversations/new/+page.svelte)) collected a title, short description, and workflow-template choice, and only persisted anything when the admin clicked "Create". The UX rework aims for *faster topic setup — users shouldn't have to decide their title/description beforehand*.
+
+## Decision
+
+Invert the flow to **create-then-edit**. The "New conversation" button becomes a dropdown with two options, both of which persist a Conversation immediately and then drop the admin on the conversation's **configure** tab:
+
+- **Start from blank** — creates a Conversation with an auto-generated title (`Untitled YYYY-MM-DD h:mm:ssAM/PM`, local browser time), empty descriptions, and an empty Workflow. Seconds are part of the title because the backend slugifies the title under a unique constraint, so two same-minute creates would otherwise collide (`DuplicateSlug`).
+- **Choose from templates** — opens a modal; "Get started" creates the Conversation the same way but seeds its Workflow from the selected template's *creation* steps.
+
+Both entry points (sidebar + dashboard) share one component and one `createConversation` helper extracted from the deleted `/new` route.
+
+## Considered options
+
+- **Keep fill-then-create** (rejected): preserves clean data but keeps the upfront-naming friction the rework exists to remove.
+- **Eager create** (chosen): delivers instant entry; the auto-title clears the existing `title min(1)` rule so the record is valid on creation.
+
+## Consequences
+
+**Accepted risk — abandoned drafts.** Every click of "Start from blank" (and every "Get started") mints a real Conversation, even if the admin immediately navigates away. These accumulate as `is_live: false` "Untitled …" records. We accept this for now; a later mitigation could filter or reap empty drafts.
+
+**Descriptions stay required at save, not at creation.** Create-time sends empty `short_description`/`description` (the API applies no length validation), but the configure schema keeps `min(1)` on both — so descriptions are *deferred*, not abolished. A Conversation cannot be saved/launched without them.
+
+**Bug fixed in passing.** The old create path hardcoded a sample-copy string into the real `description` field; eager creation stores genuinely empty descriptions and surfaces that guidance as field placeholders instead.
+
+**Online video conference has no workflow tool.** The Stakeholder engagement template can't instantiate it as a Step, so it creates its **two backed steps (learn + prioritisation) plus one empty placeholder Event** (an online video meeting the admin fills in). Its card still previews the intended learn → video → prioritisation steps; the video step lands as the Event rather than a Step.
+
+**Out of scope:** AI-generated / guided description drafting (noted as a future follow-up), and a real video-conference *workflow tool* (the placeholder Event is the interim stand-in).
+
+## Amendment (design-board template re-application)
+
+The "applied once at creation" stance above has since been **relaxed for the design board only**. The board's "Template" dropdown lets an admin re-apply a template to an existing Workflow, which **destructively replaces** it: every existing Step (and its configuration/data) is deleted, then the template's Steps are created, behind an explicit "this cannot be undone" confirmation dialog. The eager-creation flow is unchanged — this is a separate, deliberate, guarded action on an already-created Conversation. The Workflow still stores no reference to its source template, so the chip label is session-local.

--- a/documentation/adr/0003-native-polis-admin-config-proxy.md
+++ b/documentation/adr/0003-native-polis-admin-config-proxy.md
@@ -1,0 +1,44 @@
+# ADR-0003: Replace the Pol.is admin iframe with native UI backed by a server-side config-write proxy
+
+**Status:** accepted
+**Date:** 2026-07-10
+
+## Context
+
+The Pol.is Step's admin **Setup** surface embeds Pol.is's own admin console in an **iframe** ([PolisManage.svelte](../../ui/packages/comhairle/src/lib/tools/polis/PolisManage.svelte)), auto-logging in via a `POLIS_LOGIN` `postMessage`. It's clunky, visually inconsistent with the comhairle admin, and pushes Pol.is authentication into the browser.
+
+The equivalent management surfaces (statement **Moderation**, **Insights**) were already built natively in the civic_os admin (`bloom/civic_os/packages/admin`), so the functionality and analytics exist as a reference implementation. The remaining question was *how* to write Pol.is conversation-level config (topic, description, `strict_moderation`, `is_active`) without the iframe.
+
+Key facts that made this feasible:
+- The backend already logs into Pol.is as the admin **server-side** (`polis_service.rs::login`) and can `update_poll` (PUT `/api/v3/conversations`) and `post_seed_comment` with that cookie. These were internal-only.
+- `WikiPollReport` (the `report_data` export) already derives `JsonSchema`; the client method was just untyped (`z.void()`) because the route never declared its response.
+
+## Decision
+
+**Rip out the iframe and drive Pol.is entirely through the comhairle backend.** No client-side Pol.is auth.
+
+- **Pol.is-proxied config** (`is_active`, `topic`, `description`, `strict_moderation`) is written through a **new public backend route** that widens `UpdatePollRequest` and reuses the existing server-side `login()` + `update_poll()`. A generated `apiClient.PolisUpdateConfig` method fronts it.
+- **Seed authoring** (Setup textarea + Moderation "add statement" / CSV import) posts through a **new backend seed route** wrapping `post_seed_comment` against the active poll (preview while draft, live after launch) — not the browser-side cross-origin POST that civic_os used.
+- **Insights `report_data`** is typed by adding `.response::<200, Json<WikiPollReport>>()` to the route and regenerating the client — a typed api-client call, not a raw `fetch`.
+- **comhairle display flags** (`required_votes`, `show_remaining_statements`, "label seeds as conversation starter") stay in `tool_config` via the existing `UpdateConversationWorkflowStep`.
+
+## Considered options
+
+- **Keep the iframe** (rejected): least work, but keeps the clunky UX and client-side Pol.is auth the rework exists to remove.
+- **Store everything in `tool_config`** (rejected): Pol.is would never learn about topic/description/moderation changes — those must reach the Pol.is conversation to take effect.
+- **Server-side config proxy** (chosen): consistent with the existing api-client, keeps Pol.is credentials on the server, and the backend already had the auth + `update_poll`/`post_seed_comment` plumbing.
+
+## Consequences
+
+- **New backend surface to review.** Widening `UpdatePollRequest`, two new routes, and one response annotation. Shipped as a dedicated endpoints PR ahead of the UI PRs.
+- **The "show visualization" flag is deferred.** The custom participant embed renders no opinion-map, so the flag would control nothing. Building a participant PCA/opinion-map component (data via `get_math_pca`/`report_data`) is a follow-up, bundled with retiring the separate `PolisReport.svelte` iframe.
+- **Pre-launch state is a seed-staging screen, not a moderation workspace.** Real participant voting is post-launch only. `launch` mints a fresh live poll and migrates only seed **text** — aux metadata (`moderation_status`, `themes`) does not carry over, and rejected seeds are not yet filtered (`// TODO: filter seed statements`). Honouring pre-launch moderation at launch is a separate follow-up.
+- **civic_os is treated as the source of truth** for the Moderation/Insights glossary and analytics; its raw-`fetch` calls can later migrate onto the now-typed client.
+
+## Amendment (Setup pre-fill: mirror config into `tool_config`)
+
+Polis exposes no read path for a conversation's `topic` / `description` / `is_active` / `strict_moderation`, and `PolisToolConfig` (the stored tool config) drops unknown fields. So the native Setup form could not pre-fill current values from the write-only `PolisUpdateConfig` alone.
+
+**Decision:** the Polis-proxied config is **mirrored into `tool_config`**. `PolisToolConfig` gains `topic`, `description`, `is_active`, `strict_moderation` (plus the comhairle-only display flag `label_seeds_as_conversation_starter`). Saving a config field writes to **Polis first** (`PolisUpdateConfig`, enforcement) and then to `tool_config` (the value the Setup form reads back). This matches how `required_votes` / `show_remaining_statements` already work, and needs no new read endpoint.
+
+**Consequence:** `tool_config` is comhairle's copy of the config, Polis is the enforcement side — they can drift if a Polis-side write succeeds but the mirror write fails (or if Polis config is changed out-of-band). The Polis-first ordering keeps `tool_config` from ever claiming a value Polis rejected. Considered alternative: a live GET-config endpoint (single source of truth, extra round-trip and more Polis-fetch plumbing) — deferred; the mirror is enough for now.

--- a/documentation/adr/0004-sidebar-width-cookie-for-ssr-correct-first-paint.md
+++ b/documentation/adr/0004-sidebar-width-cookie-for-ssr-correct-first-paint.md
@@ -1,0 +1,89 @@
+# ADR-0004: Persist admin sidebar width in a cookie for an SSR-correct first paint
+
+**Status:** accepted
+**Date:** 2026-07-17
+
+## Context
+
+The admin sidebar is resizable. On refresh it visibly **jumped width**: the first
+painted frame showed the hardcoded `DEFAULT_WIDTH` (288px), then snapped to the
+user's saved width.
+
+Root cause: the saved width lived in **`localStorage`**
+([sidebarWidth.svelte.ts](../../ui/packages/comhairle/src/lib/components/sidebarWidth.svelte.ts)),
+which neither the server nor the first client paint can read. The width was held in a
+**module-level singleton** whose `set` / `hydrate` / `persist` are all client-guarded,
+so it was *never* mutated during SSR. The provider bound `--sidebar-width` to that
+singleton ([+layout.svelte](../../ui/packages/comhairle/src/routes/(admin)/+layout.svelte)),
+so SSR always emitted 288 and the client snapped to the real value inside an `$effect`.
+An `initializing` flag disabled the CSS transition during that snap, so the artifact was
+a hard *jump*, not a slide.
+
+This is the same class of bug as dark-mode FOUC. The app already solves *that* with a
+blocking inline script in [app.html](../../ui/packages/comhairle/src/app.html). Separately,
+the shadcn sidebar already persists its **open/collapsed** state in a **cookie**
+(`sidebar:state`, [constants.ts](../../ui/packages/comhairle/src/lib/components/ui/sidebar/constants.ts)),
+precisely so the correct state is known server-side. Width was the odd one out.
+
+Key facts that made the fix straightforward:
+- SSR is on for the admin group (no `ssr = false`), and the root layout already reads a
+  cookie server-side (`auth-token`,
+  [+layout.server.ts](../../ui/packages/comhairle/src/routes/+layout.server.ts)).
+- The theme's *server* side is a deploy-time env var (`PUBLIC_THEME`), not a per-user
+  cookie, so there was no per-user cookie-injection pattern to copy for width.
+- The `(admin)` group had only a **universal** `+layout.ts`, and universal loads cannot
+  read cookies. A **server** load is required.
+
+## Decision
+
+**Make the correct width known at first paint by storing it in a cookie the server
+reads, and move the width value out of the module singleton into layout-owned reactive
+state.** No animation (a slide-on-every-refresh masks the jump, it does not remove it).
+
+- **Cookie, not localStorage.** `sidebar:width` (parallels `sidebar:state`), 7-day
+  max-age (reuse `SIDEBAR_COOKIE_MAX_AGE`), `path=/`, `SameSite=Lax`. Written client-side
+  via `document.cookie` on drag-end / expand-click, the same way `sidebar:state` is
+  written. The value is clamped to `[MIN_WIDTH, MAX_WIDTH]` before writing **and**
+  re-clamped on read so a tampered cookie cannot produce a silly width.
+- **Read server-side** in a new `(admin)/+layout.server.ts` via `cookies.get('sidebar:width')`,
+  clamped, returned as `data.sidebarWidth`.
+- **Layout owns the width** as a writable derived seeded from load data:
+  `let width = $derived(data.sidebarWidth)`. This is the "seed from a prop, re-seed on
+  change" pattern the working agreement holds up as canonical (a `$derived`, not an
+  `$effect`-sync). Drag handlers write `width` directly; it re-seeds from the cookie on
+  the next refresh. `width` + a `persist` are exposed via a small context so
+  `SidebarResizeHandle` and `AdminNav` consume them instead of the singleton.
+- **The module singleton's *state* is deleted.** `sidebarWidth.svelte.ts` is kept only
+  for the pure constants / clamp / cookie helpers.
+
+Because the SSR value and the live value are one reactive expression seeded from the same
+per-request load data, there is structurally no hydration mismatch and no flash.
+
+## Considered options
+
+- **Animate the jump** (rejected): turns the snap into a slide on every refresh, which is
+  arguably worse and does not meet the goal of "no jump."
+- **Keep localStorage + a blocking inline script in `app.html`** (rejected): mirrors the
+  theme FOUC fix, but the provider sets `--sidebar-width` as an inline style on the
+  wrapper, which beats a `:root` var a head script would set, forcing a restructure of
+  where the var is applied. The server HTML would also still say 288, only masked by a
+  pre-paint DOM mutation.
+- **Keep the singleton, gate the style on an "interacted" flag** (rejected as the lesser
+  shape): smallest diff, but keeps the root-cause singleton and needs a hand-rolled gate
+  to switch the style from `data` to the store.
+- **Cookie + layout-owned writable derived** (chosen): SSR-correct output rather than a
+  client-side patch, no server-state leak, no `$effect`, and it matches the house
+  writable-derived-from-load pattern.
+
+## Consequences
+
+- **One-time width reset on deploy.** Existing widths live in the retired
+  `comhairle:sidebarWidth` localStorage key; the `sidebar:width` cookie is absent on first
+  load, so anyone who had customized their width falls back to 288 once and re-drags. No
+  migration code is carried for a single reset in an internal admin tool.
+- **New scoped server load.** `(admin)/+layout.server.ts` is added; the existing universal
+  `+layout.ts` continues to run and its `data` merges with the server load's.
+- **Width now rides on admin requests** as a ~10-byte cookie (negligible), the same as the
+  existing `sidebar:state` cookie.
+- **The `initializing` flag and its transition-disable path go away** (no more localStorage
+  hydrate snap); `resizing` still disables the transition during a live drag.


### PR DESCRIPTION
From our dev meeting, these were the doc follow-ups. This PR should address them.

- **Add a style guide to the repo** as a single file with generic / Svelte / Rust headings (not separate per-language files).
- **Grow it from real friction:** when the same review feedback comes up a second time, add it to the guide.
- **Document our thinking:** a glossary/context file for domain terms (e.g. "Workflow"), and architectural decisions captured as ADRs.
- **Add an `AGENTS.md`** so anyone using an LLM to build gets our context, style, and repo specifics as context automatically. Should make open-source contributions in the future easier to review, and supports the "give them the SDK, they vibe-code the frontend" path we mentioned 

### What this does

One source per kind of content, everything else points at it (so nothing drifts):

- **`AGENTS.md`** (new) is the thin entry point for any agent tool: repo map, `pnpm` commands, a short non-negotiables checklist, and pointers to the canonical docs. Portable markdown, no tool-specific syntax.
- **`STYLE_GUIDE.md`** (new, at repo root) is the single canonical guide, headed Generic / Rust / JavaScript+Svelte. 
- **`CONTEXT.md`** domain glossary I've been accumulating over time (single source for what terms mean). Should tidy up, there might be old stuff
- **`documentation/adr/`** decisions we make and the rationale behind. Included some examples.

### Notes for reviewers
- Docs only, no code changes, but still worth having a look