### PR TITLE
Prioritization tool: surface missing required fields instead of a silently disabled Submit

### DIFF
--- a/ui/packages/comhairle/src/lib/tools/prioritization/PrioritizationUser.svelte
+++ b/ui/packages/comhairle/src/lib/tools/prioritization/PrioritizationUser.svelte
@@ -157,15 +157,36 @@
 	let currentAnswers = $derived(current ? (answers[current.id] ?? {}) : {});
 	let currentSectionAnswers = $derived(current ? (sectionAnswers[current.id] ?? {}) : {});
 
-	let isComplete = $derived.by(() => {
-		if (!current) return false;
-		const proposalOk = requiredQuestions.every((q) => isAnswered(currentAnswers[q.id]));
-		const sectionsOk = current.sections.every((section) => {
+	/** Set to true once the participant tries to submit, so we only surface
+	 * "required" errors after an attempt rather than nagging up front. */
+	let submitAttempted = $state(false);
+
+	/** Keys of required questions still unanswered on the current proposal.
+	 * Proposal-level questions key on `q.id`; per-section questions on `${section.id}:${q.id}`. */
+	function sectionKey(sectionId: string, questionId: string): string {
+		return `${sectionId}:${questionId}`;
+	}
+
+	let missingKeys = $derived.by(() => {
+		const keys = new Set<string>();
+		if (!current) return keys;
+		for (const q of requiredQuestions) {
+			if (!isAnswered(currentAnswers[q.id])) keys.add(q.id);
+		}
+		for (const section of current.sections) {
 			const sa = currentSectionAnswers[section.id] ?? {};
-			return requiredSectionQuestions.every((q) => isAnswered(sa[q.id]));
-		});
-		return proposalOk && sectionsOk;
+			for (const q of requiredSectionQuestions) {
+				if (!isAnswered(sa[q.id])) keys.add(sectionKey(section.id, q.id));
+			}
+		}
+		return keys;
 	});
+
+	let isComplete = $derived(current !== null && missingKeys.size === 0);
+
+	/** Only show the required-field errors once the user has attempted a submit
+	 * and something is still missing; auto-clears as they fill the fields in. */
+	let showRequiredErrors = $derived(submitAttempted && missingKeys.size > 0);
 
 	let allDone = $derived(proposals.length > 0 && proposals.every((p) => submittedIds.has(p.id)));
 
@@ -247,7 +268,15 @@
 	}
 
 	async function submitAndAdvance() {
+		if (currentSubmitted) return;
+		/** Surface which required fields are missing rather than silently doing nothing. */
+		if (!isComplete) {
+			submitAttempted = true;
+			return;
+		}
 		await submitCurrent();
+		if (submitError) return;
+		submitAttempted = false;
 		/** If anything is left, move on. Otherwise let allDone surface the summary view. */
 		if (currentIndex < proposals.length - 1) {
 			currentIndex += 1;
@@ -255,7 +284,10 @@
 	}
 
 	function goBack() {
-		if (currentIndex > 0) currentIndex -= 1;
+		if (currentIndex > 0) {
+			submitAttempted = false;
+			currentIndex -= 1;
+		}
 	}
 
 	let progressPercent = $derived(
@@ -283,7 +315,9 @@
 	<Card.Root>
 		<Card.Content class="space-y-3 py-8 text-center">
 			<p class="text-destructive">{loadState.message}</p>
-			<Button variant="outline" onclick={() => void loadProposalsAndProgress()}>Try again</Button>
+			<Button variant="outline" onclick={() => void loadProposalsAndProgress()}
+				>Try again</Button
+			>
 		</Card.Content>
 	</Card.Root>
 {:else if proposals.length === 0}
@@ -449,8 +483,15 @@
 											question.id
 										] ?? null}
 										disabled={currentSubmitted}
+										invalid={showRequiredErrors &&
+											missingKeys.has(sectionKey(section.id, question.id))}
 										onChange={(v) =>
-											setSectionAnswer(current.id, section.id, question.id, v)}
+											setSectionAnswer(
+												current.id,
+												section.id,
+												question.id,
+												v
+											)}
 									/>
 								{/each}
 							</div>
@@ -465,6 +506,7 @@
 								{question}
 								value={currentAnswers[question.id] ?? null}
 								disabled={currentSubmitted}
