### PR TITLE
801 gate polis required votes on a server side vote count not localstorage

### DIFF
--- a/api/src/tools/polis.rs
+++ b/api/src/tools/polis.rs
@@ -160,6 +160,21 @@ impl ToolImpl for PolisTool {
                 }),
             )
             .api_route(
+                "/polis/vote_count",
+                get_with(get_user_vote_count, |op| {
+                    op.id("PolisGetUserVoteCount")
+                        .tag("Tools")
+                        .summary("Get the calling participant's vote count for a step")
+                        .description(
+                            "Counts the votes the authenticated participant has cast in the \
+                             Polis poll for the given workflow step, mapping their comhairle \
+                             user id to the Polis participant via xids. Used to seed the \
+                             required-votes progress from server data.",
+                        )
+                        .response::<200, Json<VoteCountResponse>>()
+                }),
+            )
+            .api_route(
                 "/polis/config",
                 put_with(update_polis_config, |op| {
                     op.id("PolisUpdateConfig")
@@ -358,6 +373,9 @@ pub enum PolisError {
     #[error("Failed to get xids {0}")]
     FailedToGetXIDs(StatusCode, String),
 
+    #[error("Failed to get votes {0}")]
+    FailedToGetVotes(String),
+
     #[error("Failed to update poll {0}")]
     FailedPollUpdate(StatusCode, String),
 
@@ -478,6 +496,64 @@ async fn get_report_data(
         .await?;
 
     Ok((StatusCode::OK, Json(data)))
+}
+
+#[derive(Serialize, Deserialize, JsonSchema)]
+struct VoteCountQuery {
+    pub workflow_step_id: Uuid,
+}
+
+#[derive(Serialize, Deserialize, JsonSchema, Debug)]
+pub struct VoteCountResponse {
+    pub vote_count: u32,
+}
+
+/// Returns how many votes the calling participant has cast in the poll for this
+/// step. Used to seed the "required votes" progress from server data so it is
+/// correct across devices, instead of relying only on a per-device local count.
+#[instrument(err(Debug), skip(state))]
+async fn get_user_vote_count(
+    State(state): State<Arc<ComhairleState>>,
+    RequiredUser(user): RequiredUser,
+    Query(VoteCountQuery { workflow_step_id }): Query<VoteCountQuery>,
+) -> Result<(StatusCode, Json<VoteCountResponse>), ComhairleError> {
+    let workflow_step = models::workflow_step::get_by_id(&state.db, &workflow_step_id).await?;
+
+    let config = match (workflow_step.tool_config, workflow_step.preview_tool_config) {
+        (Some(ToolConfig::Polis(config)), _) => config,
+        (None, ToolConfig::Polis(config)) => config,
+        _ => return Err(ComhairleError::WorkflowStepHasWrongType("Polis".into())),
+    };
+
+    let client = &state.wiki_poll_service;
+    let auth_cookies = client
+        .login(&WikiPollLogin {
+            email: config.admin_user.clone(),
+            password: config.admin_password.clone(),
+        })
+        .await?;
+
+    // The participant's comhairle user id is stored as their Polis xid, so we map
+    // it back to the Polis participant id (pid) to count their votes.
+    let pid = client
+        .get_xids(&config.poll_id, &auth_cookies)
+        .await?
+        .into_iter()
+        .find(|row| Uuid::parse_str(&row.xid).ok() == Some(user.id))
+        .map(|row| row.pid);
+
+    // No xid mapping means the participant has not registered in Polis yet, which
+    // only happens before they cast their first vote, so a zero count is correct.
+    let vote_count = match pid {
+        Some(pid) => {
+            client
+                .get_participant_vote_count(&config.poll_id, pid, &auth_cookies)
+                .await?
+        }
+        None => 0,
+    };
+
+    Ok((StatusCode::OK, Json(VoteCountResponse { vote_count })))
 }
 
 #[derive(Serialize, Deserialize, JsonSchema, Debug)]

--- a/api/src/wiki_poll_service.rs
+++ b/api/src/wiki_poll_service.rs
@@ -87,6 +87,16 @@ pub trait WikiPollService: Send + Sync {
         auth_cookies: &str,
     ) -> Result<Vec<WikiPollXid>, WikiPollServiceError>;
 
+    /// Number of votes a single participant has cast in a poll. Used to gate the
+    /// participant "required votes" threshold on server data instead of a
+    /// per-device local counter.
+    async fn get_participant_vote_count(
+        &self,
+        poll_id: &str,
+        pid: u32,
+        auth_cookies: &str,
+    ) -> Result<u32, WikiPollServiceError>;
+
     async fn get_report_data(&self, poll_id: &str) -> Result<WikiPollReport, WikiPollServiceError>;
 
     async fn moderate_comment(
@@ -203,6 +213,9 @@ impl MockWikiPollService {
         wiki_poll_service
             .expect_get_xids()
             .returning(|_, _| Box::pin(async move { Ok(vec![]) }));
+        wiki_poll_service
+            .expect_get_participant_vote_count()
+            .returning(|_, _, _| Box::pin(async move { Ok(0) }));
         wiki_poll_service
             .expect_moderate_comment()
             .returning(|_, _, _, _| Box::pin(async move { Ok(()) }));

--- a/api/src/wiki_poll_service/polis_service.rs
+++ b/api/src/wiki_poll_service/polis_service.rs
@@ -753,6 +753,33 @@ impl WikiPollService for PolisClient {
         Ok(xids)
     }
 
+    #[instrument(err(Debug), skip(self, auth_cookies))]
+    async fn get_participant_vote_count(
+        &self,
+        poll_id: &str,
+        pid: u32,
+        auth_cookies: &str,
+    ) -> Result<u32, WikiPollServiceError> {
+        let url = format!(
+            "https://{}/api/v3/votes?conversation_id={poll_id}&pid={pid}",
+            self.base_url
+        );
+
+        // Polis returns one object per vote. We only need the tally, so parse
+        // loosely and count rather than modelling every vote field.
+        let votes: Vec<serde_json::Value> = self
+            .client
+            .get(url)
+            .header(COOKIE, auth_cookies)
+            .send()
+            .await?
+            .json()
+            .await
+            .map_err(|e| PolisError::FailedToGetVotes(e.to_string()))?;
+
+        Ok(votes.len() as u32)
+    }
+
     async fn get_report_data(&self, poll_id: &str) -> Result<WikiPollReport, WikiPollServiceError> {
         // Fetch all the data that powers the report page
         let math_pca = self.get_math_pca(poll_id).await?;

--- a/ui/packages/api-client/src/api.ts
+++ b/ui/packages/api-client/src/api.ts
@@ -445,6 +445,10 @@ export const WikiPollReport = z
   })
   .passthrough();
 export type WikiPollReport = z.infer<typeof WikiPollReport>;
+export const VoteCountResponse = z
+  .object({ vote_count: z.number().int().gte(0) })
+  .passthrough();
+export type VoteCountResponse = z.infer<typeof VoteCountResponse>;
 export const UpdatePolisConfigRequest = z
   .object({
     description: z.union([z.string(), z.null()]).optional(),
@@ -3105,6 +3109,7 @@ export const schemas: Record<string, z.ZodType<any>> = {
   PcaPosition,
   ParticipantReportData,
   WikiPollReport,
+  VoteCountResponse,
   UpdatePolisConfigRequest,
   WikiPoll,
   PostSeedRequest,
@@ -6014,6 +6019,21 @@ Use a raw HTTP request and process the response body incrementally.
       },
     ],
     response: z.array(ThemeStatistic),
+  },
+  {
+    method: "get",
+    path: "/tools/polis/vote_count",
+    alias: "PolisGetUserVoteCount",
+    description: `Counts the votes the authenticated participant has cast in the Polis poll for the given workflow step, mapping their comhairle user id to the Polis participant via xids. Used to seed the required-votes progress from server data.`,
+    requestFormat: "json",
+    parameters: [
+      {
+        name: "workflow_step_id",
+        type: "Query",
+        schema: z.string().uuid(),
+      },
+    ],
+    response: z.object({ vote_count: z.number().int().gte(0) }).passthrough(),
   },
   {
     method: "get",

--- a/ui/packages/comhairle/src/lib/tools/polis/PolisEmbed.svelte
+++ b/ui/packages/comhairle/src/lib/tools/polis/PolisEmbed.svelte
@@ -12,12 +12,19 @@
 		MessageSquare,
 		AlertTriangle
 	} from 'lucide-svelte';
+	import { onMount } from 'svelte';
 	import PolisApi, { type PolisApiState, type PolisStatement } from './PolisApi';
-	import { getVoteData, incrementVotes, resetVoteCount } from './polisVoteStore';
+	import {
+		getVoteData,
+		incrementVotes,
+		reconcileServerVotes,
+		resetVoteCount
+	} from './polisVoteStore';
 	import { opinionCounter } from './polisCounter';
 	import * as m from '$lib/paraglide/messages';
 	import Separator from '$lib/components/ui/separator/separator.svelte';
 	import { apiClient } from '@crownshy/api-client/client';
+	import { tryCatchAsync } from '$lib/utils/errorHandling';
 
 	type Props = {
 		polis_id: string;
@@ -84,6 +91,27 @@
 	let totalVotes = $state(initialData.totalVotes);
 	let hasMetThreshold = $state(initialData.hasMetThreshold);
 	let screen = $state<Screen>('voting');
+
+	// Seed progress from the server so the required-votes threshold is correct
+	// across devices, not just this browser. Best-effort: on failure we keep the
+	// local count seeded above.
+	onMount(async () => {
+		const result = await tryCatchAsync(() =>
+			apiClient.PolisGetUserVoteCount({ queries: { workflow_step_id: stepId } })
+		);
+		if (result.err !== null) {
+			console.error('[PolisEmbed] Failed to load server vote count:', result.err);
+			return;
+		}
+		const data = reconcileServerVotes(
+			user_id,
+			voteScopeKey,
+			result.ok.vote_count,
+			safeRequiredVotes
+		);
+		totalVotes = data.totalVotes;
+		hasMetThreshold = data.hasMetThreshold;
+	});
 	let waitingForNext = $state(false);
 	let voteCooldown = $state(false);
 	let opinionText = $state('');

--- a/ui/packages/comhairle/src/lib/tools/polis/polisVoteStore.test.ts
+++ b/ui/packages/comhairle/src/lib/tools/polis/polisVoteStore.test.ts
@@ -1,6 +1,11 @@
 // @vitest-environment jsdom
 import { beforeEach, describe, expect, it } from 'vitest';
-import { getVoteData, incrementVotes, resetVoteCount } from './polisVoteStore';
+import {
+	getVoteData,
+	incrementVotes,
+	reconcileServerVotes,
+	resetVoteCount
+} from './polisVoteStore';
 
 const USER = 'user-1';
 
@@ -41,6 +46,32 @@ describe('polisVoteStore', () => {
 		expect(getVoteData(USER, 'preview-step-a')).toEqual({
 			totalVotes: 0,
 			hasMetThreshold: false
+		});
+	});
+
+	describe('reconcileServerVotes', () => {
+		it('adopts the server count when it is ahead (votes from another device)', () => {
+			const data = reconcileServerVotes(USER, 'live-step-a', 8, 10);
+			expect(data.totalVotes).toBe(8);
+			expect(data.hasMetThreshold).toBe(false);
+		});
+
+		it('keeps the local count when it is ahead of a lagging server', () => {
+			incrementVotes(USER, 'live-step-a', 10);
+			incrementVotes(USER, 'live-step-a', 10);
+			incrementVotes(USER, 'live-step-a', 10);
+			const data = reconcileServerVotes(USER, 'live-step-a', 1, 10);
+			expect(data.totalVotes).toBe(3);
+		});
+
+		it('flags the threshold once the merged count reaches it', () => {
+			const data = reconcileServerVotes(USER, 'live-step-a', 10, 10);
+			expect(data).toEqual({ totalVotes: 10, hasMetThreshold: true });
+		});
+
+		it('persists the reconciled count', () => {
+			reconcileServerVotes(USER, 'live-step-a', 5, 10);
+			expect(getVoteData(USER, 'live-step-a').totalVotes).toBe(5);
 		});
 	});
 

--- a/ui/packages/comhairle/src/lib/tools/polis/polisVoteStore.ts
+++ b/ui/packages/comhairle/src/lib/tools/polis/polisVoteStore.ts
@@ -55,3 +55,23 @@ export function incrementVotes(
 	save(userId, scopeKey, data);
 	return data;
 }
+
+// Merge an authoritative server vote count (votes this participant has cast on
+// any device) into the local progress. The server is the source of truth for
+// prior sessions, but the local count can be ahead when Polis has not yet caught
+// up with votes cast this session, so we take the higher of the two and never
+// regress. Recomputes hasMetThreshold and persists the result.
+export function reconcileServerVotes(
+	userId: string,
+	scopeKey: string,
+	serverVotes: number,
+	requiredVotes: number
+): PolisVoteData {
+	const data = load(userId, scopeKey);
+	data.totalVotes = Math.max(data.totalVotes, serverVotes);
+	if (data.totalVotes >= requiredVotes) {
+		data.hasMetThreshold = true;
+	}
+	save(userId, scopeKey, data);
+	return data;
+}


### PR DESCRIPTION
## What

Gate the Polis "required votes" threshold on a server-side vote count instead of relying only on `localStorage`. On mount, the participant embed asks the API how many votes this user has actually cast in the poll and seeds its progress from that, so the threshold is correct across devices and survives a cleared cache.

Stacks on top of #799 (the per-step scoping stopgap). Please merge that first; this PR's base is the 799 branch, so once it lands the diff here is just the endpoint work.

## Why

#799 fixed two Polis steps colliding by keying local progress per step, but the count still lived only in the browser. A participant who voted on their phone and continued on their laptop would start again from zero, and clearing storage wiped their progress. The votes already live in Polis, so we should read them back rather than trust a per-device counter.

## How

**Backend** new `GET /tools/polis/vote_count` endpoint:
- New `WikiPollService::get_participant_vote_count` trait method that calls Polis `GET /api/v3/votes?conversation_id=…&pid=…` with the admin session and returns the count.
- Handler resolves the step's poll config, logs in as admin, maps the caller's comhairle `user.id` to their Polis participant id via `get_xids`, and returns `{ vote_count }`.

**Client** regenerated `api-client` from the updated OpenAPI spec (adds `PolisGetUserVoteCount`).

**Frontend** `PolisEmbed` fetches the count on mount and reconciles it into local progress via `reconcileServerVotes`, which takes `max(local, server)` so progress never regresses: the server wins for votes cast in earlier sessions, and the local counter wins when Polis has not yet caught up with votes cast this session. The fetch is best-effort; on failure it falls back to the local count.


## Notes

- **Admin login per mount:** each participant mounting a Polis step now triggers an admin login + `get_xids` + votes fetch (same pattern as `sync_statement_aux`, but that is admin-triggered and infrequent). Fine functionally; if Polis load becomes a concern, caching the admin session or the xid lookup is the follow-up.
- The gate is votes-only, so comment counts are intentionally left out.