### PR TITLE
Handle Polis insights loading states (empty / not-ready / error)

### DIFF
--- a/ui/packages/comhairle/src/lib/reports/polis/PolisInsights.svelte
+++ b/ui/packages/comhairle/src/lib/reports/polis/PolisInsights.svelte
@@ -13,14 +13,17 @@
 	import AreaOfConsensus from './AreaOfConsensus.svelte';
 	import OpinionGroups from './OpinionGroups.svelte';
 	import { Button } from '$lib/components/ui/button';
-	import { Download, ChartNoAxesColumn } from '@lucide/svelte';
+	import { Download, ChartNoAxesColumn, TriangleAlert } from '@lucide/svelte';
 
 	let {
 		reportData,
+		reportError = null,
 		statementAux
 	}: {
 		workflowStepId: string;
 		reportData: PolisReportData | null;
+		/** Set when the report failed to load for a real reason (not just "no votes yet"). */
+		reportError?: string | null;
 		statementAux: PolisStatementAux[];
 	} = $props();
 
@@ -170,7 +173,20 @@
 	}
 </script>
 
-{#if !report || !stats}
+{#if reportError}
+	<div
+		class="border-border bg-card text-muted-foreground flex flex-col items-center justify-center gap-3 rounded-xl border border-dashed p-12 text-center"
+	>
+		<TriangleAlert class="text-destructive/70 size-8" />
+		<div class="flex flex-col gap-1">
+			<p class="text-foreground text-base font-medium">Couldn't load insights</p>
+			<p class="text-base">
+				Something went wrong fetching the report. Refresh to try again; if it keeps
+				happening, the poll service may be down.
+			</p>
+		</div>
+	</div>
+{:else if !report || !stats}
 	<div
 		class="border-border bg-card text-muted-foreground flex flex-col items-center justify-center gap-3 rounded-xl border border-dashed p-12 text-center"
 	>

--- a/ui/packages/comhairle/src/lib/reports/polis/insights-loader.ts
+++ b/ui/packages/comhairle/src/lib/reports/polis/insights-loader.ts
@@ -1,6 +1,29 @@
 import type { ApiClient } from '@crownshy/api-client/api';
 import { tryCatchAsync } from '$lib/utils/errorHandling';
 
+/**
+ * Pull a human-readable message out of whatever the api client throws. Zodios wraps
+ * axios, so a failed call carries the API's JSON body at `response.data.err`; fall back
+ * to the error's own `message`, then to `String(err)`.
+ */
+function errorText(err: unknown): string {
+	if (typeof err === 'string') return err;
+	if (err && typeof err === 'object') {
+		const e = err as { response?: { data?: { err?: unknown } }; message?: unknown };
+		if (typeof e.response?.data?.err === 'string') return e.response.data.err;
+		if (typeof e.message === 'string') return e.message;
+	}
+	return String(err);
+}
+
+// A brand-new poll has no report yet: until Polis has enough vote data to run PCA, the
+// report_data endpoint errors instead of returning empty. This matches that expected
+// pre-report state so we can show a "waiting on votes" empty state for it, and a real
+// "something broke" state for everything else (network, our-API 500s, auth). Tied to the
+// current Polis error wording; if that changes we fall back to treating it as a genuine
+// error, which is safe (shows the error state, which an admin can retry).
+const PRE_REPORT_SIGNATURE = /parse PCA data|Failed to get comments/i;
+
 export async function polisInsightsLoader(apiClient: ApiClient, workflowStepId: string) {
 	const statementAux = await apiClient.PolisListStatementAux({
 		queries: { workflow_step_id: workflowStepId }
@@ -8,24 +31,23 @@ export async function polisInsightsLoader(apiClient: ApiClient, workflowStepId: 
 
 	// PolisReportData is WikiPollReport (the client's return type) plus the client-only
 	// theme overlay, so this assigns without a cast.
-	//
-	// A brand-new poll has no report yet: until Polis has enough vote data to run PCA,
-	// this call errors ("Failed to parse PCA data: error decoding response body") rather
-	// than returning empty. That's the expected pre-vote state, not a failure we want to
-	// surface, so we swallow it to null and let the insights UI render its empty state.
-	// A real outage lands here too; it shows the same "no insights yet" state, and the
-	// underlying error is logged for debugging.
 	const reportResult = await tryCatchAsync(() =>
 		apiClient.PolisGetReportData({ queries: { workflow_step_id: workflowStepId } })
 	);
-	if (reportResult.err !== null) {
-		console.warn(
-			'Polis report data not available yet for step',
-			workflowStepId,
-			reportResult.err
-		);
-	}
-	const reportData = reportResult.err === null ? reportResult.ok : null;
 
-	return { polis: { statementAux, reportData } };
+	if (reportResult.err === null) {
+		return { polis: { statementAux, reportData: reportResult.ok, reportError: null } };
+	}
+
+	const message = errorText(reportResult.err);
+	if (PRE_REPORT_SIGNATURE.test(message)) {
+		// Expected pre-report state, not a failure: leave reportData + reportError null so
+		// the UI shows the "no insights yet, waiting on votes" empty state.
+		console.warn('Polis report not ready yet for step', workflowStepId, message);
+		return { polis: { statementAux, reportData: null, reportError: null } };
+	}
+
+	// Genuine failure: surface a distinct error state in the UI.
+	console.error('Failed to load Polis report for step', workflowStepId, reportResult.err);
+	return { polis: { statementAux, reportData: null, reportError: message } };
 }

--- a/ui/packages/comhairle/src/lib/reports/polis/insights-loader.ts
+++ b/ui/packages/comhairle/src/lib/reports/polis/insights-loader.ts
@@ -1,15 +1,31 @@
 import type { ApiClient } from '@crownshy/api-client/api';
+import { tryCatchAsync } from '$lib/utils/errorHandling';
 
 export async function polisInsightsLoader(apiClient: ApiClient, workflowStepId: string) {
 	const statementAux = await apiClient.PolisListStatementAux({
 		queries: { workflow_step_id: workflowStepId }
 	});
+
 	// PolisReportData is WikiPollReport (the client's return type) plus the client-only
-	// theme overlay, so this assigns without a cast. Fails (→ null) when the poll has no
-	// votes yet.
-	const reportData = await apiClient.PolisGetReportData({
-		queries: { workflow_step_id: workflowStepId }
-	});
+	// theme overlay, so this assigns without a cast.
+	//
+	// A brand-new poll has no report yet: until Polis has enough vote data to run PCA,
+	// this call errors ("Failed to parse PCA data: error decoding response body") rather
+	// than returning empty. That's the expected pre-vote state, not a failure we want to
+	// surface, so we swallow it to null and let the insights UI render its empty state.
+	// A real outage lands here too; it shows the same "no insights yet" state, and the
+	// underlying error is logged for debugging.
+	const reportResult = await tryCatchAsync(() =>
+		apiClient.PolisGetReportData({ queries: { workflow_step_id: workflowStepId } })
+	);
+	if (reportResult.err !== null) {
+		console.warn(
+			'Polis report data not available yet for step',
+			workflowStepId,
+			reportResult.err
+		);
+	}
+	const reportData = reportResult.err === null ? reportResult.ok : null;
 
 	return { polis: { statementAux, reportData } };
 }

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/design/step/[step_id]/insights/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/design/step/[step_id]/insights/+page.svelte
@@ -18,6 +18,7 @@
 	<PolisInsights
 		workflowStepId={step.id}
 		reportData={data.polis.reportData ?? null}
+		reportError={data.polis.reportError ?? null}
 		statementAux={data.polis.statementAux ?? []}
 	/>
 {/if}


### PR DESCRIPTION
A brand-new Polis step (no votes, or only seed statements) rendered a blank insights page. The `report_data` endpoint doesn't return empty in that state, it *errors* (`"Failed to get comments Failed to parse PCA data..."`) because Polis can't run the PCA clustering until there's real vote data. The loader awaited that call directly, so the throw bubbled up, the whole `polis` payload came back `undefined`, and nothing rendered.

**What changed**
- Pull the real message off the Zodios/axios error (`response.data.err`) and split two failure modes:
  - **Pre-report** (matches `parse PCA data` / `Failed to get comments`) → expected "no votes yet" state, not a real error.
  - **Everything else** (network, our-API 500s, auth) → surfaced as a genuine error.
- `PolisInsights` now renders three states: the report, a **"No insights yet"** empty state (waiting on votes), or a **"Couldn't load insights"** error state. The underlying error is always logged for debugging.

**Notes**
- The pre-report match is tied to the current Polis error wording; if it changes, a new poll falls through to the error state (safe, retryable) and a comment flags it.
- Raw error text isn't shown to admins (logged only), since `"error decoding response body"` isn't useful to them.

**Testing**
- New Polis step, no votes → "No insights yet" (previously blank).
- To see the error state without a real outage, temporarily return `reportError: 'test'` from the loader's success path.