### PR TITLE
Surface tool error status codes to API response

### DIFF
--- a/adaptors/heyform-rust-sdk/src/error.rs
+++ b/adaptors/heyform-rust-sdk/src/error.rs
@@ -1,3 +1,4 @@
+use reqwest::StatusCode;
 use thiserror::Error;
 
 pub type Result<T> = std::result::Result<T, HeyFormError>;
@@ -24,4 +25,44 @@ pub enum HeyFormError {
 
     #[error("Not found: {0}")]
     NotFound(String),
+}
+
+impl Into<StatusCode> for &HeyFormError {
+    fn into(self) -> StatusCode {
+        match self {
+            HeyFormError::Http(err) => {
+                if let Some(status) = err.status() {
+                    status
+                } else {
+                    StatusCode::INTERNAL_SERVER_ERROR
+                }
+            },
+            HeyFormError::Json(_)
+            | HeyFormError::Url(_)
+            | HeyFormError::GraphQL(_)
+            | HeyFormError::InvalidInput(_) => StatusCode::BAD_REQUEST,
+            HeyFormError::Authentication(_) => StatusCode::UNAUTHORIZED,
+            HeyFormError::NotFound(_) => StatusCode::NOT_FOUND,
+        }
+    }
+}
+
+impl HeyFormError {
+    pub fn status_code(&self) -> StatusCode {
+        match self {
+            HeyFormError::Http(err) => {
+                if let Some(status) = err.status() {
+                    status
+                } else {
+                    StatusCode::INTERNAL_SERVER_ERROR
+                }
+            },
+            HeyFormError::Json(_)
+            | HeyFormError::Url(_)
+            | HeyFormError::GraphQL(_)
+            | HeyFormError::InvalidInput(_) => StatusCode::BAD_REQUEST,
+            HeyFormError::Authentication(_) => StatusCode::UNAUTHORIZED,
+            HeyFormError::NotFound(_) => StatusCode::NOT_FOUND,
+        }
+    }
 }

--- a/adaptors/ragflow/src/error.rs
+++ b/adaptors/ragflow/src/error.rs
@@ -17,3 +17,20 @@ pub enum RagflowError {
     #[error("Not found: {0}")]
     NotFound(String),
 }
