### PR TITLE
135/report translations

### DIFF
--- a/api/migrations/20260723115223_convert_report_summary_to_translatable_field.sql
+++ b/api/migrations/20260723115223_convert_report_summary_to_translatable_field.sql
@@ -1,0 +1,33 @@
+-- Convert report summary to use translatable content
+-- This migration handles the complete conversation in a single step
+
+-- First, add a temporary UUID column to hold the new TextContent ID
+ALTER TABLE report ADD COLUMN new_summary uuid;
+
+-- Create TextContent and TextTranslation entries for existing reports
+DO $$
+DECLARE
+    report_record RECORD;
+    summary_content_id uuid;
+BEGIN
+    FOR report_record IN SELECT id, summary FROM report LOOP
+
+        -- Create TextContent and TextTranslation for summary
+        IF report_record.summary IS NOT NULL THEN
+            INSERT INTO TEXT_CONTENT (primary_locale, format)
+            VALUES ('en', 'rich')
+            RETURNING id INTO summary_content_id;
+
+            INSERT INTO TEXT_TRANSLATION (content_id, locale, content, ai_generated, requires_validation)
+            VALUES (summary_content_id, 'en', COALESCE(report_record.summary, ''), false, false);
+
+            UPDATE report SET new_summary = summary_content_id WHERE id = report_record.id;
+        END IF;
+
+    END LOOP;
+END $$;
+
+-- Drop the old text column and rename the new UUID column
+ALTER TABLE report DROP COLUMN summary;
+
+ALTER TABLE report RENAME COLUMN new_summary TO summary;

--- a/api/src/models/report.rs
+++ b/api/src/models/report.rs
@@ -14,12 +14,10 @@ use sqlx_postgres::{PgArgumentBuffer, PgHasArrayType, PgTypeInfo, PgValueRef};
 use tracing::instrument;
 use uuid::Uuid;
 
-use crate::error::ComhairleError;
 use crate::models::SqlxResultExt;
 use crate::models::translations::{TextContentId, TextFormat, new_translation};
 use crate::routes::feedback::dto::FeedbackDto;
 use crate::routes::report_impacts::dto::ReportImpactDto;
-use crate::routes::reports::dto::LocalizedReportDto;
 use crate::tools::elicitation_bot::ElicitationBotReport;
 use crate::tools::heyform::HeyFormReport;
 use crate::tools::learn::LearnReport;
@@ -28,6 +26,7 @@ use crate::tools::prioritization::PrioritizationReport;
 use crate::tools::stories::StoriesReport;
 use crate::tools::thinking_space::ThinkingSpaceReport;
 use crate::tools::{ReportConfig, ToolConfig};
