### PR TITLE
Learning Assistant: Rmove typing indicator and improve things while here

### DIFF
--- a/ui/packages/comhairle/src/lib/tools/learn/LearnTutor.svelte
+++ b/ui/packages/comhairle/src/lib/tools/learn/LearnTutor.svelte
@@ -68,6 +68,13 @@
 	let isStreaming = $derived(session?.isStreaming ?? false);
 
 	/**
+	 * True from first paint until the session history has finished loading.
+	 * Keyed off `initialized` (not `initializing`) so the skeleton is showing
+	 * before the init effect has even fired — no flash of the empty input.
+	 */
+	let loadingHistory = $derived(!!session && !session.initialized && !chatError);
+
+	/**
 	 * Group session messages into Q/A pairs for inline display.
 	 * A pair = a user message followed (optionally) by the next assistant message.
 	 */
@@ -194,71 +201,54 @@
 					</div>
 				{/if}
 
-				<!-- Loading skeleton: first-time history load -->
-				{#if initializing && pageQAs.length === 0}
+				<!-- Loading skeleton: shown on its own until the session is ready, then the input replaces it -->
+				{#if loadingHistory}
 					<LearnTutorSkeleton />
-				{/if}
-
-				<!-- Inline prompt -->
-				{#if !initializing && !(chatError && pageQAs.length === 0)}
+				{:else if !(chatError && pageQAs.length === 0)}
+					<!-- Inline prompt -->
 					<div class="mb-6">
-						<div
-							class="border-b transition-colors {focused
-								? 'border-primary'
-								: 'border-border'} pb-1.5"
-						>
-							{#if showPlaceholder}
-								{@const errBlocked = !!chatError && pageQAs.length === 0}
-								{@const blocked = loading || initializing || errBlocked}
-								<button
-									type="button"
-									class="text-muted-foreground flex w-full items-center bg-transparent p-0 text-left text-base disabled:cursor-not-allowed disabled:opacity-50"
-									onclick={activate}
-									disabled={blocked}
-								>
-									{loading
-										? 'Loading page...'
-										: initializing
-											? 'Loading tutor session...'
-											: errBlocked
-												? 'Tutor unavailable'
-												: 'Type a question here'}
-									<span
-										class="bg-primary ml-0.5 inline-block h-5 w-0.5 align-middle"
-									></span>
-								</button>
-							{:else}
-								<div class="flex items-center gap-2">
-									<input
-										bind:this={inputRef}
-										bind:value={inputVal}
-										onfocus={() => (focused = true)}
-										onblur={() => {
-											if (!inputVal) setTimeout(() => (focused = false), 150);
-										}}
-										onkeydown={(e) => {
-											if (e.key === 'Enter') {
-												e.preventDefault();
-												handleAsk();
-											}
-										}}
-										placeholder="Type your question..."
+						{#if showPlaceholder}
+							<button
+								type="button"
+								class="border-input bg-background text-muted-foreground hover:border-ring hover:text-foreground flex h-9 w-full cursor-text items-center rounded-lg border px-3 py-1 text-left text-base shadow-xs transition-colors disabled:cursor-not-allowed"
+								onclick={activate}
+								disabled={initializing}
+							>
+								Type a question here
+							</button>
+						{:else}
+							<div
+								class="border-ring ring-ring/50 bg-background flex h-9 items-center gap-2 rounded-lg border px-3 py-1 shadow-xs ring-[3px] transition-[color,box-shadow]"
+							>
+								<input
+									bind:this={inputRef}
+									bind:value={inputVal}
+									onfocus={() => (focused = true)}
+									onblur={() => {
+										if (!inputVal) setTimeout(() => (focused = false), 50);
+									}}
+									onkeydown={(e) => {
+										if (e.key === 'Enter') {
+											e.preventDefault();
+											handleAsk();
+										}
+									}}
+									placeholder="Type your question..."
+									disabled={inputDisabled}
+									class="text-foreground placeholder:text-muted-foreground min-w-0 flex-1 border-none bg-transparent p-0 text-base outline-none disabled:cursor-not-allowed"
+								/>
+								{#if inputVal.trim()}
+									<button
+										type="button"
+										class="text-primary shrink-0 bg-transparent p-0 text-sm font-semibold disabled:cursor-not-allowed disabled:opacity-50"
 										disabled={inputDisabled}
-										class="text-foreground placeholder:text-muted-foreground min-w-0 flex-1 border-none bg-transparent p-0 text-base outline-none disabled:cursor-not-allowed"
-									/>
-									{#if inputVal.trim()}
-										<button
-											type="button"
-											class="text-primary shrink-0 bg-transparent p-0 text-sm font-semibold disabled:cursor-not-allowed disabled:opacity-50"
-											disabled={inputDisabled}
-											onclick={handleAsk}
-										>
-											{isStreaming ? '...' : 'Ask ↵'}
-										</button>
-									{/if}
-								</div>
-							{/if}
-						</div>
+										onclick={handleAsk}
+									>
+										{isStreaming ? '...' : 'Ask ↵'}
+									</button>
+								{/if}
+							</div>
+						{/if}
 					</div>
 				{/if}
 
@@ -269,10 +259,10 @@
 							{@const isNewest = i === 0}
 							{@const open = isExpanded(qa, isNewest)}
 							{@const ts = formatTimestamp(qa.timestamp)}
-							<div class="border-border/60 rounded-xl border">
+							<div class="bg-card border-border/60 rounded-xl border">
 								<button
 									type="button"
-									class="hover:bg-muted/30 flex w-full items-start gap-3 rounded-xl bg-transparent p-4 text-left transition-colors"
+									class="hover:bg-card/50 flex w-full items-start gap-3 rounded-xl p-4 text-left transition-colors"
 									aria-expanded={open}
 									onclick={() => toggleQa(qa, isNewest)}
 								>
@@ -305,7 +295,7 @@
 								</button>
 
 								{#if open}
-									<div class="border-border/60 border-t px-4 pt-3 pb-4">
+									<div class="border-border/60 rounded-xl px-4 pt-3 pb-4">
 										<div class="text-foreground/90 text-[15px] leading-relaxed">
 											{#if qa.error && !qa.answer}
 												<div
@@ -433,18 +423,3 @@
 		{/if}
 	</Dialog.Content>
 </Dialog.Root>
-
-<style>
-	.caret-blink {
-		animation: caret-blink 1s step-end infinite;
-	}
-	@keyframes caret-blink {
-		0%,
-		100% {
-			opacity: 1;
-		}
-		50% {
-			opacity: 0;
-		}
-	}
-</style>

--- a/ui/packages/comhairle/src/lib/tools/learn/LearnTutorSkeleton.svelte
+++ b/ui/packages/comhairle/src/lib/tools/learn/LearnTutorSkeleton.svelte
@@ -1,12 +1,19 @@
 <script lang="ts">
 	/**
-	 * Skeleton placeholder for the LearnTutor "You asked" area.
-	 * Render while the chat session history (getSession) is loading.
+	 * Skeleton placeholder for the LearnTutor input + "You asked" area.
+	 * Render while the chat session history (getSession) is loading. It mirrors
+	 * the real layout (input box then answer card) so nothing shifts on reveal.
 	 */
 </script>
 
-<div class="space-y-3" aria-busy="true" aria-live="polite">
-	<div class="border-border/60 rounded-xl border p-4">
+<div aria-busy="true" aria-live="polite">
+	<!-- Input field placeholder: reserves the same box the real input takes -->
+	<div
+		class="border-input bg-background mb-6 flex h-9 w-full items-center rounded-lg border px-3 py-1"
+	>
+		<div class="bg-muted/60 h-4 w-40 animate-pulse rounded"></div>
+	</div>
+	<div class="bg-card border-border/60 rounded-xl border p-4">
 		<div class="bg-muted/60 mb-2 h-2.5 w-20 animate-pulse rounded"></div>
 		<div class="bg-muted/60 mb-3 h-4 w-3/4 animate-pulse rounded"></div>
 		<div class="space-y-2">
@@ -15,6 +22,5 @@
 			<div class="bg-muted/40 h-3 w-2/3 animate-pulse rounded"></div>
 		</div>
 	</div>
-	<p class="text-muted-foreground text-center text-xs">Loading tutor session…</p>
-	<span class="sr-only">Loading tutor session</span>
+	<span class="sr-only">Loading learning assistant</span>
 </div>


### PR DESCRIPTION
**Resolves #522 Remove the input typing indicator**

The ticket was just to kill the fake typing indicator: the input had a little blinking cursor bar after "Type a question here" that made it look like you could type straight into it, when really you have to click first.

While I was in there I fixed a couple of related things so the whole box feels better:

**What changed**
- Removed the fake caret/typing indicator (and the leftover blink animation that wasn't even wired up).
- Made the placeholder actually look like an input box (bordered field, hover state) instead of a bare line, so it's clear you click it to start.
- Fixed the contrast: the answer cards were gray text on the blue background and hard to read, so they now sit on a `bg-card` surface.
- Tidied up the loading behaviour. On refresh you now get a skeleton from the first frame (no more flash of the empty input), and the skeleton reserves the same space as the input + first answer, so nothing jumps around when the real content loads in.

After:

https://github.com/user-attachments/assets/e747108a-719c-4867-a47d-783f01f8a433

Before:


https://github.com/user-attachments/assets/bcc359f8-7c3c-412b-9e2e-61953af1bc89


