### PR TITLE
select event facilitators/moderators from attendee list

### DIFF
--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/events/[event_id]/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/events/[event_id]/+page.svelte
@@ -32,7 +32,7 @@
 	import { notifications } from '$lib/notifications.svelte';
 	import { apiClient } from '@crownshy/api-client/client';
 	import { invalidateAll } from '$app/navigation';
-	import BadgeInput from '$lib/components/ui/badge-input/badge-input.svelte';
+	import FacilitatorRoleList from './FacilitatorRoleList.svelte';
 	import Label from '$lib/components/ui/label/label.svelte';
 	import { utcTimeToLocal } from '$lib/utils/date-time';
 	import AgendaEditor from './AgendaEditor.svelte';
@@ -55,8 +55,7 @@
 
 	const event = $derived(data.event);
 	const conversation = $derived(data.conversation);
-	const facilitators = $derived(data.facilitators);
-	const moderators = $derived(data.moderators);
+	const attendees = $derived(data.attendees);
 	const recordings = $derived(data.recordings);
 
 	let emailInvites = $derived(
@@ -66,6 +65,21 @@
 				'email' in invite.inviteType &&
 				invite.inviteType.email
 		)
+	);
+
+	/** Invited-by-email people who haven't registered yet — shown non-selectable
+	 *  in the facilitators tab (a role can't attach without a registration). */
+	let pendingInvites = $derived(
+		emailInvites
+			.filter((invite) => invite.status === 'pending' || invite.status === 'open')
+			.map((invite) => ({
+				id: invite.id,
+				email:
+					typeof invite.inviteType !== 'string' && 'email' in invite.inviteType
+						? invite.inviteType.email
+						: '',
+				status: invite.status
+			}))
 	);
 	let primaryLanguage = $derived(data.conversation.primaryLocale ?? 'en');
 	let supportedLanguages = $derived(data.conversation.supportedLanguages ?? ['en']);
@@ -282,21 +296,22 @@
 		}
 	}
 
