### PR TITLE
Prioritization: neutral slider default + clear answered/unanswered states

### DIFF
--- a/ui/packages/comhairle/src/lib/tools/prioritization/PrioritizationUser.svelte
+++ b/ui/packages/comhairle/src/lib/tools/prioritization/PrioritizationUser.svelte
@@ -540,7 +540,11 @@
 					<Button onclick={onDone}>Finish</Button>
 				{/if}
 			{:else}
-				<Button onclick={submitAndAdvance} disabled={submitting}>
+				<Button
+					variant={isComplete ? 'default' : 'secondary'}
+					onclick={submitAndAdvance}
+					disabled={submitting}
+				>
 					{#if submitting}
 						<LoaderCircle class="mr-2 h-4 w-4 animate-spin" />
 					{/if}

--- a/ui/packages/comhairle/src/lib/tools/prioritization/components/QuestionField.svelte
+++ b/ui/packages/comhairle/src/lib/tools/prioritization/components/QuestionField.svelte
@@ -26,19 +26,50 @@
 		if (target) onChange(target.value);
 	}
 
-	function handleSlider(values: number[]) {
-		const v = values[0];
-		if (typeof v === 'number') onChange(v);
+	function handleSlider(v: number) {
+		gestureChanged = true;
+		onChange(v);
 	}
 
-	/** Slider goes from minValue to maxValue with step size derived from subSteps. */
+	/** Slider goes from minValue to maxValue with step size derived from subSteps.
+	 * `mid` is the neutral resting position for the thumb, `midpoint` the geometric
+	 * centre used to decide which end label leans once answered. */
 	let sliderRange = $derived.by(() => {
 		if (question.type.kind !== 'continuous') return null;
 		const { minValue, maxValue, subSteps } = question.type;
 		const span = maxValue - minValue;
 		const steps = Math.max(2, subSteps);
-		return { min: minValue, max: maxValue, step: span / steps };
+		const step = span / steps;
+		return {
+			min: minValue,
+			max: maxValue,
+			step,
+			mid: minValue + step * Math.round(steps / 2),
+			midpoint: minValue + span / 2
+		};
 	});
+
+	/** A continuous answer only counts once it holds a real number. Until then the
+	 * thumb just rests at `mid` with no track fill: the "not answered yet" state. */
+	let sliderAnswered = $derived(typeof value === 'number');
+	let sliderDisplayValue = $derived(typeof value === 'number' ? value : (sliderRange?.mid ?? 0));
+
+	/** Emphasise whichever end the thumb leans toward once the participant answers. */
+	let leaningLabel = $derived.by<'min' | 'max' | null>(() => {
+		if (!sliderAnswered || !sliderRange || typeof value !== 'number') return null;
+		if (value < sliderRange.midpoint) return 'min';
+		if (value > sliderRange.midpoint) return 'max';
+		return null;
+	});
+
+	/** Tracks whether the current pointer gesture moved the thumb. Reset in the
+	 * capture phase (before bits-ui updates), so a tap that lands exactly on the
+	 * resting thumb (e.g. choosing the middle) still commits an answer on release. */
+	let gestureChanged = $state(false);
+	function commitRestingIfUntouched() {
+		if (disabled) return;
+		if (!gestureChanged && !sliderAnswered && sliderRange) onChange(sliderRange.mid);
+	}
 </script>
 
 <div class="space-y-3" class:opacity-60={disabled}>
@@ -66,18 +97,26 @@
 		</RadioGroup.Root>
 	{:else if question.type.kind === 'continuous' && sliderRange}
 		<div class="space-y-2">
-			<Slider
-				type="single"
-				value={value ?? sliderRange.min}
-				min={sliderRange.min}
-				max={sliderRange.max}
-				step={sliderRange.step}
-				{disabled}
-				onValueChange={(v) => typeof v === 'number' && handleSlider([v])}
-			/>
+			<div class="pref-slider" data-answered={sliderAnswered}>
+				<Slider
+					type="single"
+					value={sliderDisplayValue}
+					min={sliderRange.min}
+					max={sliderRange.max}
+					step={sliderRange.step}
+					{disabled}
+					onpointerdowncapture={() => (gestureChanged = false)}
+					onpointerup={commitRestingIfUntouched}
+					onValueChange={(v) => typeof v === 'number' && handleSlider(v)}
+				/>
+			</div>
 			<div class="text-muted-foreground flex justify-between text-xs">
-				<span class="font-medium">{question.type.minLabel ?? ''}</span>
-				<span class="font-medium">{question.type.maxLabel ?? ''}</span>
+				<span class="font-medium" class:text-primary={leaningLabel === 'min'}>
+					{question.type.minLabel ?? ''}
+				</span>
+				<span class="font-medium" class:text-primary={leaningLabel === 'max'}>
+					{question.type.maxLabel ?? ''}
+				</span>
 			</div>
 		</div>
 	{:else}
@@ -94,3 +133,31 @@
 		<p class="text-destructive text-sm">Please answer this question to continue.</p>
 	{/if}
 </div>
+
+<style>
+	/* Grab affordance while dragging; the track invites a click anywhere. */
+	.pref-slider :global([data-slot='slider-thumb']) {
+		cursor: grab;
+	}
+	.pref-slider :global([data-slot='slider-thumb']:active) {
+		cursor: grabbing;
+	}
+	.pref-slider :global([data-slot='slider-track']) {
+		cursor: pointer;
+	}
+
+	/* Before the participant answers: neutral resting thumb, no track fill. */
+	.pref-slider[data-answered='false'] :global([data-slot='slider-range']) {
+		background-color: transparent;
+	}
+	.pref-slider[data-answered='false'] :global([data-slot='slider-thumb']) {
+		border-color: var(--border);
+		background-color: var(--background);
+	}
+
+	/* Once answered, the thumb fills in to match the coloured track range. */
+	.pref-slider[data-answered='true'] :global([data-slot='slider-thumb']) {
+		border-color: var(--primary);
+		background-color: var(--primary);
+	}
+</style>

--- a/ui/packages/comhairle/src/lib/tools/prioritization/components/QuestionField.svelte
+++ b/ui/packages/comhairle/src/lib/tools/prioritization/components/QuestionField.svelte
@@ -146,12 +146,20 @@
 		cursor: pointer;
 	}
 
