### PR TITLE
Live agenda push

### DIFF
--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -41,6 +41,7 @@ use tokio::fs;
 use tower_http::cors::CorsLayer;
 use translation_service::TranslationService;
 use websockets::WebSocketService;
+use websockets::handlers::video_call::VideoCallMessageHandler;
 
 use crate::bulk_storage_service::BulkStorageService;
 use crate::categorization_service::CategorizationService;
@@ -62,6 +63,9 @@ pub struct ComhairleState {
     pub config: ComhairleConfig,
     pub mailer: Arc<dyn ComhairleMailer>,
     pub websockets: Arc<dyn WebSocketService>,
+    /// Video call handler, held here (as well as registered on `websockets`) so HTTP
+    /// routes can push updates to participants currently on a call (e.g. agenda changes).
+    pub video_call_handler: Arc<VideoCallMessageHandler>,
     pub translation_service: Option<Arc<dyn TranslationService>>,
     pub bot_service: Option<Arc<dyn ComhairleBotService>>,
     pub wiki_poll_service: Arc<dyn WikiPollService>,

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -12,6 +12,7 @@ use comhairle::{
     transcription_service::amazon_transcriber::AmazonTranscriber,
     translation_service::GoogleTranslateService,
     websockets::ComhairleWebSocketService,
+    websockets::handlers::video_call::VideoCallMessageHandler,
     wiki_poll_service::polis_service::PolisClient,
     worker_service::{init_monitor, init_worker_service},
 };
@@ -139,11 +140,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
         None
     };
 
