### PR TITLE
Rich text should not be scrollable unless the content exceeds the area

### DIFF
--- a/ui/packages/comhairle/src/lib/components/RichTextEditor/editor-content.css
+++ b/ui/packages/comhairle/src/lib/components/RichTextEditor/editor-content.css
@@ -4,7 +4,6 @@
 
 .tiptap {
 	outline: none;
-	min-height: var(--editor-min-height, 200px);
 	color: var(--color-foreground);
 }
 


### PR DESCRIPTION
Fixes https://github.com/crownshy/comhairle/issues/761

Before:

https://github.com/user-attachments/assets/9e762644-2383-47c3-ac6b-6094dfcfc91e

After:

https://github.com/user-attachments/assets/58398e33-e30a-44ee-85e9-7d4aea7ba8ef
