### PR TITLE
Add actions concept to permissions model

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -43,6 +43,15 @@ A per-Step declaration of who may see the data participants produce in that Step
 _Avoid_: Private/Limited (stale Learn-guide wording for Confidential/Restricted), "data sharing", "data policy".
 _Status_: Only Confidential and Restricted are backed today — they map onto the existing `request_user_share_permission` boolean (`false`→Confidential, `true`→Restricted). Collaborative and Open appear in the UI for design fidelity but are disabled pending a team decision on introducing a real `data_protocol` enum column (flagged as an open question on the PR).
 
+**Role assignment**:
+An explicit grant that links an actor (user or organisation) to a named role on a resource (`resource_type` + `resource_id`). Role assignments are durable records and form the source of truth for authorization.
+
+**Permission action**:
+A single allowed operation (for example list, grant, revoke, read, update) that routes enforce. Roles grant sets of permission actions; authorization succeeds when any assigned role on the target resource grants the required action.
+
+**Authorization precedence**:
+Permission checks resolve in this order: resource ownership allows, then system admin grant allows globally, then role-action mapping on the target resource is evaluated. There are currently no explicit deny rules.
+
 ### Polis admin (Discuss step)
 
 The custom admin UI for a Pol.is Step, replacing the old Setup **iframe**. Its glossary and analytics are **adopted from the civic_os admin** (`bloom/civic_os/packages/admin`), taken as the source of truth because the equivalent surfaces were built out there first. Terms below carry civic_os's meaning unless noted. Canonical Polis-step subtabs: **`Configure · Setup · Moderation · Insights`** (civic_os's "Participants" tab is dropped — see Insights/Report and the Participants note).

--- a/api/src/error.rs
+++ b/api/src/error.rs
@@ -349,7 +349,7 @@ pub enum ComhairleError {
     RoleNotFound(String),
 
     #[error("Cannot revoke the last system admin role")]
-    CannotRevokeLastAdmin,
+    CannotRevokeLastSuperAdmin,
 }
 
 #[derive(Debug, Serialize, JsonSchema)]
