### PR TITLE
Add markdown table paste detection and conversion to RichTextEditor

### DIFF
--- a/ui/packages/comhairle/src/lib/components/RichTextEditor/RichTextEditor.svelte
+++ b/ui/packages/comhairle/src/lib/components/RichTextEditor/RichTextEditor.svelte
@@ -8,6 +8,7 @@
 	import { detectContentType } from '$lib/utils/contentDetection';
 	import { getBaseExtensions, getEditorProps } from './editorConfig';
 	import { SourceDocument } from './extensions/sourceDocument';
+	import { MarkdownTablePaste } from './extensions/markdownTablePaste';
 	import type { ComhairleDocument } from '@crownshy/api-client/api';
 	import './editor-content.css';
 
@@ -101,7 +102,9 @@
 				...getBaseExtensions({ mode: 'editor' }).filter(
 					(ext) => ext.name !== 'sourceDocument'
 				),
-				SourceDocument.configure({ documents: docMap, conversationId, editable: true })
+				SourceDocument.configure({ documents: docMap, conversationId, editable: true }),
+				// Editor-only: turns a pasted markdown table into a real table.
+				MarkdownTablePaste
 			],
 			content: detected.content,
 			contentType: detected.type,

--- a/ui/packages/comhairle/src/lib/components/RichTextEditor/extensions/markdownTablePaste.ts
+++ b/ui/packages/comhairle/src/lib/components/RichTextEditor/extensions/markdownTablePaste.ts
@@ -1,0 +1,34 @@
+import { Extension } from '@tiptap/core';
+import { Plugin } from '@tiptap/pm/state';
+import { containsMarkdownTable } from '../markdownTables';
+
+/**
+ * Editor-only support for pasting markdown tables. `@tiptap/markdown` can parse a GFM
+ * table (that's what powers `contentType: 'markdown'`), but it does no paste handling
+ * of its own. When the pasted plain text contains a GFM table, we re-parse the whole
+ * paste as markdown so the table (and any surrounding markdown) comes in as real nodes.
+ * Ordinary pastes fall through untouched, since the separator-row check keeps stray
+ * pipes from triggering it.
+ *
+ * (Typing markdown table syntax is intentionally NOT supported - building a table is
+ * better served by the toolbar insert button and the hover "+" controls.)
+ */
+export const MarkdownTablePaste = Extension.create({
+	name: 'markdownTablePaste',
+
+	addProseMirrorPlugins() {
+		const editor = this.editor;
+		return [
+			new Plugin({
+				props: {
+					handlePaste(_view, event) {
+						const text = event.clipboardData?.getData('text/plain');
+						if (!text || !containsMarkdownTable(text)) return false;
+						editor.commands.insertContent(text, { contentType: 'markdown' });
+						return true;
+					}
+				}
+			})
+		];
+	}
+});

--- a/ui/packages/comhairle/src/lib/components/RichTextEditor/markdownTables.test.ts
+++ b/ui/packages/comhairle/src/lib/components/RichTextEditor/markdownTables.test.ts
@@ -1,0 +1,46 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { Editor } from '@tiptap/core';
+import { getBaseExtensions } from './editorConfig';
+import { isMarkdownTableSeparator, containsMarkdownTable } from './markdownTables';
+
+describe('markdown table detection', () => {
+	it.each(['| --- | --- |', '|---|---|', '| :--- | ---: |', '  --- | --- '])(
+		'treats %p as a separator row',
+		(line) => {
+			expect(isMarkdownTableSeparator(line)).toBe(true);
+		}
+	);
+
+	it.each(['| A | B |', 'just text', '---', '| a | --- |'])(
+		'does not treat %p as a separator row',
+		(line) => {
+			expect(isMarkdownTableSeparator(line)).toBe(false);
+		}
+	);
+
+	it('detects a table inside pasted text', () => {
+		const text = ['intro', '| A | B |', '| --- | --- |', '| 1 | 2 |', 'outro'].join('\n');
+		expect(containsMarkdownTable(text)).toBe(true);
+	});
+
+	it('does not flag ordinary text with a stray pipe', () => {
+		expect(containsMarkdownTable('a | b is a choice\nsecond line')).toBe(false);
+	});
+});
+
+describe('pasted markdown table insertion', () => {
+	it('inserts a pasted GFM table as real table nodes', () => {
+		const editor = new Editor({ extensions: getBaseExtensions({ mode: 'editor' }) });
+		const pasted = ['| A | B |', '| --- | --- |', '| 1 | 2 |'].join('\n');
+
+		expect(containsMarkdownTable(pasted)).toBe(true);
+		editor.commands.insertContent(pasted, { contentType: 'markdown' });
+
+		const html = editor.getHTML();
+		expect(html).toContain('<table');
+		expect(html).toContain('<th');
+		expect(html).toContain('<td');
+		editor.destroy();
+	});
+});

--- a/ui/packages/comhairle/src/lib/components/RichTextEditor/markdownTables.test.ts
+++ b/ui/packages/comhairle/src/lib/components/RichTextEditor/markdownTables.test.ts
@@ -2,30 +2,24 @@
 import { describe, it, expect } from 'vitest';
 import { Editor } from '@tiptap/core';
 import { getBaseExtensions } from './editorConfig';
