### PR TITLE
Fix proposal translations not saving + tidy up the editor dialogs

### DIFF
--- a/ui/packages/comhairle/src/lib/components/RichTextEditor/RichTextEditor.svelte
+++ b/ui/packages/comhairle/src/lib/components/RichTextEditor/RichTextEditor.svelte
@@ -110,7 +110,15 @@
 			onTransaction: () => {
 				if (editor && !isInitializing) {
 					updateActiveStates();
-
+				}
+			},
+			// Emit changes from onUpdate, not onTransaction: tiptap fires `transaction` on every
+			// transaction (including our programmatic setContent with emitUpdate:false in the value-sync
+			// effect below), but `update` respects emitUpdate:false. Emitting from onTransaction echoed
+			// server content back as a fake user edit, spawning spurious debounced saves that raced with
+			// approve and could blank the field.
+			onUpdate: () => {
+				if (editor && !isInitializing) {
 					const newValue = JSON.stringify(editor.getJSON());
 					previousValue = newValue;
 					onChange?.(newValue);

--- a/ui/packages/comhairle/src/lib/components/Translation/TranslatableField.svelte
+++ b/ui/packages/comhairle/src/lib/components/Translation/TranslatableField.svelte
@@ -187,7 +187,7 @@
 {#if hasTranslations}
 	<Dialog.Root open={dialogOpen}>
 		<Dialog.Content
-			class="max-h-[90vh] min-w-[70vw] grid-rows-[auto_1fr] rounded-xl p-12 pt-5"
+			class="h-[90vh] min-w-[80vw] grid-rows-[auto_1fr] rounded-xl p-12 pt-5"
 			showCloseButton={false}
 			onInteractOutside={(e) => {
 				e.preventDefault();

--- a/ui/packages/comhairle/src/lib/components/Translation/translationSource.svelte.ts
+++ b/ui/packages/comhairle/src/lib/components/Translation/translationSource.svelte.ts
@@ -37,6 +37,14 @@ type TextContentSourceOptions = {
 	 * source still owns the content (see ADR-0005).
 	 */
 	onEdit?: (content: string) => void;
+	/**
+	 * How to re-fetch server truth after a write, so the optimistic overlay reconciles against fresh
+	 * data. Defaults to SvelteKit's `invalidateAll` (correct for consumers whose `getTranslation()`
+	 * reads route `data`). Tools with a self-managed store (e.g. prioritization) must pass their own
+	 * refresh here; otherwise `invalidateAll()` is a no-op for their list and edits reconcile against
+	 * stale data, i.e. saved content visibly reverts.
+	 */
+	refresh?: () => Promise<void>;
 };
 
 /**
@@ -60,6 +68,8 @@ export function createTextContentSource(options: TextContentSourceOptions): Tran
 		ensureTextContentId,
 		onEdit
 	} = options;
+
+	const refresh = options.refresh ?? invalidateAll;
 
 	const textContentId = () => getTranslation()?.textContent?.id;
 	const otherLanguages = () => getSupportedLanguages().filter((l) => l !== getPrimaryLocale());
@@ -178,7 +188,7 @@ export function createTextContentSource(options: TextContentSourceOptions): Tran
 			if (approved.length > 0)
 				await markOtherTranslationsAsDraft(id, primaryLocale, approved);
 		}
-		await invalidateAll();
+		await refresh();
 		reconcileOverlay(locale, content);
 	}
 
@@ -229,7 +239,7 @@ export function createTextContentSource(options: TextContentSourceOptions): Tran
 				// aiTranslateApi persists the generated translation against this text content id.
 				result = await aiTranslateApi(id, locale, sourceContent, getPrimaryLocale());
 				overlay = { ...overlay, [locale]: result.content };
-				await invalidateAll();
+				await refresh();
 				reconcileOverlay(locale, result.content);
 			});
 			return result!;

--- a/ui/packages/comhairle/src/lib/tools/prioritization/PrioritizationManage.svelte
+++ b/ui/packages/comhairle/src/lib/tools/prioritization/PrioritizationManage.svelte
@@ -435,7 +435,9 @@
 			/>
 		</div>
 
-		{#if store.state === 'loading'}
+		{#if store.state === 'idle' || store.state === 'loading'}
+			<!-- Skeleton on first paint too (idle = before the initial fetch fires), so the empty
+				 state never flashes before we know whether there are proposals. -->
 			<ProposalListSkeleton />
 		{:else if store.state === 'error'}
 			<p class="text-destructive text-sm">Could not load proposals: {store.error}</p>

--- a/ui/packages/comhairle/src/lib/tools/prioritization/PrioritizationManage.svelte
+++ b/ui/packages/comhairle/src/lib/tools/prioritization/PrioritizationManage.svelte
@@ -10,6 +10,7 @@
 	import { createStore } from './store.svelte';
 	import { resolveToolConfig } from './prioritizationApi';
 	import ProposalEditorDialog from './components/ProposalEditorDialog.svelte';
+	import ProposalListSkeleton from './components/ProposalListSkeleton.svelte';
 	import QuestionEditorDialog from './components/QuestionEditorDialog.svelte';
 	import type {
 		ConversationInput,
@@ -435,9 +436,7 @@
 		</div>
 
 		{#if store.state === 'loading'}
-			<div class="text-muted-foreground flex items-center gap-2 text-sm">
-				<LoaderCircle class="h-4 w-4 animate-spin" /> Loading proposals…
-			</div>
+			<ProposalListSkeleton />
 		{:else if store.state === 'error'}
 			<p class="text-destructive text-sm">Could not load proposals: {store.error}</p>
 		{:else if store.proposals.length === 0}
@@ -500,7 +499,9 @@
 		editorOpen = o;
 		if (!o) {
 			selectedProposal = null;
-			void store.refresh();
+			// Silent reconcile: the dialog already flushed + reloaded on close, so a full refresh
+			// would only flip the list to its loading state, tearing it down and jumping scroll to top.
+			void store.reload();
 		}
 	}}
 />
@@ -598,7 +599,9 @@
 			</AlertDialog.Description>
 		</AlertDialog.Header>
 		<AlertDialog.Footer>
-			<AlertDialog.Cancel disabled={deletingSectionQuestionInFlight}>Cancel</AlertDialog.Cancel>
+			<AlertDialog.Cancel disabled={deletingSectionQuestionInFlight}
+				>Cancel</AlertDialog.Cancel
+			>
 			<AlertDialog.Action
 				disabled={deletingSectionQuestionInFlight}
 				onclick={runDeleteSectionQuestion}

--- a/ui/packages/comhairle/src/lib/tools/prioritization/components/ProposalEditorDialog.svelte
+++ b/ui/packages/comhairle/src/lib/tools/prioritization/components/ProposalEditorDialog.svelte
@@ -1,13 +1,12 @@
 <script lang="ts">
 	import * as Dialog from '$lib/components/ui/dialog';
 	import { Button } from '$lib/components/ui/button';
-	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';
-	import RichTextEditor from '$lib/components/RichTextEditor/RichTextEditor.svelte';
 	import TranslatableField from '$lib/components/Translation/TranslatableField.svelte';
 	import { createTextContentSource } from '$lib/components/Translation/translationSource.svelte';
+	import type { TranslationSource } from '$lib/components/Translation/translationUtils';
 	import ProposalSectionField from './ProposalSectionField.svelte';
-	import { getLanguageName } from '$lib/config/languages';
+	import { isTiptapJson, extractTextFromTiptap } from '$lib/utils/tiptapUtils';
 	import { LoaderCircle, Plus, Trash2 } from 'lucide-svelte';
 	import type { PrioritizationStore } from '../store.svelte';
 	import type { Proposal } from '../types';
@@ -30,73 +29,77 @@
 		onOpenChange
 	}: Props = $props();
 
-	const isEditing = $derived(!!proposal);
-
-	/** In edit mode the list refreshes after section add/delete, producing a new
-	 * proposal object. Track the latest version from the store so the editor
-	 * always renders the current set of sections. */
-	const liveProposal = $derived(
-		proposal ? (store.proposals.find((p) => p.id === proposal.id) ?? proposal) : null
-	);
-
-	/** CREATE-mode local state — primary locale only. Once created, the list refreshes and the new proposal can be reopened in EDIT mode to author non-primary languages via TranslatableField. Draft sections carry a stable client id so the rich-text editors keep their identity when a section is removed. */
-	let draftTitle = $state('');
-	let draftSeq = 0;
-	let draftSections = $state<{ id: number; body: string }[]>([{ id: 0, body: '' }]);
-	let creating = $state(false);
 	let errorMessage = $state<string | null>(null);
 
+	/** Persist-first create: opening "New proposal" immediately creates an empty draft server-side so
+	 * the same edit UI (with translation badges) can back it. An untouched draft is cleaned up on close;
+	 * an explicit Cancel discards it. `draftId` is only set when we created the draft ourselves. */
+	let draftId = $state<string | null>(null);
+	let preparing = $state(false);
+	let closing = $state(false);
+
+	/** In edit mode the list refreshes after section add/delete, producing a new proposal object; in
+	 * create mode we track the draft we just made. Either way, read the latest version from the store
+	 * so the editor always renders the current set of sections. */
+	const liveProposal = $derived.by((): Proposal | null => {
+		if (proposal) return store.proposals.find((p) => p.id === proposal.id) ?? proposal;
+		if (draftId) return store.proposals.find((p) => p.id === draftId) ?? null;
+		return null;
+	});
+
+	const isEditing = $derived(!!proposal);
+
+	// Kick off (or reset) the draft as the dialog opens/closes in create mode.
 	$effect(() => {
-		if (open && !proposal) {
-			draftTitle = '';
-			draftSeq = 1;
-			draftSections = [{ id: 0, body: '' }];
+		if (open && !proposal && draftId === null && !preparing) {
+			void startDraft();
+		}
+		if (!open) {
+			draftId = null;
 			errorMessage = null;
 		}
 	});
 
-	function addDraftSection() {
-		draftSections = [...draftSections, { id: draftSeq++, body: '' }];
-	}
-
-	function removeDraftSection(id: number) {
-		draftSections = draftSections.filter((s) => s.id !== id);
-	}
-
-	async function createNew() {
-		const sections = draftSections.map((s) => s.body.trim()).filter((s) => s.length > 0);
-		if (!draftTitle.trim() || sections.length === 0) {
-			errorMessage = 'A title and at least one section are required.';
-			return;
-		}
-		creating = true;
+	async function startDraft() {
+		preparing = true;
 		errorMessage = null;
 		try {
-			await store.create({ title: draftTitle.trim(), sections });
-			onOpenChange(false);
+			const created = await store.create({ title: '', sections: [''] });
+			// If the dialog was closed while we were creating, don't leave an orphan draft.
+			if (!open) {
+				await store.remove(created.id).catch(() => {});
+				return;
+			}
+			draftId = created.id;
 		} catch (e) {
-			errorMessage = e instanceof Error ? e.message : 'Failed to create proposal.';
+			errorMessage = e instanceof Error ? e.message : 'Failed to start a new proposal.';
 		} finally {
-			creating = false;
+			preparing = false;
 		}
 	}
 
-	// EDIT-mode title source. Sections each own their source via ProposalSectionField (ADR-0005); the
-	// old `titleValue` / `sectionValues` mirrors are gone (the source's optimistic overlay gives the
-	// responsiveness they were chasing).
+	// Title owns its own source (ADR-0005); sections own theirs via ProposalSectionField. Every source
+	// is registered here so the dialog can flush pending debounced saves before it closes. `refresh`
+	// points at the store's silent reload: the prioritization list is self-managed, so `invalidateAll`
+	// alone would leave saves reconciling against stale data (see store.reload / translationSource).
+	const sources = new Map<string, TranslationSource>();
+
+	function registerSource(id: string, source: TranslationSource) {
+		sources.set(id, source);
+	}
+	function unregisterSource(id: string) {
+		sources.delete(id);
+	}
+
 	const titleSource = createTextContentSource({
 		getTranslation: () => liveProposal?.titleTranslations,
 		getPrimaryLocale: () => primaryLocale,
-		getSupportedLanguages: () => supportedLocales
+		getSupportedLanguages: () => supportedLocales,
+		refresh: () => store.reload()
 	});
+	registerSource('__title__', titleSource);
 
 	let addingSection = $state(false);
-
-	$effect(() => {
-		if (open && liveProposal) {
-			errorMessage = null;
-		}
-	});
 
 	async function addSection() {
 		if (!liveProposal) return;
@@ -120,22 +123,67 @@
 			errorMessage = e instanceof Error ? e.message : 'Failed to delete section.';
 		}
 	}
+
+	function isBlank(content: string | undefined): boolean {
+		if (!content) return true;
+		const text = isTiptapJson(content) ? extractTextFromTiptap(content) : content;
+		return text.trim().length === 0;
+	}
+
+	function isProposalEmpty(p: Proposal): boolean {
+		return isBlank(p.title) && p.sections.every((s) => isBlank(s.body));
+	}
+
+	async function flushAll() {
+		await Promise.allSettled([...sources.values()].map((s) => s.flush()));
+	}
+
+	/** Commit pending edits, then close. A self-created draft is deleted when discarded outright or
+	 * left completely empty; a real (edited) proposal is always kept. */
+	async function finalizeAndClose(opts: { discard?: boolean } = {}) {
+		if (closing) return;
+		closing = true;
+		try {
+			await flushAll();
+			if (draftId && !proposal) {
+				const current = store.proposals.find((p) => p.id === draftId);
+				const shouldDelete = opts.discard || (current ? isProposalEmpty(current) : true);
+				if (shouldDelete) {
+					await store.remove(draftId).catch(() => {});
+				}
+			}
+			draftId = null;
+			onOpenChange(false);
+		} finally {
+			closing = false;
+		}
+	}
 </script>
 
-<Dialog.Root {open} onOpenChange={(o) => onOpenChange(o)}>
+<Dialog.Root
+	{open}
+	onOpenChange={(o) => {
+		if (!o) void finalizeAndClose();
+		else onOpenChange(true);
+	}}
+>
 	<Dialog.Content class="max-h-[90vh] min-w-[70vw] overflow-y-auto">
 		<Dialog.Header>
 			<Dialog.Title>
 				{isEditing ? 'Edit proposal' : 'New proposal'}
 			</Dialog.Title>
 			<Dialog.Description>
-				{isEditing
-					? 'Edit the title and sections. Use the language badges to translate into other supported languages.'
-					: `Write the proposal in ${getLanguageName(primaryLocale)}. You can add translations after creating it.`}
+				Edit the title and sections. Use the language badges to translate into other
+				supported languages.
 			</Dialog.Description>
 		</Dialog.Header>
 
-		{#if isEditing && liveProposal}
+		{#if preparing && !liveProposal}
+			<div class="text-muted-foreground flex items-center gap-2 py-10">
+				<LoaderCircle class="h-4 w-4 animate-spin" />
+				Preparing the proposal...
+			</div>
+		{:else if liveProposal}
 			<div class="space-y-5 py-2">
 				<div class="space-y-2">
 					<Label>Title</Label>
@@ -163,7 +211,14 @@
 								<Trash2 class="mr-2 h-3.5 w-3.5" /> Remove
 							</Button>
 						</div>
-						<ProposalSectionField {section} {primaryLocale} {supportedLocales} />
+						<ProposalSectionField
+							{section}
+							{primaryLocale}
+							{supportedLocales}
+							refresh={() => store.reload()}
+							{registerSource}
+							{unregisterSource}
+						/>
 					</div>
 				{/each}
 
@@ -174,38 +229,6 @@
 					Add section
 				</Button>
 			</div>
-		{:else}
-			<div class="space-y-5 py-2">
-				<div class="space-y-2">
-					<Label for="create-title">Title</Label>
-					<Input id="create-title" bind:value={draftTitle} placeholder="Proposal title" />
-				</div>
-				{#each draftSections as section, i (section.id)}
-					<div class="space-y-2">
-						<div class="flex items-center justify-between">
-							<Label>Section {i + 1}</Label>
-							<Button
-								variant="ghost"
-								size="sm"
-								class="text-destructive hover:text-destructive"
-								disabled={draftSections.length <= 1}
-								onclick={() => removeDraftSection(section.id)}
-							>
-								<Trash2 class="mr-2 h-3.5 w-3.5" /> Remove
-							</Button>
-						</div>
-						<RichTextEditor
-							value={section.body}
-							placeholder="Describe this section"
-							minHeight="160px"
-							onChange={(v) => (section.body = v)}
-						/>
-					</div>
-				{/each}
-				<Button variant="outline" size="sm" onclick={addDraftSection}>
-					<Plus class="mr-2 h-4 w-4" /> Add section
-				</Button>
-			</div>
 		{/if}
 
 		{#if errorMessage}
@@ -214,14 +237,21 @@
 
 		<Dialog.Footer>
 			{#if isEditing}
-				<Button onclick={() => onOpenChange(false)}>Done</Button>
+				<Button onclick={() => finalizeAndClose()} disabled={closing}>
+					{#if closing}<LoaderCircle class="mr-2 h-4 w-4 animate-spin" />{/if}
+					Done
+				</Button>
 			{:else}
-				<Button variant="outline" onclick={() => onOpenChange(false)} disabled={creating}>
+				<Button
+					variant="outline"
+					onclick={() => finalizeAndClose({ discard: true })}
+					disabled={closing || preparing}
+				>
 					Cancel
 				</Button>
-				<Button onclick={createNew} disabled={creating}>
-					{#if creating}<LoaderCircle class="mr-2 h-4 w-4 animate-spin" />{/if}
-					Create proposal
+				<Button onclick={() => finalizeAndClose()} disabled={closing || preparing}>
+					{#if closing}<LoaderCircle class="mr-2 h-4 w-4 animate-spin" />{/if}
+					Done
 				</Button>
 			{/if}
 		</Dialog.Footer>

--- a/ui/packages/comhairle/src/lib/tools/prioritization/components/ProposalEditorDialog.svelte
+++ b/ui/packages/comhairle/src/lib/tools/prioritization/components/ProposalEditorDialog.svelte
@@ -4,7 +4,11 @@
 	import { Label } from '$lib/components/ui/label';
 	import TranslatableField from '$lib/components/Translation/TranslatableField.svelte';
 	import { createTextContentSource } from '$lib/components/Translation/translationSource.svelte';
-	import type { TranslationSource } from '$lib/components/Translation/translationUtils';
+	import {
+		hasUnsavedChanges,
+		type TranslationSource
+	} from '$lib/components/Translation/translationUtils';
+	import { guardUnsavedChanges } from '$lib/utils/unsavedChangesGuard.svelte';
 	import ProposalSectionField from './ProposalSectionField.svelte';
 	import { isTiptapJson, extractTextFromTiptap } from '$lib/utils/tiptapUtils';
 	import { LoaderCircle, Plus, Trash2 } from 'lucide-svelte';
@@ -98,6 +102,11 @@
 		refresh: () => store.reload()
 	});
 	registerSource('__title__', titleSource);
+
+	// Warn on refresh / tab-close / in-app navigation while any title or section save is still pending,
+	// so a mid-debounce edit isn't silently lost. The dialog is a persistent instance, so this registers
+	// once; the getter reads the live source set at event time.
+	guardUnsavedChanges(() => [...sources.values()].some(hasUnsavedChanges));
 
 	let addingSection = $state(false);
 

--- a/ui/packages/comhairle/src/lib/tools/prioritization/components/ProposalEditorDialog.svelte
+++ b/ui/packages/comhairle/src/lib/tools/prioritization/components/ProposalEditorDialog.svelte
@@ -176,7 +176,7 @@
 		else onOpenChange(true);
 	}}
 >
-	<Dialog.Content class="max-h-[90vh] min-w-[70vw] overflow-y-auto">
+	<Dialog.Content class="h-[90vh] min-w-[80vw] overflow-y-auto">
 		<Dialog.Header>
 			<Dialog.Title>
 				{isEditing ? 'Edit proposal' : 'New proposal'}

--- a/ui/packages/comhairle/src/lib/tools/prioritization/components/ProposalListSkeleton.svelte
+++ b/ui/packages/comhairle/src/lib/tools/prioritization/components/ProposalListSkeleton.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+	import * as Card from '$lib/components/ui/card';
+	import { Skeleton } from '$lib/components/ui/skeleton';
+
+	type Props = {
+		/** How many placeholder proposal cards to render. */
+		count?: number;
+	};
+
+	let { count = 3 }: Props = $props();
+</script>
+
+<!-- Loading placeholder for the proposals list. Mirrors the real card (title, a
+	 couple of section lines, Edit/Delete actions) so the list doesn't shift when
+	 the proposals arrive. -->
+<ul class="space-y-3" aria-hidden="true">
+	{#each Array(count) as _, i (i)}
+		<Card.Root>
+			<Card.Header class="flex flex-row items-start justify-between gap-4">
+				<div class="min-w-0 flex-1 space-y-2.5">
+					<Skeleton class="bg-primary/15 h-6 w-56 max-w-full rounded-md" />
+					<Skeleton class="bg-primary/10 h-4 w-full max-w-md rounded-md" />
+					<Skeleton class="bg-primary/10 h-4 w-2/3 max-w-sm rounded-md" />
+				</div>
+				<div class="flex shrink-0 gap-2">
+					<Skeleton class="bg-primary/10 h-9 w-20 rounded-md" />
+					<Skeleton class="bg-primary/10 h-9 w-20 rounded-md" />
+				</div>
+			</Card.Header>
+		</Card.Root>
+	{/each}
+</ul>

--- a/ui/packages/comhairle/src/lib/tools/prioritization/components/ProposalSectionField.svelte
+++ b/ui/packages/comhairle/src/lib/tools/prioritization/components/ProposalSectionField.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { onDestroy } from 'svelte';
+	import { onMount } from 'svelte';
 	import TranslatableField from '$lib/components/Translation/TranslatableField.svelte';
 	import { createTextContentSource } from '$lib/components/Translation/translationSource.svelte';
 	import type { TranslationSource } from '$lib/components/Translation/translationUtils';
@@ -35,8 +35,10 @@
 		refresh
 	});
 
-	registerSource?.(section.id, source);
-	onDestroy(() => unregisterSource?.(section.id));
+	onMount(() => {
+		registerSource?.(section.id, source);
+		return () => unregisterSource?.(section.id);
+	});
 </script>
 
 <TranslatableField

--- a/ui/packages/comhairle/src/lib/tools/prioritization/components/ProposalSectionField.svelte
+++ b/ui/packages/comhairle/src/lib/tools/prioritization/components/ProposalSectionField.svelte
@@ -1,15 +1,29 @@
 <script lang="ts">
+	import { onDestroy } from 'svelte';
 	import TranslatableField from '$lib/components/Translation/TranslatableField.svelte';
 	import { createTextContentSource } from '$lib/components/Translation/translationSource.svelte';
+	import type { TranslationSource } from '$lib/components/Translation/translationUtils';
 	import type { ProposalSection } from '../types';
 
 	type Props = {
 		section: ProposalSection;
 		primaryLocale: string;
 		supportedLocales: string[];
+		/** Reconcile the self-managed store after a save (see store.reload). */
+		refresh: () => Promise<void>;
+		/** Let the parent flush this section's pending save before it closes the dialog. */
+		registerSource?: (id: string, source: TranslationSource) => void;
+		unregisterSource?: (id: string) => void;
 	};
 
-	let { section, primaryLocale, supportedLocales }: Props = $props();
+	let {
+		section,
+		primaryLocale,
+		supportedLocales,
+		refresh,
+		registerSource,
+		unregisterSource
+	}: Props = $props();
 
 	// Each section owns its own source; the component boundary is the stable init site for the runes,
 	// so a section added/removed in the list mounts/disposes its source for free (see ADR-0005). The
@@ -17,8 +31,12 @@
 	const source = createTextContentSource({
 		getTranslation: () => section.bodyTranslations,
 		getPrimaryLocale: () => primaryLocale,
-		getSupportedLanguages: () => supportedLocales
+		getSupportedLanguages: () => supportedLocales,
+		refresh
 	});
+
+	registerSource?.(section.id, source);
+	onDestroy(() => unregisterSource?.(section.id));
 </script>
 
 <TranslatableField

--- a/ui/packages/comhairle/src/lib/tools/prioritization/store.svelte.ts
+++ b/ui/packages/comhairle/src/lib/tools/prioritization/store.svelte.ts
@@ -32,6 +32,18 @@ export function createStore(opts: {
 		}
 	}
 
+	/** Silent refresh used to reconcile `proposals` after inline saves. Unlike {@link refresh} it
+	 * never flips to `'loading'` (which would flash the whole list away on every keystroke-save) and
+	 * keeps the current list on a transient failure. This is what the translation sources call as
+	 * their `refresh` hook. */
+	async function reload() {
+		try {
+			proposals = await api.listProposals(opts.workflowStepId);
+		} catch (e) {
+			error = e instanceof Error ? e.message : 'Failed to load proposals';
+		}
+	}
+
 	async function create(input: { title: string; sections: string[] }) {
 		const created = await api.createProposal(opts.workflowStepId, input);
 		proposals = [...proposals, created];
@@ -94,6 +106,7 @@ export function createStore(opts: {
 			return error;
 		},
 		refresh,
+		reload,
 		create,
 		remove,
 		addSection,


### PR DESCRIPTION
Editing proposal translations was broken in a few ways: text you typed would revert, AI translations vanished right after generating, and hitting Approve saved a blank. This sorts all of that out, plus some polish on the editor dialogs.

## The actual bugs

Two root causes, both around state:

1. **The proposals list wasn't refreshing after saves.** The translation fields reconcile by calling SvelteKit's `invalidateAll()`, but the prioritization tool keeps its own list that `invalidateAll()` doesn't touch. So every save reconciled against stale data and your edit snapped back to the old value. Same reason the AI translation disappeared (it cleared back to the empty stored value) and Approve then persisted that blank.
2. **The rich text editor echoed server content back as a fake edit.** `onChange` was firing from tiptap's `onTransaction`, which runs on every transaction, including the programmatic sync we use to push saved content back in. That created spurious saves and a feedback loop on top of bug 1.

## What changed

- Added a `refresh` hook to the translation source (defaults to `invalidateAll`); the prioritization store passes a silent `reload()` so saves reconcile against fresh data without flashing the list.
- Rich text editor now emits changes from `onUpdate` (which ignores programmatic content sync) instead of `onTransaction`.
- **Create proposal is now persist-first:** opening "New proposal" creates an empty draft up front, so create and edit are one flow and translation badges work immediately (they used to only show on edit). Untouched drafts get cleaned up on close, Cancel discards, Done keeps.
- **Unsaved-changes guard** on the proposal editor so a refresh / tab close / navigation mid-save warns you instead of silently dropping the edit.
- Skeleton cards for the proposals list (including first paint, so the "No proposals yet" empty state no longer flashes before the fetch), and the list no longer tears down / jumps scroll to the top when you close the editor.
- Both editor dialogs are now a consistent `90vh` x `80vw`, so the translate dialog fully covers the proposal editor behind it instead of floating short inside it.


Demo 

https://github.com/user-attachments/assets/f1cf8269-4604-4158-8727-594fc9993d1e

