### PR TITLE
track in-call presence server-side for breakout dialog

### DIFF
--- a/api/src/websockets/handlers/video_call.rs
+++ b/api/src/websockets/handlers/video_call.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     sync::{Arc, RwLock},
 };
 
@@ -59,6 +59,10 @@ pub struct VideoCallState {
     pub status: VideoCallStatus,
     /// Map of participant user IDs to their participant data
     pub participants: HashMap<Uuid, VideoCallParticipant>,
+    /// User IDs that have actually joined the Jitsi video (as opposed to just opening
+    /// the live page / sitting in the lobby). Reported by each client on join/leave, so
+    /// it does not depend on the user-editable Jitsi display name.
+    pub in_video_participants: HashSet<Uuid>,
     /// List of breakout room assignments
     pub breakout_rooms: Vec<BreakoutRoomAssignments>,
     /// Active requests for assistance from breakout rooms
@@ -133,6 +137,7 @@ impl VideoCallState {
         Self {
             status: VideoCallStatus::Waiting,
             participants: HashMap::new(),
+            in_video_participants: HashSet::new(),
             video_call_id,
             breakout_room_assistance_requests: HashMap::new(),
             current_agenda_step: 0,
@@ -536,9 +541,49 @@ impl VideoCallMessageHandler {
         // Remove the participant from the video call
         self.with_video_call_state_mut(&leave_data.event_id, |call| {
             call.participants.remove(&user_id);
+            call.in_video_participants.remove(&user_id);
         })?;
 
         self.broadcast_state(&leave_data.event_id, state).await?;
+
+        Ok(())
+    }
+
+    /// Marks a user as having actually joined the Jitsi video for this event, then
+    /// broadcasts the updated state. Called when a client's `videoConferenceJoined`
+    /// fires — a reliable, rename-proof signal of real call presence.
+    pub async fn handle_video_joined(
+        &self,
+        event_id: &Uuid,
+        connection: &WebSocketConnection,
+        state: &Arc<ComhairleState>,
+    ) -> Result<(), VideoCallWSError> {
+        let user_id = connection.user.id;
+
+        self.with_video_call_state_mut(event_id, |call| {
+            call.in_video_participants.insert(user_id);
+        })?;
+
+        self.broadcast_state(event_id, state).await?;
+
+        Ok(())
+    }
+
+    /// Marks a user as no longer in the Jitsi video (left the call but may still have
+    /// the live page open), then broadcasts the updated state.
+    pub async fn handle_video_left(
+        &self,
+        event_id: &Uuid,
+        connection: &WebSocketConnection,
+        state: &Arc<ComhairleState>,
+    ) -> Result<(), VideoCallWSError> {
+        let user_id = connection.user.id;
+
+        self.with_video_call_state_mut(event_id, |call| {
+            call.in_video_participants.remove(&user_id);
+        })?;
+
+        self.broadcast_state(event_id, state).await?;
 
         Ok(())
     }
@@ -1102,6 +1147,13 @@ impl WebSocketMessageHandler for VideoCallMessageHandler {
                     "video_call:user_left" => {
                         self.handle_user_leave(&event_id, data, connection, state)
                             .await?
+                    }
+                    "video_call:video_joined" => {
+                        self.handle_video_joined(&event_id, connection, state)
+                            .await?
+                    }
+                    "video_call:video_left" => {
+                        self.handle_video_left(&event_id, connection, state).await?
                     }
                     "video_call:change_state" => {
                         self.change_call_status(&event_id, data, connection, state)

--- a/ui/packages/comhairle/src/lib/services/videoCallService.svelte.ts
+++ b/ui/packages/comhairle/src/lib/services/videoCallService.svelte.ts
@@ -25,6 +25,8 @@ export interface VideoCallState {
 	video_call_id: string;
 	status: VideoCallStatus;
 	participants: Record<string, VideoCallParticipant>;
+	/** User IDs that have actually joined the Jitsi video (not just the lobby). */
+	in_video_participants: string[];
 	breakout_rooms: BreakoutRoomAssignments[];
 	breakout_room_assistance_requests: Record<string, BreakoutRoomAssistanceRequest>;
 	jitsi_call_id: string;
@@ -67,6 +69,11 @@ export class VideoCallService {
 	get participants(): VideoCallParticipant[] {
 		if (!this._currentCallState) return [];
 		return Object.values(this._currentCallState.participants);
+	}
+
+	/** User IDs that have actually joined the Jitsi video (excludes lobby-only users). */
+	get inVideoParticipantIds(): Set<string> {
+		return new Set(this._currentCallState?.in_video_participants ?? []);
 	}
 
 	get breakoutRooms(): BreakoutRoomAssignments[] {
@@ -139,6 +146,20 @@ export class VideoCallService {
 		});
 		this._currentCallState = null;
 		this._agenda = null;
+	}
+
+	/** Report that this client has actually joined the Jitsi video (rename-proof presence). */
+	reportVideoJoined(eventId: string) {
+		ws.sendCustom('video_call:video_joined', {
+			event_id: eventId
+		});
+	}
+
+	/** Report that this client has left the Jitsi video. */
+	reportVideoLeft(eventId: string) {
+		ws.sendCustom('video_call:video_left', {
+			event_id: eventId
+		});
 	}
 
 	/** Moderator/facilitator only */

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
@@ -58,9 +58,13 @@
 		})
 	);
 
-	/** Participants actually in Jitsi call (excludes current user + lobby-only users) */
+	/** Participants actually in the Jitsi video (excludes current user + lobby-only users).
+	 *  Membership comes from the backend in-video set (reported by each client on join),
+	 *  so it is unaffected by users renaming themselves in the Jitsi interface. */
 	let inCallParticipants = $derived(
-		allParticipants.filter((p) => p.user_id !== user?.id && jitsiParticipantMap.has(p.user_id))
+		allParticipants.filter(
+			(p) => p.user_id !== user?.id && videoCallService.inVideoParticipantIds.has(p.user_id)
+		)
 	);
 	let currentStep = $derived(videoCallService.currentAgendaStep);
 	let breakoutSession = $derived(videoCallService.breakoutSession);
@@ -80,9 +84,6 @@
 	let activePanel = $state<PanelTab>('agenda');
 	let jitsiModeratorStatus = $state<boolean>(false);
 	let currentJitsiRoomName = $state<string>('');
-
-	// Map Jitsi participant IDs to backend user IDs
-	let jitsiParticipantMap = $state<Map<string, string>>(new Map());
 
 	/** Mock breakout rooms for dev testing */
 	let mockBreakoutRooms = $state<BreakoutRoomDisplay[]>([]);
@@ -788,8 +789,8 @@
 	function handleVideoConferenceJoined(data: any) {
 		console.log('[BREAKOUT] Entered Jitsi room:', data.roomName);
 		currentJitsiRoomName = data.roomName;
-		// Capture everyone already in the room (participantJoined won't fire for them)
-		seedJitsiParticipants();
+		// Tell the backend we're really in the video (rename-proof call presence).
+		videoCallService.reportVideoJoined(eventId);
 		// Moderator is now in Jitsi — safe to let participants in
 		if (isModerator && callStatus === 'Waiting') {
 			videoCallService.changeCallState(eventId, 'InProgress');
@@ -798,71 +799,7 @@
 
 	function handleVideoConferenceLeft(data: any) {
 		console.log('[BREAKOUT] Left Jitsi room:', data.roomName);
-	}
-
-	const normalizeName = (s: string | null | undefined) => (s ?? '').trim().toLowerCase();
-
-	/** Map a single Jitsi participant (by displayName) to a backend user in jitsiParticipantMap. */
-	function mapJitsiParticipant(jitsiId: string, displayName: string | undefined) {
-		const target = normalizeName(displayName);
-
-		// Exact (normalized) username match first, then fall back to a backend user_id
-		// embedded in the display name (guards against renamed / mis-cased Jitsi names).
-		let matchingUser =
-			allParticipants.find((p) => p.username && normalizeName(p.username) === target) ?? null;
-
-		if (!matchingUser && target) {
-			matchingUser =
-				allParticipants.find((p) => target.includes(p.user_id.toLowerCase())) ?? null;
-		}
-
-		if (matchingUser) {
-			console.log(
-				'[BREAKOUT] Mapped Jitsi participant',
-				jitsiId,
-				'→ user',
-				matchingUser.user_id
-			);
-			jitsiParticipantMap.set(matchingUser.user_id, jitsiId);
-		} else {
-			console.warn('[BREAKOUT] Could not match participant:', displayName);
-		}
-	}
-
-	/** Seed jitsiParticipantMap with everyone already in the call. `participantJoined` only
-	 *  fires for people who join AFTER our listener attaches, so pre-existing participants
-	 *  (usually most of them) would otherwise never be mapped. */
-	function seedJitsiParticipants() {
-		try {
-			const roster = jitsiApi?.getParticipantsInfo?.() ?? [];
-			console.log('[BREAKOUT] Seeding', roster.length, 'existing Jitsi participants');
-			for (const p of roster) {
-				mapJitsiParticipant(
-					p.participantId ?? p.id,
-					p.displayName ?? p.formattedDisplayName
-				);
-			}
-		} catch (error) {
-			console.error('[BREAKOUT] Failed to seed Jitsi participants:', error);
-		}
-	}
-
-	function handleParticipantJoined(participant: any) {
-		console.log('[BREAKOUT] Participant joined:', participant);
-		mapJitsiParticipant(participant.id, participant.displayName);
-	}
-
-	function handleParticipantLeft(participant: any) {
-		console.log('[BREAKOUT] Participant left:', participant);
-
-		// Remove from map
-		const entry = Array.from(jitsiParticipantMap.entries()).find(
-			([_, jitsiId]) => jitsiId === participant.id
-		);
-		if (entry) {
-			jitsiParticipantMap.delete(entry[0]);
-			console.log('[BREAKOUT] Removed participant from map:', entry[0]);
-		}
+		videoCallService.reportVideoLeft(eventId);
 	}
 </script>
 
@@ -986,8 +923,6 @@
 						onModeratorStatusChanged={handleModeratorStatusChanged}
 						onVideoConferenceJoined={handleVideoConferenceJoined}
 						onVideoConferenceLeft={handleVideoConferenceLeft}
-						onParticipantJoined={handleParticipantJoined}
-						onParticipantLeft={handleParticipantLeft}
 						startWithAudioMuted={true}
 						configOverwrite={{
 							toolbarButtons: [


### PR DESCRIPTION
Breakout room assignment listed participants by matching the Jitsi display
name back to a backend user. Since users can rename themselves in the Jitsi
join interface, renamed users matched nothing and silently disappeared from
the dialog, so they could not be assigned to a breakout room.

Replace the name matching with a server-authoritative in-video set. Each client reports video_call:video_joined / video_call:video_left as it enters
and leaves the Jitsi video; the backend records the user id (taken from the
authenticated socket, so it is unaffected by display-name changes) in VideoCallState.in_video_participants and broadcasts it. The dialog now lists
exactly the users the backend knows are in the video.

Removes the display-name matching machinery on the live page (jitsiParticipantMap, seedJitsiParticipants, mapJitsiParticipant and the participantJoined/Left handlers). Room movement was already self-driven by
each client via user id, so it is unaffected.