+    let video_call_handler = Arc::new(VideoCallMessageHandler::new());
+
     let state = Arc::new(ComhairleState {
         db,
         mailer,
         config,
         websockets,
+        video_call_handler,
         translation_service,
         transcription_service,
         bot_service,

--- a/api/src/routes/events.rs
+++ b/api/src/routes/events.rs
@@ -121,7 +121,18 @@ async fn update(
     RequiredAdminUser(_user): RequiredAdminUser,
     Json(event): Json<PartialEvent>,
 ) -> Result<(StatusCode, Json<EventDto>), ComhairleError> {
-    let event = event::update(&state.db, &event_id, &event).await?.into();
+    let agenda_updated = event.agenda.is_some();
+    let event: EventDto = event::update(&state.db, &event_id, &event).await?.into();
+
+    // If the agenda changed, push it to anyone currently on the call for this event.
+    if agenda_updated {
+        if let Ok(agenda) = serde_json::to_value(&event.agenda) {
+            let _ = state
+                .video_call_handler
+                .broadcast_agenda_update(&event_id, agenda, &state)
+                .await;
+        }
+    }
 
     Ok((StatusCode::OK, Json(event)))
 }

--- a/api/src/test_helpers.rs
+++ b/api/src/test_helpers.rs
@@ -1,6 +1,7 @@
 use crate::{
     models::permissions::{NamedRole, ResourceRole},
     redis_connection::RedisConnection,
+    websockets::handlers::video_call::VideoCallMessageHandler,
 };
 use chrono::Utc;
 use hyper::header::AUTHORIZATION;
@@ -112,6 +113,7 @@ pub fn test_state(
         mailer: mailer.unwrap_or_else(mock_mailer),
         config: config.unwrap_or_else(|| test_config().unwrap()),
         websockets: websockets.unwrap_or_else(|| mock_websockets()),
+        video_call_handler: Arc::new(VideoCallMessageHandler::new()),
         translation_service: translation_service
             .map(Some)
             .unwrap_or_else(|| mock_translation_service()),

--- a/api/src/websockets.rs
+++ b/api/src/websockets.rs
@@ -133,6 +133,15 @@ pub trait WebSocketMessageHandler: Send + Sync {
         connection: &WebSocketConnection,
         state: &Arc<ComhairleState>,
     ) -> Result<(), crate::websockets::error::WebsocketError>;
+
+    /// Local user IDs this handler considers members of `room_id`, used for
+    /// cluster-wide fan-out via [`WebSocketService::broadcast_to_room`].
+    ///
+    /// "Local" means only users whose connection this instance is aware of; each
+    /// instance answers for its own members. Default: the handler manages no rooms.
+    fn local_room_members(&self, _room_id: &Uuid) -> Vec<Uuid> {
+        Vec::new()
+    }
 }
 
 static NEXT_CONNECTION_ID: AtomicUsize = AtomicUsize::new(1);
@@ -227,6 +236,15 @@ pub enum WebsocketPubSubMessage {
         connection_ids: Vec<usize>,
         message: serde_json::Value,
     },
+    /// Deliver `message` to the members of `room_id`, as reported by the handler
+    /// registered for `domain`. Each instance resolves its OWN local members, so
+    /// participants spread across instances all receive the message.
+    SendToRoom {
+        sender_id: Uuid,
+        domain: String,
+        room_id: String,
+        message: serde_json::Value,
+    },
 }
 
 impl WebsocketPubSubMessage {
@@ -235,6 +253,7 @@ impl WebsocketPubSubMessage {
             WebsocketPubSubMessage::Broadcast { message, .. } => message.clone(),
             WebsocketPubSubMessage::SendToUser { message, .. } => message.clone(),
             WebsocketPubSubMessage::SendToConnections { message, .. } => message.clone(),
+            WebsocketPubSubMessage::SendToRoom { message, .. } => message.clone(),
         };
         serde_json::from_value(message)
             .map_err(|e| ComhairleError::DeserializationError(e.to_string()))
@@ -264,6 +283,18 @@ pub trait WebSocketService: Send + Sync {
     async fn send_to_connections(
         &self,
         connection_ids: &[ConnectionId],
+        message: &WebSocketMessage,
+    ) -> Result<usize, ComhairleError>;
+
+    /// Send `message` to every member of `room_id` across ALL instances.
+    ///
+    /// Membership is resolved per-instance by the handler registered for `domain`
+    /// (via [`WebSocketMessageHandler::local_room_members`]), so participants
+    /// connected to different instances all receive the message.
+    async fn broadcast_to_room(
+        &self,
+        domain: &str,
+        room_id: &Uuid,
         message: &WebSocketMessage,
     ) -> Result<usize, ComhairleError>;
 
@@ -299,6 +330,9 @@ impl MockWebSocketService {
         websockets
             .expect_send_to_connections()
             .returning(|_, _| Box::pin(async move { Ok(0) }));
+        websockets
+            .expect_broadcast_to_room()
+            .returning(|_, _, _| Box::pin(async move { Ok(0) }));
         websockets.expect_get_connection_count().returning(|| 0);
         websockets
             .expect_get_user_connection_count()
@@ -432,6 +466,22 @@ impl ComhairleWebSocketService {
                                 .await;
                         }
                     }
+                    WebsocketPubSubMessage::SendToRoom {
+                        domain,
+                        room_id,
+                        message,
+                        ..
+                    } => {
+                        // Deliberately NO echo-skip: the publishing instance did not deliver
+                        // locally (see `broadcast_to_room`), so it must also forward here.
+                        if let Ok(ws_message) = serde_json::from_value(message) {
+                            if let Ok(room_uuid) = Uuid::parse_str(&room_id) {
+                                let _ = self_clone
+                                    .send_to_room_members_local(&domain, &room_uuid, &ws_message)
+                                    .await;
+                            }
+                        }
+                    }
                 }
             }
         });