@@ -392,7 +392,7 @@ impl IntoResponse for ComhairleError {
             | ComhairleError::WorkflowStepHasWrongType(_) => StatusCode::UNPROCESSABLE_ENTITY,
             ComhairleError::UserIsNotConversationOwner
             | ComhairleError::UserNotAuthorized
-            | ComhairleError::CannotRevokeLastAdmin
+            | ComhairleError::CannotRevokeLastSuperAdmin
             | ComhairleError::AuthWebhookSignatureError(_) => StatusCode::FORBIDDEN,
             ComhairleError::PasswordConfirmationMismatch
             | ComhairleError::WeakPassword(_)

--- a/api/src/models/conversation.rs
+++ b/api/src/models/conversation.rs
@@ -6,16 +6,15 @@ use super::{
     user_participation::UserParticipationIden,
     workflow::WorkflowIden,
 };
-use crate::{
-    ComhairleState,
-    bot_service::{
-        ComhairleBotService, ComhairlePrompt, CreateChatRequest, DEFAULT_CHAT_NOT_FOUND_RESPONSE,
-        DEFAULT_CHAT_OPENER, DEFAULT_CHAT_PROMPT,
-    },
-    config::ComhairleConfig,
-    error::ComhairleError,
-    models::{self, SqlxResultExt, permissions::ResourcePermissionIden},
+use crate::ComhairleState;
+use crate::bot_service::{
+    ComhairleBotService, ComhairlePrompt, CreateChatRequest, DEFAULT_CHAT_NOT_FOUND_RESPONSE,
+    DEFAULT_CHAT_OPENER, DEFAULT_CHAT_PROMPT,
 };
+use crate::config::ComhairleConfig;
+use crate::error::ComhairleError;
+use crate::models::permissions::ResourcePermissionIden;
+use crate::models::{self, SqlxResultExt};
 use chrono::{DateTime, Utc};
 use comhairle_macros::Translatable;
 use partially::Partial;
@@ -955,22 +954,14 @@ mod tests {
     use fake::{Fake, Faker};
     use serde_json::json;
 
-    use crate::{
-        models::{
-            model_test_helpers::setup_default_app_and_session,
-            permissions::{
-                ConversationContentEditorRole, GrantRoleRequest, NamedRole, ResourceRole,
-                UserOrOrganizationId, grant_role,
-            },
-            users::{self, UpdateUserRequest, create_user, update_user},
-        },
-        routes::{
-            auth::SignupRequest, conversations::dto::ConversationDto,
-            organizations::dto::OrganizationDto,
-        },
-        setup_server,
-        test_helpers::{TestRole, UserSession, test_state},
-    };
+    use crate::models::model_test_helpers::setup_default_app_and_session;
+    use crate::models::permissions::{GrantRoleRequest, Role, UserOrOrganizationId, grant_role};
+    use crate::models::users::{self, UpdateUserRequest, create_user, update_user};
+    use crate::routes::auth::SignupRequest;
+    use crate::routes::conversations::dto::ConversationDto;
+    use crate::routes::organizations::dto::OrganizationDto;
+    use crate::setup_server;
+    use crate::test_helpers::{UserSession, test_state};
 
     use super::*;
     use std::error::Error;
@@ -1246,7 +1237,7 @@ mod tests {
 
         let grant_request_a_a = GrantRoleRequest {
             actor_id: UserOrOrganizationId::User(user_a.id),
-            permission_triplet: ConversationContentEditorRole::make_triplet(&conversation.id),
+            permission_triplet: Role::ConversationContentEditor.triplet(&conversation.id),
             granted_by: &session.id.unwrap(),
             grant_reason: "Testing",
         };
@@ -1254,7 +1245,7 @@ mod tests {
 
         let grant_request_a_b = GrantRoleRequest {
             actor_id: UserOrOrganizationId::User(user_a.id),
-            permission_triplet: TestRole::make_triplet(&conversation.id),
+            permission_triplet: Role::Tester.triplet(&conversation.id),
             granted_by: &session.id.unwrap(),
             grant_reason: "Testing",
         };
@@ -1277,7 +1268,7 @@ mod tests {
             page_options.clone(),
             order_options,
             filter_options,
-            ConversationContentEditorRole::name(),
+            Role::ConversationContentEditor.as_ref(),
             Some("en".to_string()),
         )
         .await?;
@@ -1294,7 +1285,7 @@ mod tests {
             page_options.clone(),
             order_options,
             filter_options,
-            ConversationContentEditorRole::name(),
+            Role::ConversationContentEditor.as_ref(),
             Some("en".to_string()),
         )
         .await?;
@@ -1320,7 +1311,7 @@ mod tests {
             page_options.clone(),
             order_options,
             filter_options,
-            TestRole::name(),
+            Role::Tester.as_ref(),
             Some("en".to_string()),
         )
         .await?;
@@ -1337,7 +1328,7 @@ mod tests {
             page_options.clone(),
             order_options,
             filter_options,
-            TestRole::name(),
+            Role::Tester.as_ref(),
             Some("en".to_string()),
         )
         .await?;

--- a/api/src/models/model_test_helpers.rs
+++ b/api/src/models/model_test_helpers.rs
@@ -68,7 +68,6 @@ pub async fn get_random_organization_id(
     session: &mut UserSession,
 ) -> Result<Uuid, Box<dyn Error>> {
     let (_, response, _) = session.create_random_organization(app).await?;
-    eprintln!("Organization creation response: {:?}", response);
     let organization: OrganizationDto = serde_json::from_value(response)?;
 
     Ok(organization.id)

--- a/api/src/models/permissions.rs
+++ b/api/src/models/permissions.rs
@@ -1,16 +1,47 @@
+//! # Permissions model
+//!
+//! This module defines the permissions model for the Comhairle application, including resource types, roles, actions, and permission handling.
+//!
+//! ## Definitions:
+//! - Resource Type      : A string that identifies a category of resources in the system (e.g., "system", "conversation").
+//! - Resource ID        : A UUID that uniquely identifies a specific resource within its category.
+//! - Role               : An alias for a group of permissions that can be assigned to a user or organization on a specific resource.
+//! - Action             : A specific operation that can be performed on a resource, such as reading, updating, or deleting it.
+//! - Policy             : Defines which actions are allowed for a specific resource type on a per-role basis.
+//! - Permission Triplet : A combination of resource type, resource ID, and role name that uniquely identifies a permission assignment.
+//!
+//! ## Adding New Resource Types, Roles, and Actions
+//! Resource types, roles, and actions are each a single enum ([`ResourceType`],
+//! [`Role`], [`Action`]). To extend the model:
+//! 1. Add a variant to the relevant enum, preserving any persisted string value via
+//!    `#[strum(serialize = "...")]` / `#[serde(rename = "...")]`.
+//! 2. Map new roles to their resource type in [`Role::resource_type`] and their allowed
+//!    actions in [`Role::actions`]; map new actions to their resource type in
+//!    [`Action::resource_type`].
+//! 3. If the resource is addressed by a path, add an extractor struct via
+//!    `define_owned_resource!` / `define_unowned_resource!` so [`crate::routes::auth::authorize`]
+//!    can resolve its id and owner.
+//!
+//! ## Helper Macros
+//! - `define_owned_resource!`   : Defines a resource struct with an owner and implements the `ExtractResourceId` and `OwnedResource` traits for it.
+//! - `define_unowned_resource!` : Defines a resource struct without an owner and implements the `ExtractResourceId` and `OwnedResource` traits for it.
+
 use std::sync::Arc;
 
 use crate::models::users::UserIden;
 use crate::redis_connection::RedisConnection;
+use aide::OperationIo;
 use axum::extract::{FromRequestParts, Path};
 use chrono::{DateTime, Utc};
 use schemars::JsonSchema;
+use sea_query::JoinType;
 use sea_query::{Expr, OnConflict, PostgresQueryBuilder, Query, enum_def};
-use sea_query::{IdenStatic, JoinType};
 use sea_query_binder::SqlxBinder;
 use serde::{Deserialize, Serialize};
 use sqlx::prelude::FromRow;
-use sqlx::{PgPool, Row, query_as_with};
+use sqlx::{PgPool, query_as_with};
+use strum::IntoEnumIterator;
+use strum_macros::{AsRefStr, Display, EnumIter, EnumString, IntoStaticStr};
 use tracing::instrument;
 use uuid::Uuid;
 
@@ -21,80 +52,86 @@ use crate::models::{
     pagination::{PageOptions, PaginatedResults},
 };
 
-/// Represents the system administrator role.
-#[derive(Debug)]
-pub struct SystemAdminRole;
+// ---------- //
+// * MACROS * //
+// ---------- //
 
-impl NamedRole for SystemAdminRole {
-    fn name() -> &'static str {
-        "admin"
-    }
+macro_rules! define_unowned_resource {
+    ($resource_struct:ident, $resource_id_field:ident, $extract_logic:expr) => {
+        #[derive(Debug, OperationIo)]
+        pub struct $resource_struct {
+            pub $resource_id_field: Uuid,
+        }
+
+        impl FromRequestParts<Arc<ComhairleState>> for $resource_struct {
+            type Rejection = ComhairleError;
+
+            async fn from_request_parts(
+                parts: &mut axum::http::request::Parts,
+                state: &Arc<ComhairleState>,
+            ) -> Result<Self, Self::Rejection> {
+                ($extract_logic)(parts, state).await
+            }
+        }
+
+        impl ExtractResourceId for $resource_struct {
+            fn resource_id(&self) -> Uuid {
+                self.$resource_id_field
+            }
+        }
+
+        impl OwnedResource for $resource_struct {}
+    };
 }
 
-impl SystemResourceRole for SystemAdminRole {}
+macro_rules! define_owned_resource {
+    ($resource_struct:ident, $resource_id_field:ident, $owner_id_field:ident, $extract_logic:expr) => {
+        #[derive(Debug, OperationIo)]
+        pub struct $resource_struct {
+            pub $resource_id_field: Uuid,
+            pub $owner_id_field: Uuid,
+        }
 
-/// Represents the system resource, which is a global resource used for system-level permissions.
-#[derive(Debug)]
-pub struct SystemResource;
+        impl FromRequestParts<Arc<ComhairleState>> for $resource_struct {
+            type Rejection = ComhairleError;
 
-impl FromRequestParts<Arc<ComhairleState>> for SystemResource {
-    type Rejection = ComhairleError;
+            async fn from_request_parts(
+                parts: &mut axum::http::request::Parts,
+                state: &Arc<ComhairleState>,
+            ) -> Result<Self, Self::Rejection> {
+                ($extract_logic)(parts, state).await
+            }
+        }
 
-    async fn from_request_parts(
-        _parts: &mut axum::http::request::Parts,
-        _state: &Arc<ComhairleState>,
-    ) -> Result<Self, Self::Rejection> {
-        Ok(SystemResource)
-    }
+        impl ExtractResourceId for $resource_struct {
+            fn resource_id(&self) -> Uuid {
+                self.$resource_id_field
+            }
+        }
+
+        impl OwnedResource for $resource_struct {
+            fn owner_id(&self) -> Option<Uuid> {
+                Some(self.$owner_id_field)
+            }
+        }
+    };
 }
 
-#[derive(Deserialize)]
-pub struct ConversationPath {
-    pub conversation_id: Uuid,
-}
+// ------------------ //
+// * RESOURCE TYPES * //
+// ------------------ //
+//
+// - A resource type is a string that identifies a category of resources in the system.
+// - A resource ID is a UUID that uniquely identifies a specific resource within its category.
+//
 
-#[derive(Debug)]
-pub struct ConversationResource {
-    conversation_id: Uuid,
-    owner_id: Uuid,
-}
-
-impl FromRequestParts<Arc<ComhairleState>> for ConversationResource {
-    type Rejection = ComhairleError;
-
-    async fn from_request_parts(
-        parts: &mut axum::http::request::Parts,
-        state: &Arc<ComhairleState>,
-    ) -> Result<Self, Self::Rejection> {
-        let Path(ConversationPath { conversation_id }) =
-            Path::<ConversationPath>::from_request_parts(parts, state)
-                .await
-                .map_err(|_| {
-                    ComhairleError::ResourceNotFound(
-                        "Path must contain a conversation_id".to_string(),
-                    )
-                })?;
-
-        let conversation = models::conversation::get_by_id(&state.db, &conversation_id).await?;
-
-        Ok(ConversationResource {
-            conversation_id,
-            owner_id: conversation.owner_id,
-        })
-    }
-}
+// -- TRAITS -- //
 
 /// A trait for extracting a resource ID from a request.
 pub trait ExtractResourceId:
     FromRequestParts<Arc<ComhairleState>> + 'static + Send + Sync + OwnedResource
 {
     fn resource_id(&self) -> Uuid;
-}
-
-impl ExtractResourceId for SystemResource {
-    fn resource_id(&self) -> Uuid {
-        SYSTEM_RESOURCE_ID
-    }
 }
 
 /// A trait for extracting owner_id for a resource if available
@@ -104,19 +141,316 @@ pub trait OwnedResource {
     }
 }
 
-impl OwnedResource for SystemResource {}
+// -- ENUM -- //
 
-impl ExtractResourceId for ConversationResource {
+/// The set of resource categories that permissions can be granted on.
+///
+/// The string form (via [`AsRefStr`] / [`Display`]) is what is persisted in the
+/// `resource_permissions.resource_type` column, so those values are load bearing.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    Serialize,
+    Deserialize,
+    JsonSchema,
+    Display,
+    EnumString,
+    AsRefStr,
+    EnumIter,
+    IntoStaticStr,
+)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum ResourceType {
+    System,
+    Conversation,
+    #[cfg(test)]
+    Test,
+}
+
+impl ResourceType {
+    /// Returns every resource type, for discovery endpoints.
+    pub fn all() -> impl Iterator<Item = ResourceType> {
+        ResourceType::iter()
+    }
+}
+
+// -- SYSTEM RESOURCE -- //
+
+/// The global system resource uses a fixed ID as a workaround to avoid having a
+/// separate table for system-level permissions.
+pub const SYSTEM_RESOURCE_ID: Uuid = Uuid::nil();
+
+define_unowned_resource!(
+    SystemResource,
+    resource_id,
+    |_parts: &mut axum::http::request::Parts, _state: &Arc<ComhairleState>| async {
+        Ok(SystemResource {
+            resource_id: SYSTEM_RESOURCE_ID,
+        })
+    }
+);
+
+#[derive(Debug, Deserialize)]
+pub struct PermissionTargetPath {
+    pub resource_type: String,
+    pub resource_id: Uuid,
+}
+
+#[derive(Debug, OperationIo)]
+pub struct PermissionTargetResource {
+    pub resource_type: String,
+    pub resource_id: Uuid,
+    pub owner_id: Option<Uuid>,
+}
+
+impl FromRequestParts<Arc<ComhairleState>> for PermissionTargetResource {
+    type Rejection = ComhairleError;
+
+    async fn from_request_parts(
+        parts: &mut axum::http::request::Parts,
+        state: &Arc<ComhairleState>,
+    ) -> Result<Self, Self::Rejection> {
+        let Path(PermissionTargetPath {
+            resource_type,
+            resource_id,
+        }) = Path::<PermissionTargetPath>::from_request_parts(parts, state)
+            .await
+            .map_err(|_| {
+                ComhairleError::ResourceNotFound(
+                    "Path must contain resource_type and resource_id".to_string(),
+                )
+            })?;
+
+        let owner_id = if resource_type == ResourceType::Conversation.as_ref() {
+            models::conversation::get_by_id(&state.db, &resource_id)
+                .await
+                .ok()
+                .map(|conversation| conversation.owner_id)
+        } else {
+            None
+        };
+
+        Ok(PermissionTargetResource {
+            resource_type,
+            resource_id,
+            owner_id,
+        })
+    }
+}
+
+impl ExtractResourceId for PermissionTargetResource {
     fn resource_id(&self) -> Uuid {
-        self.conversation_id
+        self.resource_id
     }
 }
 
-impl OwnedResource for ConversationResource {
+impl OwnedResource for PermissionTargetResource {
     fn owner_id(&self) -> Option<Uuid> {
-        Some(self.owner_id)
+        self.owner_id
     }
 }
+
+// -- CONVERSATION RESOURCE -- //
+
+/// A struct representing the path parameters for a conversation resource.
+#[derive(Deserialize)]
+pub struct ConversationPath {
+    pub conversation_id: Uuid,
+}
+
+async fn extract_conversation_resource(
+    parts: &mut axum::http::request::Parts,
+    state: &Arc<ComhairleState>,
+) -> Result<ConversationResource, ComhairleError> {
+    let Path(ConversationPath { conversation_id }) =
+        Path::<ConversationPath>::from_request_parts(parts, state)
+            .await
+            .map_err(|_| {
+                ComhairleError::ResourceNotFound("Path must contain a conversation_id".to_string())
+            })?;
+
+    let conversation = models::conversation::get_by_id(&state.db, &conversation_id).await?;
+
+    Ok(ConversationResource {
+        conversation_id,
+        owner_id: conversation.owner_id,
+    })
+}
+
+define_owned_resource!(
+    ConversationResource,
+    conversation_id,
+    owner_id,
+    extract_conversation_resource
+);
+
+// --------- //
+// * ROLES * //
+// --------- //
+//
+// - A role is an alias for a group of permissions that can be assigned to a user or organization on a specific resource.
+//
+
+/// The set of roles that can be assigned to a user or organization.
+///
+/// The string form (via [`AsRefStr`] / [`Display`]) is what is persisted in the
+/// `resource_permissions.role_name` column, so those values are load bearing.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    Serialize,
+    Deserialize,
+    JsonSchema,
+    Display,
+    EnumString,
+    AsRefStr,
+    EnumIter,
+    IntoStaticStr,
+)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum Role {
+    SuperAdmin,
+    Admin,
+    #[serde(rename = "content_editor")]
+    #[strum(serialize = "content_editor")]
+    ConversationContentEditor,
+    #[cfg(test)]
+    Tester,
+}
+
+impl Role {
+    /// The resource type this role applies to.
+    pub fn resource_type(self) -> ResourceType {
+        match self {
+            Role::SuperAdmin | Role::Admin => ResourceType::System,
+            Role::ConversationContentEditor => ResourceType::Conversation,
+            #[cfg(test)]
+            Role::Tester => ResourceType::Test,
+        }
+    }
+
+    /// The actions this role is permitted to perform (the permission policy).
+    pub fn actions(self) -> &'static [Action] {
+        match self {
+            Role::SuperAdmin => &[
+                Action::ListPermission,
+                Action::GrantPermission,
+                Action::RevokePermission,
+            ],
+            Role::Admin => &[],
+            Role::ConversationContentEditor => {
+                &[Action::ConversationRead, Action::ConversationUpdate]
+            }
+            #[cfg(test)]
+            Role::Tester => &[],
+        }
+    }
+
+    /// Builds a [`PermissionTriplet`] for this role on a specific resource.
+    pub fn triplet(self, resource_id: &Uuid) -> PermissionTriplet<'_> {
+        if self.resource_type() == ResourceType::System && *resource_id != SYSTEM_RESOURCE_ID {
+            panic!(
+                "Cannot create a triplet for a system role with a specific resource ID. Use `system_triplet()` instead."
+            );
+        }
+        PermissionTriplet(self.resource_type().into(), resource_id, self.into())
+    }
+
+    /// Builds a [`PermissionTriplet`] for this role on the global system resource.
+    pub fn system_triplet(self) -> PermissionTriplet<'static> {
+        if self.resource_type() != ResourceType::System {
+            panic!("Cannot create a system triplet for a non-system role.");
+        }
+        PermissionTriplet(
+            ResourceType::System.into(),
+            &SYSTEM_RESOURCE_ID,
+            self.into(),
+        )
+    }
+
+    /// Returns every role, for discovery endpoints.
+    pub fn all() -> impl Iterator<Item = Role> {
+        Role::iter()
+    }
+
+    /// Returns the roles that apply to a given resource type.
+    pub fn for_resource_type(resource_type: ResourceType) -> impl Iterator<Item = Role> {
+        Role::iter().filter(move |role| role.resource_type() == resource_type)
+    }
+}
+
+// ----------- //
+// * ACTIONS * //
+// ----------- //
+//
+// - An action represents a specific operation that can be performed on a resource, such as reading, updating, or deleting it.
+//
+
+/// The set of actions that can be performed on a resource.
+#[derive(
+    Debug,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    Hash,
+    Serialize,
+    Deserialize,
+    JsonSchema,
+    Display,
+    EnumString,
+    AsRefStr,
+    EnumIter,
+    IntoStaticStr,
+)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum Action {
+    ListPermission,
+    GrantPermission,
+    RevokePermission,
+    ConversationRead,
+    ConversationUpdate,
+}
+
+impl Action {
+    /// The resource type this action applies to.
+    pub fn resource_type(self) -> ResourceType {
+        match self {
+            Action::ListPermission | Action::GrantPermission | Action::RevokePermission => {
+                ResourceType::System
+            }
+            Action::ConversationRead | Action::ConversationUpdate => ResourceType::Conversation,
+        }
+    }
+
+    /// Returns every action, for discovery endpoints.
+    pub fn all() -> impl Iterator<Item = Action> {
+        Action::iter()
+    }
+
+    /// Returns the actions that apply to a given resource type.
+    pub fn for_resource_type(resource_type: ResourceType) -> impl Iterator<Item = Action> {
+        Action::iter().filter(move |action| action.resource_type() == resource_type)
+    }
+}
+
+// ----------------------- //
+// * PERMISSION HANDLING * //
+// ----------------------- //
+//
+// - Permission handling involves granting, revoking, and checking permissions for users and organizations on specific resources.
+//
 
 /// The triplet associated with a permission for a resource.
 #[derive(Debug)]
@@ -125,70 +459,6 @@ pub struct PermissionTriplet<'a>(
     pub &'a Uuid, // resource_id
     pub &'a str,  // role_name
 );
-
-/// A trait for roles that have a name, used for permission checks.
-pub trait NamedRole: Send + Sync {
-    /// Returns the name of the role as a static string.
-    fn name() -> &'static str;
-}
-
-/// The resource type associated with system-level permissions.
-pub const SYSTEM_RESOURCE_TYPE: &str = "system";
-/// The global system resource uses a fixed ID as a workaround to avoid having a
-/// separate table for system-level permissions.
-pub const SYSTEM_RESOURCE_ID: Uuid = Uuid::nil();
-
-/// Represents a role that can be assigned to a user or organization on the global
-/// system resource.
-pub trait SystemResourceRole: NamedRole {
-    /// Returns a `PermissionTriplet` for the global system resource.
-    fn make_system_triplet() -> PermissionTriplet<'static> {
-        PermissionTriplet(SYSTEM_RESOURCE_TYPE, &SYSTEM_RESOURCE_ID, Self::name())
-    }
-}
-
-/// The resource type associated with conversation-level permissions.
-pub const CONVERSATION_RESOURCE_TYPE: &str = "conversation";
-
-/// Grants read and update access to a resource, but not full write access —
-/// only a subset of update operations are permitted (e.g. editing content), while
-/// others (e.g. `launch`) are excluded and require a higher-privileged role.
-pub const CONTENT_EDITOR_ROLE: &str = "content_editor";
-
-#[derive(Debug)]
-pub struct ConversationContentEditorRole;
-
-impl NamedRole for ConversationContentEditorRole {
-    fn name() -> &'static str {
-        "content_editor"
-    }
-}
-
-impl ResourceRole for ConversationContentEditorRole {
-    fn resource_type() -> &'static str {
-        CONVERSATION_RESOURCE_TYPE
-    }
-}
-
-/// Represents a role that can be assigned to a user or organization on a specific
-/// resource.
-pub trait ResourceRole: NamedRole {
-    /// Returns a `PermissionTriplet` for the given resource ID, combining the
-    /// resource type, resource ID, and role name.
-    fn make_triplet<'a>(resource_id: &'a Uuid) -> PermissionTriplet<'a> {
-        PermissionTriplet(Self::resource_type(), resource_id, Self::name())
-    }
-
-    /// Returns the resource type associated with the role.
-    fn resource_type() -> &'static str;
-}
-
-// Automatically implement `ResourceRole` for any type that implements `SystemResourceRole`.
-impl<SystemRole: SystemResourceRole> ResourceRole for SystemRole {
-    fn resource_type() -> &'static str {
-        SYSTEM_RESOURCE_TYPE
-    }
-}
 
 /// Represents a role assignment for a user or organization on a specific resource.
 #[derive(Debug, Deserialize, Serialize, FromRow, Clone, JsonSchema)]
