### PR TITLE
Tiptap: Cell background colours

### DIFF
--- a/ui/packages/comhairle/src/lib/components/RichTextEditor/TableControlsPopover.svelte
+++ b/ui/packages/comhairle/src/lib/components/RichTextEditor/TableControlsPopover.svelte
@@ -9,6 +9,7 @@
 		tableDeleteAction,
 		type TableAction
 	} from './tableActions';
+	import { TABLE_CELL_COLORS, type TableCellColorOption } from './tableColors';
 
 	type Props = {
 		editor: Editor | undefined;
@@ -29,6 +30,27 @@
 		// Row/column edits keep the menu open for repeated tweaks; deleting the
 		// table leaves nothing to manage, so close.
 		if (action.destructive) open = false;
+	}
+
+	function setColor(option: TableCellColorOption) {
+		// Applies to every cell in the current selection (or the caret's cell).
+		editor?.chain().focus().setCellAttribute('cellColor', option.key).run();
+	}
+
+	// Preview swatch: the same mix used in editor-content.css, so it matches the cell.
+	function swatchBackground(option: TableCellColorOption): string {
+		const hue: Record<string, string> = {
+			gray: '#6b7280',
+			red: '#ef4444',
+			orange: '#f97316',
+			yellow: '#eab308',
+			green: '#22c55e',
+			blue: '#3b82f6',
+			purple: '#a855f7',
+			pink: '#ec4899'
+		};
+		if (!option.key) return 'var(--color-background)';
+		return `color-mix(in srgb, ${hue[option.key]} 16%, var(--color-background))`;
 	}
 </script>
 
