### PR TITLE
728 Polis report: scaffold lib/reports/polis + MetricOverviewCard stat row

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -85,6 +85,13 @@ The three-value review state of a statement: `accepted · pending · rejected` (
 **Theme**:
 A human-authored topic tag string in `polis_statement_aux.themes: string[]`, added via the admin ThemePicker. Polis has no theme concept; sync never imports one. (Future: T3C may write machine themes into the same store.)
 
+**Opinion group**:
+A cluster of participants who voted similarly, discovered by Polis's math (PCA + k-means), labelled A/B/C… Backed by `GroupReportData` (`group_id`, `members`, `total_members`, `representative_comments`). A single Polis poll yields a **variable** number of opinion groups (typically 1–5, not a fixed two), so all report components render N groups, not a hardcoded A/B pair. **Not** a demographic segment, recruitment cohort, or any admin-defined set — it is derived purely from vote patterns.
+_Avoid_: Group (bare — collides with invitee groupings), cluster, faction.
+
+**Representative comment**:
+A statement that most distinguishes an Opinion group from the others (Polis's "representative comments", per `GroupReportData.representative_comments`). Used in the report's Groups section to characterise what each group believes. Distinct from an [[#area-of-consensus]] statement, which is one *every* group agrees on.
+
 **Controversy**:
 A per-Theme classification `low | moderate | high`, from the average per-statement group-agree spread across that theme's statements. Buckets: `<15` low, `15–30` moderate, `>30` high (tunable in `report.ts`; civic_os marks the exact cuts "to confirm").
 

--- a/documentation/adr/0008-report-pieces-embed-in-tiptap-as-frozen-snapshots.md
+++ b/documentation/adr/0008-report-pieces-embed-in-tiptap-as-frozen-snapshots.md
@@ -1,0 +1,38 @@
+# ADR-0008: Report pieces embed in TipTap as frozen snapshots
+
+**Status:** accepted (explicitly revisitable)
+**Date:** 2026-07-23
+
+## Context
+
+The End-of-engagement [report view](../../CONTEXT.md) is a human-authored TipTap document that
+pulls report pieces in — an editor curates auto-generated insights and drops in component blocks.
+Report pieces are dumb Svelte components (data in, markup out).
+
+The question is what a report block *stores* in the document. Two models:
+
+- **Live** — the node stores a query/reference and re-renders against current data on every view.
+  Always fresh, interactive. But it only works in JS contexts: it breaks in the email and
+  `@tiptap/static-renderer` paths (no DOM, no JS), and needs a Svelte node-view bridge we don't
+  have.
+- **Frozen** — at publish/freeze time the dumb component is rendered to HTML and that HTML is
+  baked into the node. Every downstream path (participant web view, email, print) shows the same
+  output because it is just HTML.
+
+## Decision
+
+**Embed report pieces as frozen HTML snapshots**, rendered from the same dumb components at
+freeze/publish time. This matches the glossary definition of the End-of-engagement report as a
+"final frozen snapshot", and it renders in every path including email because it carries no
+runtime dependency.
+
+A live in-app preview *while the author is composing* is a separate, optional nicety layered on
+top; it does not change what gets stored or shipped.
+
+## Consequences
+
+- The stored artifact is portable HTML, not a live binding — a future reader may expect embedded
+  reports to update after publish. They do not, by design; re-freeze to refresh.
+- This is deliberately **revisitable**: if we later want post-publish-live embeds, it means adding
+  a node-view bridge and a static fallback, and revising this ADR. We chose frozen first because
+  it is simpler and the end-of-engagement report is a snapshot by definition.

--- a/ui/packages/comhairle/src/lib/reports/polis/PolisInsights.svelte
+++ b/ui/packages/comhairle/src/lib/reports/polis/PolisInsights.svelte
@@ -22,6 +22,7 @@
 	import StatementSection from '$lib/components/polis-report/StatementSection.svelte';
 	import ThemeBar from '$lib/components/polis-report/ThemeBar.svelte';
 	import ThemeChip from '$lib/components/polis-report/ThemeChip.svelte';
+	import MetricOverviewCard from '$lib/reports/MetricOverviewCard.svelte';
 	import * as Card from '$lib/components/ui/card';
 	import { Button } from '$lib/components/ui/button';
 	import { Download, ChevronDown } from '@lucide/svelte';
@@ -74,6 +75,17 @@
 	});
 
 	const stats = $derived(report ? getEngagementStats(report) : null);
+	// Stat-card subtexts. Statement split reads aux moderation_status ("accepted" →
+	// "approved" in the UI); avg is mean votes cast per unique voter.
+	const approvedCount = $derived(
+		Object.values(auxByTid).filter((a) => a.moderation_status === 'accepted').length
+	);
+	const pendingCount = $derived(
+		Object.values(auxByTid).filter((a) => a.moderation_status === 'pending').length
+	);
+	const avgVotesPerVoter = $derived(
+		stats && stats.totalParticipants > 0 ? stats.totalVotes / stats.totalParticipants : 0
+	);
 	// Theme roll-up over ALL tagged statements (aux), not just the Polis report
 	// set. Controversy needs vote data (only the report carries), so themes on
 	// non-report statements fall back to 'low'.
@@ -369,15 +381,22 @@
 	<div class="flex flex-col gap-10 pb-8">
 		<!-- ===== Top stats ===== -->
 		<div class="flex flex-wrap items-end justify-between gap-4">
-			<div class="flex flex-wrap gap-6">
-				{#each [{ label: 'Total Statements', value: stats.totalStatements }, { label: 'Themes', value: themes.length }, { label: 'Areas of Consensus', value: consensus.length }] as s (s.label)}
-					<div class="flex flex-col gap-1">
-						<span class="text-foreground text-2xl font-bold tabular-nums"
-							>{s.value}</span
-						>
-						<span class="text-muted-foreground text-sm">{s.label}</span>
-					</div>
-				{/each}
+			<div class="flex flex-wrap gap-4">
+				<MetricOverviewCard
+					superText="Participants"
+					metric={stats.totalParticipants}
+					subText="unique voters"
+				/>
+				<MetricOverviewCard
+					superText="Statements"
+					metric={stats.totalStatements}
+					subText="{approvedCount} approved · {pendingCount} pending"
+				/>
+				<MetricOverviewCard
+					superText="Vote cast"
+					metric={stats.totalVotes}
+					subText="{avgVotesPerVoter.toFixed(1)} avg per voter"
+				/>
 			</div>
 			<Button onclick={handleDownloadCsv} class="w-full sm:w-auto">
 				<Download class="size-4" />

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/design/step/[step_id]/insights/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/design/step/[step_id]/insights/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import PolisInsights from '$lib/tools/polis/PolisInsights.svelte';
+	import PolisInsights from '$lib/reports/polis/PolisInsights.svelte';
 	import ThinkingSpaceInsights from '$lib/reports/thinking-space/ThinkingSpaceInsights.svelte';
 
 	let { data } = $props();


### PR DESCRIPTION
First slice of the Polis report rebuild (#670). Sets up the shared home and top stat row that the later section PRs build on. 

No new sections yet, this is deliberately a small, behaviour-preserving foundation.

## What changed
- **Moved** `PolisInsights.svelte` from `lib/tools/polis/` → `lib/reports/polis/`,
  consolidating report UI under `lib/reports/<tool>/` (matches the thinking-space
  report). All imports are `$lib` aliases, so the move is a clean rename; only the
  `insights/+page.svelte` reference changed.
- **Stat row** now uses the shared `MetricOverviewCard` instead of the inlined
  markup: Participants (`unique voters`), Statements (`N approved · M pending`,
  from aux moderation status), Vote cast (`X avg per voter`).
- Glossary: added **Opinion group** and **Representative comment** (CONTEXT.md).
- ADR-0008: report pieces embed in TipTap as frozen snapshots (would love some opinions on this)


 Closes #728.

<img width="1456" height="458" alt="image" src="https://github.com/user-attachments/assets/5746b11f-07a8-4d05-87b0-afaf0e3c8174" />
