### PR TITLE
Reorder step sub-tabs so Setup leads, and land on the board after adding a step

### DIFF
--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/design/+layout.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/design/+layout.svelte
@@ -45,13 +45,14 @@
 			newStepHighlight.flag(created.id);
 			addStepDialog.open = false;
 
-			// Drop the operator straight into the new step's Configure tab, rather than leaving them
-			// on the board to hunt for it.
+			// Return to the design board (works from either entry point: the board's own Add step
+			// button or the workflow strip's while inside a step editor). The design page reacts to
+			// `newStepHighlight` by scrolling the new card into view and briefly highlighting it, so
+			// the operator sees exactly which step was just created instead of landing in its editor.
 			await goto(
-				resolve(
-					'/(admin)/admin/conversations/[conversation_id]/design/step/[step_id]/configure',
-					{ conversation_id: conversation.id, step_id: created.id }
-				)
+				resolve('/(admin)/admin/conversations/[conversation_id]/design', {
+					conversation_id: conversation.id
+				})
 			);
 		} catch (e) {
 			console.error(e);

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/design/step/[step_id]/+layout.ts
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/design/step/[step_id]/+layout.ts
@@ -2,9 +2,10 @@ import type { LayoutLoad } from './$types';
 
 /**
  * Shared shell for a single workflow step. Derives the step's sub-tab list from its
- * tool type (polis exposes Moderation/Insights; every other tool is Configure + Setup)
+ * tool type (polis exposes Moderation/Insights; every other tool is Setup + Configure)
  * so the sub-tab strip can render from server data in `+layout.svelte`, instead of the
- * page injecting it post-hydration via an `$effect`.
+ * page injecting it post-hydration via an `$effect`. Setup (the tool work) leads; it's
+ * the canonical landing and the most-visited tab.
  */
 export const load: LayoutLoad = async (event) => {
 	const step_id = event.params.step_id;
@@ -20,14 +21,14 @@ export const load: LayoutLoad = async (event) => {
 	const subtabItems =
 		toolConfig?.type === 'polis'
 			? [
-					{ label: 'Configure', value: 'configure' },
 					{ label: 'Setup', value: 'setup' },
+					{ label: 'Configure', value: 'configure' },
 					{ label: 'Moderation', value: 'moderation' },
 					{ label: 'Insights', value: 'insights' }
 				]
 			: [
-					{ label: 'Configure', value: 'configure' },
-					{ label: 'Setup', value: 'setup' }
+					{ label: 'Setup', value: 'setup' },
+					{ label: 'Configure', value: 'configure' }
 				];
 
 	// `step` and `toolConfig` are shared by every sub-tab page (Configure/Setup/Moderation/

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/design/step/[step_id]/+page.ts
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/design/step/[step_id]/+page.ts
@@ -5,14 +5,14 @@ import type { PageLoad } from './$types';
 const SUBTAB_SEGMENTS = ['configure', 'setup', 'moderation', 'insights'];
 
 /**
- * The step index has no content of its own; it lands on the Configure sub-tab. Old
- * `?subtab=` deep links redirect to the matching route so existing bookmarks keep working.
- * (A `moderation`/`insights` target on a non-polis step is bounced on to Configure by that
- * route's own guard.)
+ * The step index has no content of its own; it lands on the Setup sub-tab (the tool work,
+ * the most-visited tab). Old `?subtab=` deep links redirect to the matching route so existing
+ * bookmarks keep working. (A `moderation`/`insights` target on a non-polis step is bounced on
+ * to Setup by that route's own guard.)
  */
 export const load: PageLoad = async (event) => {
 	const legacy = event.url.searchParams.get('subtab');
-	const target = legacy && SUBTAB_SEGMENTS.includes(legacy) ? legacy : 'configure';
+	const target = legacy && SUBTAB_SEGMENTS.includes(legacy) ? legacy : 'setup';
 	redirect(
 		307,
 		`/admin/conversations/${event.params.conversation_id}/design/step/${event.params.step_id}/${target}`

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/design/step/[step_id]/insights/+page.ts
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/design/step/[step_id]/insights/+page.ts
@@ -4,7 +4,7 @@ import type { PolisReportData } from '$lib/tools/polis/reportTypes';
 import type { PageLoad } from './$types';
 
 /**
- * Insights only exists for Polis steps; non-polis steps are bounced to Configure. Both the
+ * Insights only exists for Polis steps; non-polis steps are bounced to Setup. Both the
  * statement_aux and report/vote-export fetches live here so they run only when this tab is
  * open. `polis:statement-aux` and `polis:report` are the invalidation keys the insights
  * actions re-run after sync.
@@ -15,7 +15,7 @@ export const load: PageLoad = async (event) => {
 	if (toolConfig?.type !== 'polis') {
 		redirect(
 			307,
-			`/admin/conversations/${event.params.conversation_id}/design/step/${event.params.step_id}/configure`
+			`/admin/conversations/${event.params.conversation_id}/design/step/${event.params.step_id}/setup`
 		);
 	}
 

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/design/step/[step_id]/moderation/+page.ts
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/design/step/[step_id]/moderation/+page.ts
@@ -3,7 +3,7 @@ import type { PolisStatementAux } from '@crownshy/api-client/api';
 import type { PageLoad } from './$types';
 
 /**
- * Moderation only exists for Polis steps. Non-polis steps are bounced to Configure. The
+ * Moderation only exists for Polis steps. Non-polis steps are bounced to Setup. The
  * statement_aux fetch lives here (not the step's shared load) so it runs only when this tab
  * is actually open. `polis:statement-aux` is the invalidation key the moderation actions
  * re-run after sync/moderate/seed.
@@ -14,7 +14,7 @@ export const load: PageLoad = async (event) => {
 	if (toolConfig?.type !== 'polis') {
 		redirect(
 			307,
-			`/admin/conversations/${event.params.conversation_id}/design/step/${event.params.step_id}/configure`
+			`/admin/conversations/${event.params.conversation_id}/design/step/${event.params.step_id}/setup`
 		);
 	}
 


### PR DESCRIPTION

### 1. Setup leads the step sub-tabs

Opening a step now lands on **Setup** (the actual tool work: Polis / HeyForm / Learn / etc.) instead of **Configure** (name, description, flags). Setup is the tab operators visit most, so it's now the canonical landing and sits first.

Note: later we will merge the contents of the tabs into 1, but for now, just reordered

- Tab order flipped to Setup then Configure in both strips (2-tab for most tools, 4-tab for Polis: Setup, Configure, Moderation, Insights).
- The step index redirect now defaults to `setup` instead of `configure` (legacy `?subtab=` deep links still honored).
- The Moderation and Insights guards bounce non-Polis steps to `setup` instead of `configure`, so there is one consistent landing.

Names ("Setup" / "Configure") are unchanged for now. Renaming and a "was the metadata edited" nudge were considered and deliberately parked.

### 2. Adding a step returns you to the board with the new step highlighted

Creating a step (from either the board's Add step button or the workflow strip's + Add step while inside a step editor) now returns to the design board instead of dropping you into the new step's editor. The board's existing scroll-into-view and highlight logic (`newStepHighlight`) then makes it obvious which card was just created. Both entry points share one `addStep()` handler, so this is a single redirect change.