@@ -530,6 +580,27 @@ impl ComhairleWebSocketService {
 
         for failed_id in failed_connections {
             self.remove_connection(&failed_id);
+        }
+
+        Ok(sent_count)
+    }
+
+    /// Deliver `message` to this instance's locally-connected members of `room_id`,
+    /// as reported by the handler for `domain`. Does not touch Redis.
+    async fn send_to_room_members_local(
+        &self,
+        domain: &str,
+        room_id: &Uuid,
+        message: &WebSocketMessage,
+    ) -> Result<usize, ComhairleError> {
+        let members = match self.handlers.get(domain) {
+            Some(handler) => handler.local_room_members(room_id),
+            None => return Ok(0),
+        };
+
+        let mut sent_count = 0;
+        for user_id in members {
+            sent_count += self.send_to_user_local(&user_id, message).await?;
         }
 
         Ok(sent_count)
@@ -670,6 +741,38 @@ impl WebSocketService for ComhairleWebSocketService {
         }
 
         Ok(sent_count)
+    }
+
+    async fn broadcast_to_room(
+        &self,
+        domain: &str,
+        room_id: &Uuid,
+        message: &WebSocketMessage,
+    ) -> Result<usize, ComhairleError> {
+        // With Redis, publish once and let EVERY instance — including this one, via its
+        // own subscription — forward to the members it holds. That keeps a single code
+        // path and avoids local/remote duplication.
+        //
+        // Without Redis (single instance / dev) there is no subscriber loop, so publishing
+        // would reach nobody; deliver locally as a fallback instead.
+        match &self.redis_service {
+            Some(redis_service) => {
+                let pubsub_message = WebsocketPubSubMessage::SendToRoom {
+                    sender_id: redis_service.instance_id,
+                    domain: domain.to_string(),
+                    room_id: room_id.to_string(),
+                    message: serde_json::to_value(message)
+                        .map_err(|e| ComhairleError::SerializationError(e.to_string()))?,
+                };
+
+                self.publish_to_redis(&pubsub_message).await?;
+                Ok(0)
+            }
+            None => {
+                self.send_to_room_members_local(domain, room_id, message)
+                    .await
+            }
+        }
     }
 
     fn get_connection_count(&self) -> usize {
@@ -1078,5 +1181,157 @@ mod tests {
         // Verify the message was received by both services
         assert_eq!(service_1.get_connection_count(), 1);
         assert_eq!(service_2.get_connection_count(), 1);
+    }
+
+    /// Returns a usable Redis URL (plus the temp-server guard, if one was spawned),
+    /// or None if Redis is unavailable and the test should skip.
+    fn redis_url_or_skip() -> Option<(Option<RedisServer>, String)> {
+        let can_connect = redis::Client::open("redis://localhost:6379/")
+            .map(|c| c.get_connection().is_ok())
+            .unwrap_or(false);
+        if can_connect {
+            return Some((None, "redis://localhost:6379/".to_string()));
+        }
+
+        let server =
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(RedisServer::new)).ok()?;
+        let redis_url = format!("redis://{}/", server.connection_info().addr());
+        for _ in 0..5 {
+            std::thread::sleep(std::time::Duration::from_millis(100));
+            if let Ok(client) = redis::Client::open(redis_url.as_str()) {
+                if client.get_connection().is_ok() {
+                    return Some((Some(server), redis_url));
+                }
+            }
+        }
+        None
+    }
+
+    fn test_user(id: Uuid) -> crate::models::users::User {
+        crate::models::users::User {
+            id,
+            email: Some("test@example.com".to_string()),
+            username: Some("test_user".to_string()),
+            password: None,
+            avatar_url: None,
+            email_verified: true,
+            auth_type: crate::models::users::UserAuthType::EmailPassword,
+            organization_id: None,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+            signup_ip: None,
+        }
+    }
+
+    /// Registers `user_id` as a participant of `event_id`'s call in the handler's local map.
+    fn insert_call_participant(
+        handler: &crate::websockets::handlers::video_call::VideoCallMessageHandler,
+        event_id: Uuid,
+        user_id: Uuid,
+    ) {
+        use crate::websockets::handlers::video_call::{VideoCallParticipant, VideoCallState};
+        let mut calls = handler.video_calls.write().unwrap();
+        let mut state = VideoCallState::new(event_id);
+        state.participants.insert(
+            user_id,
+            VideoCallParticipant {
+                user_id,
+                username: Some("test_user".to_string()),
+                role: "participant".to_string(),
+            },
+        );
+        calls.insert(event_id, state);
+    }
+
+    async fn assert_received_agenda_update(
+        receiver: &mut mpsc::UnboundedReceiver<Message>,
+        who: &str,
+    ) {
+        let msg = tokio::time::timeout(std::time::Duration::from_millis(1000), receiver.recv())
+            .await
+            .unwrap_or_else(|_| panic!("{who} timed out waiting for a message"))
+            .unwrap_or_else(|| panic!("{who} channel closed"));
+        let text = msg.to_text().expect("text frame");
+        let ws_msg: WebSocketMessage = serde_json::from_str(text).expect("parse ws message");
+        match ws_msg {
+            WebSocketMessage::Custom { event, .. } => {
+                assert_eq!(
+                    event, "video_call:agenda_updated",
+                    "{who} received wrong event"
+                );
+            }
+            other => panic!("{who} expected Custom message, got {other:?}"),
+        }
+    }
+
+    /// A participant connected to a DIFFERENT instance than the one that publishes an
+    /// agenda update must still receive it, via Redis fan-out through `broadcast_to_room`.
+    #[tokio::test]
+    async fn test_broadcast_to_room_fans_out_across_instances() {
+        use crate::websockets::handlers::video_call::VideoCallMessageHandler;
+
+        let Some((_redis_server, redis_url)) = redis_url_or_skip() else {
+            eprintln!("Redis unavailable - skipping test");
+            return;
+        };
+
+        let websocket_config = Some(WebsocketConfig {
+            redis_pubsub_url: redis_url.clone(),
+        });
+
+        let service_1 = ComhairleWebSocketService::new(websocket_config.as_ref())
+            .await
+            .expect("Failed to create service 1");
+        let service_2 = ComhairleWebSocketService::new(websocket_config.as_ref())
+            .await
+            .expect("Failed to create service 2");
+
+        let _subscriber_1 = service_1
+            .start_pubsub_subscriber()
+            .await
+            .expect("Failed to start subscriber 1");
+        let _subscriber_2 = service_2
+            .start_pubsub_subscriber()
+            .await
+            .expect("Failed to start subscriber 2");
+
+        let event_id = Uuid::new_v4();
+        let user_a = Uuid::new_v4(); // connected to service_1 (the publisher)
+        let user_b = Uuid::new_v4(); // connected to service_2 (a different instance)
+
+        // Each instance's handler knows only the participant connected to it.
+        let handler_1 = Arc::new(VideoCallMessageHandler::new());
+        insert_call_participant(&handler_1, event_id, user_a);
+        service_1.register_handler(handler_1);
+
+        let handler_2 = Arc::new(VideoCallMessageHandler::new());
+        insert_call_participant(&handler_2, event_id, user_b);
+        service_2.register_handler(handler_2);
+
+        let addr = "127.0.0.1:9999".parse().unwrap();
+        let (conn_a, mut recv_a) = WebSocketConnection::new(test_user(user_a), addr);
+        let (conn_b, mut recv_b) = WebSocketConnection::new(test_user(user_b), addr);
+        service_1.add_connection(conn_a);
+        service_2.add_connection(conn_b);
+
+        // Let both subscriptions settle.
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        let message = WebSocketMessage::Custom {
+            event: "video_call:agenda_updated".to_string(),
+            data: serde_json::json!([{ "Basic": { "title": "Updated agenda item" } }]),
+        };
+
+        // Publish from service_1 ONLY.
+        service_1
+            .broadcast_to_room("video_call", &event_id, &message)
+            .await
+            .expect("broadcast_to_room failed");
+
+        // The publisher's own participant receives it (no local pre-delivery — it comes
+        // back through service_1's own subscription)...
+        assert_received_agenda_update(&mut recv_a, "user_a (publishing instance)").await;
+        // ...and so does the participant on the OTHER instance. This is the fan-out.
+        assert_received_agenda_update(&mut recv_b, "user_b (remote instance)").await;
     }
 }