+use crate::{error::ComhairleError, routes::reports::ReportView};
 
 use super::{
     feedback::{self},
@@ -39,7 +38,7 @@ use super::{
 #[serde(rename_all = "camelCase")]
 pub struct FullReportDto {
     #[serde(flatten)]
-    pub report: LocalizedReportDto,
+    pub report: ReportView,
     pub facilitator_feedback: Vec<FeedbackDto>,
     pub participant_feedback: Vec<FeedbackDto>,
     pub impacts: Vec<ReportImpactDto>,
@@ -48,20 +47,24 @@ pub struct FullReportDto {
 impl FullReportDto {
     pub async fn from_report(
         db: &PgPool,
-        report: LocalizedReport,
+        report: ReportView,
     ) -> Result<FullReportDto, ComhairleError> {
-        let feedback = feedback::list_for_conversation(db, &report.conversation_id)
+        let (report_id, conversation_id) = match &report {
+            ReportView::WithTranslations(report) => (report.id, report.conversation_id),
+            ReportView::Localized(report) => (report.id, report.conversation_id),
+        };
+        let feedback = feedback::list_for_conversation(db, &conversation_id)
             .await?
             .into_iter()
             .map(Into::into)
             .collect();
-        let impacts = report_impact::get_for_report(db, &report.id)
+        let impacts = report_impact::get_for_report(db, &report_id)
             .await?
             .into_iter()
             .map(Into::into)
             .collect();
         Ok(FullReportDto {
-            report: report.into(),
+            report,
             impacts,
             facilitator_feedback: feedback,
             participant_feedback: vec![],
@@ -361,6 +364,35 @@ mod tests {
 
         assert_eq!(
             summary_translation.content, "Summary to be filled out by facilitator",
+            "incorrect summary translation text"
+        );
+
+        Ok(())
+    }
+
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
+    async fn should_get_localized_report(pool: PgPool) -> Result<(), Box<dyn Error>> {
+        let (app, mut session) = setup_default_app_and_session(&pool).await?;
+        let conversation_id = get_random_conversation_id(&app, &mut session).await?;
+        let (_, value, _) = session
+            .create_random_workflow(&app, &conversation_id.to_string())
+            .await?;
+        let workflow: WorkflowDto = serde_json::from_value(value)?;
+        session
+            .create_random_workflow_steps(
+                &app,
+                &conversation_id.to_string(),
+                &workflow.id.to_string(),
+                2,
+            )
+            .await?;
+
+        create_for_conversation(&pool, conversation_id, "en").await?;
+
+        let report = get_localized_for_conversation(&pool, conversation_id, "en").await?;
+
+        assert_eq!(
+            report.summary, "Summary to be filled out by facilitator",
             "incorrect summary translation text"
         );
 

--- a/api/src/models/report.rs
+++ b/api/src/models/report.rs
@@ -14,19 +14,20 @@ use sqlx_postgres::{PgArgumentBuffer, PgHasArrayType, PgTypeInfo, PgValueRef};
 use tracing::instrument;
 use uuid::Uuid;
 
+use crate::error::ComhairleError;
+use crate::models::SqlxResultExt;
 use crate::models::translations::{TextContentId, TextFormat, new_translation};
-use crate::{
-    error::ComhairleError,
-    models::SqlxResultExt,
-    routes::{
-        feedback::dto::FeedbackDto, report_impacts::dto::ReportImpactDto, reports::dto::ReportDto,
-    },
-    tools::{
-        ReportConfig, ToolConfig, elicitation_bot::ElicitationBotReport, heyform::HeyFormReport,
-        learn::LearnReport, polis::PolisReport, prioritization::PrioritizationReport,
-        stories::StoriesReport, thinking_space::ThinkingSpaceReport,
-    },
-};
+use crate::routes::feedback::dto::FeedbackDto;
+use crate::routes::report_impacts::dto::ReportImpactDto;
+use crate::routes::reports::dto::LocalizedReportDto;
+use crate::tools::elicitation_bot::ElicitationBotReport;
+use crate::tools::heyform::HeyFormReport;
+use crate::tools::learn::LearnReport;
+use crate::tools::polis::PolisReport;
+use crate::tools::prioritization::PrioritizationReport;
+use crate::tools::stories::StoriesReport;
+use crate::tools::thinking_space::ThinkingSpaceReport;
+use crate::tools::{ReportConfig, ToolConfig};
 
 use super::{
     feedback::{self},
@@ -38,14 +39,17 @@ use super::{
 #[serde(rename_all = "camelCase")]
 pub struct FullReportDto {
     #[serde(flatten)]
-    pub report: ReportDto,
+    pub report: LocalizedReportDto,
     pub facilitator_feedback: Vec<FeedbackDto>,
     pub participant_feedback: Vec<FeedbackDto>,
     pub impacts: Vec<ReportImpactDto>,
 }
 
 impl FullReportDto {
-    pub async fn from_report(db: &PgPool, report: Report) -> Result<FullReportDto, ComhairleError> {
+    pub async fn from_report(
+        db: &PgPool,
+        report: LocalizedReport,
+    ) -> Result<FullReportDto, ComhairleError> {
         let feedback = feedback::list_for_conversation(db, &report.conversation_id)
             .await?
             .into_iter()
@@ -156,11 +160,11 @@ impl PartialReport {
 }
 
 #[instrument(err(Debug))]
-pub async fn get_by_id(db: &PgPool, id: &Uuid) -> Result<Report, ComhairleError> {
+pub async fn get_by_id(db: &PgPool, id: Uuid) -> Result<Report, ComhairleError> {
     let (sql, values) = Query::select()
         .columns(DEFAULT_COLUMNS)
         .from(ReportIden::Table)
-        .and_where(Expr::col(ReportIden::Id).eq(id.to_owned()))
+        .and_where(Expr::col(ReportIden::Id).eq(id))
         .build_sqlx(PostgresQueryBuilder);
 
     let conversation = sqlx::query_as_with::<_, Report, _>(&sql, values)
@@ -278,15 +282,38 @@ pub async fn create_for_conversation(
 #[instrument(err(Debug))]
 pub async fn get_for_conversation(
     db: &PgPool,
-    conversation_id: &Uuid,
+    conversation_id: Uuid,
 ) -> Result<Report, ComhairleError> {
     let (sql, values) = Query::select()
         .columns(DEFAULT_COLUMNS)
         .from(ReportIden::Table)
-        .and_where(Expr::col(ReportIden::ConversationId).eq(conversation_id.to_owned()))
+        .and_where(Expr::col(ReportIden::ConversationId).eq(conversation_id))
         .build_sqlx(PostgresQueryBuilder);
 
     let report = sqlx::query_as_with::<_, Report, _>(&sql, values)
+        .fetch_one(db)
+        .await
+        .resolve_db_err("Report")?;
+
+    Ok(report)
+}
+
+#[instrument(err(Debug))]
+pub async fn get_localized_for_conversation(
+    db: &PgPool,
+    conversation_id: Uuid,
+    locale: &str,
+) -> Result<LocalizedReport, ComhairleError> {
+    let query = Query::select()
+        .columns(DEFAULT_COLUMNS.map(|col| (ReportIden::Table, col)))
+        .from(ReportIden::Table)
+        .and_where(Expr::col((ReportIden::Table, ReportIden::ConversationId)).eq(conversation_id))
+        .to_owned();
+
+    let (sql, values) =
+        LocalizedReport::query_to_localisation(query, locale).build_sqlx(PostgresQueryBuilder);
+
+    let report = sqlx::query_as_with(&sql, values)
         .fetch_one(db)
         .await
         .resolve_db_err("Report")?;

--- a/api/src/models/report.rs
+++ b/api/src/models/report.rs
@@ -1,4 +1,5 @@
 use chrono::{DateTime, Utc};
+use comhairle_macros::Translatable;
 use partially::Partial;
 use schemars::JsonSchema;
 use sea_query::{Expr, PostgresQueryBuilder, Query, enum_def};
@@ -13,6 +14,7 @@ use sqlx_postgres::{PgArgumentBuffer, PgHasArrayType, PgTypeInfo, PgValueRef};
 use tracing::instrument;
 use uuid::Uuid;
 
+use crate::models::translations::{TextContentId, TextFormat, new_translation};
 use crate::{
     error::ComhairleError,
     models::SqlxResultExt,
@@ -63,7 +65,7 @@ impl FullReportDto {
     }
 }
 
-#[derive(Partial, Debug, Deserialize, Serialize, FromRow, Clone, JsonSchema)]
+#[derive(Partial, Debug, Deserialize, Serialize, FromRow, Clone, JsonSchema, Translatable)]
 #[enum_def(table_name = "report")]
 #[partially(derive(Deserialize, Debug, JsonSchema))]
 pub struct Report {
@@ -71,7 +73,8 @@ pub struct Report {
     pub id: Uuid,
     pub is_public: bool,
     pub conversation_id: Uuid,
-    pub summary: String,
+    #[partially(omit)]
+    pub summary: TextContentId,
     pub section_configs: ReportSectionConfigs,
     #[partially(omit)]
     pub created_at: DateTime<Utc>,
@@ -89,10 +92,10 @@ const DEFAULT_COLUMNS: [ReportIden; 7] = [
     ReportIden::UpdatedAt,
 ];
 
-#[derive(Debug, Deserialize, Serialize, FromRow, Clone, JsonSchema)]
+#[derive(PartialEq, Debug, Deserialize, Serialize, FromRow, Clone, JsonSchema)]
 pub struct ReportSectionConfigs(pub Vec<ReportSectionConfig>);
 
-#[derive(Debug, Deserialize, Serialize, Clone, JsonSchema)]
+#[derive(PartialEq, Debug, Deserialize, Serialize, Clone, JsonSchema)]
 #[serde(rename_all = "lowercase", tag = "type")]
 pub struct ReportSectionConfig {
     workflow_step_id: Uuid,
@@ -142,9 +145,6 @@ impl PartialReport {
         if let Some(value) = self.is_public {
             values.push((ReportIden::IsPublic, value.into()));
         }
-        if let Some(value) = &self.summary {
-            values.push((ReportIden::Summary, value.into()));
-        }
         if let Some(value) = &self.section_configs {
             values.push((
                 ReportIden::SectionConfigs,
@@ -155,6 +155,7 @@ impl PartialReport {
     }
 }
 
+#[instrument(err(Debug))]
 pub async fn get_by_id(db: &PgPool, id: &Uuid) -> Result<Report, ComhairleError> {
     let (sql, values) = Query::select()
         .columns(DEFAULT_COLUMNS)
@@ -170,6 +171,7 @@ pub async fn get_by_id(db: &PgPool, id: &Uuid) -> Result<Report, ComhairleError>
     Ok(conversation)
 }
 
+#[instrument(err(Debug))]
 pub async fn update(
     db: &PgPool,
     conversation_id: Uuid,
@@ -193,6 +195,7 @@ pub async fn update(
 pub async fn create_for_conversation(
     db: &PgPool,
     conversation_id: Uuid,
+    locale: &str,
 ) -> Result<Report, ComhairleError> {
     let workflows = workflow::list(db, conversation_id, None).await?;
     let workflow_steps = workflow_step::list(db, &workflows[0].id).await?;
@@ -231,23 +234,33 @@ pub async fn create_for_conversation(
 
     let section_configs = ReportSectionConfigs(section_configs?);
 
-    let values: Vec<sea_query::SimpleExpr> = vec![
+    let mut values: Vec<sea_query::SimpleExpr> = vec![
         false.into(),
         conversation_id.into(),
-        "Summary to be filled out by facilitator".into(),
         serde_json::to_value(&section_configs).unwrap().into(),
     ];
 
+    let mut columns = vec![
+        ReportIden::IsPublic,
+        ReportIden::ConversationId,
+        ReportIden::SectionConfigs,
+    ];
+
+    let summary = new_translation(
+        db,
+        locale,
+        "Summary to be filled out by facilitator",
+        TextFormat::Rich,
+    )
+    .await?;
+
+    columns.push(ReportIden::Summary);
+    values.push(summary.id.into());
+
     let (sql, values) = Query::insert()
         .into_table(ReportIden::Table)
-        .columns(vec![
-            ReportIden::IsPublic,
-            ReportIden::ConversationId,
-            ReportIden::Summary,
-            ReportIden::SectionConfigs,
-        ])
-        .values(values)
-        .unwrap()
+        .columns(columns)
+        .values(values)?
         .returning(Query::returning().columns(DEFAULT_COLUMNS))
         .build_sqlx(PostgresQueryBuilder);
 
@@ -262,6 +275,7 @@ pub async fn create_for_conversation(
     Ok(report)
 }
 
+#[instrument(err(Debug))]
 pub async fn get_for_conversation(
     db: &PgPool,
     conversation_id: &Uuid,
@@ -278,4 +292,51 @@ pub async fn get_for_conversation(
         .resolve_db_err("Report")?;
 
     Ok(report)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::error::Error;
+
+    use sqlx::PgPool;
+
+    use crate::models::model_test_helpers::{
+        get_random_conversation_id, setup_default_app_and_session,
+    };
+    use crate::models::translations::get_text_translation_by_content_and_locale;
+    use crate::routes::workflows::dto::WorkflowDto;
+
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
+    async fn should_create_report_for_conversation_with_translation(
+        pool: PgPool,
+    ) -> Result<(), Box<dyn Error>> {
+        let (app, mut session) = setup_default_app_and_session(&pool).await?;
+        let conversation_id = get_random_conversation_id(&app, &mut session).await?;
+        let (_, value, _) = session
+            .create_random_workflow(&app, &conversation_id.to_string())
+            .await?;
+        let workflow: WorkflowDto = serde_json::from_value(value)?;
+        session
+            .create_random_workflow_steps(
+                &app,
+                &conversation_id.to_string(),
+                &workflow.id.to_string(),
+                2,
+            )
+            .await?;
+
+        let report = create_for_conversation(&pool, conversation_id, "en").await?;
+
+        let summary_translation =
+            get_text_translation_by_content_and_locale(&pool, &report.summary, "en").await?;
+
+        assert_eq!(
+            summary_translation.content, "Summary to be filled out by facilitator",
+            "incorrect summary translation text"
+        );
+
+        Ok(())
+    }
 }

--- a/api/src/routes/invites.rs
+++ b/api/src/routes/invites.rs
@@ -10,7 +10,6 @@ use axum::{
 };
 use axum_extra::extract::CookieJar;
 use hyper::StatusCode;
-use minijinja::context;
 use tracing::{instrument, warn};
 use uuid::Uuid;
 

--- a/api/src/routes/media.rs
+++ b/api/src/routes/media.rs
@@ -263,7 +263,7 @@ mod tests {
             store_name: "comhairle-media-test".to_string(),
             storage_key: format!("images/{random_name}.jpg"),
             filename: format!("{random_name}.jpg"),
-            name: format!("{random_name}"),
+            name: random_name,
             content_type: MediaContentType::Jpeg,
         };
 

--- a/api/src/routes/reports.rs
+++ b/api/src/routes/reports.rs
@@ -6,35 +6,70 @@ use aide::axum::{
 };
 use axum::{
     Json,
-    extract::{Path, State},
+    extract::{Path, Query, State},
 };
 use hyper::StatusCode;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 use tracing::instrument;
 use uuid::Uuid;
 
-use crate::{
-    ComhairleState,
-    error::ComhairleError,
-    models::{
-        self,
-        report::{FullReportDto, PartialReport},
-    },
-    routes::{reports::dto::ReportDto, translations::LocaleExtractor},
-};
+use crate::models;
+use crate::models::report::{FullReportDto, PartialReport, ReportWithTranslations};
+use crate::routes::auth::{OptionalUser, RequiredAdminUser, is_user_admin};
+use crate::routes::reports::dto::{LocalizedReportDto, ReportDto};
+use crate::routes::translations::LocaleExtractor;
+use crate::{ComhairleState, error::ComhairleError};
 
 pub mod dto;
+
+#[derive(Deserialize, Debug, JsonSchema)]
+struct GetReportQuery {
+    #[serde(rename = "withTranslations", default)]
+    with_translations: bool,
+}
+
+#[derive(Serialize, Deserialize, JsonSchema, Debug)]
+#[serde(untagged)]
+pub enum ReportView {
+    WithTranslations(ReportWithTranslations),
+    Localized(LocalizedReportDto),
+}
 
 #[instrument(err(Debug), skip(state))]
 async fn get_report(
     State(state): State<Arc<ComhairleState>>,
     Path(conversation_id): Path<Uuid>,
+    Query(query): Query<GetReportQuery>,
+    OptionalUser(user): OptionalUser,
     LocaleExtractor(locale): LocaleExtractor,
 ) -> Result<(StatusCode, Json<FullReportDto>), ComhairleError> {
-    let report =
-        models::report::get_localized_for_conversation(&state.db, conversation_id, &locale).await?;
-    let report = FullReportDto::from_report(&state.db, report).await?;
+    let should_return_with_translations = if let Some(user) = user {
+        query.with_translations && is_user_admin(&state, &user).await
+    } else {
+        false
+    };
 
-    Ok((StatusCode::OK, Json(report)))
+    if should_return_with_translations {
+        let raw_report = models::report::get_for_conversation(&state.db, conversation_id).await?;
+        let report_with_translations =
+            ReportWithTranslations::from_original(&state.db, raw_report, &locale).await?;
+        let full_report = FullReportDto::from_report(
+            &state.db,
+            ReportView::WithTranslations(report_with_translations),
+        )
+        .await?;
+
+        Ok((StatusCode::OK, Json(full_report)))
+    } else {
+        let report =
+            models::report::get_localized_for_conversation(&state.db, conversation_id, &locale)
+                .await?;
+        let full_report =
+            FullReportDto::from_report(&state.db, ReportView::Localized(report.into())).await?;
+
+        Ok((StatusCode::OK, Json(full_report)))
+    }
 }
 
 #[instrument(err(Debug), skip(state))]
@@ -53,13 +88,21 @@ async fn update_report(
 async fn create_report(
     State(state): State<Arc<ComhairleState>>,
     Path(conversation_id): Path<Uuid>,
+    RequiredAdminUser(_user): RequiredAdminUser,
     LocaleExtractor(locale): LocaleExtractor,
 ) -> Result<(StatusCode, Json<FullReportDto>), ComhairleError> {
     models::report::create_for_conversation(&state.db, conversation_id, &locale).await?;
-    let report =
-        models::report::get_localized_for_conversation(&state.db, conversation_id, &locale).await?;
-    let report = FullReportDto::from_report(&state.db, report).await?;
-    Ok((StatusCode::CREATED, Json(report)))
+    let raw_report = models::report::get_for_conversation(&state.db, conversation_id).await?;
+
+    let report_with_translations =
+        ReportWithTranslations::from_original(&state.db, raw_report, &locale).await?;
+    let full_report = FullReportDto::from_report(
+        &state.db,
+        ReportView::WithTranslations(report_with_translations),
+    )
+    .await?;
+
+    Ok((StatusCode::CREATED, Json(full_report)))
 }
 
 pub fn router(state: Arc<ComhairleState>) -> ApiRouter {

--- a/api/src/routes/reports.rs
+++ b/api/src/routes/reports.rs
@@ -18,7 +18,7 @@ use crate::{
         self,
         report::{FullReportDto, PartialReport},
     },
-    routes::reports::dto::ReportDto,
+    routes::{reports::dto::ReportDto, translations::LocaleExtractor},
 };
 
 pub mod dto;
@@ -46,8 +46,10 @@ async fn update_report(
 async fn create_report(
     State(state): State<Arc<ComhairleState>>,
     Path(conversation_id): Path<Uuid>,
+    LocaleExtractor(locale): LocaleExtractor,
 ) -> Result<(StatusCode, Json<FullReportDto>), ComhairleError> {
-    let report = models::report::create_for_conversation(&state.db, conversation_id).await?;
+    let report =
+        models::report::create_for_conversation(&state.db, conversation_id, &locale).await?;
     let report = FullReportDto::from_report(&state.db, report).await?;
     Ok((StatusCode::CREATED, Json(report)))
 }

--- a/api/src/routes/reports.rs
+++ b/api/src/routes/reports.rs
@@ -9,6 +9,7 @@ use axum::{
     extract::{Path, State},
 };
 use hyper::StatusCode;
+use tracing::instrument;
 use uuid::Uuid;
 
 use crate::{
@@ -23,15 +24,20 @@ use crate::{
 
 pub mod dto;
 
+#[instrument(err(Debug), skip(state))]
 async fn get_report(
     State(state): State<Arc<ComhairleState>>,
     Path(conversation_id): Path<Uuid>,
+    LocaleExtractor(locale): LocaleExtractor,
 ) -> Result<(StatusCode, Json<FullReportDto>), ComhairleError> {
-    let report = models::report::get_for_conversation(&state.db, &conversation_id).await?;
+    let report =
+        models::report::get_localized_for_conversation(&state.db, conversation_id, &locale).await?;
     let report = FullReportDto::from_report(&state.db, report).await?;
+
     Ok((StatusCode::OK, Json(report)))
 }
 
+#[instrument(err(Debug), skip(state))]
 async fn update_report(
     State(state): State<Arc<ComhairleState>>,
     Path(conversation_id): Path<Uuid>,
@@ -43,13 +49,15 @@ async fn update_report(
     Ok((StatusCode::OK, Json(updated_report)))
 }
 
+#[instrument(err(Debug), skip(state))]
 async fn create_report(
     State(state): State<Arc<ComhairleState>>,
     Path(conversation_id): Path<Uuid>,
     LocaleExtractor(locale): LocaleExtractor,
 ) -> Result<(StatusCode, Json<FullReportDto>), ComhairleError> {
+    models::report::create_for_conversation(&state.db, conversation_id, &locale).await?;
     let report =
-        models::report::create_for_conversation(&state.db, conversation_id, &locale).await?;
+        models::report::get_localized_for_conversation(&state.db, conversation_id, &locale).await?;
     let report = FullReportDto::from_report(&state.db, report).await?;
     Ok((StatusCode::CREATED, Json(report)))
 }

--- a/api/src/routes/reports/dto.rs
+++ b/api/src/routes/reports/dto.rs
@@ -17,12 +17,12 @@ use crate::models::translations::TextContentId;
 #[derive(Serialize, Deserialize, JsonSchema, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct ReportDto {
-    id: Uuid,
-    is_public: bool,
-    conversation_id: Uuid,
-    summary: TextContentId,
-    section_configs: ReportSectionConfigs,
-    created_at: DateTime<Utc>,
+    pub id: Uuid,
+    pub is_public: bool,
+    pub conversation_id: Uuid,
+    pub summary: TextContentId,
+    pub section_configs: ReportSectionConfigs,
+    pub created_at: DateTime<Utc>,
 }
 
 impl From<Report> for ReportDto {
@@ -49,12 +49,12 @@ impl From<Report> for ReportDto {
 #[derive(Serialize, Deserialize, JsonSchema, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct LocalizedReportDto {
-    id: Uuid,
-    is_public: bool,
-    conversation_id: Uuid,
-    summary: String,
-    section_configs: ReportSectionConfigs,
-    created_at: DateTime<Utc>,
+    pub id: Uuid,
+    pub is_public: bool,
+    pub conversation_id: Uuid,
+    pub summary: String,
+    pub section_configs: ReportSectionConfigs,
+    pub created_at: DateTime<Utc>,
 }
 
 impl From<LocalizedReport> for LocalizedReportDto {

--- a/api/src/routes/reports/dto.rs
+++ b/api/src/routes/reports/dto.rs
@@ -3,7 +3,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::models::report::{Report, ReportSectionConfigs};
+use crate::models::report::{LocalizedReport, Report, ReportSectionConfigs};
 use crate::models::translations::TextContentId;
 
 /// Data transfer object (public API representation) for a Report.
@@ -27,6 +27,38 @@ pub struct ReportDto {
 
 impl From<Report> for ReportDto {
     fn from(r: Report) -> Self {
+        Self {
+            id: r.id,
+            is_public: r.is_public,
+            conversation_id: r.conversation_id,
+            summary: r.summary,
+            section_configs: r.section_configs,
+            created_at: r.created_at,
+        }
+    }
+}
+
+/// Data transfer object (public API representation) for a Report.
+///
+/// This DTO is returned by report related endpoints and is safe to expose
+/// to clients. It intentionally omits fields such as:
+///
+/// * `updated_at`
+///
+/// Serialized to JSON using camelCase field names for frontend (JavaScript) compatibility.
+#[derive(Serialize, Deserialize, JsonSchema, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct LocalizedReportDto {
+    id: Uuid,
+    is_public: bool,
+    conversation_id: Uuid,
+    summary: String,
+    section_configs: ReportSectionConfigs,
+    created_at: DateTime<Utc>,
+}
+
+impl From<LocalizedReport> for LocalizedReportDto {
+    fn from(r: LocalizedReport) -> Self {
         Self {
             id: r.id,
             is_public: r.is_public,

--- a/api/src/routes/reports/dto.rs
+++ b/api/src/routes/reports/dto.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::models::report::{Report, ReportSectionConfigs};
+use crate::models::translations::TextContentId;
 
 /// Data transfer object (public API representation) for a Report.
 ///
@@ -19,7 +20,7 @@ pub struct ReportDto {
     id: Uuid,
     is_public: bool,
     conversation_id: Uuid,
-    summary: String,
+    summary: TextContentId,
     section_configs: ReportSectionConfigs,
     created_at: DateTime<Utc>,
 }

--- a/api/src/tools.rs
+++ b/api/src/tools.rs
@@ -276,7 +276,7 @@ pub fn router(state: Arc<ComhairleState>) -> ApiRouter {
         .merge(thinking_space::ThinkingSpaceTool::routes(&state))
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone, JsonSchema)]
+#[derive(PartialEq, Debug, Deserialize, Serialize, Clone, JsonSchema)]
 pub enum ReportConfig {
     Polis(PolisReport),
     HeyForm(HeyFormReport),

--- a/api/src/tools/elicitation_bot.rs
+++ b/api/src/tools/elicitation_bot.rs
@@ -49,7 +49,7 @@ pub struct ElicitationBotToolSetup {
     pub topic: String,
 }
 
-#[derive(Clone, Deserialize, Serialize, Debug, JsonSchema)]
+#[derive(PartialEq, Clone, Deserialize, Serialize, Debug, JsonSchema)]
 pub struct ElicitationBotReport;
 
 async fn elicitation_bot_setup(

--- a/api/src/tools/heyform.rs
+++ b/api/src/tools/heyform.rs
@@ -50,7 +50,7 @@ pub struct HeyFormToolSetup {
     pub server_url: String,
 }
 
-#[derive(Clone, Deserialize, Serialize, Debug, JsonSchema)]
+#[derive(PartialEq, Clone, Deserialize, Serialize, Debug, JsonSchema)]
 pub struct HeyFormReport;
 
 fn generate_password() -> String {

--- a/api/src/tools/learn.rs
+++ b/api/src/tools/learn.rs
@@ -54,7 +54,7 @@ impl ToolConfigSanitize for LearnToolConfig {
     }
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug, JsonSchema)]
+#[derive(PartialEq, Clone, Serialize, Deserialize, Debug, JsonSchema)]
 pub struct LearnReport;
 
 #[derive(Clone, Deserialize, Serialize, Debug, JsonSchema)]

--- a/api/src/tools/polis.rs
+++ b/api/src/tools/polis.rs
@@ -92,7 +92,7 @@ pub struct PolisToolSetup {
     pub show_remaining_statements: bool,
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug, JsonSchema)]
+#[derive(PartialEq, Clone, Serialize, Deserialize, Debug, JsonSchema)]
 pub struct PolisReport;
 
 /// Zero-sized marker type for Polis tool implementation

--- a/api/src/tools/prioritization.rs
+++ b/api/src/tools/prioritization.rs
@@ -123,7 +123,7 @@ pub struct PrioritizationToolSetup {
     pub randomize_order: bool,
 }
 
-#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
+#[derive(PartialEq, Serialize, Deserialize, Debug, JsonSchema, Clone)]
 pub struct PrioritizationReport;
 
 pub struct PrioritizationTool;

--- a/api/src/tools/stories.rs
+++ b/api/src/tools/stories.rs
@@ -24,7 +24,7 @@ pub struct StoriesToolConfig {
     pub to_see: i32,
 }
 
-#[derive(Debug, Default, JsonSchema, Serialize, Deserialize, Clone)]
+#[derive(PartialEq, Debug, Default, JsonSchema, Serialize, Deserialize, Clone)]
 pub struct StoriesReport;
 
 #[derive(Debug, Default, JsonSchema, Serialize, Deserialize, Clone)]

--- a/api/src/tools/thinking_space.rs
+++ b/api/src/tools/thinking_space.rs
@@ -91,7 +91,7 @@ pub struct ThinkingSpaceToolSetup {
     pub follow_up_rounds_count: u8,
 }
 
-#[derive(Clone, Deserialize, Serialize, Debug, JsonSchema)]
+#[derive(PartialEq, Clone, Deserialize, Serialize, Debug, JsonSchema)]
 pub struct ThinkingSpaceReport;
 
 /// Zero-sized marker type for ThinkingSpace tool implementation

--- a/ui/packages/api-client/src/api.ts
+++ b/ui/packages/api-client/src/api.ts
@@ -1537,26 +1537,6 @@ export const DailyResponseStats = z
   })
   .passthrough();
 export type DailyResponseStats = z.infer<typeof DailyResponseStats>;
-export const FeedbackDto = z
-  .object({
-    content: z.string(),
-    conversationId: z.string().uuid(),
-    id: z.string().uuid(),
-  })
-  .passthrough();
-export type FeedbackDto = z.infer<typeof FeedbackDto>;
-export const ReportImpactDto = z
-  .object({
-    createdAt: z.string().datetime({ offset: true }),
-    createdBy: z.string().uuid(),
-    details: z.string(),
-    id: z.string().uuid(),
-    kind: z.string(),
-    reportId: z.string().uuid(),
-    title: z.string(),
-  })
-  .passthrough();
-export type ReportImpactDto = z.infer<typeof ReportImpactDto>;
 export const PolisReport = z.null();
 export type PolisReport = z.infer<typeof PolisReport>;
 export const HeyFormReport = z.null();
@@ -1592,19 +1572,45 @@ export const ReportSectionConfig = z
 export type ReportSectionConfig = z.infer<typeof ReportSectionConfig>;
 export const ReportSectionConfigs = z.array(ReportSectionConfig);
 export type ReportSectionConfigs = z.infer<typeof ReportSectionConfigs>;
-export const FullReportDto = z
+export const Translation5 = z
+  .object({
+    textContent: TextContentDto,
+    textTranslations: z.array(TextTranslationDto),
+  })
+  .passthrough();
+export type Translation5 = z.infer<typeof Translation5>;
+export const ReportTranslations = z
+  .object({ summary: Translation5 })
+  .passthrough();
+export type ReportTranslations = z.infer<typeof ReportTranslations>;
+export const ReportWithTranslations = z
   .object({
     conversationId: z.string().uuid(),
     createdAt: z.string().datetime({ offset: true }),
-    facilitatorFeedback: z.array(FeedbackDto),
     id: z.string().uuid(),
-    impacts: z.array(ReportImpactDto),
     isPublic: z.boolean(),
-    participantFeedback: z.array(FeedbackDto),
+    sectionConfigs: ReportSectionConfigs,
+    summary: z.string(),
+    translations: ReportTranslations,
+    updatedAt: z.string().datetime({ offset: true }),
+  })
+  .passthrough();
+export type ReportWithTranslations = z.infer<typeof ReportWithTranslations>;
+export const LocalizedReportDto = z
+  .object({
+    conversationId: z.string().uuid(),
+    createdAt: z.string().datetime({ offset: true }),
+    id: z.string().uuid(),
+    isPublic: z.boolean(),
     sectionConfigs: ReportSectionConfigs,
     summary: z.string(),
   })
   .passthrough();
+export type LocalizedReportDto = z.infer<typeof LocalizedReportDto>;
+export const FullReportDto = z.union([
+  ReportWithTranslations,
+  LocalizedReportDto,
+]);
 export type FullReportDto = z.infer<typeof FullReportDto>;
 export const PartialReport = z
   .object({
@@ -1626,6 +1632,18 @@ export const ReportDto = z
   })
   .passthrough();
 export type ReportDto = z.infer<typeof ReportDto>;
+export const ReportImpactDto = z
+  .object({
+    createdAt: z.string().datetime({ offset: true }),
+    createdBy: z.string().uuid(),
+    details: z.string(),
+    id: z.string().uuid(),
+    kind: z.string(),
+    reportId: z.string().uuid(),
+    title: z.string(),
+  })
+  .passthrough();
+export type ReportImpactDto = z.infer<typeof ReportImpactDto>;
 export const PartialReportImpact = z
   .object({
     created_at: z.union([z.string(), z.null()]),
@@ -1644,6 +1662,14 @@ export const CreateImpactDTO = z
   .object({ details: z.string(), kind: z.string(), title: z.string() })
   .passthrough();
 export type CreateImpactDTO = z.infer<typeof CreateImpactDTO>;
+export const FeedbackDto = z
+  .object({
+    content: z.string(),
+    conversationId: z.string().uuid(),
+    id: z.string().uuid(),
+  })
+  .passthrough();
+export type FeedbackDto = z.infer<typeof FeedbackDto>;
 export const CreateFeedbackDTO = z
   .object({ content: z.string() })
   .passthrough();
@@ -1796,15 +1822,15 @@ export const EventDto = z
   })
   .passthrough();
 export type EventDto = z.infer<typeof EventDto>;
-export const Translation5 = z
+export const Translation6 = z
   .object({
     textContent: TextContentDto,
     textTranslations: z.array(TextTranslationDto),
   })
   .passthrough();
-export type Translation5 = z.infer<typeof Translation5>;
+export type Translation6 = z.infer<typeof Translation6>;
 export const EventTranslations = z
-  .object({ description: Translation5, name: Translation5 })
+  .object({ description: Translation6, name: Translation6 })
   .passthrough();
 export type EventTranslations = z.infer<typeof EventTranslations>;
 export const EventWithTranslations = z
@@ -2479,8 +2505,6 @@ export const schemas: Record<string, z.ZodType<any>> = {
   CreateInviteDTO,
   PartialInvite,
   DailyResponseStats,
-  FeedbackDto,
-  ReportImpactDto,
   PolisReport,
   HeyFormReport,
   LearnReport,
@@ -2491,11 +2515,17 @@ export const schemas: Record<string, z.ZodType<any>> = {
   ReportConfig,
   ReportSectionConfig,
   ReportSectionConfigs,
+  Translation5,
+  ReportTranslations,
+  ReportWithTranslations,
+  LocalizedReportDto,
   FullReportDto,
   PartialReport,
   ReportDto,
+  ReportImpactDto,
   PartialReportImpact,
   CreateImpactDTO,
+  FeedbackDto,
   CreateFeedbackDTO,
   PartialFeedback,
   ComhairleChatSession,
@@ -2518,7 +2548,7 @@ export const schemas: Record<string, z.ZodType<any>> = {
   PaginatedResults_for_LocalizedEventDto,
   CreateEvent,
   EventDto,
-  Translation5,
+  Translation6,
   EventTranslations,
   EventWithTranslations,
   EventResponse,
@@ -3625,6 +3655,13 @@ Use query param withUserProgress&#x3D;true to get the active user&#x27;s progres
     path: "/conversation/:conversation_id/report",
     alias: "GetReportForConversation",
     requestFormat: "json",
+    parameters: [
+      {
+        name: "withTranslations",
+        type: "Query",
+        schema: z.boolean().optional().default(false),
+      },
+    ],
     response: FullReportDto,
   },
   {

--- a/ui/packages/api-client/src/api.ts
+++ b/ui/packages/api-client/src/api.ts
@@ -1602,7 +1602,7 @@ export const FullReportDto = z
     isPublic: z.boolean(),
     participantFeedback: z.array(FeedbackDto),
     sectionConfigs: ReportSectionConfigs,
-    summary: z.string().uuid(),
+    summary: z.string(),
   })
   .passthrough();
 export type FullReportDto = z.infer<typeof FullReportDto>;

--- a/ui/packages/api-client/src/api.ts
+++ b/ui/packages/api-client/src/api.ts
@@ -1602,7 +1602,7 @@ export const FullReportDto = z
     isPublic: z.boolean(),
     participantFeedback: z.array(FeedbackDto),
     sectionConfigs: ReportSectionConfigs,
-    summary: z.string(),
+    summary: z.string().uuid(),
   })
   .passthrough();
 export type FullReportDto = z.infer<typeof FullReportDto>;
@@ -1611,7 +1611,6 @@ export const PartialReport = z
     conversation_id: z.union([z.string(), z.null()]),
     is_public: z.union([z.boolean(), z.null()]),
     section_configs: z.union([ReportSectionConfigs, z.null()]),
-    summary: z.union([z.string(), z.null()]),
   })
   .partial()
   .passthrough();
@@ -1623,7 +1622,7 @@ export const ReportDto = z
     id: z.string().uuid(),
     isPublic: z.boolean(),
     sectionConfigs: ReportSectionConfigs,
-    summary: z.string(),
+    summary: z.string().uuid(),
   })
   .passthrough();
 export type ReportDto = z.infer<typeof ReportDto>;

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/report/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/report/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import TranslatableField from '$lib/components/Translation/TranslatableField.svelte';
 	import Button from '$lib/components/ui/button/button.svelte';
 	import PageHeader from '$lib/components/PageHeader.svelte';
 	import { buttonVariants } from '$lib/components/ui/button/index.js';
@@ -18,17 +19,14 @@
 	import Delete from 'lucide-svelte/icons/delete';
 	import { Separator } from '$lib/components/ui/separator';
 	import { report_url } from '$lib/urls.js';
-	import { MarkdownEditor } from 'carta-md';
-	import { createCarta } from '$lib/utils/carta';
 	import 'carta-md/default.css';
 	import '@cartamd/plugin-slash/default.css';
 	import 'carta-plugin-video/default.css';
+	import { createTextContentSource } from '$lib/components/Translation/translationSource.svelte.js';
 
 	let { data } = $props();
 	let report = $derived(data.report);
 	let conversation = $derived(data.conversation);
-
-	const carta = createCarta();
 
 	let newImpact = $state({
 		title: '',
@@ -44,14 +42,11 @@
 	let impactOpen = $state(false);
 	let feedbackOpen = $state(false);
 
-	let localSummary = $state(report.summary);
-
-	async function saveSummary() {
-		await apiClient.UpdateReport(
-			{ summary: localSummary },
-			{ params: { conversation_id: conversation.id } }
-		);
-	}
+	const summaryTranslationSource = createTextContentSource({
+		getTranslation: () => report.translations.summary,
+		getPrimaryLocale: () => conversation.primaryLocale,
+		getSupportedLanguages: () => conversation.supportedLanguages
+	});
 
 	async function createFeedback() {}
 
@@ -88,9 +83,16 @@
 			<Card.Description>Overall summary of the conversation</Card.Description>
 		</Card.Header>
 		<Card.Content>
-			<MarkdownEditor {carta} bind:value={localSummary} />
+			<TranslatableField
+				source={summaryTranslationSource}
+				primaryLocale={conversation.primaryLocale}
+				supportedLanguages={conversation.supportedLanguages}
+				inputType="textarea"
+				placeholder="Summary to be filled out by the facilitator"
+				editorType="rich"
+				minHeight="100px"
+			/>
 		</Card.Content>
-		<Button variant="secondary" onclick={saveSummary}>Save</Button>
 	</Card.Root>
 
 	<Card.Root>

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/report/+page.ts
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/report/+page.ts
@@ -7,7 +7,8 @@ export const load: PageLoad = async ({ parent }) => {
 
 	try {
 		report = await api.GetReportForConversation({
-			params: { conversation_id: conversation.id }
+			params: { conversation_id: conversation.id },
+			queries: { withTranslations: true }
 		});
 	} catch (e) {
 		report = await api.GenerateReportForConversation(undefined, {


### PR DESCRIPTION
Actions:

- migration to convert report summary to translatable field
- model and endpoint updates to return report with translations or localised report depending on circumstances
- replace markdown editor in admin with translatable rich text editor

Motivation:

- allow report summary to be translatable