### PR TITLE
fix: scope Polis vote progress per step instead of per poll

### DIFF
--- a/ui/packages/comhairle/src/lib/tools/polis/PolisEmbed.svelte
+++ b/ui/packages/comhairle/src/lib/tools/polis/PolisEmbed.svelte
@@ -26,6 +26,7 @@
 		onDone: () => void | Promise<void>;
 		requiredVotes?: number;
 		workflowStepId?: string;
+		isPreview?: boolean;
 		showRemainingStatementCount?: boolean;
 		onCanContinueChange?: (canContinue: boolean) => void;
 	};
@@ -37,11 +38,16 @@
 		onDone,
 		requiredVotes = 10,
 		workflowStepId = polis_id,
+		isPreview = false,
 		onCanContinueChange,
 		showRemainingStatementCount
 	}: Props = $props();
 
 	const stepId = workflowStepId;
+
+	// Vote progress is stored per step (and separately for preview vs live) so two
+	// Polis steps, even ones sharing a poll, never share their threshold state.
+	const voteScopeKey = `${isPreview ? 'preview' : 'live'}-${stepId}`;
 
 	let polisCurrentStatement = $state<PolisStatement | undefined>(undefined);
 	let polisLoading = $state(false);
@@ -74,7 +80,7 @@
 
 	type Screen = 'voting' | 'add-opinion' | 'continue-prompt' | 'completed';
 
-	const initialData = getVoteData(user_id, polis_id);
+	const initialData = getVoteData(user_id, voteScopeKey);
 	let totalVotes = $state(initialData.totalVotes);
 	let hasMetThreshold = $state(initialData.hasMetThreshold);
 	let screen = $state<Screen>('voting');
@@ -166,7 +172,7 @@
 			anchoredRemaining--;
 		}
 
-		const data = incrementVotes(user_id, polis_id, safeRequiredVotes);
+		const data = incrementVotes(user_id, voteScopeKey, safeRequiredVotes);
 		hasMetThreshold = data.hasMetThreshold;
 
 		if (data.totalVotes === safeRequiredVotes) {
@@ -184,7 +190,7 @@
 	}
 
 	function resumeVoting() {
-		resetVoteCount(user_id, polis_id);
+		resetVoteCount(user_id, voteScopeKey);
 		totalVotes = 0;
 		screen = 'voting';
 	}

--- a/ui/packages/comhairle/src/lib/tools/polis/polisVoteStore.test.ts
+++ b/ui/packages/comhairle/src/lib/tools/polis/polisVoteStore.test.ts
@@ -1,0 +1,55 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from 'vitest';
+import { getVoteData, incrementVotes, resetVoteCount } from './polisVoteStore';
+
+const USER = 'user-1';
+
+describe('polisVoteStore', () => {
+	beforeEach(() => {
+		localStorage.clear();
+	});
+
+	it('starts empty for an unseen scope', () => {
+		expect(getVoteData(USER, 'live-step-a')).toEqual({ totalVotes: 0, hasMetThreshold: false });
+	});
+
+	it('flags the threshold once the required votes are reached', () => {
+		incrementVotes(USER, 'live-step-a', 2);
+		expect(getVoteData(USER, 'live-step-a')).toEqual({ totalVotes: 1, hasMetThreshold: false });
+
+		const data = incrementVotes(USER, 'live-step-a', 2);
+		expect(data).toEqual({ totalVotes: 2, hasMetThreshold: true });
+	});
+
+	// The bug: two Polis steps sharing one poll used to share their progress.
+	// Keying by a per-step scope must keep them fully independent.
+	it('keeps progress independent across scopes', () => {
+		incrementVotes(USER, 'live-step-a', 2);
+		incrementVotes(USER, 'live-step-a', 2);
+
+		// A second step (even one on the same poll) is untouched.
+		expect(getVoteData(USER, 'live-step-b')).toEqual({ totalVotes: 0, hasMetThreshold: false });
+
+		incrementVotes(USER, 'live-step-b', 2);
+		expect(getVoteData(USER, 'live-step-b')).toEqual({ totalVotes: 1, hasMetThreshold: false });
+		// Step A's met-threshold state did not leak into step B.
+		expect(getVoteData(USER, 'live-step-a').hasMetThreshold).toBe(true);
+	});
+
+	it('separates preview from live for the same step', () => {
+		incrementVotes(USER, 'live-step-a', 1);
+		expect(getVoteData(USER, 'preview-step-a')).toEqual({
+			totalVotes: 0,
+			hasMetThreshold: false
+		});
+	});
+
+	it('resetVoteCount zeroes the count for that scope only', () => {
+		incrementVotes(USER, 'live-step-a', 5);
+		incrementVotes(USER, 'live-step-b', 5);
+
+		resetVoteCount(USER, 'live-step-a');
+		expect(getVoteData(USER, 'live-step-a').totalVotes).toBe(0);
+		expect(getVoteData(USER, 'live-step-b').totalVotes).toBe(1);
+	});
+});

--- a/ui/packages/comhairle/src/lib/tools/polis/polisVoteStore.ts
+++ b/ui/packages/comhairle/src/lib/tools/polis/polisVoteStore.ts
@@ -5,50 +5,53 @@ interface PolisVoteData {
 	hasMetThreshold: boolean;
 }
 
