### PR TITLE
Rename LearnTutor to LearningAssistant to stay consistent with the rename we did a while ago

### DIFF
--- a/ui/packages/comhairle/src/lib/api/chatSession.svelte.ts
+++ b/ui/packages/comhairle/src/lib/api/chatSession.svelte.ts
@@ -1,7 +1,7 @@
 import { ChatClient, type ChatReference } from './chatClient.svelte';
 
 /**
- * Unified chat message shape shared across all chat surfaces (ChatBot, LearnTutor, etc.).
+ * Unified chat message shape shared across all chat surfaces (ChatBot, LearningAssistant, etc.).
  */
 export type ChatMessage = {
 	id: string;
@@ -16,7 +16,7 @@ export type ChatMessage = {
 /**
  * Reactive chat session. One instance per conversation id, cached in a module-level map.
  * Owns a single ChatClient and the canonical message list so multiple UI components
- * (ChatBot, LearnTutor, etc.) stay in sync without duplicating state or API calls.
+ * (ChatBot, LearningAssistant, etc.) stay in sync without duplicating state or API calls.
  */
 export class ChatSession {
 	messages = $state<ChatMessage[]>([]);

--- a/ui/packages/comhairle/src/lib/tools/learn/LearnUI.svelte
+++ b/ui/packages/comhairle/src/lib/tools/learn/LearnUI.svelte
@@ -12,7 +12,7 @@
 	} from '@crownshy/api-client/api';
 	import { tick } from 'svelte';
 	import { navigating } from '$app/state';
-	import LearnTutor from './LearnTutor.svelte';
+	import LearningAssistant from './LearningAssistant.svelte';
 	import LearnArticleSkeleton from './LearnArticleSkeleton.svelte';
 	import { apiClient } from '@crownshy/api-client/client';
 	import { delayedFlag } from '$lib/utils/delayedFlag.svelte';
@@ -128,7 +128,7 @@
 
 	{#if tutorAvailable && conversation}
 		<div class="mx-auto w-full max-w-[65ch]">
-			<LearnTutor
+			<LearningAssistant
 				conversationId={conversation.id}
 				pageTitle={pageHeading}
 				loading={showSkeleton.current}

--- a/ui/packages/comhairle/src/lib/tools/learn/LearningAssistant.svelte
+++ b/ui/packages/comhairle/src/lib/tools/learn/LearningAssistant.svelte
@@ -5,7 +5,7 @@
 	import type { ChatReference, ReferenceChunk } from '$lib/api/chatClient.svelte';
 	import MessageWithReferences from '$lib/components/Chatbot/MessageWithReferences.svelte';
 	import * as Dialog from '$lib/components/ui/dialog';
-	import LearnTutorSkeleton from './LearnTutorSkeleton.svelte';
+	import LearningAssistantSkeleton from './LearningAssistantSkeleton.svelte';
 
 	type QA = {
 		id: string;
@@ -203,7 +203,7 @@
 
 				<!-- Loading skeleton: shown on its own until the session is ready, then the input replaces it -->
 				{#if loadingHistory}
-					<LearnTutorSkeleton />
+					<LearningAssistantSkeleton />
 				{:else if !(chatError && pageQAs.length === 0)}
 					<!-- Inline prompt -->
 					<div class="mb-6">

--- a/ui/packages/comhairle/src/lib/tools/learn/LearningAssistantSkeleton.svelte
+++ b/ui/packages/comhairle/src/lib/tools/learn/LearningAssistantSkeleton.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	/**
-	 * Skeleton placeholder for the LearnTutor input + "You asked" area.
+	 * Skeleton placeholder for the LearningAssistant input + "You asked" area.
 	 * Render while the chat session history (getSession) is loading. It mirrors
 	 * the real layout (input box then answer card) so nothing shifts on reveal.
 	 */

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/workflow/[workflow_id]/s/[workflow_step_id]/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/workflow/[workflow_id]/s/[workflow_step_id]/+page.svelte
@@ -20,7 +20,7 @@
 	import { page, navigating } from '$app/state';
 	import LearnArticleSkeleton from '$lib/tools/learn/LearnArticleSkeleton.svelte';
 	import { delayedFlag } from '$lib/utils/delayedFlag.svelte';
-	import LearnTutorSkeleton from '$lib/tools/learn/LearnTutorSkeleton.svelte';
+	import LearningAssistantSkeleton from '$lib/tools/learn/LearningAssistantSkeleton.svelte';
 	import type { ComhairleDocument } from '@crownshy/api-client/api';
 
 	const url = $derived(page.url);
@@ -298,7 +298,7 @@
 							<LearnArticleSkeleton />
 							{#if conversation?.chatBotId && conversation.enableQaChatBot}
 								<div class="mx-auto mt-6 w-full max-w-[65ch]">
-									<LearnTutorSkeleton />
+									<LearningAssistantSkeleton />
 								</div>
 							{/if}
 						{/if}


### PR DESCRIPTION

Actions:
- rename LearnTutor.svelte → LearningAssistant.svelte
- rename LearnTutorSkeleton.svelte → LearningAssistantSkeleton.svelte
- update all imports and component references in LearnUI.svelte and workflow step page
- update JSDoc comments in chatSession.svelte.ts and skeleton component to reflect new naming

Context: Learning Assistant used to be called Tutor Bot, but we decided to move away from "Bot"
I was doing some stuff there and it annoyed me