### PR TITLE
Ip logging

### DIFF
--- a/api/migrations/20260723120000_add_signup_ip_to_comhairle_user.sql
+++ b/api/migrations/20260723120000_add_signup_ip_to_comhairle_user.sql
@@ -1,0 +1,5 @@
+-- Record the client IP address captured at account creation time.
+-- Stored for internal/audit purposes only; never exposed via the API.
+
+ALTER TABLE comhairle_user
+ADD COLUMN signup_ip TEXT DEFAULT NULL;

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -309,6 +309,10 @@ pub async fn setup_server(state: Arc<ComhairleState>) -> Result<Router<()>, Comh
         .nest_api_service("/permissions", routes::permissions::router(state.clone()))
         .nest_api_service("/docs", docs_routes(state.clone()))
         .finish_api_with(&mut api, api_docs)
+        .layer(axum::middleware::from_fn_with_state(
+            state.clone(),
+            middleware::request_logging::log_requests,
+        ))
         .layer(Extension(Arc::new(api.clone()))) // Arc is very important here or you will face massive memory and performance issues
         .layer(DefaultBodyLimit::max(10 * 1024 * 1024))
         .layer(cors);

--- a/api/src/middleware.rs
+++ b/api/src/middleware.rs
@@ -1,1 +1,2 @@
 pub mod rate_limit;
+pub mod request_logging;

--- a/api/src/middleware/request_logging.rs
+++ b/api/src/middleware/request_logging.rs
@@ -1,0 +1,86 @@
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use axum::{
+    body::Body,
+    extract::{ConnectInfo, State},
+    http::{HeaderMap, Request},
+    middleware::Next,
+    response::Response,
+};
+use axum_extra::extract::CookieJar;
+use tracing::Instrument;
+
+use crate::ComhairleState;
+use crate::routes::auth::{AUTH_KEY, user_id_from_session_token};
+
+/// The resolved client IP for the current request, stamped into the request
+/// extensions by [`log_requests`] so downstream handlers can read it without
+/// re-deriving it. Handlers extract it with `Extension<ClientIp>`.
+#[derive(Debug, Clone)]
+pub struct ClientIp(pub String);
+
+/// Middleware that opens an `api_request` span carrying the client IP, method,
+/// path, and the logged-in user's id (when a valid session cookie is present).
+/// Running the handler inside the span stamps those fields onto every
+/// request-scoped log event, giving per-IP / per-user request tracing.
+///
+/// It also inserts a [`ClientIp`] into the request extensions so handlers (e.g.
+/// signup) can persist the client IP without re-parsing proxy headers.
+pub async fn log_requests(
+    State(state): State<Arc<ComhairleState>>,
+    mut req: Request<Body>,
+    next: Next,
+) -> Response {
+    // `ConnectInfo` is placed in the request extensions by
+    // `into_make_service_with_connect_info`; it is absent in tests that drive
+    // the router directly (e.g. via `oneshot`), so treat it as optional.
+    let addr = req
+        .extensions()
+        .get::<ConnectInfo<SocketAddr>>()
+        .map(|ci| ci.0);
+    let ip = client_ip(req.headers(), addr);
+    req.extensions_mut().insert(ClientIp(ip.clone()));
+
+    let user_id = CookieJar::from_headers(req.headers())
+        .get(AUTH_KEY)
+        .and_then(|cookie| user_id_from_session_token(cookie.value(), &state.config.jwt_secret));
+
+    let method = req.method().clone();
+    let path = req.uri().path().to_owned();
+
+    let span = tracing::info_span!(
+        "api_request",
+        %ip,
+        user_id = user_id.as_deref().unwrap_or("-"),
+        %method,
+        %path,
+    );
+
+    next.run(req).instrument(span).await
+}
+
+/// Determine the client IP, preferring proxy headers (`X-Forwarded-For`,
+/// `X-Real-IP`) and falling back to the socket address. Mirrors the behaviour
+/// of the rate limiter's `SmartIpKeyExtractor`. `addr` is `None` only when the
+/// connection info extension is absent (e.g. in tests), in which case we fall
+/// back to `"unknown"`.
+pub fn client_ip(headers: &HeaderMap, addr: Option<SocketAddr>) -> String {
+    if let Some(forwarded) = headers.get("x-forwarded-for").and_then(|v| v.to_str().ok()) {
+        if let Some(first) = forwarded.split(',').next() {
+            let trimmed = first.trim();
+            if !trimmed.is_empty() {
+                return trimmed.to_owned();
+            }
+        }
+    }
+
+    if let Some(real_ip) = headers.get("x-real-ip").and_then(|v| v.to_str().ok()) {
+        if !real_ip.is_empty() {
+            return real_ip.to_owned();
+        }
+    }
+
+    addr.map(|a| a.ip().to_string())
+        .unwrap_or_else(|| "unknown".to_string())
+}

