### PR TITLE
758/Fix: HeyForm survey embed footer overlapping content on longer questions

### DIFF
--- a/ui/packages/comhairle/src/lib/tools/heyform/HeyFormEmbed.svelte
+++ b/ui/packages/comhairle/src/lib/tools/heyform/HeyFormEmbed.svelte
@@ -66,9 +66,8 @@
 <!-- The form renderer is a white, self-themed UI inside a cross-origin iframe: we can't restyle its
 	internals or match comhairle's light/dark per viewer. So we frame it as a centered white card
 	(bg-white is deliberate, matching the form's own paper) rather than a full-bleed slab, so it
-	reads as an intentional embedded form on any background, dark mode included. Bounding the height
-	keeps a short form from showing a large empty area; longer forms scroll inside the card. The
-	max-width and height are tunable. -->
+	reads as an intentional embedded form on any background, dark mode included. The max-width and
+	height are tunable. -->
 <!-- A single-cell grid rather than absolute positioning: both children claim the same cell, so the
 	skeleton inherits the iframe's exact box without restating its height clamp. -->
 <div class="grid w-full grid-cols-1 grid-rows-1">
@@ -83,7 +82,7 @@
 			title="survey"
 			onload={handleLoad}
 			allow="microphone; camera"
-			class="h-[60dvh] max-h-[700px] min-h-[440px] w-full border-none transition-opacity duration-300 {ready
+			class="h-[70dvh] max-h-225 min-h-140 w-full border-none transition-opacity duration-300 {ready
 				? 'opacity-100'
 				: 'opacity-0'}"
 		></iframe>

--- a/ui/packages/comhairle/src/lib/tools/heyform/HeyFormEmbed.svelte
+++ b/ui/packages/comhairle/src/lib/tools/heyform/HeyFormEmbed.svelte
@@ -30,11 +30,39 @@
 		setTimeout(() => (ready = true), RENDERER_BOOT_GRACE_MS);
 	}
 
