### PR TITLE
Fix: [Participate page] The search bar disappeared when there's no conversation result matched

### DIFF
--- a/ui/packages/comhairle/src/routes/(public)/conversations/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/+page.svelte
@@ -39,30 +39,29 @@
 <div class="flex h-full flex-col pt-10 md:pt-20">
 	<header class="mb:pb-20 px-2 pb-5 md:px-0">
 		<h1 class="mb-4 text-4xl font-bold">{m.conversations()}</h1>
+		<p class="mb-4">
+			{m.find_open_conversations()}
+		</p>
+		<div class="flex justify-between">
+			<DropdownMenu.Root>
+				<DropdownMenu.Trigger
+					class={buttonVariants({ variant: 'outline-solid', size: 'sm' })}
+				>
+					<ChevronDown class="h-4 w-4" />{m.sort()}
+				</DropdownMenu.Trigger>
+				<DropdownMenu.Content>
+					<DropdownMenu.Group>
+						{@render sortOption(pageUrl, 'title+asc')}
+						{@render sortOption(pageUrl, 'title+desc')}
+						{@render sortOption(pageUrl, 'created_at+desc')}
+						{@render sortOption(pageUrl, 'created_at+asc')}
+					</DropdownMenu.Group>
+				</DropdownMenu.Content>
+			</DropdownMenu.Root>
+			<Search />
+		</div>
 		{#if data.records.length === 0}
-			<h2 class="text-muted-foreground">No conversations found</h2>
-		{:else}
-			<p class="mb-4">
-				{m.find_open_conversations()}
-			</p>
-			<div class="flex justify-between">
-				<DropdownMenu.Root>
-					<DropdownMenu.Trigger
-						class={buttonVariants({ variant: 'outline-solid', size: 'sm' })}
-					>
-						<ChevronDown class="h-4 w-4" />{m.sort()}
-					</DropdownMenu.Trigger>
-					<DropdownMenu.Content>
-						<DropdownMenu.Group>
-							{@render sortOption(pageUrl, 'title+asc')}
-							{@render sortOption(pageUrl, 'title+desc')}
-							{@render sortOption(pageUrl, 'created_at+desc')}
-							{@render sortOption(pageUrl, 'created_at+asc')}
-						</DropdownMenu.Group>
-					</DropdownMenu.Content>
-				</DropdownMenu.Root>
-				<Search />
-			</div>
+			<h2 class="text-muted-foreground pt-10">No conversations found</h2>
 		{/if}
 	</header>
 


### PR DESCRIPTION
Fixes https://github.com/crownshy/comhairle/issues/776

The issue was because it was filtering the data to 0, it was removing the search bar, so I've just changed it so that the search bar is always visible

### Testing

Before

<img width="1900" height="885" alt="Screenshot from 2026-07-30 11-40-55" src="https://github.com/user-attachments/assets/d3cdba04-7705-445c-9576-dc6df82cbfe8" />

After

<img width="1900" height="885" alt="Screenshot from 2026-07-30 11-39-13" src="https://github.com/user-attachments/assets/d70838cd-d012-48fc-b2df-c3df0102e467" />