--- a/api/src/models/invites.rs
+++ b/api/src/models/invites.rs
@@ -419,6 +419,7 @@ mod tests {
             organization_id: None,
             created_at: Utc::now(),
             updated_at: Utc::now(),
+            signup_ip: None,
         };
 
         let invite = Invite {

--- a/api/src/models/users.rs
+++ b/api/src/models/users.rs
@@ -144,9 +144,13 @@ pub struct User {
     pub organization_id: Option<Uuid>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+    /// Client IP captured at account creation. Internal/audit only — never
+    /// serialized to API responses (see `skip_serializing`).
+    #[serde(skip_serializing)]
+    pub signup_ip: Option<String>,
 }
 
-const DEFAULT_COLUMNS: [UserIden; 10] = [
+const DEFAULT_COLUMNS: [UserIden; 11] = [
     UserIden::Id,
     UserIden::Username,
     UserIden::Password,
@@ -157,6 +161,7 @@ const DEFAULT_COLUMNS: [UserIden; 10] = [
     UserIden::OrganizationId,
     UserIden::CreatedAt,
     UserIden::UpdatedAt,
+    UserIden::SignupIp,
 ];
 
 /// Create a user from a signup request
@@ -309,6 +314,21 @@ async fn insert_otp_user(
         }
         Err(e) => Err(ComhairleError::DatabaseError(e)),
     }
+}
+
+/// Record the client IP address for a freshly created user.
+///
+/// Stored purely for internal/audit purposes; the value is never serialized
+/// back out over the API (the `signup_ip` field is `skip_serializing`).
+pub async fn set_signup_ip(user_id: &Uuid, ip: &str, db: &PgPool) -> Result<(), ComhairleError> {
+    let (sql, values) = Query::update()
+        .table(UserIden::Table)
+        .value(UserIden::SignupIp, ip)
+        .and_where(Expr::col(UserIden::Id).eq(user_id.to_owned()))
+        .build_sqlx(PostgresQueryBuilder);
+
+    sqlx::query_with(&sql, values).execute(db).await?;
+    Ok(())
 }
 
 /// Return a user by ID
@@ -688,6 +708,40 @@ mod tests {
             user.email,
             Some("test_otp@test.com".to_string()),
             "incorrect email"
+        );
+
+        Ok(())
+    }
+
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
+    async fn should_record_and_hide_signup_ip(pool: PgPool) -> Result<(), Box<dyn Error>> {
+        let user = create_user(
+            &SignupRequest {
+                username: "ip_user".to_string(),
+                password: "test_pw".to_string(),
+                email: "ip_user@test.com".to_string(),
+                avatar_url: None,
+            },
+            &pool,
+        )
+        .await?;
+
+        assert!(user.signup_ip.is_none(), "signup_ip unset before recording");
+
+        set_signup_ip(&user.id, "203.0.113.7", &pool).await?;
+
+        let stored = get_user_by_id(&user.id, &pool).await?;
+        assert_eq!(
+            stored.signup_ip.as_deref(),
+            Some("203.0.113.7"),
+            "signup_ip should be persisted"
+        );
+
+        // The IP must never leak through API serialization.
+        let json = serde_json::to_value(&stored)?;
+        assert!(
+            json.get("signup_ip").is_none(),
+            "signup_ip must not be serialized"
         );
 
         Ok(())

--- a/api/src/routes/auth.rs
+++ b/api/src/routes/auth.rs
@@ -4,7 +4,7 @@ use aide::axum::routing::{get_with, post_with};
 
 use argon2::{Argon2, PasswordHash, PasswordHasher, PasswordVerifier, password_hash::SaltString};
 use axum::{
-    RequestPartsExt,
+    Extension, RequestPartsExt,
     extract::{FromRequestParts, Json, Path, State},
     http::{StatusCode, request::Parts},
     response::{IntoResponse, Response},
@@ -57,11 +57,12 @@ use tracing::{instrument, warn};
 use uuid::Uuid;
 
 use crate::ComhairleState;
+use crate::middleware::request_logging::ClientIp;
 use crate::models::permissions::{ConversationPath, ResourceRole, has_resource_permission};
 use crate::models::users::{
     self, Resource, Role, UpdateUserRequest, User, UserAuthType, UserResourceRole,
     create_annon_user, create_otp_user, create_user, get_user_by_email, get_user_by_id,
-    get_user_by_username, get_user_resource_roles, update_user,
+    get_user_by_username, get_user_resource_roles, set_signup_ip, update_user,
 };
 use crate::models::{api_key, otp};
 use crate::routes::user::dto::UserDto;
@@ -291,10 +292,21 @@ pub struct SignupRequest {
     pub email: String,
 }
 
+/// Best-effort recording of the client IP on a newly created user. Failures are
+/// logged but never surfaced to the caller, so IP capture can't break signup.
+/// The IP is resolved by the request-logging middleware and passed through the
+/// request extensions as [`ClientIp`].
+async fn record_signup_ip(state: &Arc<ComhairleState>, user_id: &Uuid, client_ip: &ClientIp) {
+    if let Err(error) = set_signup_ip(user_id, &client_ip.0, &state.db).await {
+        warn!("Failed to record signup IP for user {user_id}: {error}");
+    }
+}
+
 /// Signup handler
-#[instrument(err(Debug), skip(state, payload))]
+#[instrument(err(Debug), skip(state, client_ip, payload))]
 async fn signup(
     State(state): State<Arc<ComhairleState>>,
+    Extension(client_ip): Extension<ClientIp>,
     jar: CookieJar,
     Json(payload): Json<SignupRequest>,
 ) -> Result<(CookieJar, (StatusCode, Json<UserDto>)), ComhairleError> {
@@ -302,6 +314,8 @@ async fn signup(
     validate_password_strength(&payload.password)?;
 
     let user = create_user(&payload, &state.db).await?;
+
+    record_signup_ip(&state, &user.id, &client_ip).await;
 
     send_verification_email(&user, &state)?;
 
@@ -327,12 +341,15 @@ async fn signup(
 }
 
 /// Signup handler for annon
-#[instrument(err(Debug), skip(state))]
+#[instrument(err(Debug), skip(state, client_ip))]
 async fn signup_annon(
     State(state): State<Arc<ComhairleState>>,
+    Extension(client_ip): Extension<ClientIp>,
     jar: CookieJar,
 ) -> Result<(CookieJar, (StatusCode, Json<UserDto>)), ComhairleError> {
     let user = create_annon_user(&state.db).await?;
+
+    record_signup_ip(&state, &user.id, &client_ip).await;
 
     let cookie = create_session_cookie(&user, &state);
 
@@ -347,13 +364,16 @@ pub struct OtpSignupRequest {
     pub username: Option<String>,
 }
 
-#[instrument(err(Debug), skip(state, payload))]
+#[instrument(err(Debug), skip(state, client_ip, payload))]
 async fn signup_otp(
     State(state): State<Arc<ComhairleState>>,
+    Extension(client_ip): Extension<ClientIp>,
     jar: CookieJar,
     Json(payload): Json<OtpSignupRequest>,
 ) -> Result<(CookieJar, (StatusCode, Json<UserDto>)), ComhairleError> {
     let user = create_otp_user(&payload, &state.db).await?;
+
+    record_signup_ip(&state, &user.id, &client_ip).await;
 
     send_verification_email(&user, &state)?;
 
@@ -1489,6 +1509,7 @@ mod tests {
             organization_id: None,
             created_at: Utc::now(),
             updated_at: Utc::now(),
+            signup_ip: None,
         };
         let claims = SessionClaims {
             username: user.username.clone(),
@@ -1539,6 +1560,7 @@ mod tests {
             organization_id: None,
             created_at: Utc::now(),
             updated_at: Utc::now(),
+            signup_ip: None,
         };
         let claims = SessionClaims {
             username: user.username.clone(),
@@ -1593,6 +1615,7 @@ mod tests {
             organization_id: None,
             created_at: Utc::now(),
             updated_at: Utc::now(),
+            signup_ip: None,
         };
         let claims = SessionClaims {
             username: user.username.clone(),
@@ -1915,6 +1938,7 @@ mod tests {
             organization_id: None,
             created_at: Utc::now(),
             updated_at: Utc::now(),
+            signup_ip: None,
         };
         let claims = EmailLinkClaims {
             email: Some(email.to_string()),
@@ -1979,6 +2003,7 @@ mod tests {
             organization_id: None,
             created_at: Utc::now(),
             updated_at: Utc::now(),
+            signup_ip: None,
         };
         let claims = EmailLinkClaims {
             email: Some(email.to_string()),
@@ -2028,6 +2053,7 @@ mod tests {
             organization_id: None,
             created_at: Utc::now(),
             updated_at: Utc::now(),
+            signup_ip: None,
         };
         let claims = EmailLinkClaims { email: None };
         let token = generate_jwt()

--- a/api/src/routes/auth.rs
+++ b/api/src/routes/auth.rs
@@ -696,6 +696,15 @@ pub fn decode_jwt<T: Serialize + DeserializeOwned>(
     result
 }
 
+/// Best-effort extraction of the current user's id from a session JWT cookie.
+/// Intended for logging: it validates the token signature/expiry but does not
+/// hit the database, and returns `None` for any missing or invalid token.
+pub fn user_id_from_session_token(token: &str, secret: &str) -> Option<String> {
+    decode_jwt::<SessionClaims>(token, secret)
+        .ok()
+        .map(|data| data.claims.id)
+}
+
 /// An extractor to ensure that a required user has a role.
 /// If the user does not have the role then this will fail and
 /// return a Not Authorized response

--- a/api/src/routes/invites.rs
+++ b/api/src/routes/invites.rs
@@ -5,7 +5,7 @@ use aide::axum::{
     routing::{get_with, patch_with, post_with},
 };
 use axum::{
-    Json,
+    Extension, Json,
     extract::{Path, State},
 };
 use axum_extra::extract::CookieJar;
@@ -17,6 +17,7 @@ use uuid::Uuid;
 use crate::{
     ComhairleState,
     error::ComhairleError,
+    middleware::request_logging::ClientIp,
     models::{
         self, conversation, event,
         event_attendance::{self, CreateEventAttendance},
@@ -280,9 +281,10 @@ async fn list_invites_for_event(
     Ok((StatusCode::OK, Json(invites)))
 }
 
-#[instrument(err(Debug), skip(state))]
+#[instrument(err(Debug), skip(state, client_ip))]
 async fn auto_register_event_attendance(
     State(state): State<Arc<ComhairleState>>,
+    Extension(client_ip): Extension<ClientIp>,
     Path((conversation_id, invite_id)): Path<(Uuid, Uuid)>,
     jar: CookieJar,
 ) -> Result<(CookieJar, (StatusCode, Json<InviteDto>)), ComhairleError> {
@@ -304,14 +306,24 @@ async fn auto_register_event_attendance(
     let user = match users::get_user_by_email(email, &state.db).await.ok() {
         Some(existing) => existing,
         None => {
-            users::create_otp_user(
+            let new_user = users::create_otp_user(
                 &OtpSignupRequest {
                     email: email.to_string(),
                     username: None,
                 },
                 &state.db,
             )
-            .await?
+            .await?;
+
+            // Best-effort: record the signup IP for the freshly created account.
+            if let Err(error) = users::set_signup_ip(&new_user.id, &client_ip.0, &state.db).await {
+                warn!(
+                    "Failed to record signup IP for user {}: {error}",
+                    new_user.id
+                );
+            }
+
+            new_user
         }
     };
 

--- a/api/src/websockets.rs
+++ b/api/src/websockets.rs
@@ -1013,6 +1013,7 @@ mod tests {
             organization_id: None,
             created_at: Utc::now(),
             updated_at: Utc::now(),
+            signup_ip: None,
         };
 
         let addr = "127.0.0.1:9999".parse().unwrap();


### PR DESCRIPTION
This PR does two things 

1. Adds IP extraction to the logging middleware so we see ip addresses in route spans. It additionally adds user_id to the spans if a user is logged in ("-") otherwise 

2. Associates the users IP at signup on the user model. This isn't exposed anywhere in the API or frontend and is just for internal use