@@ -65,6 +87,26 @@
 			{#each tableColumnActions as action (action.label)}
 				{@render menuItem(action)}
 			{/each}
+
+			<div class="bg-border my-1 h-px"></div>
+
+			<p class="text-muted-foreground px-2 py-1 text-xs font-medium">Cell colour</p>
+			<div class="flex flex-wrap gap-1 px-2 py-1">
+				{#each TABLE_CELL_COLORS as option (option.label)}
+					<button
+						type="button"
+						class="border-border flex h-6 w-6 items-center justify-center rounded-md border"
+						style="background: {swatchBackground(option)};"
+						title={option.label}
+						aria-label={option.key ? `${option.label} background` : 'No background'}
+						onclick={() => setColor(option)}
+					>
+						{#if !option.key}
+							<span class="text-muted-foreground text-xs leading-none">/</span>
+						{/if}
+					</button>
+				{/each}
+			</div>
 
 			<div class="bg-border my-1 h-px"></div>
 

--- a/ui/packages/comhairle/src/lib/components/RichTextEditor/editor-content.css
+++ b/ui/packages/comhairle/src/lib/components/RichTextEditor/editor-content.css
@@ -143,6 +143,44 @@
 	margin: 0;
 }
 
+/* Cell background colours. A cell stores a palette KEY as `data-cell-color`; each
+   key resolves to a mix of a base hue with the current `--color-background`, so it
+   renders as a soft tint in light mode and a muted dark tint in dark mode - readable
+   in both, no theme-specific values stored. Attribute selectors out-specify the
+   plain `.tiptap th` background above. Keep keys in sync with tableColors.ts. */
+.tiptap th[data-cell-color='gray'],
+.tiptap td[data-cell-color='gray'] {
+	background: color-mix(in srgb, #6b7280 16%, var(--color-background));
+}
+.tiptap th[data-cell-color='red'],
+.tiptap td[data-cell-color='red'] {
+	background: color-mix(in srgb, #ef4444 16%, var(--color-background));
+}
+.tiptap th[data-cell-color='orange'],
+.tiptap td[data-cell-color='orange'] {
+	background: color-mix(in srgb, #f97316 16%, var(--color-background));
+}
+.tiptap th[data-cell-color='yellow'],
+.tiptap td[data-cell-color='yellow'] {
+	background: color-mix(in srgb, #eab308 16%, var(--color-background));
+}
+.tiptap th[data-cell-color='green'],
+.tiptap td[data-cell-color='green'] {
+	background: color-mix(in srgb, #22c55e 16%, var(--color-background));
+}
+.tiptap th[data-cell-color='blue'],
+.tiptap td[data-cell-color='blue'] {
+	background: color-mix(in srgb, #3b82f6 16%, var(--color-background));
+}
+.tiptap th[data-cell-color='purple'],
+.tiptap td[data-cell-color='purple'] {
+	background: color-mix(in srgb, #a855f7 16%, var(--color-background));
+}
+.tiptap th[data-cell-color='pink'],
+.tiptap td[data-cell-color='pink'] {
+	background: color-mix(in srgb, #ec4899 16%, var(--color-background));
+}
+
 /* Both the editor (via the NodeView) and the renderer (via the table node's
    `renderWrapper` option) wrap the table in `.tableWrapper`, so wide/resized
    tables scroll horizontally the same way in both, and a table fills the width

--- a/ui/packages/comhairle/src/lib/components/RichTextEditor/editorConfig.ts
+++ b/ui/packages/comhairle/src/lib/components/RichTextEditor/editorConfig.ts
@@ -3,7 +3,7 @@ import { Link } from '@tiptap/extension-link';
 import { Image } from '@tiptap/extension-image';
 import { Audio } from '@tiptap/extension-audio';
 import { TextAlign } from '@tiptap/extension-text-align';
-import { TableKit } from '@tiptap/extension-table';
+import { TableKit, TableCell, TableHeader } from '@tiptap/extension-table';
 import { Markdown } from '@tiptap/markdown';
 import { Color } from '@tiptap/extension-color';
 import { Iframe } from '$lib/components/RichTextEditor/extensions/iframe';
@@ -30,6 +30,33 @@ export const RENDERER_LINK_ATTRIBUTES = {
 	target: '_blank',
 	rel: 'noopener noreferrer'
 } as const;
+
+/**
+ * A `cellColor` attribute added to table cells + headers. It stores a palette KEY
+ * (see tableColors.ts), rendered as `data-cell-color`, which editor-content.css
+ * turns into a theme-aware background. `this.parent()` preserves the built-in
+ * colspan / rowspan / colwidth attributes.
+ */
+const cellColorAttribute = {
+	cellColor: {
+		default: null as string | null,
+		parseHTML: (element: HTMLElement) => element.getAttribute('data-cell-color'),
+		renderHTML: (attributes: Record<string, unknown>) =>
+			attributes.cellColor ? { 'data-cell-color': attributes.cellColor as string } : {}
+	}
+};
+
+const TableCellWithColor = TableCell.extend({
+	addAttributes() {
+		return { ...this.parent?.(), ...cellColorAttribute };
+	}
+});
+
+const TableHeaderWithColor = TableHeader.extend({
+	addAttributes() {
+		return { ...this.parent?.(), ...cellColorAttribute };
+	}
+});
 
 export type EditorMode = 'editor' | 'renderer';
 
@@ -65,9 +92,15 @@ export function getBaseExtensions(options: EditorConfigOptions): Extensions {
 		// same `.tableWrapper` div the editor's NodeView uses, so a stored table looks
 		// identical (full-width, same overflow behaviour) in the editor and the renderer.
 		// One registration wires editor + both renderers via getBaseExtensions.
+		// TableKit's own cell/header are disabled in favour of the colour-aware
+		// versions below, so a stored `cellColor` renders in editor and renderer alike.
 		TableKit.configure({
-			table: { resizable: true, renderWrapper: true }
+			table: { resizable: true, renderWrapper: true },
+			tableCell: false,
+			tableHeader: false
 		}),
+		TableCellWithColor,
+		TableHeaderWithColor,
 		StarterKit.configure({
 			heading: {
 				levels: [1, 2, 3, 4, 5, 6]

--- a/ui/packages/comhairle/src/lib/components/RichTextEditor/tableColors.ts
+++ b/ui/packages/comhairle/src/lib/components/RichTextEditor/tableColors.ts
@@ -1,0 +1,34 @@
+/**
+ * Fixed palette for table cell backgrounds. Cells store a colour KEY (not a raw
+ * hex), rendered as `data-cell-color="<key>"`. The actual colour is resolved in
+ * editor-content.css via `color-mix(... var(--color-background))`, so each key is
+ * a soft tint in light mode and a muted dark tint in dark mode - readable in both,
+ * without storing theme-specific values. Keep these keys in sync with the CSS.
+ */
+export type TableCellColorKey =
+	| 'gray'
+	| 'red'
+	| 'orange'
+	| 'yellow'
+	| 'green'
+	| 'blue'
+	| 'purple'
+	| 'pink';
+
+export type TableCellColorOption = {
+	/** null clears any colour (the "None" swatch). */
+	key: TableCellColorKey | null;
+	label: string;
+};
+
+export const TABLE_CELL_COLORS: TableCellColorOption[] = [
+	{ key: null, label: 'None' },
+	{ key: 'gray', label: 'Gray' },
+	{ key: 'red', label: 'Red' },
+	{ key: 'orange', label: 'Orange' },
+	{ key: 'yellow', label: 'Yellow' },
+	{ key: 'green', label: 'Green' },
+	{ key: 'blue', label: 'Blue' },
+	{ key: 'purple', label: 'Purple' },
+	{ key: 'pink', label: 'Pink' }
+];

--- a/ui/packages/comhairle/src/lib/utils/renderRichText.test.ts
+++ b/ui/packages/comhairle/src/lib/utils/renderRichText.test.ts
@@ -165,4 +165,36 @@ describe('renderRichTextToHtml', () => {
 		// full-width, horizontally-scrollable layout
 		expect(html).toContain('class="tableWrapper"');
 	});
+
+	it('renders a cell colour key as data-cell-color (SSR path)', () => {
+		const content = JSON.stringify({
+			type: 'doc',
+			content: [
+				{
+					type: 'table',
+					content: [
+						{
+							type: 'tableRow',
+							content: [
+								{
+									type: 'tableCell',
+									attrs: { cellColor: 'blue' },
+									content: [
+										{
+											type: 'paragraph',
+											content: [{ type: 'text', text: 'x' }]
+										}
+									]
+								}
+							]
+						}
+					]
+				}
+			]
+		});
+
+		const html = renderRichTextToHtml(content);
+
+		expect(html).toContain('data-cell-color="blue"');
+	});
 });


### PR DESCRIPTION
Builds on the table support (#714): lets you give table cells a background colour from a fixed palette.

### What you can do
- Caret in a table -> toolbar dropdown has a **Cell colour** row of swatches (none/gray/red/orange/yellow/green/blue/purple/pink)
- Pick one to colour the current cell, or drag-select several cells and colour them all at once
- The "/" swatch clears the colour

### Should be theme-safe 
Cells store a colour *key* (`data-cell-color="blue"`), not a raw hex. The CSS resolves each key with `color-mix(in srgb, <hue> 16%, var(--color-background))`, so it's a soft pastel in light mode and a muted tint in dark mode, readable in both. Nothing theme-specific is stored, and it adapts on its own.

Colours render in the editor and the read-only renderer alike: I disabled TableKit's built-in cell/header and swapped in colour-aware versions in the shared `getBaseExtensions`, so all render paths pick it up.

### Notes
- Pasted raw cell colours are still dropped (raw hex doesn't map cleanly to the theme keys), so re-apply from the palette.
- No data model change, it's just a new `cellColor` node attribute.
- To tweak: hexes live in `editor-content.css` + the `swatchBackground` map in `TableControlsPopover.svelte`, keys in `tableColors.ts`.

### Testing
Added an SSR test that a colour key renders `data-cell-color` in read-only output..
The live picker/dark-mode look wants a manual pass.
 
## Demos: 

Adding colors to cells: 

https://github.com/user-attachments/assets/e393d1fa-bd16-42ff-b03c-43211b251b1e



Pasting tables from google docs drops the color:

https://github.com/user-attachments/assets/fae0a27a-75dc-4e1c-b8d5-092a009d0572


But pasting our own tables, should work fine :)

https://github.com/user-attachments/assets/62bf50c0-6c60-4ecd-bc43-5bb09280858e