-	/* Before the participant answers: neutral resting thumb, no track fill. */
+	/* The track is the same grey whether or not the question is answered, so the
+	 * unfilled remainder after voting matches the unvoted state. */
+	.pref-slider :global([data-slot='slider-track']) {
+		background-color: var(--border);
+	}
+
+	/* Before the participant answers: no track fill, and a blue-outlined resting
+	 * thumb so it reads as "interactive but unset" rather than disabled. */
 	.pref-slider[data-answered='false'] :global([data-slot='slider-range']) {
 		background-color: transparent;
 	}
 	.pref-slider[data-answered='false'] :global([data-slot='slider-thumb']) {
-		border-color: var(--border);
+		border-width: 2px;
+		border-color: var(--primary);
 		background-color: var(--background);
 	}
 


### PR DESCRIPTION
Follow-up to the required-fields work (#750). That change surfaced *when* a rating is unanswered; this one fixes the slider itself so "unanswered" reads clearly and answering the neutral value isn't a fiddle.

## Problem

The continuous (slider) question had two rough edges:
- The thumb sat at the **minimum** but the value was actually `null` until dragged, so it looked answered while counting as unanswered.
- To pick a value at the resting position, you had to drag the thumb away and back, a click that landed on it registered nothing.

## Change

**Slider now has an explicit "not answered yet" state.** The thumb rests in the **middle** as a neutral starting position, but with **no track fill** and a hollow grey thumb. That absence of fill is the "you haven't answered" cue, so:
- it doesn't anchor participants toward either end the way defaulting-to-min did, and
- the value stays genuinely unanswered until they interact, so required-field validation still fires.

**On touch:** the track fills, the thumb fills in with the theme's primary colour, and the leaning-side label (e.g. "Public") highlights.

**Middle-tap fixed:** a single tap on the resting thumb now commits the middle value instead of doing nothing, handled with a capture-phase gesture flag + pointerup so drags and clicks-elsewhere aren't affected.

**Cursor:** proper `grab`/`grabbing` on the thumb, `pointer` on the track.

**Submit button:** muted (`secondary`) while the proposal is incomplete, solid (`default`) once complete. Still always clickable, so clicking while incomplete triggers the required-field highlights.


https://github.com/user-attachments/assets/90efbbe0-939a-42bf-9524-ef7df4fde246

