### PR TITLE
Comment out VIDEO_CONFERENCE from palette tools until behaviour is decided

### DIFF
--- a/ui/packages/comhairle/src/lib/tool_meta.ts
+++ b/ui/packages/comhairle/src/lib/tool_meta.ts
@@ -255,7 +255,7 @@ export const PALETTE_TOOLS: PaletteItem[] = [
 	TOOL_META.learn,
 	TOOL_META.polis,
 	TOOL_META.heyform,
-	VIDEO_CONFERENCE,
+	// VIDEO_CONFERENCE, // commenting this out until we decide the behaviour we want
 	TOOL_META.thinkingspace,
 	TOOL_META.prioritization,
 	TOOL_META.elicitationbot,


### PR DESCRIPTION
Revisit this later, but let's not have half-done steps:

Shu's proposal:
1. add a step here called video call
2. when entering configuration, go to event setup
3. for the user they see a registration page

I think we were also deciding whether to enable adding a video step here or not. If not, we would need to be clear that workflow is for online asynchronous engagements. and I think the workaround we discussed as a temporary solution is to allow adding video step, but for the users they see a registration page instead of a video call lobby (bc when taking part in an online asynchronous engagements, most people are not there in the lobby..) 

Action Items/Followup:
- [ ] run through the team and document the behaviour we want + implement