@@ -240,59 +510,117 @@ pub struct RevokeRoleRequest<'request> {
     pub permission_triplet: PermissionTriplet<'request>,
 }
 
-/// Generates a cache key for storing permission checks in Redis.
-fn permission_cache_key(
-    permission_triplet: &PermissionTriplet<'_>,
+/// Generates a cache key for storing all assigned role names for an actor on a resource.
+fn role_list_cache_key(
+    resource_type: &str,
+    resource_id: &Uuid,
     actor_id: &UserOrOrganizationId,
 ) -> String {
-    let PermissionTriplet(resource_type, resource_id, role_name) = *permission_triplet;
     match *actor_id {
         UserOrOrganizationId::User(user_id) => {
-            format!("perm:v1:{resource_type}:{resource_id}:{role_name}:user:{user_id}")
+            format!("roles:v1:{resource_type}:{resource_id}:user:{user_id}")
         }
         UserOrOrganizationId::Org(org_id) => {
-            format!("perm:v1:{resource_type}:{resource_id}:{role_name}:org:{org_id}")
+            format!("roles:v1:{resource_type}:{resource_id}:org:{org_id}")
         }
     }
 }
 
-/// Checks the Redis cache for a permission check result.
-async fn cache_get(
-    conn: &dyn RedisConnection,
-    user_key: &str,
-    org_key: Option<&str>,
-) -> Option<bool> {
-    let mut keys = vec![user_key];
-    if let Some(k) = org_key {
-        keys.push(k);
-    }
-    let results = match conn.get_multi(&keys).await {
-        Ok(v) => v,
-        Err(_) => return None,
-    };
-    let user_result = results.first().cloned().flatten();
-    let org_result = if results.len() > 1 {
-        results.get(1).cloned().flatten()
-    } else {
-        None
-    };
-
-    match (user_result.as_deref(), org_result.as_deref()) {
-        (Some("1"), _) | (_, Some("1")) => Some(true),
-        (None, None) => None,
-        _ => Some(false),
-    }
-}
-
-/// Sets a permission check result in the Redis cache.
-async fn cache_set(conn: &dyn RedisConnection, key: &str, value: bool, ttl_secs: u64) {
-    let val = if value { "1" } else { "0" };
-    let _ = conn.set_ex(key, val, ttl_secs).await;
-}
-
-/// Deletes a permission check result from the Redis cache.
+/// Deletes a cache key from Redis.
 async fn cache_delete(conn: &dyn RedisConnection, key: &str) {
     let _ = conn.del(key).await;
+}
+
+/// Reads a cached role list for an actor on a resource.
+async fn cache_get_role_list(conn: &dyn RedisConnection, key: &str) -> Option<Vec<String>> {
+    let raw = match conn.get(key).await {
+        Ok(Some(value)) => value,
+        Ok(None) => return None,
+        Err(_) => return None,
+    };
+
+    serde_json::from_str(&raw).ok()
+}
+
+/// Stores a role list for an actor on a resource.
+async fn cache_set_role_list(
+    conn: &dyn RedisConnection,
+    key: &str,
+    roles: &[String],
+    ttl_secs: u64,
+) {
+    let serialized = match serde_json::to_string(roles) {
+        Ok(value) => value,
+        Err(_) => return,
+    };
+    let _ = conn.set_ex(key, &serialized, ttl_secs).await;
+}
+
+/// Loads all role names assigned to a specific actor on a specific resource from Postgres.
+async fn fetch_actor_roles_for_resource(
+    db: &PgPool,
+    resource_type: &str,
+    resource_id: &Uuid,
+    actor_id: UserOrOrganizationId,
+) -> Result<Vec<String>, ComhairleError> {
+    let mut query = Query::select();
+    query
+        .column(ResourcePermissionIden::RoleName)
+        .from(ResourcePermissionIden::Table)
+        .and_where(Expr::col(ResourcePermissionIden::ResourceId).eq(*resource_id))
+        .and_where(Expr::col(ResourcePermissionIden::ResourceType).eq(resource_type));
+
+    match actor_id {
+        UserOrOrganizationId::User(user_id) => {
+            query.and_where(Expr::col(ResourcePermissionIden::UserId).eq(user_id));
+        }
+        UserOrOrganizationId::Org(org_id) => {
+            query.and_where(Expr::col(ResourcePermissionIden::OrganizationId).eq(org_id));
+        }
+    }
+
+    let (sql, values) = query.build_sqlx(PostgresQueryBuilder);
+
+    let roles: Vec<String> = sqlx::query_as_with::<_, (String,), _>(&sql, values)
+        .fetch_all(db)
+        .await
+        .map_err(ComhairleError::DatabaseError)?
+        .into_iter()
+        .map(|(role_name,)| role_name)
+        .collect();
+
+    Ok(roles)
+}
+
+/// Returns role names for an actor on a resource, using Redis cache when available.
+async fn get_actor_roles_for_resource(
+    state: &Arc<ComhairleState>,
+    resource_type: &str,
+    resource_id: &Uuid,
+    actor_id: UserOrOrganizationId,
+) -> Result<Vec<String>, ComhairleError> {
+    let cache_key = role_list_cache_key(resource_type, resource_id, &actor_id);
+
+    if let Some(conn) = &state.redis_conn {
+        if let Some(cached_roles) = cache_get_role_list(conn.as_ref(), &cache_key).await {
+            return Ok(cached_roles);
+        }
+    }
+
+    let roles =
+        fetch_actor_roles_for_resource(&state.db, resource_type, resource_id, actor_id).await?;
+
+    if let Some(conn) = &state.redis_conn {
+        cache_set_role_list(
+            conn.as_ref(),
+            &cache_key,
+            &roles,
+            state.config.redis_cache_ttl_secs,
+        )
+        .await;
+    }
+
+    Ok(roles)
 }
 
 /// Grants a role to a user or organization on a specific resource.
@@ -349,8 +677,8 @@ pub async fn grant_role(
         response.ok_or_else(|| ComhairleError::RoleAlreadyGranted(role_name.to_string()))?;
 
     if let Some(conn) = &state.redis_conn {
-        let key = permission_cache_key(&request.permission_triplet, &request.actor_id);
-        cache_delete(conn.as_ref(), &key).await;
+        let role_list_key = role_list_cache_key(resource_type, resource_id, &request.actor_id);
+        cache_delete(conn.as_ref(), &role_list_key).await;
     }
 
     Ok(permission)
@@ -376,13 +704,15 @@ pub async fn revoke_role(
         .await
         .map_err(ComhairleError::DatabaseError)?;
 
-    if resource_type == SYSTEM_RESOURCE_TYPE && role_name == "admin" {
+    if resource_type == ResourceType::System.as_ref() && role_name == Role::SuperAdmin.as_ref() {
         let mut count_query = Query::select();
         count_query
             .expr(sea_query::Expr::cust("count(*)"))
             .from(ResourcePermissionIden::Table)
-            .and_where(Expr::col(ResourcePermissionIden::ResourceType).eq(SYSTEM_RESOURCE_TYPE))
-            .and_where(Expr::col(ResourcePermissionIden::RoleName).eq("admin"));
+            .and_where(
+                Expr::col(ResourcePermissionIden::ResourceType).eq(ResourceType::System.as_ref()),
+            )
+            .and_where(Expr::col(ResourcePermissionIden::RoleName).eq(Role::SuperAdmin.as_ref()));
 
         let (sql, values) = count_query.build_sqlx(PostgresQueryBuilder);
 
@@ -392,7 +722,7 @@ pub async fn revoke_role(
             .map_err(ComhairleError::DatabaseError)?;
 
         if count <= 1 {
-            return Err(ComhairleError::CannotRevokeLastAdmin);
+            return Err(ComhairleError::CannotRevokeLastSuperAdmin);
         }
     }
 
@@ -426,8 +756,8 @@ pub async fn revoke_role(
     tx.commit().await.map_err(ComhairleError::DatabaseError)?;
 
     if let Some(conn) = &state.redis_conn {
-        let key = permission_cache_key(&request.permission_triplet, &request.actor_id);
-        cache_delete(conn.as_ref(), &key).await;
+        let role_list_key = role_list_cache_key(resource_type, resource_id, &request.actor_id);
+        cache_delete(conn.as_ref(), &role_list_key).await;
     }
 
     Ok(())
@@ -494,84 +824,91 @@ pub async fn has_resource_permission(
     user_id: &Uuid,
     organization_id: Option<&Uuid>,
 ) -> Result<bool, ComhairleError> {
-    let redis_conn = state.redis_conn.clone();
-    if let Some(ref conn) = redis_conn {
-        let key = permission_cache_key(&permission_triplet, &UserOrOrganizationId::User(*user_id));
-        let org_key = organization_id.map(|org_id| {
-            permission_cache_key(&permission_triplet, &UserOrOrganizationId::Org(*org_id))
-        });
-        if let Some(cached) = cache_get(conn.as_ref(), &key, org_key.as_deref()).await {
-            return Ok(cached);
-        }
-    }
-
     let PermissionTriplet(resource_type, resource_id, role_name) = permission_triplet;
 
-    let mut query = Query::select();
-    query
-        .expr(Expr::val(1))
-        .from(ResourcePermissionIden::Table)
-        .and_where(Expr::col(ResourcePermissionIden::ResourceId).eq(*resource_id))
-        .and_where(Expr::col(ResourcePermissionIden::ResourceType).eq(resource_type))
-        .and_where(Expr::col(ResourcePermissionIden::RoleName).eq(role_name))
-        .limit(1);
-
-    match organization_id {
-        Some(organization_id) => {
-            query.and_where(
-                Expr::col(ResourcePermissionIden::UserId)
-                    .eq(*user_id)
-                    .or(Expr::col(ResourcePermissionIden::OrganizationId).eq(*organization_id)),
-            );
-        }
-        None => {
-            query.and_where(Expr::col(ResourcePermissionIden::UserId).eq(*user_id));
-        }
-    }
-
-    let (sql, values) = query.build_sqlx(PostgresQueryBuilder);
-
-    let response = sqlx::query_with(&sql, values)
-        .fetch_optional(&state.db)
-        .await
-        .map_err(ComhairleError::DatabaseError)?;
-
-    let result = response.is_some();
-
-    if let Some(ref conn) = redis_conn {
-        // If organization_id is not None and the returned PgRow has a populated organization_id, cache the result for the organization only.
-        // Otherwise, cache the result for the user only.
-        let is_user = if organization_id.is_some() {
-            match response {
-                Some(row) => {
-                    let org_id_in_row: Option<Uuid> = row
-                        .try_get(ResourcePermissionIden::OrganizationId.as_str())
-                        .unwrap_or(None);
-                    org_id_in_row.is_none()
-                }
-                None => true,
-            }
-        } else {
-            true
-        };
-        let key = if is_user {
-            permission_cache_key(&permission_triplet, &UserOrOrganizationId::User(*user_id))
-        } else {
-            permission_cache_key(
-                &permission_triplet,
-                &UserOrOrganizationId::Org(*organization_id.unwrap()),
+    let user_roles = get_actor_roles_for_resource(
+        state,
+        resource_type,
+        resource_id,
+        UserOrOrganizationId::User(*user_id),
+    )
+    .await?;
+    let org_roles = match organization_id {
+        Some(org_id) => Some(
+            get_actor_roles_for_resource(
+                state,
+                resource_type,
+                resource_id,
+                UserOrOrganizationId::Org(*org_id),
             )
-        };
-        cache_set(
-            conn.as_ref(),
-            &key,
-            result,
-            state.config.redis_cache_ttl_secs,
-        )
-        .await;
+            .await?,
+        ),
+        None => None,
+    };
+
+    let user_has_role = user_roles
+        .iter()
+        .any(|cached_role| cached_role == role_name);
+    let org_has_role = org_roles
+        .as_ref()
+        .is_some_and(|roles| roles.iter().any(|cached_role| cached_role == role_name));
+
+    Ok(user_has_role || org_has_role)
+}
+
+/// Check whether a user, or their organization, can perform an action on a resource.
+pub async fn can_perform_resource_action(
+    state: &Arc<ComhairleState>,
+    resource_id: &Uuid,
+    action: Action,
+    user_id: &Uuid,
+    organization_id: Option<&Uuid>,
+    owner_id: Option<&Uuid>,
+) -> Result<bool, ComhairleError> {
+    if owner_id.is_some_and(|resource_owner_id| resource_owner_id == user_id) {
+        return Ok(true);
     }
 
-    Ok(result)
+    // Bypass permission checks for super admins
+    if has_resource_permission(
+        state,
+        Role::SuperAdmin.system_triplet(),
+        user_id,
+        organization_id,
+    )
+    .await?
+    {
+        return Ok(true);
+    }
+
+    let resource_type = action.resource_type();
+
+    let mut roles = get_actor_roles_for_resource(
+        state,
+        resource_type.as_ref(),
+        resource_id,
+        UserOrOrganizationId::User(*user_id),
+    )
+    .await?;
+
+    if let Some(org_id) = organization_id {
+        let org_roles = get_actor_roles_for_resource(
+            state,
+            resource_type.as_ref(),
+            resource_id,
+            UserOrOrganizationId::Org(*org_id),
+        )
+        .await?;
+        roles.extend(org_roles);
+    }
+
+    roles.dedup();
+
+    Ok(roles.iter().any(|role_name| {
+        role_name
+            .parse::<Role>()
+            .is_ok_and(|role| role.actions().contains(&action))
+    }))
 }
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema, FromRow)]
@@ -654,27 +991,24 @@ mod tests {
     use crate::redis_connection::{MockRedis, RedisConnection};
     use crate::test_helpers::{TEST_RESOURCE_TYPE, TEST_ROLE_NAME, TestRole, test_state};
 
+    use sea_query::DeleteStatement;
     use sqlx::PgPool;
 
     const OTHER_ROLE_NAME: &str = "other_role";
     struct OtherRole;
 
-    impl NamedRole for OtherRole {
+    impl OtherRole {
         fn name() -> &'static str {
             OTHER_ROLE_NAME
         }
-    }
 
-    impl ResourceRole for OtherRole {
-        fn resource_type() -> &'static str {
-            TEST_RESOURCE_TYPE
+        fn make_triplet(resource_id: &Uuid) -> PermissionTriplet<'_> {
+            PermissionTriplet(TEST_RESOURCE_TYPE, resource_id, OTHER_ROLE_NAME)
         }
     }
 
-    #[sqlx::test]
-    async fn test_grant_and_check_user_role(
-        pool: PgPool,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
+    fn test_grant_and_check_user_role(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
         let state = Arc::new(test_state().db(pool).call()?);
         let (app, mut session) = setup_default_app_and_session(&state.db).await?;
 
@@ -717,8 +1051,8 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
-    async fn test_grant_and_check_organization_role(
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
+    fn test_grant_and_check_organization_role(
         pool: PgPool,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let state = Arc::new(test_state().db(pool).call()?);
@@ -774,8 +1108,8 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
-    async fn test_unauthorized_access(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
+    fn test_unauthorized_access(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
         let state = Arc::new(test_state().db(pool).call()?);
         let (app, mut session) = setup_default_app_and_session(&state.db).await?;
 
@@ -805,10 +1139,8 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
-    async fn test_grant_role_already_granted(
-        pool: PgPool,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
+    fn test_grant_role_already_granted(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
         let state = Arc::new(test_state().db(pool).call()?);
         let (app, mut session) = setup_default_app_and_session(&state.db).await?;
 
@@ -848,8 +1180,8 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
-    async fn test_revoke_user_role(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
+    fn test_revoke_user_role(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
         let state = Arc::new(test_state().db(pool).call()?);
         let (app, mut session) = setup_default_app_and_session(&state.db).await?;
 
@@ -893,33 +1225,45 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
-    async fn test_revoke_last_admin_fails(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
+    fn test_revoke_last_admin_fails(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
         let state = Arc::new(test_state().db(pool).call()?);
         let (app, mut session) = setup_default_app_and_session(&state.db).await?;
 
         let (_, user, _) = session.current_user(&app).await?;
+
+        // Grant the user the super admin role, which should be the only one.
+        grant_role(
+            &state,
+            GrantRoleRequest {
+                actor_id: UserOrOrganizationId::User(user.id),
+                permission_triplet: Role::SuperAdmin.system_triplet(),
+                granted_by: &session.id.unwrap(),
+                grant_reason: "Testing",
+            },
+        )
+        .await?;
 
         // Attempt to revoke the admin role, which should be the only one
         let result = revoke_role(
             &state,
             RevokeRoleRequest {
                 actor_id: UserOrOrganizationId::User(user.id),
-                permission_triplet: SystemAdminRole::make_system_triplet(),
+                permission_triplet: Role::SuperAdmin.system_triplet(),
             },
         )
         .await;
 
         assert!(
-            matches!(result, Err(ComhairleError::CannotRevokeLastAdmin)),
-            "Expected CannotRevokeLastAdmin, got {result:?}"
+            matches!(result, Err(ComhairleError::CannotRevokeLastSuperAdmin)),
+            "Expected CannotRevokeLastSuperAdmin, got {result:?}"
         );
 
         Ok(())
     }
 
-    #[sqlx::test]
-    async fn test_revoke_role_not_found(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
+    fn test_revoke_role_not_found(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
         let state = Arc::new(test_state().db(pool).call()?);
         let (app, mut session) = setup_default_app_and_session(&state.db).await?;
 
@@ -945,8 +1289,8 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
-    async fn test_list_permissions(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
+    fn test_list_permissions(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
         let state = Arc::new(test_state().db(pool).call()?);
         let (app, mut session) = setup_default_app_and_session(&state.db).await?;
 
@@ -1053,8 +1397,8 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
-    async fn test_list_permissions_offset_pagination(
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
+    fn test_list_permissions_offset_pagination(
         pool: PgPool,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let state = Arc::new(test_state().db(pool).call()?);
@@ -1135,8 +1479,8 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
-    async fn test_permission_is_cached_after_first_call(
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
+    fn test_role_list_is_cached_after_first_call(
         pool: PgPool,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let mock = Arc::new(MockRedis::new());
@@ -1169,15 +1513,17 @@ mod tests {
                 .await?;
         assert!(first, "expected permission to be present");
 
-        let key = permission_cache_key(
-            &TestRole::make_triplet(&resource_id),
+        let key = role_list_cache_key(
+            TestRole::resource_type(),
+            &resource_id,
             &UserOrOrganizationId::User(user_id),
         );
         let cached = mock.get_value(&key).await;
-        assert_eq!(
-            cached.as_deref(),
-            Some("1"),
-            "expected cache key to hold \"1\" after first positive check"
+        assert!(
+            cached
+                .as_ref()
+                .is_some_and(|raw| raw.contains(TestRole::name())),
+            "expected cache key to contain the granted role after first positive check"
         );
 
         // Remove the DB row directly – bypassing the permission model so the
@@ -1202,8 +1548,8 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
-    async fn test_cache_invalidated_on_grant(
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
+    fn test_role_list_cache_invalidated_on_grant(
         pool: PgPool,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let mock = Arc::new(MockRedis::new());
@@ -1218,52 +1564,41 @@ mod tests {
         let user_id = get_random_user_id(&app, &mut session).await?;
         let resource_id = Uuid::new_v4();
 
-        // First check: no permission exists; false result is cached.
-        let first =
+        let initial_has_role =
             has_resource_permission(&state, TestRole::make_triplet(&resource_id), &user_id, None)
                 .await?;
-        assert!(!first, "expected no permission to exist yet");
+        assert!(!initial_has_role, "expected no role before grant");
 
-        let key = permission_cache_key(
-            &TestRole::make_triplet(&resource_id),
+        let role_list_key = role_list_cache_key(
+            TestRole::resource_type(),
+            &resource_id,
             &UserOrOrganizationId::User(user_id),
         );
-        let cached = mock.get_value(&key).await;
-        assert_eq!(
-            cached.as_deref(),
-            Some("0"),
-            "expected cache key to hold \"0\" after first negative check"
-        );
+        let cached_before_grant = mock.get_value(&role_list_key).await;
+        assert_eq!(cached_before_grant.as_deref(), Some("[]"));
 
-        // Grant the role, which should invalidate the cache.
         grant_role(
             &state,
             GrantRoleRequest {
                 actor_id: UserOrOrganizationId::User(user_id),
                 permission_triplet: TestRole::make_triplet(&resource_id),
                 granted_by: &session.id.unwrap(),
-                grant_reason: "Testing cache invalidation",
+                grant_reason: "Testing role list cache invalidation on grant",
             },
         )
         .await?;
 
-        let after_grant = mock.get_value(&key).await;
+        let cached_after_grant = mock.get_value(&role_list_key).await;
         assert!(
-            after_grant.is_none(),
-            "expected cache key to be deleted after grant_role, got {after_grant:?}"
+            cached_after_grant.is_none(),
+            "expected actor role-list cache key to be deleted after grant"
         );
-
-        // Permission check now re-queries the DB and should return true.
-        let second =
-            has_resource_permission(&state, TestRole::make_triplet(&resource_id), &user_id, None)
-                .await?;
-        assert!(second, "expected permission to be present after grant");
 
         Ok(())
     }
 
-    #[sqlx::test]
-    async fn test_cache_invalidated_on_revoke(
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
+    fn test_role_list_cache_invalidated_on_revoke(
         pool: PgPool,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let mock = Arc::new(MockRedis::new());
@@ -1278,35 +1613,35 @@ mod tests {
         let user_id = get_random_user_id(&app, &mut session).await?;
         let resource_id = Uuid::new_v4();
 
-        // Grant the role and confirm it is cached.
         grant_role(
             &state,
             GrantRoleRequest {
                 actor_id: UserOrOrganizationId::User(user_id),
                 permission_triplet: TestRole::make_triplet(&resource_id),
                 granted_by: &session.id.unwrap(),
-                grant_reason: "Testing cache invalidation",
+                grant_reason: "Testing role list cache invalidation on revoke",
             },
         )
         .await?;
 
-        let first =
+        let has_role =
             has_resource_permission(&state, TestRole::make_triplet(&resource_id), &user_id, None)
                 .await?;
-        assert!(first, "expected permission to be present");
+        assert!(has_role, "expected role to exist before revoke");
 
-        let key = permission_cache_key(
-            &TestRole::make_triplet(&resource_id),
+        let role_list_key = role_list_cache_key(
+            TestRole::resource_type(),
+            &resource_id,
             &UserOrOrganizationId::User(user_id),
         );
-        let cached = mock.get_value(&key).await;
-        assert_eq!(
-            cached.as_deref(),
-            Some("1"),
-            "expected cache key to hold \"1\" after positive check"
+        let cached_before_revoke = mock.get_value(&role_list_key).await;
+        assert!(
+            cached_before_revoke
+                .as_ref()
+                .is_some_and(|raw| raw.contains(TEST_ROLE_NAME)),
+            "expected role list cache to include the granted role"
         );
 
-        // Revoke the role, which should invalidate the cache.
         revoke_role(
             &state,
             RevokeRoleRequest {
@@ -1316,25 +1651,94 @@ mod tests {
         )
         .await?;
 
-        let after_revoke = mock.get_value(&key).await;
+        let cached_after_revoke = mock.get_value(&role_list_key).await;
         assert!(
-            after_revoke.is_none(),
-            "expected cache key to be deleted after revoke_role, got {after_revoke:?}"
+            cached_after_revoke.is_none(),
+            "expected actor role-list cache key to be deleted after revoke"
         );
-
-        // Permission check now re-queries the DB and should return false.
-        let second =
-            has_resource_permission(&state, TestRole::make_triplet(&resource_id), &user_id, None)
-                .await?;
-        assert!(!second, "expected no permission after revoke");
 
         Ok(())
     }
 
     #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
-    async fn should_list_users_with_permission(
+    fn test_action_check_uses_cached_role_list(
         pool: PgPool,
     ) -> Result<(), Box<dyn std::error::Error>> {
+        let mock = Arc::new(MockRedis::new());
+        let (app, mut session) = setup_default_app_and_session(&pool).await?;
+        let state = Arc::new(
+            test_state()
+                .db(pool.clone())
+                .redis_conn(mock.clone() as Arc<dyn RedisConnection>)
+                .call()?,
+        );
+
+        let user_id = get_random_user_id(&app, &mut session).await?;
+        let resource_id = Uuid::new_v4();
+
+        grant_role(
+            &state,
+            GrantRoleRequest {
+                actor_id: UserOrOrganizationId::User(user_id),
+                permission_triplet: Role::ConversationContentEditor.triplet(&resource_id),
+                granted_by: &session.id.unwrap(),
+                grant_reason: "Testing action role list cache",
+            },
+        )
+        .await?;
+
+        let first = can_perform_resource_action(
+            &state,
+            &resource_id,
+            Action::ConversationRead,
+            &user_id,
+            None,
+            None,
+        )
+        .await?;
+        assert!(first, "expected first action check to be allowed");
+
+        let role_list_key = role_list_cache_key(
+            ResourceType::Conversation.as_ref(),
+            &resource_id,
+            &UserOrOrganizationId::User(user_id),
+        );
+        let cached_roles = mock.get_value(&role_list_key).await;
+        assert!(
+            cached_roles
+                .as_ref()
+                .is_some_and(|raw| raw.contains(Role::ConversationContentEditor.as_ref())),
+            "expected cached role list to include content editor role"
+        );
+
+        let (sql, values) = DeleteStatement::new()
+            .from_table("resource_permissions")
+            .and_where(Expr::col("user_id").eq(user_id))
+            .and_where(Expr::col("resource_id").eq(resource_id))
+            .and_where(Expr::col("resource_type").eq(ResourceType::Conversation.as_ref()))
+            .and_where(Expr::col("role_name").eq(Role::ConversationContentEditor.as_ref()))
+            .build_sqlx(PostgresQueryBuilder);
+        sqlx::query_with(&sql, values).execute(&pool).await?;
+
+        let second = can_perform_resource_action(
+            &state,
+            &resource_id,
+            Action::ConversationRead,
+            &user_id,
+            None,
+            None,
+        )
+        .await?;
+        assert!(
+            second,
+            "expected second action check to be served by cached role list"
+        );
+
+        Ok(())
+    }
+
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
+    fn should_list_users_with_permission(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
         let state = Arc::new(test_state().db(pool).call()?);
         let (app, mut session) = setup_default_app_and_session(&state.db).await?;
 
@@ -1385,6 +1789,90 @@ mod tests {
                 .iter()
                 .all(|u| u.role_name == TestRole::name()),
             "wrong role_name"
+        );
+
+        Ok(())
+    }
+
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
+    fn test_action_permission_granted_for_content_editor(
+        pool: PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let state = Arc::new(test_state().db(pool).call()?);
+        let (app, mut session) = setup_default_app_and_session(&state.db).await?;
+
+        let user_id = get_random_user_id(&app, &mut session).await?;
+        let resource_id = Uuid::new_v4();
+
+        grant_role(
+            &state,
+            GrantRoleRequest {
+                actor_id: UserOrOrganizationId::User(user_id),
+                permission_triplet: Role::ConversationContentEditor.triplet(&resource_id),
+                granted_by: &session.id.unwrap(),
+                grant_reason: "Testing action checks",
+            },
+        )
+        .await?;
+
+        let can_read = can_perform_resource_action(
+            &state,
+            &resource_id,
+            Action::ConversationRead,
+            &user_id,
+            None,
+            None,
+        )
+        .await?;
+        assert!(can_read, "content editor should allow read action");
+
+        let can_update = can_perform_resource_action(
+            &state,
+            &resource_id,
+            Action::ConversationUpdate,
+            &user_id,
+            None,
+            None,
+        )
+        .await?;
+        assert!(can_update, "content editor should allow update action");
+
+        Ok(())
+    }
+
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
+    fn test_action_permission_denied_when_resource_type_mismatch(
+        pool: PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let state = Arc::new(test_state().db(pool).call()?);
+        let (app, mut session) = setup_default_app_and_session(&state.db).await?;
+
+        let user_id = get_random_user_id(&app, &mut session).await?;
+        let resource_id = Uuid::new_v4();
+
+        grant_role(
+            &state,
+            GrantRoleRequest {
+                actor_id: UserOrOrganizationId::User(user_id),
+                permission_triplet: OtherRole::make_triplet(&resource_id),
+                granted_by: &session.id.unwrap(),
+                grant_reason: "Testing action checks",
+            },
+        )
+        .await?;
+
+        let can_read = can_perform_resource_action(
+            &state,
+            &resource_id,
+            Action::ConversationRead,
+            &user_id,
+            None,
+            None,
+        )
+        .await?;
+        assert!(
+            !can_read,
+            "conversation read action should be denied for non-conversation role assignment"
         );
 
         Ok(())

--- a/api/src/models/users.rs
+++ b/api/src/models/users.rs
@@ -4,7 +4,9 @@ use crate::{
     error::ComhairleError,
     models::{
         pagination::{Order, PageOptions, PaginatedResults},
-        permissions::{NamedRole, ResourcePermissionIden, SYSTEM_RESOURCE_TYPE, SystemAdminRole},
+        permissions::{
+            ResourcePermissionIden, ResourceType as PermissionResourceType, Role as PermissionRole,
+        },
     },
     routes::auth::{OtpSignupRequest, SignupRequest, hash_pw, validate_password_strength},
     tools::id::gen_id,
@@ -610,14 +612,14 @@ impl UserFilterOptions {
                         ResourcePermissionIden::Table,
                         ResourcePermissionIden::ResourceType,
                     ))
-                    .eq(SYSTEM_RESOURCE_TYPE),
+                    .eq(PermissionResourceType::System.as_ref()),
                 )
                 .and_where(
                     Expr::col((
                         ResourcePermissionIden::Table,
                         ResourcePermissionIden::RoleName,
                     ))
-                    .eq(SystemAdminRole::name()),
+                    .eq(PermissionRole::Admin.as_ref()),
                 )
                 .to_owned();
 

--- a/api/src/routes/auth.rs
+++ b/api/src/routes/auth.rs
@@ -29,7 +29,7 @@ pub async fn is_user_admin(state: &Arc<ComhairleState>, user: &crate::models::us
     // Check if the user has the system admin role
     if has_resource_permission(
         &state,
-        SystemAdminRole::make_system_triplet(),
+        PermissionRole::Admin.system_triplet(),
         &user.id,
         user.organization_id.as_ref(),
     )
@@ -57,8 +57,12 @@ use tracing::{instrument, warn};
 use uuid::Uuid;
 
 use crate::ComhairleState;
+use crate::error::ComhairleError;
 use crate::middleware::request_logging::ClientIp;
-use crate::models::permissions::{ConversationPath, ResourceRole, has_resource_permission};
+use crate::models::permissions::{
+    Action, ConversationPath, ExtractResourceId, GrantRoleRequest, Role as PermissionRole,
+    UserOrOrganizationId, can_perform_resource_action, grant_role, has_resource_permission,
+};
 use crate::models::users::{
     self, Resource, Role, UpdateUserRequest, User, UserAuthType, UserResourceRole,
     create_annon_user, create_otp_user, create_user, get_user_by_email, get_user_by_id,
@@ -66,13 +70,6 @@ use crate::models::users::{
 };
 use crate::models::{api_key, otp};
 use crate::routes::user::dto::UserDto;
-use crate::{
-    error::ComhairleError,
-    models::permissions::{
-        ExtractResourceId, GrantRoleRequest, SystemAdminRole, SystemResourceRole,
-        UserOrOrganizationId, grant_role,
-    },
-};
 
 #[cfg(test)]
 use fake::Dummy;
@@ -325,7 +322,7 @@ async fn signup(
                 &state,
                 GrantRoleRequest {
                     actor_id: UserOrOrganizationId::User(user.id),
-                    permission_triplet: SystemAdminRole::make_system_triplet(),
+                    permission_triplet: PermissionRole::Admin.system_triplet(),
                     grant_reason: "Admin signup",
                     granted_by: &user.id,
                 },
@@ -889,57 +886,35 @@ async fn resolve_user_from_request(
             .ok_or(ComhairleError::UserRequired)
     }
 }
-
-/// An extractor to get a required role for the current user and target resource.
-#[derive(OperationIo)]
-pub struct RequiredUserPermission<Role: ResourceRole, Id: ExtractResourceId> {
-    pub user: User,
-    pub _phantom_data: PhantomData<(Role, Id)>,
-}
-
-impl<Role, Id> FromRequestParts<Arc<ComhairleState>> for RequiredUserPermission<Role, Id>
-where
-    Role: ResourceRole,
-    Id: ExtractResourceId,
-{
-    type Rejection = ComhairleError;
-
-    /// Extracts the current user and resource ID from the request, then checks if
-    /// the user has the required role for that resource.
-    ///
-    /// # Errors
-    ///
-    /// * Returns [`ComhairleError::UserRequired`] if no user is logged in.
-    /// * Returns [`ComhairleError::ResourceNotFound`] if the resource ID cannot be
-    ///   extracted from the request.
-    /// * Returns [`ComhairleError::UserNotAuthorized`] if the user does not have
-    ///   the required role.
-    async fn from_request_parts(
-        parts: &mut Parts,
-        state: &Arc<ComhairleState>,
-    ) -> Result<Self, Self::Rejection> {
-        let user = resolve_user_from_request(parts, state).await?;
-
-        let id = Id::from_request_parts(parts, state).await.map_err(|_| {
-            ComhairleError::ResourceNotFound("Path must contain a resource id".to_string())
-        })?;
-
-        if id.owner_id() == Some(user.id)
-            || has_resource_permission(
-                state,
-                Role::make_triplet(&id.resource_id()),
-                &user.id,
-                user.organization_id.as_ref(),
-            )
-            .await?
-        {
-            Ok(RequiredUserPermission {
-                user,
-                _phantom_data: PhantomData,
-            })
-        } else {
-            Err(ComhairleError::UserNotAuthorized)
-        }
+/// Authorizes `user` to perform `action` on `resource`.
+///
+/// Access is granted if the user owns the resource, or if the user (or their
+/// organization) holds a role whose policy permits the action. Super admins are
+/// always permitted (handled by [`can_perform_resource_action`]).
+///
+/// # Errors
+///
+/// * Returns [`ComhairleError::UserNotAuthorized`] if the user is not permitted.
+/// * Propagates [`ComhairleError`] from the underlying permission lookup.
+pub async fn authorize<R: ExtractResourceId>(
+    state: &Arc<ComhairleState>,
+    user: &User,
+    action: Action,
+    resource: &R,
+) -> Result<(), ComhairleError> {
+    if can_perform_resource_action(
+        state,
+        &resource.resource_id(),
+        action,
+        &user.id,
+        user.organization_id.as_ref(),
+        resource.owner_id().as_ref(),
+    )
+    .await?
+    {
+        Ok(())
+    } else {
+        Err(ComhairleError::UserNotAuthorized)
     }
 }
 
@@ -1331,7 +1306,7 @@ mod tests {
     use uuid::Uuid;
 
     #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
-    async fn user_should_be_able_to_sign_up(pool: PgPool) -> Result<(), Box<dyn Error>> {
+    fn user_should_be_able_to_sign_up(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let username = "test_user";
         let password = crate::test_helpers::TEST_PASSWORD;
         let email = "test_email";
@@ -1369,7 +1344,7 @@ mod tests {
     }
 
     #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
-    async fn user_should_receive_signup_email(pool: PgPool) -> Result<(), Box<dyn Error>> {
+    fn user_should_receive_signup_email(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let username = "test_user";
         let password = crate::test_helpers::TEST_PASSWORD;
         let email = "test_email";
@@ -1416,7 +1391,7 @@ mod tests {
     }
 
     #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
-    async fn should_signup_otp_user(pool: PgPool) -> Result<(), Box<dyn Error>> {
+    fn should_signup_otp_user(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let email = "test_email";
 
         let mut mailer = MockComhairleMailer::new();
@@ -1449,7 +1424,7 @@ mod tests {
     }
 
     #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
-    async fn user_should_receive_verification_email(pool: PgPool) -> Result<(), Box<dyn Error>> {
+    fn user_should_receive_verification_email(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let mut mailer = MockComhairleMailer::new();
         mailer
             .expect_send_welcome_email()
@@ -1485,7 +1460,7 @@ mod tests {
     }
 
     #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
-    async fn unverified_user_should_be_verified(pool: PgPool) -> Result<(), Box<dyn Error>> {
+    fn unverified_user_should_be_verified(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let username = "test_user";
         let password = crate::test_helpers::TEST_PASSWORD;
         let email = "test_email";
@@ -1537,7 +1512,7 @@ mod tests {
     }
 
     #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
-    async fn annon_user_cannot_be_verified(pool: PgPool) -> Result<(), Box<dyn Error>> {
+    fn annon_user_cannot_be_verified(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let username = "test_user";
         let password = crate::test_helpers::TEST_PASSWORD;
         let email = "test_email";
@@ -1585,7 +1560,7 @@ mod tests {
     }
 
     #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
-    async fn user_cannot_be_verified_twice(pool: PgPool) -> Result<(), Box<dyn Error>> {
+    fn user_cannot_be_verified_twice(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let username = "test_user";
         let password = crate::test_helpers::TEST_PASSWORD;
         let email = "test_email";
@@ -1636,7 +1611,7 @@ mod tests {
     }
 
     #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
-    async fn user_should_not_be_able_to_login_with_wrong_password(
+    fn user_should_not_be_able_to_login_with_wrong_password(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {
         let state = test_state().db(pool).call()?;
@@ -1662,7 +1637,7 @@ mod tests {
     }
 
     #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
-    async fn user_should_be_able_to_login_with_email_with_different_case(
+    fn user_should_be_able_to_login_with_email_with_different_case(
         pool: PgPool,
     ) -> Result<(), Box<dyn Error>> {
         let state = test_state().db(pool).call()?;
@@ -1742,7 +1717,7 @@ mod tests {
     }
 
     #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
-    async fn username_and_email_should_be_unique(pool: PgPool) -> Result<(), Box<dyn Error>> {
+    fn username_and_email_should_be_unique(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let state = test_state().db(pool).call()?;
         let app = setup_server(Arc::new(state)).await?;
 
@@ -1774,7 +1749,7 @@ mod tests {
     }
 
     #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
-    async fn user_should_be_able_to_logout(pool: PgPool) -> Result<(), Box<dyn Error>> {
+    fn user_should_be_able_to_logout(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let state = test_state().db(pool).call()?;
         let app = setup_server(Arc::new(state)).await?;
 
@@ -1807,7 +1782,7 @@ mod tests {
     }
 
     #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
-    async fn annon_user_should_by_able_to_signup(pool: PgPool) -> Result<(), Box<dyn Error>> {
+    fn annon_user_should_by_able_to_signup(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let state = test_state().db(pool).call()?;
         let app = setup_server(Arc::new(state)).await?;
 
@@ -1841,7 +1816,7 @@ mod tests {
     }
 
     #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
-    async fn user_should_receive_password_reset_email(pool: PgPool) -> Result<(), Box<dyn Error>> {
+    fn user_should_receive_password_reset_email(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let username = "test_user";
         let password = crate::test_helpers::TEST_PASSWORD;
         let email = "test_email";
@@ -1881,7 +1856,7 @@ mod tests {
     }
 
     #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
-    async fn unknown_user_returns_not_found(pool: PgPool) -> Result<(), Box<dyn Error>> {
+    fn unknown_user_returns_not_found(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let username = "test_user";
         let password = crate::test_helpers::TEST_PASSWORD;
         let email = "test_email";
@@ -1913,7 +1888,7 @@ mod tests {
     }
 
     #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
-    async fn users_password_should_be_updated(pool: PgPool) -> Result<(), Box<dyn Error>> {
+    fn users_password_should_be_updated(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let username = "test_user";
         let password = crate::test_helpers::TEST_PASSWORD;
         let email = "test_email";
@@ -1979,7 +1954,7 @@ mod tests {
     }
 
     #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
-    async fn password_and_confirmation_should_match(pool: PgPool) -> Result<(), Box<dyn Error>> {
+    fn password_and_confirmation_should_match(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let username = "test_username";
         let email = "test_email";
         let password = crate::test_helpers::TEST_PASSWORD;
@@ -2027,7 +2002,7 @@ mod tests {
     }
 
     #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
-    async fn annon_users_cannot_reset_password(pool: PgPool) -> Result<(), Box<dyn Error>> {
+    fn annon_users_cannot_reset_password(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let state = test_state().db(pool).call()?;
         let secret = state.config.jwt_secret.clone();
         let app = setup_server(Arc::new(state)).await?;
@@ -2126,7 +2101,7 @@ mod tests {
     }
 
     #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
-    async fn should_return_user_from_api_key(pool: PgPool) -> Result<(), Box<dyn Error>> {
+    fn should_return_user_from_api_key(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let (app, mut session) = setup_default_app_and_session(&pool).await?;
         session
             .login(&app, "admin@crown-shy.com", TEST_PASSWORD)
@@ -2259,7 +2234,7 @@ mod tests {
     }
 
     #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
-    async fn test_signup_with_weak_password(pool: PgPool) -> Result<(), Box<dyn Error>> {
+    fn test_signup_with_weak_password(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let username = "test_user_weak_pw";
         let password = "weak"; // Too short
         let email = "test_weak@example.com";
@@ -2280,7 +2255,7 @@ mod tests {
     }
 
     #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
-    async fn test_password_reset_with_weak_password(pool: PgPool) -> Result<(), Box<dyn Error>> {
+    fn test_password_reset_with_weak_password(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let username = "test_user_reset";
         let password = "ValidPassword123!";
         let email = "test_reset@example.com";
@@ -2329,7 +2304,7 @@ mod tests {
     }
 
     #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
-    async fn test_update_user_with_weak_password(pool: PgPool) -> Result<(), Box<dyn Error>> {
+    fn test_update_user_with_weak_password(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let username = "test_user_update";
         let password = "ValidPassword123!";
         let email = "test_update@example.com";
@@ -2360,7 +2335,7 @@ mod tests {
     }
 
     #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
-    async fn should_send_email_with_otp(pool: PgPool) -> Result<(), Box<dyn Error>> {
+    fn should_send_email_with_otp(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let email = "test_email@test.com";
         let username = "test_user";
         let password = "qwe321QWE^%$qwe321";
@@ -2395,7 +2370,7 @@ mod tests {
     }
 
     #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
-    async fn should_sign_user_in_with_otp(pool: PgPool) -> Result<(), Box<dyn Error>> {
+    fn should_sign_user_in_with_otp(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let email = "test_email@test.com";
         let username = "test_user";
         let password = "qwe321QWE^%$qwe321";
@@ -2431,7 +2406,7 @@ mod tests {
     }
 
     #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
-    async fn otp_should_be_invalid_after_single_use(pool: PgPool) -> Result<(), Box<dyn Error>> {
+    fn otp_should_be_invalid_after_single_use(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let email = "test_email@test.com";
         let username = "test_user";
         let password = "qwe321QWE^%$qwe321";
@@ -2477,7 +2452,7 @@ mod tests {
     }
 
     #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
-    async fn should_login_user_from_otp_jwt(pool: PgPool) -> Result<(), Box<dyn Error>> {
+    fn should_login_user_from_otp_jwt(pool: PgPool) -> Result<(), Box<dyn Error>> {
         let email = "test_email@test.com";
         let username = "test_user";
         let password = "qwe321QWE^%$qwe321";

--- a/api/src/routes/conversations.rs
+++ b/api/src/routes/conversations.rs
@@ -32,22 +32,19 @@ use crate::{
             self as notification_delivery_model, CreateNotificationDelivery, DeliveryMethod,
         },
         pagination::{OrderParams, PageOptions, PaginatedResults},
-        permissions::{
-            ConversationContentEditorRole, ConversationResource, ResourceRole,
-            has_resource_permission,
-        },
+        permissions::{Action, ConversationResource, can_perform_resource_action},
         user_conversation_preferences,
         user_participation::{self},
         user_profile,
     },
     routes::{
-        auth::RequiredUserPermission,
+        auth::authorize,
         conversations::dto::{ConversationDto, LocalizedConversationDto},
         translations::LocaleExtractor,
     },
 };
 
-use super::auth::{OptionalUser, RequiredAdminUser, is_user_admin};
+use super::auth::{OptionalUser, RequiredAdminUser, RequiredUser, is_user_admin};
 
 pub mod dto;
 
@@ -74,15 +71,14 @@ async fn create_conversation(
 /// Update conversation handler
 async fn update_conversation(
     State(state): State<Arc<ComhairleState>>,
-    RequiredAdminUser(_user): RequiredAdminUser,
-    RequiredUserPermission { .. }: RequiredUserPermission<
-        ConversationContentEditorRole,
-        ConversationResource,
-    >,
-    Path(id): Path<Uuid>,
+    RequiredUser(user): RequiredUser,
+    resource: ConversationResource,
     Json(conversation): Json<PartialConversation>,
 ) -> Result<(StatusCode, Json<ConversationDto>), ComhairleError> {
-    let conversation = conversation::update(&state.db, &id, &conversation).await?;
+    authorize(&state, &user, Action::ConversationUpdate, &resource).await?;
+
+    let conversation =
+        conversation::update(&state.db, &resource.conversation_id, &conversation).await?;
     let conversation: ConversationDto = conversation.into();
     Ok((StatusCode::OK, Json(conversation)))
 }
@@ -192,11 +188,13 @@ async fn get_conversation(
     if !original_conversation.is_live {
         if let Some(user) = &user {
             if user.id != original_conversation.owner_id
-                && !has_resource_permission(
+                && !can_perform_resource_action(
                     &state,
-                    ConversationContentEditorRole::make_triplet(&original_conversation.id),
+                    &original_conversation.id,
+                    Action::ConversationRead,
                     &user.id,
                     None,
+                    Some(&original_conversation.owner_id),
                 )
                 .await?
             {
@@ -905,6 +903,7 @@ mod tests {
     use crate::bulk_storage_service::{MockBulkStorageService, UploadResult};
     use crate::config::BotServiceConfig;
     use crate::models::conversation::PartialConversation;
+    use crate::models::permissions::{GrantRoleRequest, Role, UserOrOrganizationId, grant_role};
     use crate::routes::conversations::ConversationResponse;
     use crate::routes::conversations::dto::{ConversationDto, LocalizedConversationDto};
     use crate::routes::media::dto::MediaDto;
@@ -919,6 +918,7 @@ mod tests {
     use std::collections::HashMap;
     use std::error::Error;
     use std::sync::Arc;
+    use uuid::Uuid;
 
     const CONVERSATION_RESOURCE_TYPE: &str = "conversation";
 
@@ -1506,7 +1506,7 @@ mod tests {
         let privacy_policy: TextContentDto = serde_json::from_value(privacy_policy_res)?;
         let faqs: TextContentDto = serde_json::from_value(faqs_res)?;
 
-        let (_, update_res, _) = session
+        let (_, _update_res, _) = session
             .put(
                 &app,
                 &format!("/conversation/{}", conversation.id),
@@ -2034,7 +2034,7 @@ mod tests {
     }
 
     #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
-    async fn broadcast_email_only_sent_to_opted_in_authenticated_users(
+    fn broadcast_email_only_sent_to_opted_in_authenticated_users(
         pool: sqlx::PgPool,
     ) -> Result<(), Box<dyn Error>> {
         use crate::models::user_conversation_preferences::{
@@ -2153,7 +2153,7 @@ mod tests {
     }
 
     #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
-    async fn broadcast_email_respects_anonymous_opt_in_flag(
+    fn broadcast_email_respects_anonymous_opt_in_flag(
         pool: sqlx::PgPool,
     ) -> Result<(), Box<dyn Error>> {
         use crate::models::conversation_email_notification_recipients::{
@@ -2226,7 +2226,7 @@ mod tests {
     }
 
     #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
-    async fn broadcast_email_returns_zero_when_nobody_is_opted_in(
+    fn broadcast_email_returns_zero_when_nobody_is_opted_in(
         pool: sqlx::PgPool,
     ) -> Result<(), Box<dyn Error>> {
         use std::sync::{Arc, Mutex};
@@ -2273,7 +2273,7 @@ mod tests {
     }
 
     #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
-    async fn recipients_endpoint_lists_only_opted_in_emails(
+    fn recipients_endpoint_lists_only_opted_in_emails(
         pool: sqlx::PgPool,
     ) -> Result<(), Box<dyn Error>> {
         use crate::models::conversation_email_notification_recipients::{
@@ -2402,9 +2402,7 @@ mod tests {
     }
 
     #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
-    async fn recipients_endpoint_denies_non_owner(
-        pool: sqlx::PgPool,
-    ) -> Result<(), Box<dyn Error>> {
+    fn recipients_endpoint_denies_non_owner(pool: sqlx::PgPool) -> Result<(), Box<dyn Error>> {
         let state = test_state().db(pool).call()?;
         let app = setup_server(Arc::new(state)).await?;
 
@@ -2428,7 +2426,7 @@ mod tests {
     }
 
     #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
-    async fn should_allow_permitted_user_to_update_conversation(
+    fn should_allow_permitted_user_to_update_conversation(
         pool: sqlx::PgPool,
     ) -> Result<(), Box<dyn Error>> {
         let state = test_state().db(pool).call()?;
@@ -2444,7 +2442,9 @@ mod tests {
         editor_session.signup(&app).await?;
         let (_, editor, _) = editor_session.current_user(&app).await?;
 
-        let (_, value, _) = owner_session.create_random_conversation(&app).await?;
+        let (_, value, _) = owner_session
+            .create_random_unlaunched_conversation(&app)
+            .await?;
         let conversation: ConversationDto = serde_json::from_value(value)?;
 
         // Grant editor user `content_editor` permission
@@ -2452,7 +2452,7 @@ mod tests {
             user_id: Some(editor.id),
             organization_id: None,
             user_email: None,
-            role_name: "content_editor".into(),
+            role_name: Role::ConversationContentEditor.as_ref().into(),
             grant_reason: "Testing".into(),
         };
 
@@ -2505,11 +2505,11 @@ mod tests {
     }
 
     #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
-    async fn should_not_allow_non_permitted_admin_users_to_update_conversation(
+    fn should_allow_non_permitted_super_admin_users_to_update_conversation(
         pool: sqlx::PgPool,
     ) -> Result<(), Box<dyn Error>> {
-        let state = test_state().db(pool).call()?;
-        let app = setup_server(Arc::new(state)).await?;
+        let state = Arc::new(test_state().db(pool).call()?);
+        let app = setup_server(Arc::clone(&state)).await?;
 
         let mut owner_session = UserSession::new_admin();
         owner_session.signup(&app).await?;
@@ -2521,10 +2521,24 @@ mod tests {
             UserSession::new("editor", other_user_password, other_user_email);
         other_user_session.signup(&app).await?;
 
-        let (_, value, _) = owner_session.create_random_conversation(&app).await?;
+        // Grant other user super admin role
+        grant_role(
+            &state,
+            GrantRoleRequest {
+                actor_id: UserOrOrganizationId::User(other_user_session.id.unwrap()),
+                permission_triplet: Role::SuperAdmin.system_triplet(),
+                granted_by: &owner_session.id.unwrap(),
+                grant_reason: "Testing".into(),
+            },
+        )
+        .await?;
+
+        let (_, value, _) = owner_session
+            .create_random_unlaunched_conversation(&app)
+            .await?;
         let conversation: ConversationDto = serde_json::from_value(value)?;
 
-        // Update by editor
+        // Update by other super admin user. Super admins are globally authorized.
         let other_user_update = PartialConversation {
             is_public: Some(true),
             ..Default::default()
@@ -2533,11 +2547,11 @@ mod tests {
         let (_, other_user_response, _) = other_user_session
             .put(&app, &format!("/conversation/{}", conversation.id), body)
             .await?;
-
-        assert_eq!(
-            other_user_response.get("err").unwrap(),
-            "User is not authorized to perform this action",
-            "incorrect error message"
+        let other_user_updated_conversation: ConversationDto =
+            serde_json::from_value(other_user_response)?;
+        assert!(
+            other_user_updated_conversation.is_public,
+            "is_public incorrect after other admin update"
         );
 
         // Update by owner
@@ -2555,6 +2569,73 @@ mod tests {
             owner_updated_conversation.is_public,
             "is_public incorrect after owner update"
         );
+
+        Ok(())
+    }
+
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
+    fn should_allow_content_editor_to_read_draft_conversation(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn Error>> {
+        let state = test_state().db(pool).call()?;
+        let app = setup_server(Arc::new(state)).await?;
+
+        let mut owner_session = UserSession::new_admin();
+        owner_session.signup(&app).await?;
+
+        let mut editor_session = UserSession::new(
+            "content_editor_user",
+            "Password_123(*&)",
+            "content_editor@example.com",
+        );
+        editor_session.signup(&app).await?;
+        let (_, editor, _) = editor_session.current_user(&app).await?;
+
+        let (_, value, _) = owner_session
+            .create_random_unlaunched_conversation(&app)
+            .await?;
+        let conversation: ConversationDto = serde_json::from_value(value)?;
+
+        // Non-owner without role should be denied draft access.
+        let (status, _, _) = editor_session
+            .get_conversation(&app, &conversation.id.to_string())
+            .await?;
+        assert_eq!(status, StatusCode::FORBIDDEN);
+
+        // Grant read permission via content editor role.
+        let grant_body = GrantPermissionBody {
+            user_id: Some(editor.id),
+            organization_id: None,
+            user_email: None,
+            role_name: Role::ConversationContentEditor.as_ref().into(),
+            grant_reason: "Testing draft read permission".into(),
+        };
+        let body = Body::from(serde_json::to_string(&grant_body)?);
+
+        let (status, _, _) = owner_session
+            .post(
+                &app,
+                &format!(
+                    "/permissions/{}/{}",
+                    CONVERSATION_RESOURCE_TYPE, conversation.id
+                ),
+                body,
+            )
+            .await?;
+        assert_eq!(status, StatusCode::CREATED);
+
+        // Non-owner with content_editor should now be allowed to read draft.
+        let (status, value, _) = editor_session
+            .get_conversation(&app, &conversation.id.to_string())
+            .await?;
+        assert_eq!(status, StatusCode::OK);
+
+        let response_id = value
+            .get("id")
+            .cloned()
+            .ok_or("missing conversation response payload")?;
+        let id: uuid::Uuid = serde_json::from_value(response_id)?;
+        assert_eq!(id, conversation.id);
 
         Ok(())
     }

--- a/api/src/routes/permissions.rs
+++ b/api/src/routes/permissions.rs
@@ -15,14 +15,15 @@ use tracing::instrument;
 use uuid::Uuid;
 
 use crate::models::permissions::{
-    self, GrantRoleRequest, ListPermissionsFilters, PermissionTriplet, RevokeRoleRequest,
-    SystemAdminRole, SystemResource, UserOrOrganizationId, UserWithPermissionDto, list_permissions,
+    self, Action, GrantRoleRequest, ListPermissionsFilters, PermissionTargetResource,
+    PermissionTriplet, RevokeRoleRequest, SystemResource, UserOrOrganizationId,
+    UserWithPermissionDto, list_permissions,
 };
 use crate::models::{
     pagination::{PageOptions, PaginatedResults},
     users,
 };
-use crate::routes::auth::RequiredUserPermission;
+use crate::routes::auth::{RequiredUser, authorize};
 use crate::{
     ComhairleState,
     error::ComhairleError,
@@ -102,13 +103,13 @@ async fn resolve_actor(
 #[instrument(err(Debug), skip(state))]
 async fn grant(
     State(state): State<Arc<ComhairleState>>,
-    RequiredUserPermission { user: caller, .. }: RequiredUserPermission<
-        SystemAdminRole,
-        SystemResource,
-    >,
+    RequiredUser(caller): RequiredUser,
+    resource: PermissionTargetResource,
     Path(path): Path<TargetResourceId>,
     Json(body): Json<GrantPermissionBody>,
 ) -> Result<(StatusCode, Json<permissions::ResourcePermission>), ComhairleError> {
+    authorize(&state, &caller, Action::GrantPermission, &resource).await?;
+
     let actor_id = resolve_actor(
         &state.db,
         body.user_id,
@@ -158,10 +159,13 @@ async fn grant(
 #[instrument(err(Debug), skip(state))]
 async fn revoke(
     State(state): State<Arc<ComhairleState>>,
-    RequiredUserPermission { .. }: RequiredUserPermission<SystemAdminRole, SystemResource>,
+    RequiredUser(caller): RequiredUser,
+    resource: PermissionTargetResource,
     Path(path): Path<TargetResourceId>,
     Query(query): Query<RevokePermissionQuery>,
 ) -> Result<StatusCode, ComhairleError> {
+    authorize(&state, &caller, Action::RevokePermission, &resource).await?;
+
     let actor_id = resolve_actor(&state.db, query.user_id, query.organization_id, None, false)
         .await?
         .unwrap();
@@ -189,7 +193,8 @@ async fn revoke(
 #[instrument(err(Debug), skip(state))]
 async fn list(
     State(state): State<Arc<ComhairleState>>,
-    RequiredUserPermission { .. }: RequiredUserPermission<SystemAdminRole, SystemResource>,
+    RequiredUser(caller): RequiredUser,
+    system: SystemResource,
     Query(query): Query<ListPermissionsQuery>,
 ) -> Result<
     (
@@ -198,6 +203,8 @@ async fn list(
     ),
     ComhairleError,
 > {
+    authorize(&state, &caller, Action::ListPermission, &system).await?;
+
     let actor = resolve_actor(&state.db, query.user_id, query.organization_id, None, true).await?;
     let page_options = PageOptions {
         limit: query.limit,
@@ -225,7 +232,8 @@ async fn list(
 #[instrument(err(Debug), skip(state))]
 async fn list_for_resource(
     State(state): State<Arc<ComhairleState>>,
-    RequiredUserPermission { .. }: RequiredUserPermission<SystemAdminRole, SystemResource>,
+    RequiredUser(caller): RequiredUser,
+    resource: PermissionTargetResource,
     Path(path): Path<TargetResourceId>,
     Query(query): Query<ListPermissionsQuery>,
 ) -> Result<
@@ -235,6 +243,8 @@ async fn list_for_resource(
     ),
     ComhairleError,
 > {
+    authorize(&state, &caller, Action::ListPermission, &resource).await?;
+
     let actor = resolve_actor(&state.db, query.user_id, query.organization_id, None, true).await?;
     let page_options = PageOptions {
         limit: query.limit,
@@ -257,9 +267,13 @@ async fn list_for_resource(
 #[instrument(err(Debug), skip(state))]
 async fn list_users_with_permission(
     State(state): State<Arc<ComhairleState>>,
+    RequiredUser(caller): RequiredUser,
+    resource: PermissionTargetResource,
     Path(path): Path<TargetResourceId>,
     Query(query): Query<ListPermissionsQuery>,
 ) -> Result<(StatusCode, Json<Vec<UserWithPermissionDto>>), ComhairleError> {
+    authorize(&state, &caller, Action::ListPermission, &resource).await?;
+
     let users_with_permission = permissions::list_users_with_permission(
         &state.db,
         &path.resource_type,
@@ -356,12 +370,11 @@ pub fn router(state: Arc<ComhairleState>) -> ApiRouter {
 mod tests {
     use crate::models::pagination::PaginatedResults;
     use crate::models::permissions::{
-        GrantRoleRequest, ListPermissionsFilters, NamedRole, PermissionTriplet, ResourcePermission,
-        ResourceRole, SystemResourceRole, UserOrOrganizationId, grant_role,
-        has_resource_permission, list_permissions,
+        GrantRoleRequest, ListPermissionsFilters, PermissionTriplet, ResourcePermission, Role,
+        UserOrOrganizationId, grant_role, has_resource_permission, list_permissions,
     };
     use crate::routes::permissions::{
-        GrantPermissionBody, ListPermissionsQuery, RevokePermissionQuery, SystemAdminRole,
+        GrantPermissionBody, ListPermissionsQuery, RevokePermissionQuery,
     };
     use crate::test_helpers::{test_config, test_state};
     use crate::{setup_server, test_helpers::UserSession};
@@ -376,15 +389,13 @@ mod tests {
 
     struct TestRole;
 
-    impl NamedRole for TestRole {
+    impl TestRole {
         fn name() -> &'static str {
             "editor"
         }
-    }
 
-    impl ResourceRole for TestRole {
-        fn resource_type() -> &'static str {
-            RESOURCE_TYPE
+        fn make_triplet(resource_id: &uuid::Uuid) -> PermissionTriplet<'_> {
+            PermissionTriplet(RESOURCE_TYPE, resource_id, "editor")
         }
     }
 
@@ -423,8 +434,8 @@ mod tests {
         url.trim_end_matches('&').trim_end_matches('?').to_string()
     }
 
-    #[sqlx::test]
-    async fn test_admin_user_should_have_system_admin_role(
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
+    fn test_admin_user_should_have_system_admin_role(
         pool: PgPool,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let mut config = test_config()?;
@@ -440,7 +451,7 @@ mod tests {
         // Check if the user has the system admin role
         let has_admin_role = has_resource_permission(
             &state,
-            SystemAdminRole::make_system_triplet(),
+            Role::Admin.system_triplet(),
             &user.id,
             user.organization_id.as_ref(),
         )
@@ -455,8 +466,8 @@ mod tests {
     }
 
     // Grant permission
-    #[sqlx::test]
-    async fn test_post_permission(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
+    fn test_post_permission(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
         let mut config = test_config()?;
         config.bot_service = None;
         let state = Arc::new(test_state().db(pool).config(config).call()?);
@@ -466,6 +477,18 @@ mod tests {
         session.signup(&app).await?;
 
         let (_, user, _) = session.current_user(&app).await?;
+
+        // Assign super admin role to the user to ensure they can grant/revoke permissions
+        grant_role(
+            &state,
+            GrantRoleRequest {
+                actor_id: UserOrOrganizationId::User(user.id),
+                permission_triplet: Role::SuperAdmin.system_triplet(),
+                granted_by: &user.id,
+                grant_reason: "Testing".into(),
+            },
+        )
+        .await?;
 
         // Create a resource to grant permissions on
         let resource_id = uuid::Uuid::new_v4();
@@ -508,8 +531,8 @@ mod tests {
     }
 
     // Revoke permission
-    #[sqlx::test]
-    async fn test_delete_permission(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
+    fn test_delete_permission(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
         let mut config = test_config()?;
         config.bot_service = None;
         let state = Arc::new(test_state().db(pool).config(config).call()?);
@@ -519,6 +542,18 @@ mod tests {
         session.signup(&app).await?;
 
         let (_, user, _) = session.current_user(&app).await?;
+
+        // Assign super admin role to the user to ensure they can grant/revoke permissions
+        grant_role(
+            &state,
+            GrantRoleRequest {
+                actor_id: UserOrOrganizationId::User(user.id),
+                permission_triplet: Role::SuperAdmin.system_triplet(),
+                granted_by: &user.id,
+                grant_reason: "Testing".into(),
+            },
+        )
+        .await?;
 
         // Create a resource to grant permissions on
         let resource_id = uuid::Uuid::new_v4();
@@ -557,8 +592,8 @@ mod tests {
     }
 
     // List permissions (general)
-    #[sqlx::test]
-    async fn test_get_permissions(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
+    fn test_get_permissions(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
         let mut config = test_config()?;
         config.bot_service = None;
         let state = Arc::new(test_state().db(pool).config(config).call()?);
@@ -568,6 +603,18 @@ mod tests {
         session.signup(&app).await?;
 
         let (_, user, _) = session.current_user(&app).await?;
+
+        // Assign super admin role to the user to ensure they can grant/revoke permissions
+        grant_role(
+            &state,
+            GrantRoleRequest {
+                actor_id: UserOrOrganizationId::User(user.id),
+                permission_triplet: Role::SuperAdmin.system_triplet(),
+                granted_by: &user.id,
+                grant_reason: "Testing".into(),
+            },
+        )
+        .await?;
 
         // Create a resource to grant permissions on
         let resource_id = uuid::Uuid::new_v4();
@@ -606,7 +653,7 @@ mod tests {
         let permissions_page =
             serde_json::from_value::<PaginatedResults<ResourcePermission>>(response)?;
 
-        assert_eq!(permissions_page.total, 6);
+        assert_eq!(permissions_page.total, 7);
         assert_eq!(permissions_page.records.len(), 4);
 
         let next_query = ListPermissionsQuery {
@@ -622,16 +669,14 @@ mod tests {
         let next_permissions_page =
             serde_json::from_value::<PaginatedResults<ResourcePermission>>(response)?;
 
-        assert_eq!(next_permissions_page.records.len(), 2);
+        assert_eq!(next_permissions_page.records.len(), 3);
 
         Ok(())
     }
 
     // List permissions (for resource)
-    #[sqlx::test]
-    async fn test_get_permissions_for_resource(
-        pool: PgPool,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
+    fn test_get_permissions_for_resource(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
         let mut config = test_config()?;
         config.bot_service = None;
         let state = Arc::new(test_state().db(pool).config(config).call()?);
@@ -641,6 +686,18 @@ mod tests {
         session.signup(&app).await?;
 
         let (_, user, _) = session.current_user(&app).await?;
+
+        // Assign super admin role to the user to ensure they can grant/revoke permissions
+        grant_role(
+            &state,
+            GrantRoleRequest {
+                actor_id: UserOrOrganizationId::User(user.id),
+                permission_triplet: Role::SuperAdmin.system_triplet(),
+                granted_by: &user.id,
+                grant_reason: "Testing".into(),
+            },
+        )
+        .await?;
 
         // Create two resources to grant permissions on
         let resource_id = uuid::Uuid::new_v4();
@@ -723,8 +780,8 @@ mod tests {
     }
 
     // List permissions for a resource with filters
-    #[sqlx::test]
-    async fn test_get_permissions_for_resource_with_filters(
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
+    fn test_get_permissions_for_resource_with_filters(
         pool: PgPool,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let mut config = test_config()?;
@@ -736,6 +793,18 @@ mod tests {
         session.signup(&app).await?;
 
         let (_, user, _) = session.current_user(&app).await?;
+
+        // Assign super admin role to the user to ensure they can grant/revoke permissions
+        grant_role(
+            &state,
+            GrantRoleRequest {
+                actor_id: UserOrOrganizationId::User(user.id),
+                permission_triplet: Role::SuperAdmin.system_triplet(),
+                granted_by: &user.id,
+                grant_reason: "Testing".into(),
+            },
+        )
+        .await?;
 
         // Create a resource to grant permissions on
         let resource_id = uuid::Uuid::new_v4();
@@ -797,8 +866,8 @@ mod tests {
         Ok(())
     }
 
-    #[sqlx::test]
-    async fn test_permissions_audit_trail(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
+    fn test_permissions_audit_trail(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
         let mut config = test_config()?;
         config.bot_service = None;
         let state = Arc::new(test_state().db(pool).config(config).call()?);
@@ -808,6 +877,18 @@ mod tests {
         session.signup(&app).await?;
 
         let (_, user, _) = session.current_user(&app).await?;
+
+        // Assign super admin role to the user to ensure they can grant/revoke permissions
+        grant_role(
+            &state,
+            GrantRoleRequest {
+                actor_id: UserOrOrganizationId::User(user.id),
+                permission_triplet: Role::SuperAdmin.system_triplet(),
+                granted_by: &user.id,
+                grant_reason: "Testing".into(),
+            },
+        )
+        .await?;
 
         // Create a resource to grant permissions on
         let resource_id = uuid::Uuid::new_v4();

--- a/api/src/test_helpers.rs
+++ b/api/src/test_helpers.rs
@@ -1,8 +1,6 @@
-use crate::{
-    models::permissions::{NamedRole, ResourceRole},
-    redis_connection::RedisConnection,
-    websockets::handlers::video_call::VideoCallMessageHandler,
-};
+use crate::models::permissions::{PermissionTriplet, ResourceType, Role};
+use crate::redis_connection::RedisConnection;
+use crate::websockets::handlers::video_call::VideoCallMessageHandler;
 use chrono::Utc;
 use hyper::header::AUTHORIZATION;
 use std::{collections::HashMap, error::Error, sync::Arc};
@@ -144,19 +142,24 @@ pub fn test_config() -> Result<ComhairleConfig, Box<dyn Error>> {
     Ok(config)
 }
 
-pub const TEST_RESOURCE_TYPE: &str = "test_resource_type";
+pub const TEST_RESOURCE_TYPE: &str = "test";
 pub const TEST_ROLE_NAME: &str = "tester";
+
+/// Test-only shim around [`Role::Test`] / [`ResourceType::Test`] so existing
+/// tests can keep using `TestRole::name()` / `resource_type()` / `make_triplet()`.
 pub struct TestRole;
 
-impl NamedRole for TestRole {
-    fn name() -> &'static str {
-        TEST_ROLE_NAME
+impl TestRole {
+    pub fn name() -> &'static str {
+        Role::Tester.as_ref()
     }
-}
 
-impl ResourceRole for TestRole {
-    fn resource_type() -> &'static str {
-        TEST_RESOURCE_TYPE
+    pub fn resource_type() -> &'static str {
+        ResourceType::Test.as_ref()
+    }
+
+    pub fn make_triplet(resource_id: &Uuid) -> PermissionTriplet<'_> {
+        Role::Tester.triplet(resource_id)
     }
 }
 

--- a/api/src/websockets.rs
+++ b/api/src/websockets.rs
@@ -1048,7 +1048,6 @@ mod tests {
         };
 
         if can_connect {
-            eprintln!("Using Redis at localhost:6379 (CI environment)");
             _redis_server = None;
             redis_url = "redis://localhost:6379/".to_string();
         } else {
@@ -1063,19 +1062,16 @@ mod tests {
                         std::thread::sleep(std::time::Duration::from_millis(100));
                         if let Ok(client) = redis::Client::open(redis_url.as_str()) {
                             if client.get_connection().is_ok() {
-                                eprintln!("Temporary Redis server started at {}", addr);
                                 break;
                             }
                         }
                         if attempt == 4 {
-                            eprintln!("Failed to start temporary Redis server");
                             return;
                         }
                     }
                     _redis_server = Some(server);
                 }
                 Err(_) => {
-                    eprintln!("Could not start temporary Redis - skipping test");
                     return;
                 }
             }
@@ -1271,7 +1267,6 @@ mod tests {
         use crate::websockets::handlers::video_call::VideoCallMessageHandler;
 
         let Some((_redis_server, redis_url)) = redis_url_or_skip() else {
-            eprintln!("Redis unavailable - skipping test");
             return;
         };
 

--- a/scripts/add-super-admin.sh
+++ b/scripts/add-super-admin.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Add the super admin role into resource_permissions for chosen existing users.
+#
+# Finds users in comhairle_user whose email matches ADMIN_USERS_REGEX and inserts
+# a super admin permission row for each one, skipping any that already have it.
+#
+# Usage: ./scripts/add-super-admin.sh
+#
+# Env:
+#   DATABASE_URL        Postgres connection string (required)
+#                       e.g. postgres://user:pass@localhost:5432/comhairle
+#   ADMIN_USERS_REGEX   Postgres regular expression matched against email (required)
+#                       e.g. '@example\.com$' or '^(alice|bob)@example\.com$'
+
+set -euo pipefail
+
+: "${DATABASE_URL:?DATABASE_URL must be set}"
+: "${ADMIN_USERS_REGEX:?ADMIN_USERS_REGEX must be set (Postgres regex matched against email)}"
+
+command -v psql >/dev/null || { echo "missing psql"; exit 1; }
+
+echo "→ Checking users matching: $ADMIN_USERS_REGEX"
+
+# Dry-run: show which users would be affected and how many lack the role already
+AFFECTED=$(psql "$DATABASE_URL" --tuples-only --no-align <<SQL
+SELECT COUNT(*), string_agg(email, ', ' ORDER BY email)
+FROM comhairle_user
+WHERE LOWER(email) ~* ${ADMIN_USERS_REGEX@Q}
+  AND id NOT IN (
+      SELECT user_id
+      FROM resource_permissions
+      WHERE resource_type = 'system'
+        AND resource_id   = '00000000-0000-0000-0000-000000000000'
+        AND role_name     = 'super_admin'
+        AND user_id IS NOT NULL
+  );
+SQL
+)
+
+AFFECTED_COUNT=$(echo "$AFFECTED" | awk -F'|' '{print $1}' | xargs)
+AFFECTED_EMAILS=$(echo "$AFFECTED" | awk -F'|' '{print $2}' | xargs)
+
+if [[ "$AFFECTED_COUNT" -eq 0 ]]; then
+    echo "No users to update — all matching users already have the super admin role."
+    exit 0
+fi
+
+echo ""
+echo "WARNING: This will grant the super admin role to $AFFECTED_COUNT user(s):"
+echo "$AFFECTED_EMAILS"
+echo ""
+read -r -p "Type 'yes' to continue: " CONFIRM
+
+if [[ "$CONFIRM" != "yes" ]]; then
+    echo "Aborted."
+    exit 1
+fi
+
+echo ""
+echo "→ Adding super admin role for emails matching: $ADMIN_USERS_REGEX"
+
+GRANTED=$(psql "$DATABASE_URL" --tuples-only --no-align <<SQL
+WITH target_users AS (
+    SELECT id
+    FROM comhairle_user
+    WHERE LOWER(email) ~* ${ADMIN_USERS_REGEX@Q}
+),
+grantor_user AS (
+    SELECT id
+    FROM comhairle_user
+    WHERE LOWER(email) = 'admin@crown-shy.com'
+    LIMIT 1
+),
+selected_grantor AS (
+    SELECT COALESCE(
+        (SELECT id FROM grantor_user),
+        (SELECT id FROM target_users ORDER BY id LIMIT 1)
+    ) AS id
+),
+inserted AS (
+    INSERT INTO resource_permissions (
+        user_id,
+        resource_id,
+        resource_type,
+        role_name,
+        granted_by,
+        grant_reason,
+        granted_at
+    )
+    SELECT
+        id,
+        '00000000-0000-0000-0000-000000000000'::UUID,
+        'system',
+        'super_admin',
+        (SELECT id FROM selected_grantor),
+        'Backfilled by backfill-admin-permissions script',
+        NOW()
+    FROM target_users
+    ON CONFLICT DO NOTHING
+    RETURNING user_id
+)
+SELECT COUNT(*) FROM inserted;
+SQL
+)
+
+GRANTED=$(echo "$GRANTED" | xargs)
+echo "Granted $GRANTED new super admin permission(s)"


### PR DESCRIPTION
Motivations:

 - Modifying the permissions model to check for allowed actions instead of assigned roles allowa for much easier extraction-based verification when multiple overlapping roles can perform the same actions.
 - This introduction can be performed without impacting existing databases.
 - In future, we could extend this to allow custom roles, should the need arise.

Actions:

 - Added the concept of actions.
 - Added actions enums for existing system and conversation resources, and associated said actions with the existing roles.
 - Restructured permissions model code to improve maintainability.
 - Update permissions caching strategy to cache all user/org roles.