+
+impl Into<StatusCode> for &RagflowError {
+    fn into(self) -> StatusCode {
+        match self {
+            RagflowError::Http(err) => {
+                if let Some(status) = err.status() {
+                    status
+                } else {
+                    StatusCode::INTERNAL_SERVER_ERROR
+                }
+            }
+            RagflowError::Api { status, .. } => *status,
+            RagflowError::Serde(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            RagflowError::NotFound(_) => StatusCode::NOT_FOUND,
+        }
+    }
+}

--- a/api/src/bulk_storage_service/error.rs
+++ b/api/src/bulk_storage_service/error.rs
@@ -1,3 +1,4 @@
+use hyper::StatusCode;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -19,4 +20,10 @@ pub enum BulkStorageError {
 
     #[error("Failed list: {0}")]
     FailedList(String),
+}
+
+impl Into<StatusCode> for &BulkStorageError {
+    fn into(self) -> StatusCode {
+        StatusCode::INTERNAL_SERVER_ERROR
+    }
 }

--- a/api/src/error.rs
+++ b/api/src/error.rs
@@ -398,6 +398,14 @@ impl IntoResponse for ComhairleError {
             | ComhairleError::WeakPassword(_)
             | ComhairleError::UnsupportedContentType(_)
             | ComhairleError::BadRequest(_) => StatusCode::BAD_REQUEST,
+            ComhairleError::PolisError(ref err) => Into::<StatusCode>::into(err),
+            ComhairleError::WikiPollServiceError(ref err) => Into::<StatusCode>::into(err),
+            ComhairleError::TranslationError(ref err) => Into::<StatusCode>::into(err),
+            ComhairleError::BulkStorageError(ref err) => Into::<StatusCode>::into(err),
+            ComhairleError::TranscriptionError(ref err) => Into::<StatusCode>::into(err),
+            ComhairleError::WorkerError(ref err) => Into::<StatusCode>::into(err),
+            ComhairleError::HeyFormError(ref err) => Into::<StatusCode>::into(err),
+            ComhairleError::RagflowError(ref err) => Into::<StatusCode>::into(err),
             _ => StatusCode::INTERNAL_SERVER_ERROR,
         };
 

--- a/api/src/tools/polis.rs
+++ b/api/src/tools/polis.rs
@@ -325,31 +325,54 @@ pub enum PolisError {
     Serde(#[from] serde_json::Error),
 
     #[error("Failed to create new admin user")]
-    FailedToCreateNewAdminUser,
+    FailedToCreateNewAdminUser(StatusCode),
 
     #[error("Failed to login")]
-    FailedToLogin,
+    FailedToLogin(StatusCode),
 
     #[error("Failed to create new poll")]
-    FailedToCreateNewPoll,
+    FailedToCreateNewPoll(StatusCode),
 
     #[error("Failed to get comments {0}")]
-    FailedToGetComments(String),
+    FailedToGetComments(StatusCode, String),
 
     #[error("Failed to get xids {0}")]
-    FailedToGetXIDs(String),
+    FailedToGetXIDs(StatusCode, String),
 
     #[error("Failed to update poll {0}")]
-    FailedPollUpdate(String),
+    FailedPollUpdate(StatusCode, String),
 
     #[error("Failed to post seed comment {0}")]
-    FailedToPostSeedComment(String),
+    FailedToPostSeedComment(StatusCode, String),
 
     #[error("Failed to moderate comment {0}")]
-    FailedToModerateComment(String),
+    FailedToModerateComment(StatusCode, String),
 
     #[error("Failed to proxy route {from} : {to}")]
     ProxyError { from: String, to: String },
+}
+
+impl Into<StatusCode> for &PolisError {
+    fn into(self) -> StatusCode {
+        match self {
+            PolisError::Http(err) => {
+                if let Some(status) = err.status() {
+                    status
+                } else {
+                    StatusCode::INTERNAL_SERVER_ERROR
+                }
+            }
+            PolisError::FailedToCreateNewAdminUser(status) => *status,
+            PolisError::FailedToLogin(status) => *status,
+            PolisError::FailedToCreateNewPoll(status) => *status,
+            PolisError::FailedToGetComments(status, _) => *status,
+            PolisError::FailedToGetXIDs(status, _) => *status,
+            PolisError::FailedPollUpdate(status, _) => *status,
+            PolisError::FailedToPostSeedComment(status, _) => *status,
+            PolisError::FailedToModerateComment(status, _) => *status,
+            _ => StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
 }
 
 #[derive(Deserialize, Serialize)]

--- a/api/src/transcription_service/error.rs
+++ b/api/src/transcription_service/error.rs
@@ -1,3 +1,4 @@
+use hyper::StatusCode;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -18,3 +19,13 @@ pub enum TranscriptionServiceError {
     BatchTranscriptionFailure(String),
 }
 pub type Result<T> = std::result::Result<T, TranscriptionServiceError>;
+
+impl Into<StatusCode> for &TranscriptionServiceError {
+    fn into(self) -> StatusCode {
+        match self {
+            TranscriptionServiceError::BatchProcessingUnsupported
+            | TranscriptionServiceError::StreamingProcessingUnsupported => StatusCode::BAD_REQUEST,
+            _ => StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
+}

--- a/api/src/translation_service/error.rs
+++ b/api/src/translation_service/error.rs
@@ -1,3 +1,4 @@
+use hyper::StatusCode;
 use thiserror::Error;
 #[derive(Error, Debug)]
 pub enum TranslationError {
@@ -5,3 +6,9 @@ pub enum TranslationError {
     TranslationFailed(String),
 }
 pub type Result<T> = std::result::Result<T, TranslationError>;
+
+impl Into<StatusCode> for &TranslationError {
+    fn into(self) -> StatusCode {
+        StatusCode::INTERNAL_SERVER_ERROR
+    }
+}

--- a/api/src/wiki_poll_service/error.rs
+++ b/api/src/wiki_poll_service/error.rs
@@ -1,4 +1,5 @@
 use aide::OperationIo;
+use hyper::StatusCode;
 use thiserror::Error;
 
 use crate::tools::polis::PolisError;
@@ -14,4 +15,20 @@ pub enum WikiPollServiceError {
 
     #[error("Moderation status integer not recognized")]
     UnknownModerationStatus,
+}
+
+impl Into<StatusCode> for &WikiPollServiceError {
+    fn into(self) -> StatusCode {
+        match self {
+            WikiPollServiceError::PolisError(polis_error) => Into::<StatusCode>::into(polis_error),
+            WikiPollServiceError::Http(err) => {
+                if let Some(status) = err.status() {
+                    status
+                } else {
+                    StatusCode::INTERNAL_SERVER_ERROR
+                }
+            }
+            WikiPollServiceError::UnknownModerationStatus => StatusCode::BAD_REQUEST,
+        }
+    }
 }

--- a/api/src/wiki_poll_service/polis_service.rs
+++ b/api/src/wiki_poll_service/polis_service.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeMap, HashMap};
 
 use async_trait::async_trait;
 use cookie::Cookie;
+use hyper::StatusCode;
 use rand::{Rng, distributions::Alphanumeric};
 use reqwest::{
     Client,
@@ -232,7 +233,10 @@ impl PolisClient {
 
         let response = self.client.get(&url).send().await.map_err(|e| {
             warn!("Failed to get comments: {e}");
-            PolisError::FailedToGetComments(format!("Failed to get comments: {e}"))
+            PolisError::FailedToGetComments(
+                e.status().unwrap_or(StatusCode::INTERNAL_SERVER_ERROR),
+                format!("Failed to get comments: {e}"),
+            )
         })?;
 
         let data = response
@@ -240,7 +244,10 @@ impl PolisClient {
             .await
             .map_err(|e| {
                 warn!("Failed to parse comments: {e}");
-                PolisError::FailedToGetComments(format!("Failed to parse comments: {e}"))
+                PolisError::FailedToGetComments(
+                    e.status().unwrap_or(StatusCode::INTERNAL_SERVER_ERROR),
+                    format!("Failed to parse comments: {e}"),
+                )
             })?;
 
         Ok(data)
@@ -251,15 +258,20 @@ impl PolisClient {
             "https://{}/api/v3/comments?conversation_id={poll_id}&moderation=true",
             self.base_url
         );
-        let comments: Vec<PolisComment> =
-            self.client
-                .get(url)
-                .send()
-                .await
-                .unwrap()
-                .json()
-                .await
-                .map_err(|e| PolisError::FailedToGetComments(e.to_string()))?;
+        let comments: Vec<PolisComment> = self
+            .client
+            .get(url)
+            .send()
+            .await
+            .unwrap()
+            .json()
+            .await
+            .map_err(|e| {
+            PolisError::FailedToGetComments(
+                e.status().unwrap_or(StatusCode::INTERNAL_SERVER_ERROR),
+                e.to_string(),
+            )
+        })?;
 
         Ok(comments)
     }
@@ -282,7 +294,12 @@ impl PolisClient {
             .json(params)
             .send()
             .await
-            .map_err(|e| PolisError::FailedPollUpdate(e.to_string()))?
+            .map_err(|e| {
+                PolisError::FailedPollUpdate(
+                    e.status().unwrap_or(StatusCode::INTERNAL_SERVER_ERROR),
+                    e.to_string(),
+                )
+            })?
             .json::<PolisPoll>()
             .await?;
 
@@ -297,12 +314,18 @@ impl PolisClient {
 
         let response = self.client.get(&url).send().await.map_err(|e| {
             warn!("Failed to get PCA data: {e}");
-            PolisError::FailedToGetComments(format!("Failed to get PCA data: {e}"))
+            PolisError::FailedToGetComments(
+                e.status().unwrap_or(StatusCode::INTERNAL_SERVER_ERROR),
+                format!("Failed to get PCA data: {e}"),
+            )
         })?;
 
         let data = response.json::<PolisMathPca>().await.map_err(|e| {
             warn!("Failed to parse PCA data: {e:#?}");
-            PolisError::FailedToGetComments(format!("Failed to parse PCA data: {e}"))
+            PolisError::FailedToGetComments(
+                e.status().unwrap_or(StatusCode::INTERNAL_SERVER_ERROR),
+                format!("Failed to parse PCA data: {e}"),
+            )
         })?;
 
         Ok(data)
@@ -487,13 +510,17 @@ impl WikiPollService for PolisClient {
             .await
             .map_err(|e| {
                 warn!("{e}");
-                PolisError::FailedToCreateNewAdminUser
+                PolisError::FailedToCreateNewAdminUser(
+                    e.status().unwrap_or(StatusCode::INTERNAL_SERVER_ERROR),
+                )
             })?
             .text()
             .await
             .map_err(|e| {
                 warn!("{e}");
-                PolisError::FailedToCreateNewAdminUser
+                PolisError::FailedToCreateNewAdminUser(
+                    e.status().unwrap_or(StatusCode::INTERNAL_SERVER_ERROR),
+                )
             })?;
 
         Ok((new_user.email, new_user.password))
@@ -528,7 +555,9 @@ impl WikiPollService for PolisClient {
             .json(&login)
             .send()
             .await
-            .map_err(|_| PolisError::FailedToLogin)?;
+            .map_err(|err| {
+                PolisError::FailedToLogin(err.status().unwrap_or(StatusCode::INTERNAL_SERVER_ERROR))
+            })?;
 
         let cookies = resp
             .headers()
@@ -540,10 +569,9 @@ impl WikiPollService for PolisClient {
             .collect::<Vec<_>>()
             .join("; ");
 
-        let _ = resp
-            .json::<LoginResp>()
-            .await
-            .map_err(|_| PolisError::FailedToLogin)?;
+        let _ = resp.json::<LoginResp>().await.map_err(|err| {
+            PolisError::FailedToLogin(err.status().unwrap_or(StatusCode::INTERNAL_SERVER_ERROR))
+        })?;
 
         Ok(cookies)
     }
@@ -557,13 +585,17 @@ impl WikiPollService for PolisClient {
             .await
             .map_err(|e| {
                 warn!("Failed to create new poll: {e:#?}");
-                PolisError::FailedToCreateNewPoll
+                PolisError::FailedToCreateNewPoll(
+                    e.status().unwrap_or(StatusCode::INTERNAL_SERVER_ERROR),
+                )
             })?
             .json::<NewPollResp>()
             .await
             .map_err(|e| {
                 warn!("Failed to create new poll: {e:#?}");
-                PolisError::FailedToCreateNewPoll
+                PolisError::FailedToCreateNewPoll(
+                    e.status().unwrap_or(StatusCode::INTERNAL_SERVER_ERROR),
+                )
             })?;
         Ok(new_poll.conversation_id.to_owned())
     }
@@ -630,10 +662,20 @@ impl WikiPollService for PolisClient {
             .json(&post_json)
             .send()
             .await
-            .map_err(|e| PolisError::FailedToPostSeedComment(e.to_string()))?
+            .map_err(|e| {
+                PolisError::FailedToPostSeedComment(
+                    e.status().unwrap_or(StatusCode::INTERNAL_SERVER_ERROR),
+                    e.to_string(),
+                )
+            })?
             .json::<PolisCommentCreateResponse>()
             .await
-            .map_err(|e| PolisError::FailedToPostSeedComment(e.to_string()))?;
+            .map_err(|e| {
+                PolisError::FailedToPostSeedComment(
+                    e.status().unwrap_or(StatusCode::INTERNAL_SERVER_ERROR),
+                    e.to_string(),
+                )
+            })?;
 
         Ok(resp.tid.to_string())
     }
@@ -654,7 +696,12 @@ impl WikiPollService for PolisClient {
             .await?
             .json()
             .await
-            .map_err(|e| PolisError::FailedToGetComments(e.to_string()))?;
+            .map_err(|e| {
+                PolisError::FailedToGetComments(
+                    e.status().unwrap_or(StatusCode::INTERNAL_SERVER_ERROR),
+                    e.to_string(),
+                )
+            })?;
 
         Ok(comments)
     }
@@ -679,7 +726,12 @@ impl WikiPollService for PolisClient {
             .await?
             .json()
             .await
-            .map_err(|e| PolisError::FailedToGetXIDs(e.to_string()))?;
+            .map_err(|e| {
+                PolisError::FailedToGetXIDs(
+                    e.status().unwrap_or(StatusCode::INTERNAL_SERVER_ERROR),
+                    e.to_string(),
+                )
+            })?;
 
         Ok(xids)
     }
@@ -717,14 +769,20 @@ impl WikiPollService for PolisClient {
             .json(&body)
             .send()
             .await
-            .map_err(|e| PolisError::FailedToModerateComment(e.to_string()))?;
+            .map_err(|e| {
+                PolisError::FailedToModerateComment(
+                    e.status().unwrap_or(StatusCode::INTERNAL_SERVER_ERROR),
+                    e.to_string(),
+                )
+            })?;
 
         if !resp.status().is_success() {
             let status = resp.status();
             let text = resp.text().await.unwrap_or_default();
-            return Err(PolisError::FailedToModerateComment(format!(
-                "polis returned {status}: {text}"
-            ))
+            return Err(PolisError::FailedToModerateComment(
+                status,
+                format!("polis returned {status}: {text}"),
+            )
             .into());
         }
 

--- a/api/src/worker_service/error.rs
+++ b/api/src/worker_service/error.rs
@@ -1,4 +1,5 @@
 use chrono::Utc;
+use hyper::StatusCode;
 use sqlx::PgPool;
 use thiserror::Error;
 use uuid::Uuid;
@@ -54,6 +55,30 @@ pub enum WorkerServiceError {
 
     #[error("Job failure: {0}")]
     JobFailure(String),
+}
+
+impl Into<StatusCode> for &WorkerServiceError {
+    fn into(self) -> StatusCode {
+        match self {
+            WorkerServiceError::NoWorkerServiceConfigured
+            | WorkerServiceError::NoTranscriptionServiceConfigured
+            | WorkerServiceError::NoBulkStorageServiceConfigured
+            | WorkerServiceError::NoBotServiceConfigured
+            | WorkerServiceError::NoCategorizationServiceError => StatusCode::SERVICE_UNAVAILABLE,
+
+            WorkerServiceError::SerdeJsonError(_)
+            | WorkerServiceError::DbError(_)
+            | WorkerServiceError::MailerError(_)
+            | WorkerServiceError::WrongUserType
+            | WorkerServiceError::BackgroundJobFailedToQueue
+            | WorkerServiceError::TranscriptionServiceError(_)
+            | WorkerServiceError::BulkStorageServiceError(_)
+            | WorkerServiceError::CategorizationServiceError(_)
+            | WorkerServiceError::InvalidState(_)
+            | WorkerServiceError::ExternalServiceFailure(_)
+            | WorkerServiceError::JobFailure(_) => StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
 }
 
 pub type Result<T> = std::result::Result<T, WorkerServiceError>;


### PR DESCRIPTION
Motivation:

 - Currently all tool errors result in a 500 status code, which makes it difficult to show the user an appropriate response on the frontend.

Actions:

 - Implemented Into<StatusCode> for tool error types.