--- a/api/src/websockets/handlers/video_call.rs
+++ b/api/src/websockets/handlers/video_call.rs
@@ -1034,12 +1034,49 @@ impl VideoCallMessageHandler {
 
         Ok(())
     }
+
+    /// Pushes an updated agenda to every participant currently on the call for `event_id`,
+    /// across all API instances in the cluster.
+    ///
+    /// `agenda` must already be serialized in the same shape the frontend receives from
+    /// the events API (i.e. the `EventDto.agenda` value). No-op if nobody is on the call,
+    /// so callers can fire this unconditionally.
+    pub async fn broadcast_agenda_update(
+        &self,
+        event_id: &Uuid,
+        agenda: serde_json::Value,
+        state: &Arc<ComhairleState>,
+    ) -> Result<(), VideoCallWSError> {
+        let message = WebSocketMessage::Custom {
+            event: "video_call:agenda_updated".into(),
+            data: agenda,
+        };
+
+        // Fan out across the cluster: each instance resolves its own local participants
+        // for this event (see `local_room_members`), so users on any instance receive it.
+        let _ = state
+            .websockets
+            .broadcast_to_room(self.domain(), event_id, &message)
+            .await;
+
+        Ok(())
+    }
 }
 
 #[async_trait]
 impl WebSocketMessageHandler for VideoCallMessageHandler {
     fn domain(&self) -> &str {
         "video_call"
+    }
+
+    /// Participants of the call for `room_id` (the event id) known to THIS instance.
+    fn local_room_members(&self, room_id: &Uuid) -> Vec<Uuid> {
+        self.with_video_call_state(room_id, |call| {
+            call.participants.keys().copied().collect::<Vec<Uuid>>()
+        })
+        .ok()
+        .flatten()
+        .unwrap_or_default()
     }
 
     async fn handle_message(

--- a/api/src/websockets/setup.rs
+++ b/api/src/websockets/setup.rs
@@ -4,8 +4,7 @@ use tracing::info;
 use crate::ComhairleState;
 
 use super::handlers::{
-    notifications::NotificationMessageHandler, video_call::VideoCallMessageHandler,
-    workflow::WorkflowMessageHandler,
+    notifications::NotificationMessageHandler, workflow::WorkflowMessageHandler,
 };
 
 /// Register all WebSocket message handlers with the application state.
@@ -69,9 +68,11 @@ pub fn register_handlers(state: &Arc<ComhairleState>) {
     let workflow_handler = Arc::new(WorkflowMessageHandler::new());
     state.websockets.register_handler(workflow_handler);
 
-    // Register video call handler
-    let video_call_handler = Arc::new(VideoCallMessageHandler::new());
-    state.websockets.register_handler(video_call_handler);
+    // Register video call handler (the same instance held on state, so HTTP routes
+    // and WS messages share one call registry).
+    state
+        .websockets
+        .register_handler(state.video_call_handler.clone());
 
     info!("WebSocket message handlers registered successfully");
 }

--- a/ui/packages/comhairle/src/lib/services/videoCallService.svelte.ts
+++ b/ui/packages/comhairle/src/lib/services/videoCallService.svelte.ts
@@ -1,4 +1,5 @@
 import { ws } from '$lib/api/websockets.svelte';
+import type { EventAgendaItem } from '@crownshy/api-client/api';
 
 export type VideoCallStatus = 'Waiting' | 'InProgress' | 'Ended';
 
@@ -38,6 +39,8 @@ export interface BroadcastMessage {
 export class VideoCallService {
 	private _currentCallState = $state<VideoCallState | null>(null);
 	private _lastBroadcastMessage = $state<string | null>(null);
+	/** Latest agenda pushed over WS (overrides the SSR-loaded agenda when set). */
+	private _agenda = $state<EventAgendaItem[] | null>(null);
 	private isListening = false;
 
 	constructor() {
@@ -50,6 +53,11 @@ export class VideoCallService {
 
 	get lastBroadcastMessage(): string | null {
 		return this._lastBroadcastMessage;
+	}
+
+	/** Agenda pushed over WS since the call was joined, or null if none received yet. */
+	get agenda(): EventAgendaItem[] | null {
+		return this._agenda;
 	}
 
 	get isInCall(): boolean {
@@ -90,6 +98,8 @@ export class VideoCallService {
 				this.handleStateUpdate(payload.data as VideoCallState);
 			} else if (payload.event === 'video_call:message') {
 				this.handleBroadcastMessage(payload.data as BroadcastMessage);
+			} else if (payload.event === 'video_call:agenda_updated') {
+				this.handleAgendaUpdate(payload.data as EventAgendaItem[]);
 			}
 		});
 	}
@@ -112,6 +122,11 @@ export class VideoCallService {
 		this._lastBroadcastMessage = data.message;
 	}
 
+	private handleAgendaUpdate(agenda: EventAgendaItem[]) {
+		console.log('[BREAKOUT-SVC] agenda updated:', agenda?.length, 'items');
+		this._agenda = agenda;
+	}
+
 	joinCall(eventId: string) {
 		ws.sendCustom('video_call:user_joined', {
 			event_id: eventId
@@ -123,6 +138,7 @@ export class VideoCallService {
 			event_id: eventId
 		});
 		this._currentCallState = null;
+		this._agenda = null;
 	}
 
 	/** Moderator/facilitator only */

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
@@ -152,7 +152,8 @@
 		});
 	}
 
-	let agendaItems = $derived(mapApiAgenda(event?.agenda ?? []));
+	// Prefer the agenda pushed over WS (live edits) over the SSR-loaded one, which can go stale.
+	let agendaItems = $derived(mapApiAgenda(videoCallService.agenda ?? event?.agenda ?? []));
 
 	let meetingPhase = $derived.by(() => {
 		let phase: 'loading' | 'ended' | 'incall' | 'lobby';


### PR DESCRIPTION
Sets up a broadcast to room pattern for more easily broadcasting to video call users regardless of if they are on the same server or not. 

Uses  this to update the agenda when it changes across all rooms 