### PR TITLE
Add unsaved changes guard to conversation configure and event pages

### DIFF
--- a/ui/packages/comhairle/src/lib/components/Translation/TranslatableField.svelte
+++ b/ui/packages/comhairle/src/lib/components/Translation/TranslatableField.svelte
@@ -214,18 +214,16 @@
 				</button>
 			</Dialog.Header>
 			<div class="max-h-[calc(90vh-120px)] overflow-y-auto">
-				{#if dialogOpen}
-					<TranslationEditor
-						{source}
-						{primaryLocale}
-						{supportedLanguages}
-						{editorType}
-						minHeight={dialogMinHeight}
-						initialTargetLang={clickedLang}
-						{availableDocuments}
-						{conversationId}
-					/>
-				{/if}
+				<TranslationEditor
+					{source}
+					{primaryLocale}
+					{supportedLanguages}
+					{editorType}
+					minHeight={dialogMinHeight}
+					initialTargetLang={clickedLang}
+					{availableDocuments}
+					{conversationId}
+				/>
 			</div>
 		</Dialog.Content>
 	</Dialog.Root>

--- a/ui/packages/comhairle/src/lib/components/Translation/translationSource.svelte.ts
+++ b/ui/packages/comhairle/src/lib/components/Translation/translationSource.svelte.ts
@@ -72,6 +72,14 @@ export function createTextContentSource(options: TextContentSourceOptions): Tran
 	let savedResetTimer: ReturnType<typeof setTimeout> | undefined;
 	const activeSaves = new Set<Promise<unknown>>();
 
+	// Flip to "saving" the instant an edit is queued (not just when the debounced request fires), so the
+	// indicator reflects "unsaved changes" during the debounce window and an unsaved-changes guard can
+	// see it. Mirrors what the learn Pages controller does.
+	function markSaving() {
+		clearTimeout(savedResetTimer);
+		saveState = 'saving';
+	}
+
 	function runSave(fn: () => Promise<void>): Promise<void> {
 		clearTimeout(savedResetTimer);
 		saveState = 'saving';
@@ -206,11 +214,13 @@ export function createTextContentSource(options: TextContentSourceOptions): Tran
 		saveSource(content: string) {
 			onEdit?.(content);
 			overlay = { ...overlay, [getPrimaryLocale()]: content };
+			markSaving();
 			debouncedSaveSource(content);
 		},
 
 		saveTarget(locale: string, content: string) {
 			overlay = { ...overlay, [locale]: content };
+			markSaving();
 			debouncedSaveTarget(locale, content);
 		},
 

--- a/ui/packages/comhairle/src/lib/components/Translation/translationUtils.ts
+++ b/ui/packages/comhairle/src/lib/components/Translation/translationUtils.ts
@@ -56,6 +56,14 @@ export interface TranslationSource {
 	flush(): Promise<void>;
 }
 
+/**
+ * True while a source still has an edit in flight (or a failed save), i.e. there are unsaved changes.
+ * Handy for an unsaved-changes guard: `guardUnsavedChanges(() => sources.some(hasUnsavedChanges))`.
+ */
+export function hasUnsavedChanges(source: TranslationSource): boolean {
+	return source.saveState === 'saving' || source.saveState === 'error';
+}
+
 export function getTextInLocale(
 	translation: Translation | Translation2 | undefined,
 	locale: string,

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/configure/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/configure/+page.svelte
@@ -18,6 +18,8 @@
 	import ExampleDialog from './ExampleDialog.svelte';
 	import TranslatableField from '$lib/components/Translation/TranslatableField.svelte';
 	import { createTextContentSource } from '$lib/components/Translation/translationSource.svelte';
+	import { hasUnsavedChanges } from '$lib/components/Translation/translationUtils';
+	import { guardUnsavedChanges } from '$lib/utils/unsavedChangesGuard.svelte';
 	import { autoTranslateNewLanguage } from '$lib/components/Translation/translationUtils';
 	import { LanguageSelector } from '$lib/components/ui/language-selector';
 	import type {
@@ -322,6 +324,19 @@
 	const callToActionSource = fieldSource('callToAction', (content) =>
 		handleInitOptionalTranslationField(content, 'callToAction', 'plain')
 	);
+
+	// Warn on refresh / navigate-away while any field is still autosaving.
+	const fieldSources = [
+		titleSource,
+		shortDescriptionSource,
+		descriptionSource,
+		privacyPolicySource,
+		shortPrivacyPolicySource,
+		faqsSource,
+		thankYouMessageSource,
+		callToActionSource
+	];
+	guardUnsavedChanges(() => fieldSources.some(hasUnsavedChanges));
 
 	// Access toggles autosave on change (the page has no Save button — see ADR-0004).
 	// `$form.<field>` is updated optimistically by `bind:checked`; on failure we revert it.

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/events/[event_id]/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/events/[event_id]/+page.svelte
@@ -6,6 +6,8 @@
 	import * as Select from '$lib/components/ui/select';
 	import TranslatableField from '$lib/components/Translation/TranslatableField.svelte';
 	import { createTextContentSource } from '$lib/components/Translation/translationSource.svelte';
+	import { hasUnsavedChanges } from '$lib/components/Translation/translationUtils';
+	import { guardUnsavedChanges } from '$lib/utils/unsavedChangesGuard.svelte';
 	import Combobox from '$lib/components/ui/combobox/combobox.svelte';
 	import Input from '$lib/components/ui/input/input.svelte';
 	import { TimeRangePicker } from '$lib/components/ui/time-picker';
@@ -113,6 +115,9 @@
 		getPrimaryFallback: () => $form.description ?? '',
 		onEdit: (content) => ($form.description = content)
 	});
+
+	// Warn on refresh / navigate-away while a field is still autosaving.
+	guardUnsavedChanges(() => [nameSource, descriptionSource].some(hasUnsavedChanges));
 
 	function convertTimeToSelectedZone(date: string, time: string, timeZone: string) {
 		const localTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;


### PR DESCRIPTION
Add the unsaved-changes guard that was added in #678 to the autosave admin pages (learn, configure, events): refreshing or navigating away while a field is still saving now warns you first (native browser prompt on refresh/close, a cancelable confirm on in-app nav), instead of silently dropping the in-flight edit.

**Notes**: 

Small supporting change: textContent-backed fields now show **Saving** the moment you type rather than after the ~1s debounce, needed so a refresh mid-debounce is actually caught, and it makes the indicator feel snappier (now matches the learn step).

Reusable `guardUnsavedChanges(() => …)` helper + a `hasUnsavedChanges(source)` predicate; wired as a one-liner per page. 

Prioritization is intentionally left out for now (its section editors are nested child components)