-	async function handleAddFacilitator(value: string) {
+	async function handleSetAttendeeRole(attendanceId: string, role: string) {
 		try {
-			await apiClient.CreateFacilitatorEventAttendance(
-				{ email: value },
+			await apiClient.UpdateEventAttendance(
+				{ role },
 				{
 					params: {
 						conversation_id: conversation.id,
-						event_id: event.id
+						event_id: event.id,
+						attendance_id: attendanceId
 					}
 				}
 			);
 
 			notifications.send({
 				priority: 'INFO',
-				message: 'Facilitator added'
+				message: 'Role updated'
 			});
 
 			await invalidateAll();
@@ -304,33 +319,7 @@
 			console.error(e);
 			notifications.send({
 				priority: 'ERROR',
-				message:
-					e.status === 404 ? 'Unable to find user' : 'Failed to add facilitator to event'
-			});
-		}
-	}
-
-	async function handleDeleteFacilitator(id: string) {
-		try {
-			await apiClient.DeleteEventAttendance(undefined, {
-				params: {
-					conversation_id: conversation.id,
-					event_id: event.id,
-					attendance_id: id
-				}
-			});
-
-			notifications.send({
-				priority: 'INFO',
-				message: 'Facilitator removed'
-			});
-
-			await invalidateAll();
-		} catch (e) {
-			console.error(e);
-			notifications.send({
-				priority: 'ERROR',
-				message: 'Failed to remove facilitator from event'
+				message: 'Failed to update role'
 			});
 		}
 	}
@@ -632,15 +621,7 @@
 	>
 		<div class="contents">
 			<Label class="text-sm font-semibold lg:w-50 lg:shrink-0 lg:pt-2">Facilitators</Label>
-			<BadgeInput
-				onAddBadge={handleAddFacilitator}
-				onDeleteBadge={handleDeleteFacilitator}
-				badges={[...facilitators, ...moderators].map((f) => ({
-					id: f.id,
-					value: f.email
-				}))}
-				placeholder="Enter an email address"
-			/>
+			<FacilitatorRoleList {attendees} {pendingInvites} onSetRole={handleSetAttendeeRole} />
 		</div>
 	</div>
 {:else if activeTab === 'location'}

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/events/[event_id]/+page.ts
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/events/[event_id]/+page.ts
@@ -13,13 +13,12 @@ export const load: PageLoad = async ({ params, parent }) => {
 			queries: { withTranslations: true }
 		});
 
-		const facilitators = await api.ListEventAttendances({
+		// All registered attendees (any role), so the facilitators tab can list
+		// everyone and let an admin promote/demote them per person. Large limit to
+		// pull the whole roster in one page.
+		const attendees = await api.ListEventAttendances({
 			params: { conversation_id, event_id },
-			queries: { role: 'facilitator' }
-		});
-		const moderators = await api.ListEventAttendances({
-			params: { conversation_id, event_id },
-			queries: { role: 'moderator' }
+			queries: { limit: 1000 }
 		});
 
 		const invites = await api.ListInvitesForEvent({
@@ -33,8 +32,7 @@ export const load: PageLoad = async ({ params, parent }) => {
 		return {
 			event,
 			conversation,
-			facilitators: facilitators.records,
-			moderators: moderators.records,
+			attendees: attendees.records,
 			invites,
 			recordings
 		};

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/events/[event_id]/FacilitatorRoleList.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/events/[event_id]/FacilitatorRoleList.svelte
@@ -1,0 +1,88 @@
+<script lang="ts">
+	import Button from '$lib/components/ui/button/button.svelte';
+
+	type Attendee = {
+		id: string;
+		userId: string;
+		email?: string | null;
+		role: string;
+	};
+
+	type PendingInvite = {
+		id: string;
+		email: string;
+		status: string;
+	};
+
+	type Props = {
+		attendees: Attendee[];
+		pendingInvites: PendingInvite[];
+		/** Set a registered attendee's role by attendance id. */
+		onSetRole: (attendanceId: string, role: string) => void;
+	};
+
+	let { attendees, pendingInvites, onSetRole }: Props = $props();
+
+	/** Roles an admin can assign, in display order. 'participant' is the plain,
+	 *  non-privileged role a registered attendee gets by default. */
+	const ROLES = [
+		{ value: 'participant', label: 'Attendee' },
+		{ value: 'facilitator', label: 'Facilitator' },
+		{ value: 'moderator', label: 'Moderator' }
+	];
+
+	function displayName(a: Attendee): string {
+		return a.email && a.email.trim() ? a.email : a.userId.slice(0, 8);
+	}
+</script>
+
+<div class="flex w-full flex-col gap-6">
+	<section class="flex flex-col gap-3">
+		<h3 class="text-sm font-semibold">Registered attendees</h3>
+		{#if attendees.length === 0}
+			<p class="text-muted-foreground text-sm">No one has registered for this event yet.</p>
+		{:else}
+			<ul class="flex flex-col divide-y">
+				{#each attendees as attendee (attendee.id)}
+					<li
+						class="flex flex-col gap-2 py-3 sm:flex-row sm:items-center sm:justify-between"
+					>
+						<span class="text-sm">{displayName(attendee)}</span>
+						<div class="flex gap-1">
+							{#each ROLES as role (role.value)}
+								<Button
+									size="sm"
+									variant={attendee.role === role.value ? 'default' : 'outline'}
+									aria-pressed={attendee.role === role.value}
+									disabled={attendee.role === role.value}
+									onclick={() => onSetRole(attendee.id, role.value)}
+								>
+									{role.label}
+								</Button>
+							{/each}
+						</div>
+					</li>
+				{/each}
+			</ul>
+		{/if}
+	</section>
+
+	{#if pendingInvites.length > 0}
+		<section class="flex flex-col gap-3">
+			<h3 class="text-sm font-semibold">Invited (not registered yet)</h3>
+			<p class="text-muted-foreground text-xs">
+				These people have been invited but haven't registered, so a role can't be assigned
+				until they join.
+			</p>
+			<ul class="flex flex-col divide-y opacity-60">
+				{#each pendingInvites as invite (invite.id)}
+					<li class="flex items-center justify-between py-3">
+						<span class="text-sm">{invite.email}</span>
+						<span class="text-muted-foreground text-xs capitalize">{invite.status}</span
+						>
+					</li>
+				{/each}
+			</ul>
+		</section>
+	{/if}
+</div>


### PR DESCRIPTION
Replace the free-text email box on the event facilitators tab with a list of registered attendees, each with a per-person role toggle (Attendee / Facilitator / Moderator) backed by UpdateEventAttendance. Promoting an existing attendee no longer 409s the way the old email->create_facilitator path did when the user was already registered.

Invited-but-not-yet-registered people are shown disabled, since a role cannot attach without an attendance record.