### PR TITLE
Fix Translation Dialog flash on close

### DIFF
--- a/ui/packages/comhairle/src/lib/components/Translation/TranslatableField.svelte
+++ b/ui/packages/comhairle/src/lib/components/Translation/TranslatableField.svelte
@@ -214,18 +214,16 @@
 				</button>
 			</Dialog.Header>
 			<div class="max-h-[calc(90vh-120px)] overflow-y-auto">
-				{#if dialogOpen}
-					<TranslationEditor
-						{source}
-						{primaryLocale}
-						{supportedLanguages}
-						{editorType}
-						minHeight={dialogMinHeight}
-						initialTargetLang={clickedLang}
-						{availableDocuments}
-						{conversationId}
-					/>
-				{/if}
+				<TranslationEditor
+					{source}
+					{primaryLocale}
+					{supportedLanguages}
+					{editorType}
+					minHeight={dialogMinHeight}
+					initialTargetLang={clickedLang}
+					{availableDocuments}
+					{conversationId}
+				/>
 			</div>
 		</Dialog.Content>
 	</Dialog.Root>


### PR DESCRIPTION
Removed `{#if dialogOpen}` guard: bits-ui already mounts `Dialog.Content` only while open and keeps it mounted through the 200ms close animation. Gating on dialogOpen would unmount the editor the instant we close, collapsing the grid body and making the dialog visibly shrink/jump mid-animation.

Before:

https://github.com/user-attachments/assets/ba0ad4d7-c663-4a9c-a17d-41ea9e4d8b2e


After: 

https://github.com/user-attachments/assets/932ce83f-673a-4668-bc6f-68da2413d2f8