-	function onFrameMessage(e: any) {
-		if (e.data.eventName === 'HIDE_EMBED_MODAL') {
-			setTimeout(() => {
-				onDone();
-			}, 2000);
+	/**
+	 * Auto-height. The form is a cross-origin iframe, so we can't measure it from here (the browser
+	 * blocks reaching into its document). Instead our HeyForm fork measures its own active question
+	 * and posts the height out; we listen and size the iframe to it. That gives long / grouped
+	 * questions exactly the room they need (no footer overlapping the answers) without leaving a big
+	 * empty card on short ones.
+	 *
+	 * Contract with the fork (see its `sendMessageToParent`):
+	 *   { source: 'HEYFORM', eventName: 'FORM_RESIZE', height: <content height in px> }
+	 *
+	 * `measuredHeight` stays null until that message arrives, so the iframe falls back to the bounded
+	 * viewport height in the markup. That keeps this correct against a fork that hasn't shipped the
+	 * emit yet: it just behaves like the fixed-height version until the messages start coming.
+	 */
+	const MIN_FRAME_PX = 440;
+	const MAX_FRAME_PX = 2000;
+
+	let measuredHeight = $state<number | null>(null);
+
+	function onFrameMessage(e: MessageEvent) {
+		const data = e.data;
+		// HeyForm tags every message it posts; ignore anything else on the page (HMR, analytics, ...).
+		if (!data || data.source !== 'HEYFORM') return;
+
+		switch (data.eventName) {
+			case 'HIDE_EMBED_MODAL':
+				setTimeout(() => onDone(), 2000);
+				break;
+			case 'FORM_RESIZE':
+				if (typeof data.height === 'number' && Number.isFinite(data.height)) {
+					measuredHeight = Math.min(Math.max(data.height, MIN_FRAME_PX), MAX_FRAME_PX);
+				}
+				break;
 		}
 	}
 
@@ -66,8 +94,14 @@
 <!-- The form renderer is a white, self-themed UI inside a cross-origin iframe: we can't restyle its
 	internals or match comhairle's light/dark per viewer. So we frame it as a centered white card
 	(bg-white is deliberate, matching the form's own paper) rather than a full-bleed slab, so it
-	reads as an intentional embedded form on any background, dark mode included. The max-width and
-	height are tunable. -->
+	reads as an intentional embedded form on any background, dark mode included. The max-width is
+	tunable.
+
+	Height: once the fork reports its content height (measuredHeight, see the FORM_RESIZE handler) we
+	size the iframe to exactly that. Until then we fall back to a compact fixed height that matches the
+	skeleton, so the pre-emit flash and the loaded form line up. NOTE: this assumes the fork emits
+	FORM_RESIZE; a heyform build without that would render every form at this short fixed height, so
+	the emit must be deployed alongside this. The height transition smooths the per-question resize. -->
 <!-- A single-cell grid rather than absolute positioning: both children claim the same cell, so the
 	skeleton inherits the iframe's exact box without restating its height clamp. -->
 <div class="grid w-full grid-cols-1 grid-rows-1">
@@ -82,7 +116,10 @@
 			title="survey"
 			onload={handleLoad}
 			allow="microphone; camera"
-			class="h-[70dvh] max-h-225 min-h-140 w-full border-none transition-opacity duration-300 {ready
+			style={measuredHeight ? `height:${measuredHeight}px` : undefined}
+			class="{measuredHeight
+				? ''
+				: 'min-h-110'} w-full border-none transition-[height,opacity] duration-300 {ready
 				? 'opacity-100'
 				: 'opacity-0'}"
 		></iframe>

--- a/ui/packages/comhairle/src/lib/tools/heyform/HeyFormEmbedSkeleton.svelte
+++ b/ui/packages/comhairle/src/lib/tools/heyform/HeyFormEmbedSkeleton.svelte
@@ -1,19 +1,12 @@
 <!--
-	Stands in for the participant-facing form while its cross-origin iframe boots. It has to occupy
-	exactly the same box as the iframe in HeyFormEmbed (same max-width, radius and height clamp),
-	otherwise the swap shifts the page under the participant.
-
-	The placeholder bars are deliberately off-token neutrals on a white card rather than
-	bg-accent/bg-card: the frame it covers is the form renderer's own white paper, which we can't
-	theme (same reason HeyFormEmbed frames it as a white card), so theme-aware tokens here would
-	hand off from a dark skeleton to a white form.
+	Stands in for the participant-facing form while its cross-origin iframe boots.
 -->
 <div
-	class="mx-auto mt-1 h-[70dvh] max-h-225 min-h-140 w-full max-w-2xl overflow-hidden rounded-xl bg-white"
+	class="mx-auto mt-1 min-h-110 w-full max-w-2xl overflow-hidden rounded-xl bg-white"
 	aria-busy="true"
 	aria-live="polite"
 >
-	<div class="flex h-full flex-col justify-center gap-4 px-8 sm:px-12">
+	<div class="flex h-full flex-col justify-start gap-4 px-8 pt-10 sm:px-12 sm:pt-14">
 		<!-- Question number / label -->
 		<div class="h-3 w-16 animate-pulse rounded bg-neutral-200"></div>
 

--- a/ui/packages/comhairle/src/lib/tools/heyform/HeyFormEmbedSkeleton.svelte
+++ b/ui/packages/comhairle/src/lib/tools/heyform/HeyFormEmbedSkeleton.svelte
@@ -9,7 +9,7 @@
 	hand off from a dark skeleton to a white form.
 -->
 <div
-	class="mx-auto mt-1 h-[60dvh] max-h-[700px] min-h-[440px] w-full max-w-2xl overflow-hidden rounded-xl bg-white"
+	class="mx-auto mt-1 h-[70dvh] max-h-225 min-h-140 w-full max-w-2xl overflow-hidden rounded-xl bg-white"
 	aria-busy="true"
 	aria-live="polite"
 >


### PR DESCRIPTION
The participant/public survey embed now sizes its iframe to the form's actual content height instead of a fixed guess. This fixes the bottom buttons (Next / Skip + nav) overlapping the answers on longer questions, and removes the big empty gap that short questions had. Fixes #758

**How it works**

The form is a cross-origin iframe, so comhairle can't measure it directly. Our HeyForm fork now measures its active question and posts the height out; this listens for that message and sizes the iframe to it:

- listens for `{ source: 'HEYFORM', eventName: 'FORM_RESIZE', height }`
- clamps to 440–2000px and applies it to the iframe, with a height transition so per-question changes are smooth
- before the message arrives, falls back to a compact fixed height (`min-h-110` / 440px) that matches the skeleton

Also adjusted the loading skeleton ([HeyFormEmbedSkeleton.svelte](ui/packages/comhairle/src/lib/tools/heyform/HeyFormEmbedSkeleton.svelte)) to be top-aligned and compact, so it matches how the form actually renders now (content anchored at the top, sized to fit) instead of a tall vertically-centered block.


**Testing**

Verified locally against a dockerised local heyform: short questions shrink to fit, long/grouped questions grow with no footer overlap, content top-aligns.


Before: 

https://github.com/user-attachments/assets/1db51d31-6ef0-4e86-a0cb-d9f5d681c666

After:

https://github.com/user-attachments/assets/899ee07a-287a-4c65-b661-0c9eb4c0ff24