### PR TITLE
751 prioritisation completion feedback

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -285,6 +285,46 @@ If you copy a block a second time, stop and extract it.
 - Use the **flat shadcn design tokens** (`bg-card`, `text-muted-foreground`, …). When
   translating from Figma, map its doubled token names to the flat token in markup.
 
+### Motion and reduced motion
+
+Animation can make people with vestibular disorders motion sick, and the OS exposes their
+"reduce motion" setting to us through the `prefers-reduced-motion: reduce` media query.
+Honour it, but with judgement: not every animation needs to be gated, and reaching for
+`animation: none` reflexively can break flows that depend on an animation finishing.
+
+- **Gate large motion; small motion is usually fine.** The vestibular triggers are _big_
+  movements: parallax, scaling or panning a medium-to-large object, an element that
+  travels a long distance. A brief opacity fade, a colour transition, or a small (a few
+  px) hover nudge generally does not need gating. When you can't tell whether a motion is
+  "large", gate it. Background:
+  [MDN on `prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
+  and
+  [the A11Y Project on vestibular disorders](https://www.a11yproject.com/posts/understanding-vestibular-disorders/).
+
+- **CSS with Tailwind → the `motion-reduce:` / `motion-safe:` variants.** For a Tailwind
+  `animate-*`, add `motion-reduce:animate-none` (see the submit interstitial in
+  `src/lib/tools/prioritization/PrioritizationUser.svelte`). For hand-written keyframes in
+  a `<style>` block, wrap the rule in `@media (prefers-reduced-motion: reduce)` (see
+  `src/lib/components/LiveEvent/AnimatedLoader.svelte`).
+
+- **JS-driven motion → branch on `matchMedia`.** Anything you animate imperatively (a
+  smooth `scrollIntoView`, a programmatic scroll or transition) has to read the query
+  yourself, since the CSS variants don't reach it:
+
+    ```ts
+    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    el.scrollIntoView({ behavior: reduceMotion ? 'auto' : 'smooth' });
+    ```
+
+    (see `scrollToProposalTop` in the same prioritization component).
+
+- **Shorten, don't kill, an animation something waits on.** If code advances state off an
+  `animationend` / `transitionend` event (or a Svelte transition's outro end),
+  `animation: none` means that event never fires and the flow stalls. In that case set the
+  duration to near-zero (`0.001s`) rather than removing the animation, so the event still
+  fires but the motion is imperceptible. When nothing listens for the end,
+  `motion-reduce:animate-none` is the simpler choice.
+
 ### Svelte (runes only)
 
 State is `$state` / `$derived` / `$props`, not the Svelte 4 style. Do not write

--- a/ui/packages/comhairle/src/lib/tools/prioritization/PrioritizationUser.svelte
+++ b/ui/packages/comhairle/src/lib/tools/prioritization/PrioritizationUser.svelte
@@ -57,7 +57,11 @@
 
 	async function scrollToProposalTop() {
 		await tick();
-		proposalTopEl?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+		const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+		proposalTopEl?.scrollIntoView({
+			behavior: reduceMotion ? 'auto' : 'smooth',
+			block: 'start'
+		});
 	}
 
 	/** Brief success interstitial shown between proposals so a submit registers as a
@@ -596,12 +600,12 @@
 {#if showSubmitted}
 	<Portal>
 		<div
-			class="bg-background/70 animate-in fade-in-0 fixed inset-0 z-100 flex items-center justify-center backdrop-blur-sm duration-200"
+			class="bg-background/70 animate-in fade-in-0 fixed inset-0 z-100 flex items-center justify-center backdrop-blur-sm duration-200 motion-reduce:animate-none"
 			role="status"
 			aria-live="polite"
 		>
 			<div
-				class="bg-card border-border animate-in zoom-in-95 fade-in-0 flex flex-col items-center gap-3 rounded-2xl border px-10 py-8 text-center shadow-lg duration-200"
+				class="bg-card border-border animate-in zoom-in-95 fade-in-0 flex flex-col items-center gap-3 rounded-2xl border px-10 py-8 text-center shadow-lg duration-200 motion-reduce:animate-none"
 			>
 				<CheckCircle2 class="text-primary size-12" />
 				<span class="text-foreground text-lg font-semibold">Response submitted</span>

--- a/ui/packages/comhairle/src/lib/tools/prioritization/PrioritizationUser.svelte
+++ b/ui/packages/comhairle/src/lib/tools/prioritization/PrioritizationUser.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import { tick } from 'svelte';
+	import { Portal } from 'bits-ui';
 	import { Button } from '$lib/components/ui/button';
 	import * as Card from '$lib/components/ui/card';
 	import { Progress } from '$lib/components/ui/progress';
@@ -49,6 +51,29 @@
 	let submitError = $state<string | null>(null);
 	let savingReview = $state(false);
 	let reviewError = $state<string | null>(null);
+	/** Top of the current-proposal view; scrolled into view after advancing so it's
+	 * clear the participant has moved on to the next proposal. */
+	let proposalTopEl = $state<HTMLDivElement | null>(null);
+
+	async function scrollToProposalTop() {
+		await tick();
+		proposalTopEl?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+	}
+
+	/** Brief success interstitial shown between proposals so a submit registers as a
+	 * distinct, deliberate moment rather than a silent form reset. */
+	let showSubmitted = $state(false);
+	const SUBMITTED_INTERSTITIAL_MS = 1100;
+
+	function flashSubmittedInterstitial(): Promise<void> {
+		showSubmitted = true;
+		return new Promise((resolve) =>
+			setTimeout(() => {
+				showSubmitted = false;
+				resolve();
+			}, SUBMITTED_INTERSTITIAL_MS)
+		);
+	}
 
 	/** Text answers are optional — completeness only requires likert / continuous. */
 	const requiredQuestions = $derived<Question[]>(
@@ -277,9 +302,13 @@
 		await submitCurrent();
 		if (submitError) return;
 		submitAttempted = false;
-		/** If anything is left, move on. Otherwise let allDone surface the summary view. */
+		/** Confirm the submission with a short interstitial before revealing what's next. */
+		await flashSubmittedInterstitial();
+		/** If anything is left, move on and scroll the fresh proposal to the top so the
+		 * jump to the next one is unmistakable. Otherwise let allDone surface the summary. */
 		if (currentIndex < proposals.length - 1) {
 			currentIndex += 1;
+			await scrollToProposalTop();
 		}
 	}
 
@@ -426,7 +455,7 @@
 		</div>
 	</div>
 {:else if current}
-	<div class="space-y-6">
+	<div class="space-y-6" bind:this={proposalTopEl}>
 		<div class="space-y-2">
 			<div class="flex items-center justify-between gap-3 text-sm">
 				<span class="text-muted-foreground">
@@ -562,4 +591,21 @@
 			<p class="text-destructive text-right text-sm">{submitError}</p>
 		{/if}
 	</div>
+{/if}
+
+{#if showSubmitted}
+	<Portal>
+		<div
+			class="bg-background/70 animate-in fade-in-0 fixed inset-0 z-100 flex items-center justify-center backdrop-blur-sm duration-200"
+			role="status"
+			aria-live="polite"
+		>
+			<div
+				class="bg-card border-border animate-in zoom-in-95 fade-in-0 flex flex-col items-center gap-3 rounded-2xl border px-10 py-8 text-center shadow-lg duration-200"
+			>
+				<CheckCircle2 class="text-primary size-12" />
+				<span class="text-foreground text-lg font-semibold">Response submitted</span>
+			</div>
+		</div>
+	</Portal>
 {/if}


### PR DESCRIPTION
Right now when you submit your feedback on a single proposal, nothing happens visually. The form just resets and it's not obvious the submission worked or that you've moved to the next proposal.

This adds:

- **A short "Response submitted" interstitial** a card with a checkmark fades in over the screen for about a second after each submit, so it's a clear, deliberate moment instead of a silent reset.
- **Auto-scroll to the top of the next proposal** once the interstitial clears, we advance and scroll the new proposal into view, so it's obvious you're starting a fresh one.

Built on the existing `Portal` overlay pattern (same one `LoadingOverlay` uses) and standard shadcn tokens, so no new deps.

**Notes for review**
- The interstitial fires on every submit, including the last one right before the summary view. Happy to skip it on the final proposal if that feels like one beat too many.
- Timing is a single constant (`SUBMITTED_INTERSTITIAL_MS`, 1100ms) if we want it snappier/slower.


https://github.com/user-attachments/assets/f2f25372-8e24-436f-8ae1-bd5816f89e02