+								invalid={showRequiredErrors && missingKeys.has(question.id)}
 								onChange={(v) => setAnswer(current.id, question.id, v)}
 							/>
 						{/each}
@@ -486,14 +528,19 @@
 
 			{#if currentSubmitted}
 				{#if currentIndex < proposals.length - 1}
-					<Button onclick={() => (currentIndex += 1)}>
+					<Button
+						onclick={() => {
+							submitAttempted = false;
+							currentIndex += 1;
+						}}
+					>
 						Next <ArrowRight class="ml-2 h-4 w-4" />
 					</Button>
 				{:else}
 					<Button onclick={onDone}>Finish</Button>
 				{/if}
 			{:else}
-				<Button onclick={submitAndAdvance} disabled={!isComplete || submitting}>
+				<Button onclick={submitAndAdvance} disabled={submitting}>
 					{#if submitting}
 						<LoaderCircle class="mr-2 h-4 w-4 animate-spin" />
 					{/if}
@@ -502,6 +549,11 @@
 				</Button>
 			{/if}
 		</div>
+		{#if showRequiredErrors}
+			<p class="text-destructive text-right text-sm">
+				Please answer the highlighted question{missingKeys.size > 1 ? 's' : ''} before continuing.
+			</p>
+		{/if}
 		{#if submitError}
 			<p class="text-destructive text-right text-sm">{submitError}</p>
 		{/if}

--- a/ui/packages/comhairle/src/lib/tools/prioritization/components/QuestionField.svelte
+++ b/ui/packages/comhairle/src/lib/tools/prioritization/components/QuestionField.svelte
@@ -9,10 +9,12 @@
 		question: Question;
 		value: number | string | null;
 		disabled?: boolean;
+		/** When true, the question is required but unanswered after a submit attempt. */
+		invalid?: boolean;
 		onChange: (value: number | string) => void;
 	};
 
-	let { question, value, disabled = false, onChange }: Props = $props();
+	let { question, value, disabled = false, invalid = false, onChange }: Props = $props();
 
 	function handleLikert(raw: string) {
 		const n = Number(raw);
@@ -40,7 +42,7 @@
 </script>
 
 <div class="space-y-3" class:opacity-60={disabled}>
-	<p class="text-base font-medium">{question.text}</p>
+	<p class="text-base font-medium" class:text-destructive={invalid}>{question.text}</p>
 
 	{#if question.type.kind === 'likert'}
 		<RadioGroup.Root
@@ -86,5 +88,9 @@
 			value={typeof value === 'string' ? value : ''}
 			oninput={handleText}
 		/>
+	{/if}
+
+	{#if invalid}
+		<p class="text-destructive text-sm">Please answer this question to continue.</p>
 	{/if}
 </div>


### PR DESCRIPTION
Closes #750

## Problem

The ticket reported that you can't submit feedback on a proposal when the comment box is blank. Digging in, the comment field is **already optional** (text questions are excluded from validation, and blank comments are dropped on submit). The real issue was the *other* half of the ticket: when a required rating (likert/slider) was unanswered, the **Submit button was disabled with no explanation**. Participants saw a greyed-out button, assumed the empty comment was the blocker, and got stuck with no feedback about what was actually missing.

## Change

Submit is now always clickable. Clicking with unanswered required questions no longer moves on silently. It highlights exactly what's missing:

- Each unanswered required question turns its title red and shows "Please answer this question to continue."
- A summary line appears near the button: "Please answer the highlighted question(s) before continuing."
- Errors only show *after* a submit attempt (no nagging up front) and clear automatically as fields get filled. The attempt state resets on navigation, so warnings don't bleed into the next proposal.

The comment field stays optional, as it already was.

## Implementation notes

- Replaced the boolean `isComplete` with a derived `missingKeys` set so the same source of truth both gates submission and drives per-field highlighting (keyed per-section where questions repeat).
- Added an `invalid` prop to `QuestionField` for the inline error state.




Before (button disabled):

https://github.com/user-attachments/assets/a314bcb3-9c48-44ed-826b-e60cb4bcf8f5



After:

https://github.com/user-attachments/assets/116a7fe9-9310-42f5-b44a-b136686e3216