-import { isMarkdownTableSeparator, containsMarkdownTable } from './markdownTables';
+import { containsMarkdownTable } from './markdownTables';
 
 describe('markdown table detection', () => {
-	it.each(['| --- | --- |', '|---|---|', '| :--- | ---: |', '  --- | --- '])(
-		'treats %p as a separator row',
-		(line) => {
-			expect(isMarkdownTableSeparator(line)).toBe(true);
-		}
-	);
-
-	it.each(['| A | B |', 'just text', '---', '| a | --- |'])(
-		'does not treat %p as a separator row',
-		(line) => {
-			expect(isMarkdownTableSeparator(line)).toBe(false);
-		}
-	);
-
 	it('detects a table inside pasted text', () => {
 		const text = ['intro', '| A | B |', '| --- | --- |', '| 1 | 2 |', 'outro'].join('\n');
 		expect(containsMarkdownTable(text)).toBe(true);
 	});
 
+	it('detects a table with alignment colons', () => {
+		expect(containsMarkdownTable('| A | B |\n| :--- | ---: |\n| 1 | 2 |')).toBe(true);
+	});
+
 	it('does not flag ordinary text with a stray pipe', () => {
 		expect(containsMarkdownTable('a | b is a choice\nsecond line')).toBe(false);
+	});
+
+	it('does not flag a horizontal rule', () => {
+		expect(containsMarkdownTable('some text\n\n---\n\nmore text')).toBe(false);
 	});
 });
 

--- a/ui/packages/comhairle/src/lib/components/RichTextEditor/markdownTables.ts
+++ b/ui/packages/comhairle/src/lib/components/RichTextEditor/markdownTables.ts
@@ -1,0 +1,32 @@
+/**
+ * Markdown-table detection. The parsing itself is done by `@tiptap/markdown` (via
+ * `contentType: 'markdown'`); this module only decides *when* a paste is a genuine
+ * GFM table, so ordinary pastes are left to the normal behaviour.
+ */
+
+/**
+ * A GFM table separator row, e.g. `| --- | :--: |`. It contains only pipes,
+ * dashes, colons and spaces, and has at least one dash and one pipe - which a
+ * normal data row (with letters) never does, and a plain `---` horizontal rule
+ * (no pipe) never does either.
+ */
+export function isMarkdownTableSeparator(line: string): boolean {
+	const trimmed = line.trim();
+	if (!trimmed.includes('-') || !trimmed.includes('|')) return false;
+	return /^[|\-:\s]+$/.test(trimmed);
+}
+
+/**
+ * True if the text contains a GFM table: a pipe row immediately followed by a
+ * separator row. The separator requirement keeps false positives away from
+ * ordinary text that happens to contain a stray `|`.
+ */
+export function containsMarkdownTable(text: string): boolean {
+	const lines = text.split(/\r?\n/);
+	for (let i = 0; i < lines.length - 1; i++) {
+		const header = lines[i];
+		if (!header.includes('|') || isMarkdownTableSeparator(header)) continue;
+		if (isMarkdownTableSeparator(lines[i + 1])) return true;
+	}
+	return false;
+}

--- a/ui/packages/comhairle/src/lib/components/RichTextEditor/markdownTables.ts
+++ b/ui/packages/comhairle/src/lib/components/RichTextEditor/markdownTables.ts
@@ -1,32 +1,17 @@
-/**
- * Markdown-table detection. The parsing itself is done by `@tiptap/markdown` (via
- * `contentType: 'markdown'`); this module only decides *when* a paste is a genuine
- * GFM table, so ordinary pastes are left to the normal behaviour.
- */
+import { marked } from 'marked';
 
 /**
- * A GFM table separator row, e.g. `| --- | :--: |`. It contains only pipes,
- * dashes, colons and spaces, and has at least one dash and one pipe - which a
- * normal data row (with letters) never does, and a plain `---` horizontal rule
- * (no pipe) never does either.
- */
-export function isMarkdownTableSeparator(line: string): boolean {
-	const trimmed = line.trim();
-	if (!trimmed.includes('-') || !trimmed.includes('|')) return false;
-	return /^[|\-:\s]+$/.test(trimmed);
-}
-
-/**
- * True if the text contains a GFM table: a pipe row immediately followed by a
- * separator row. The separator requirement keeps false positives away from
- * ordinary text that happens to contain a stray `|`.
+ * True if the pasted text contains a GFM table, according to marked's lexer (the
+ * same markdown family `@tiptap/markdown` parses, and already a dependency).
+ *
+ * This is only a gate: pastes that are actually tables get re-parsed as markdown,
+ * everything else falls through to the normal paste path. The real parsing is the
+ * library's job, so we don't hand-roll table detection here.
  */
 export function containsMarkdownTable(text: string): boolean {
-	const lines = text.split(/\r?\n/);
-	for (let i = 0; i < lines.length - 1; i++) {
-		const header = lines[i];
-		if (!header.includes('|') || isMarkdownTableSeparator(header)) continue;
-		if (isMarkdownTableSeparator(lines[i + 1])) return true;
+	try {
+		return marked.lexer(text).some((token) => token.type === 'table');
+	} catch {
+		return false;
 	}
-	return false;
 }


### PR DESCRIPTION
### What it does
Paste plain text like:
```
| Header | Meow |
| -- | -- |
| a | b |
```
and it becomes an actual table, not literal text with pipes.

### How
Most of this was free. The table extension already ships `parseMarkdown`, and `@tiptap/markdown` (which we already use) parses GFM tables out of the box, so a stored/rendered markdown table already worked. The only gap was that `@tiptap/markdown` does no paste handling.

So this adds one small editor-only extension (`MarkdownTablePaste`): on paste, if the text contains a GFM table (a pipe row followed by a `| --- |` separator row), re-parse the paste as markdown. Ordinary pastes fall through untouched, the separator-row check keeps stray pipes from triggering it.

### Scope
- **Paste only.** No typing support, aka hand-typing `| --- | --- |`. Building a table is better served by the toolbar button + hover "+". (I tried a type-to-convert path, it meant intercepting the Enter key globally and was flaky, so I cut it.)
- No new deps


## Demo

https://github.com/user-attachments/assets/03ae7ae1-146b-4fcd-8b32-34f1141bd43a