-function storageKey(userId: string, polisId: string): string {
-	return `${STORAGE_PREFIX}-${userId}-${polisId}`;
+// `scopeKey` must be unique per workflow step (and per preview vs live), not per
+// Polis poll. Two Polis steps can point at the same poll, so keying by poll id
+// lets their vote progress and threshold-met flag bleed across each other.
+function storageKey(userId: string, scopeKey: string): string {
+	return `${STORAGE_PREFIX}-${userId}-${scopeKey}`;
 }
 
-function load(userId: string, polisId: string): PolisVoteData {
+function load(userId: string, scopeKey: string): PolisVoteData {
 	if (typeof window === 'undefined') return { totalVotes: 0, hasMetThreshold: false };
 	try {
-		const raw = localStorage.getItem(storageKey(userId, polisId));
+		const raw = localStorage.getItem(storageKey(userId, scopeKey));
 		return raw ? JSON.parse(raw) : { totalVotes: 0, hasMetThreshold: false };
 	} catch {
 		return { totalVotes: 0, hasMetThreshold: false };
 	}
 }
 
-function save(userId: string, polisId: string, data: PolisVoteData): void {
+function save(userId: string, scopeKey: string, data: PolisVoteData): void {
 	if (typeof window === 'undefined') return;
 	try {
-		localStorage.setItem(storageKey(userId, polisId), JSON.stringify(data));
+		localStorage.setItem(storageKey(userId, scopeKey), JSON.stringify(data));
 	} catch {
 		/* ignore */
 	}
 }
 
-export function getVoteData(userId: string, polisId: string): PolisVoteData {
-	return load(userId, polisId);
+export function getVoteData(userId: string, scopeKey: string): PolisVoteData {
+	return load(userId, scopeKey);
 }
 
-export function resetVoteCount(userId: string, polisId: string): PolisVoteData {
-	const data = load(userId, polisId);
+export function resetVoteCount(userId: string, scopeKey: string): PolisVoteData {
+	const data = load(userId, scopeKey);
 	data.totalVotes = 0;
-	save(userId, polisId, data);
+	save(userId, scopeKey, data);
 	return data;
 }
 
 export function incrementVotes(
 	userId: string,
-	polisId: string,
+	scopeKey: string,
 	requiredVotes: number
 ): PolisVoteData {
-	const data = load(userId, polisId);
+	const data = load(userId, scopeKey);
 	data.totalVotes++;
 	if (data.totalVotes >= requiredVotes) {
 		data.hasMetThreshold = true;
 	}
-	save(userId, polisId, data);
+	save(userId, scopeKey, data);
 	return data;
 }

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/workflow/[workflow_id]/s/[workflow_step_id]/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/workflow/[workflow_id]/s/[workflow_step_id]/+page.svelte
@@ -296,16 +296,19 @@
 						{/key}
 					{/if}
 					{#if toolConfig?.type === Polis.TOOL_NAME}
-						<Polis.UserUI
-							user_id={user.id}
-							polis_id={toolConfig.poll_id}
-							polis_url={toolConfig.server_url}
-							requiredVotes={toolConfig.required_votes}
-							workflowStepId={workflowStep.id}
-							onDone={stepComplete}
-							onCanContinueChange={handleCanContinueChange}
-							showRemainingStatementCount={toolConfig.show_remaining_statements}
-						/>
+						{#key workflowStep.id}
+							<Polis.UserUI
+								user_id={user.id}
+								polis_id={toolConfig.poll_id}
+								polis_url={toolConfig.server_url}
+								requiredVotes={toolConfig.required_votes}
+								workflowStepId={workflowStep.id}
+								{isPreview}
+								onDone={stepComplete}
+								onCanContinueChange={handleCanContinueChange}
+								showRemainingStatementCount={toolConfig.show_remaining_statements}
+							/>
+						{/key}
 					{/if}
 					{#if toolConfig.type === HeyForm.TOOL_NAME}
 						{#key workflowStep.id}


### PR DESCRIPTION
## What

Fixes two Polis steps bleeding vote progress into each other: hitting the required-votes threshold on one step unlocked "continue" on another without voting.

## The actual cause

First read was a storage-keying bug: vote progress in `localStorage` was keyed by the Polis poll id, not the step. True, but the deeper issue is that the Polis embed was the **only** tool on the step page not wrapped in `{#key workflowStep.id}`. SvelteKit reuses the page component on param-only nav, so two adjacent Polis steps shared one `<PolisEmbed>` instance (vote count, threshold flag, and even the live `PolisApi` conversation) regardless of poll id. Re-keying the store alone wouldn't have fixed that, since those values are captured once at mount.

Also worth noting: two steps landing on the same poll id isn't a normal state anyway. Each step mints its own poll at setup, so this only happens in edge configs.

## Changes

- Wrap the Polis embed in `{#key workflowStep.id}` so it remounts per step (fixes the adjacent case, rebuilds `PolisApi` against the right poll).
- Key the vote store per step + preview/live (`voteScopeKey`) instead of per poll id.
- Add unit tests for the store scoping.

## Follow-up

This is still per-device `localStorage`. The real long-term fix is a server-side source of truth (an endpoint returning the participant's vote count for a step, gated on that instead of a local counter). I'll open a separate issue/PR for that endpoint.


After fix:

https://github.com/user-attachments/assets/27ac7614-f3a4-4a09-88d0-6e9111c0046c

Before Fix:

https://github.com/user-attachments/assets/99754b3f-340f-4e04-9e7d-b4f01df9d38e


