### PR TITLE
Organizations admin interface

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -52,6 +52,32 @@ A single allowed operation (for example list, grant, revoke, read, update) that 
 **Authorization precedence**:
 Permission checks resolve in this order: resource ownership allows, then system admin grant allows globally, then role-action mapping on the target resource is evaluated. There are currently no explicit deny rules.
 
+### Organizations and access
+
+**Organization Administrator**:
+A user explicitly assigned elevated permissions on one Organization, including organization update, organization delete, and organization member add/remove.
+_Avoid_: Org owner, org contact, organization user.
+
+**Organization Member**:
+A user associated with an Organization for membership purposes, without implied administrative permissions.
+_Avoid_: Organization admin (unless they also hold Organization Administrator assignment).
+
+**Organization contact email**:
+A communication address for the Organization entity itself. It is not a permission grant and is distinct from both member emails and Organization Administrator emails.
+_Avoid_: Admin email, owner email.
+
+**Initial Organization Administrators**:
+The set of users selected during Organization creation who receive Organization Administrator permissions for that new Organization.
+_Avoid_: Default members, contact email recipients.
+
+**Silent account bootstrap**:
+When an Initial Organization Administrator email has no matching user account, the system auto-creates a full email-password user account without a blocking confirmation step, then assigns permissions.
+_Avoid_: OTP-only bootstrap, manual pre-provisioning.
+
+**Initial password reset email**:
+The first-access email sent to newly created Organization Administrators at creation time, containing a one-time password reset link with 24-hour validity so they set their own password before first login.
+_Avoid_: Magic-link sign-in email, plaintext password email.
+
 ### Polis admin (Discuss step)
 
 The custom admin UI for a Pol.is Step, replacing the old Setup **iframe**. Its glossary and analytics are **adopted from the civic_os admin** (`bloom/civic_os/packages/admin`), taken as the source of truth because the equivalent surfaces were built out there first. Terms below carry civic_os's meaning unless noted. Canonical Polis-step subtabs: **`Configure · Setup · Moderation · Insights`** (civic_os's "Participants" tab is dropped — see Insights/Report and the Participants note).

--- a/api/migrations/20260804122333_add_contact_email_to_organization.sql
+++ b/api/migrations/20260804122333_add_contact_email_to_organization.sql
@@ -1,0 +1,3 @@
+-- Add nullable contact_email to organization
+ALTER TABLE organization
+ADD COLUMN contact_email TEXT;

--- a/api/src/email_templates/organization_team_onboarding.html
+++ b/api/src/email_templates/organization_team_onboarding.html
@@ -1,0 +1,10 @@
+{% extends "email_layout.html" %}
+{% block content %}
+  <p>Hello!</p>
+
+  <p>You were added to {{ organization_name }} as a {{ role_label }}.</p>
+
+  <p>You can sign in to Comhairle Admin using the link below.</p>
+
+  <p><a href="{{ admin_sign_in_link }}">Sign in to Comhairle admin</a></p>
+{% endblock %}

--- a/api/src/email_templates/user_account_created.html
+++ b/api/src/email_templates/user_account_created.html
@@ -1,0 +1,10 @@
+{% extends "email_layout.html" %}
+{% block content %}
+  <p>Hello{% if username %} {{ username }}{% endif %}!</p>
+
+  <p>A Comhairle user account has been created for you.</p>
+
+  <p>To finish setup, please set your password using the secure link below. This link expires in 24 hours.</p>
+
+  <p><a href="{{ set_password_link }}">Set your password</a></p>
+{% endblock %}

--- a/api/src/mailer.rs
+++ b/api/src/mailer.rs
@@ -61,6 +61,13 @@ pub trait ComhairleMailer: Send + Sync {
         reset_link: String,
     ) -> Result<(), ComhairleError>;
 
+    fn send_user_account_created_email(
+        &self,
+        to: &Option<String>,
+        username: &Option<String>,
+        set_password_link: String,
+    ) -> Result<(), ComhairleError>;
+
     fn send_verification_email(
         &self,
         username: &Option<String>,
@@ -152,6 +159,9 @@ impl MockComhairleMailer {
             .returning(|_, _, _, _| Ok(()));
         mailer
             .expect_send_password_reset_email()
+            .returning(|_, _, _| Ok(()));
+        mailer
+            .expect_send_user_account_created_email()
             .returning(|_, _, _| Ok(()));
         mailer
             .expect_send_event_registration_email()
@@ -402,6 +412,25 @@ impl ComhairleMailer for Mailer {
                 "Reset your Comhairle password",
                 "password_reset.html",
                 context! { username, reset_link },
+                None,
+            )
+        } else {
+            Err(ComhairleError::WrongUserType)
+        }
+    }
+
+    fn send_user_account_created_email(
+        &self,
+        to: &Option<String>,
+        username: &Option<String>,
+        set_password_link: String,
+    ) -> Result<(), ComhairleError> {
+        if let Some(email) = to {
+            self.send_email(
+                email,
+                "A user account has been created for you",
+                "user_account_created.html",
+                context! { username, set_password_link },
                 None,
             )
         } else {

--- a/api/src/models/model_test_helpers.rs
+++ b/api/src/models/model_test_helpers.rs
@@ -1,5 +1,6 @@
 use std::{error::Error, sync::Arc};
 
+use crate::models::permissions::{GrantRoleRequest, Role, UserOrOrganizationId, grant_role};
 use crate::models::users::{UpdateUserRequest, update_user};
 use crate::routes::conversations::dto::ConversationDto;
 use crate::routes::organizations::dto::OrganizationDto;
@@ -16,11 +17,28 @@ use uuid::Uuid;
 pub async fn setup_default_app_and_session(
     pool: &PgPool,
 ) -> Result<(Router, UserSession), Box<dyn Error>> {
-    let state = test_state().db(pool.clone()).call()?;
-    let app = setup_server(Arc::new(state)).await?;
+    let state = Arc::new(test_state().db(pool.clone()).call()?);
+    let app = setup_server(state.clone()).await?;
 
     let mut session = UserSession::new_admin();
-    session.signup(&app).await?;
+    let (_, user, _) = session.signup(&app).await?;
+    let user_id = user
+        .get("id")
+        .and_then(|value| value.as_ref())
+        .and_then(|value| value.as_str())
+        .ok_or("missing signup user id")?;
+    let user_id = Uuid::parse_str(user_id)?;
+
+    let _ = grant_role(
+        &state,
+        GrantRoleRequest {
+            actor_id: UserOrOrganizationId::User(user_id),
+            permission_triplet: Role::Admin.system_triplet(),
+            granted_by: &user_id,
+            grant_reason: "Default admin test setup",
+        },
+    )
+    .await;
 
     Ok((app, session))
 }
@@ -67,7 +85,12 @@ pub async fn get_random_organization_id(
     app: &Router,
     session: &mut UserSession,
 ) -> Result<Uuid, Box<dyn Error>> {
-    let (_, response, _) = session.create_random_organization(app).await?;
+    let (status, response, _) = session.create_random_organization(app).await?;
+    if !status.is_success() {
+        return Err(
+            format!("organization creation failed with status {status}: {response}").into(),
+        );
+    }
     let organization: OrganizationDto = serde_json::from_value(response)?;
 
     Ok(organization.id)

--- a/api/src/models/organization.rs
+++ b/api/src/models/organization.rs
@@ -33,6 +33,7 @@ pub struct Organization {
     #[partially(omit)]
     pub mission: TextContentId,
     pub org_type: OrganizationType,
+    pub contact_email: Option<String>,
     pub external_url: Option<String>,
     pub regions: Vec<Uuid>,
     #[partially(omit)]
@@ -74,12 +75,13 @@ impl std::fmt::Display for OrganizationType {
     }
 }
 
-const DEFAULT_COLUMNS: [OrganizationIden; 9] = [
+const DEFAULT_COLUMNS: [OrganizationIden; 10] = [
     OrganizationIden::Id,
     OrganizationIden::Name,
     OrganizationIden::Description,
     OrganizationIden::Mission,
     OrganizationIden::OrgType,
+    OrganizationIden::ContactEmail,
     OrganizationIden::ExternalUrl,
     OrganizationIden::Regions,
     OrganizationIden::CreatedAt,
@@ -92,6 +94,7 @@ pub struct CreateOrganization {
     pub description: String,
     pub mission: String,
     pub org_type: OrganizationType,
+    pub contact_email: Option<String>,
     pub external_url: Option<String>,
     pub regions: Option<Vec<Uuid>>,
 }
@@ -100,6 +103,9 @@ impl CreateOrganization {
     fn columns(&self) -> Vec<OrganizationIden> {
         let mut columns = vec![OrganizationIden::Name, OrganizationIden::OrgType];
 
+        if self.contact_email.is_some() {
+            columns.push(OrganizationIden::ContactEmail);
+        }
         if self.external_url.is_some() {
             columns.push(OrganizationIden::ExternalUrl);
         }
@@ -113,6 +119,9 @@ impl CreateOrganization {
     fn values(&self) -> Vec<sea_query::SimpleExpr> {
         let mut values = vec![(*self.name).into(), self.org_type.clone().into()];
 
+        if let Some(value) = &self.contact_email {
+            values.push(value.clone().into());
+        }
         if let Some(value) = &self.external_url {
             values.push(value.clone().into());
         }
@@ -164,6 +173,9 @@ impl PartialOrganization {
         }
         if let Some(value) = &self.org_type {
             values.push((OrganizationIden::OrgType, value.clone().into()));
+        }
+        if let Some(value) = &self.contact_email {
+            values.push((OrganizationIden::ContactEmail, value.clone().into()));
         }
         if let Some(value) = &self.external_url {
             values.push((OrganizationIden::ExternalUrl, value.clone().into()));
@@ -346,11 +358,13 @@ mod tests {
             description: "test_org".to_string(),
             mission: "to_pass_test".to_string(),
             org_type: OrganizationType::NonProfit,
+            contact_email: Some("test@org.com".to_string()),
             external_url: Some("test.com".to_string()),
             ..Default::default()
         };
 
         let org = create(&pool, &new_org, "en").await?;
+        let fetched_org = get_by_id(&pool, &org.id).await?;
 
         assert_eq!(org.name, "test_org".to_string(), "incorrect name");
         assert_eq!(
@@ -361,6 +375,11 @@ mod tests {
         assert!(
             org.regions.is_empty(),
             "regions not initialized as empty vec"
+        );
+        assert_eq!(
+            fetched_org.contact_email,
+            Some("test@org.com".to_string()),
+            "contact_email not persisted"
         );
 
         Ok(())
@@ -478,6 +497,7 @@ mod tests {
             description: "test_org_1".to_string(),
             mission: "to_pass_test".to_string(),
             org_type: OrganizationType::NonProfit,
+            contact_email: None,
             external_url: Some("test.com".to_string()),
             regions: Some(vec![region_1.id]),
         };
@@ -486,6 +506,7 @@ mod tests {
             description: "test_org_2".to_string(),
             mission: "to_pass_test".to_string(),
             org_type: OrganizationType::NonProfit,
+            contact_email: None,
             external_url: Some("test.com".to_string()),
             regions: Some(vec![region_2.id]),
         };
@@ -494,6 +515,7 @@ mod tests {
             description: "test_org_3".to_string(),
             mission: "to_pass_test".to_string(),
             org_type: OrganizationType::NonProfit,
+            contact_email: None,
             external_url: Some("test.com".to_string()),
             regions: Some(vec![region_1.id]),
         };

--- a/api/src/models/organization.rs
+++ b/api/src/models/organization.rs
@@ -6,6 +6,7 @@ use sea_query::{Expr, PostgresQueryBuilder, Query, SelectStatement, enum_def};
 use sea_query_binder::SqlxBinder;
 use serde::{Deserialize, Serialize};
 use sqlx::{PgPool, prelude::FromRow, query_as_with};
+use std::collections::HashSet;
 use tracing::instrument;
 use uuid::Uuid;
 
@@ -18,6 +19,7 @@ use crate::{
         SqlxResultExt,
         pagination::{Order, PageOptions, PaginatedResults},
         translations::{TextContentId, TextFormat, new_translation},
+        users,
     },
 };
 
@@ -97,6 +99,32 @@ pub struct CreateOrganization {
     pub contact_email: Option<String>,
     pub external_url: Option<String>,
     pub regions: Option<Vec<Uuid>>,
+    pub user_emails: Option<Vec<String>>,
+    pub organization_admin_emails: Option<Vec<String>>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct OrganizationAdminBootstrapResult {
+    pub email: String,
+    pub user_id: Option<Uuid>,
+    pub created_account: bool,
+    pub assigned: bool,
+    pub emailed: bool,
+    pub error: Option<String>,
+}
+
+impl OrganizationAdminBootstrapResult {
+    fn failed(email: &str, error: &str) -> Self {
+        Self {
+            email: email.to_string(),
+            user_id: None,
+            created_account: false,
+            assigned: false,
+            emailed: false,
+            error: Some(error.to_string()),
+        }
+    }
 }
 
 impl CreateOrganization {
@@ -163,6 +191,138 @@ pub async fn create(
     let organization = sqlx::query_as_with(&sql, values).fetch_one(db).await?;
 
     Ok(organization)
+}
+
+#[instrument(err(Debug))]
+pub async fn add_member_emails(
+    db: &PgPool,
+    organization_id: &Uuid,
+    user_emails: &[String],
+) -> Result<(), ComhairleError> {
+    for user_email in user_emails {
+        let trimmed = user_email.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        match users::get_user_by_email(trimmed, db).await {
+            Ok(user) => {
+                let update_request = users::UpdateUserRequest {
+                    organization_id: Some(*organization_id),
+                    ..Default::default()
+                };
+                if let Err(error) = users::update_user(&user.id, &update_request, db).await {
+                    tracing::warn!(
+                        "Failed to add user {} to organization {}: {:?}",
+                        user.id,
+                        organization_id,
+                        error
+                    );
+                }
+            }
+            Err(error) => {
+                tracing::warn!(
+                    "Failed to resolve user email {} for organization {}: {:?}",
+                    trimmed,
+                    organization_id,
+                    error
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[instrument]
+pub async fn bootstrap_organization_admin_accounts(
+    db: &PgPool,
+    organization_id: &Uuid,
+    admin_emails: &[String],
+) -> Vec<OrganizationAdminBootstrapResult> {
+    let mut results = Vec::with_capacity(admin_emails.len());
+    let mut seen_emails = HashSet::new();
+
+    for email in admin_emails {
+        let trimmed = email.trim().to_lowercase();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if !seen_emails.insert(trimmed.clone()) {
+            continue;
+        }
+
+        let mut created_account = false;
+        let user = match users::get_user_by_email(&trimmed, db).await {
+            Ok(user) => user,
+            Err(ComhairleError::NoUserFoundForEmail(_)) => {
+                created_account = true;
+                match users::create_organization_admin_user(&trimmed, db).await {
+                    Ok(user) => user,
+                    Err(error) => {
+                        tracing::warn!(
+                            "Failed to create admin user for email {} on organization {}: {:?}",
+                            trimmed,
+                            organization_id,
+                            error
+                        );
+                        results.push(OrganizationAdminBootstrapResult::failed(
+                            &trimmed,
+                            &error.to_string(),
+                        ));
+                        continue;
+                    }
+                }
+            }
+            Err(error) => {
+                tracing::warn!(
+                    "Failed to resolve admin email {} for organization {}: {:?}",
+                    trimmed,
+                    organization_id,
+                    error
+                );
+                results.push(OrganizationAdminBootstrapResult::failed(
+                    &trimmed,
+                    &error.to_string(),
+                ));
+                continue;
+            }
+        };
+
+        let update_request = users::UpdateUserRequest {
+            organization_id: Some(*organization_id),
+            ..Default::default()
+        };
+
+        if let Err(error) = users::update_user(&user.id, &update_request, db).await {
+            tracing::warn!(
+                "Failed to associate admin user {} with organization {}: {:?}",
+                user.id,
+                organization_id,
+                error
+            );
+            results.push(OrganizationAdminBootstrapResult {
+                email: trimmed,
+                user_id: Some(user.id),
+                created_account,
+                assigned: false,
+                emailed: false,
+                error: Some(error.to_string()),
+            });
+            continue;
+        }
+
+        results.push(OrganizationAdminBootstrapResult {
+            email: trimmed,
+            user_id: Some(user.id),
+            created_account,
+            assigned: true,
+            emailed: false,
+            error: None,
+        });
+    }
+
+    results
 }
 
 impl PartialOrganization {
@@ -326,6 +486,25 @@ pub async fn get_by_id(db: &PgPool, id: &Uuid) -> Result<Organization, Comhairle
 
 #[instrument(err(Debug))]
 pub async fn delete(db: &PgPool, id: &Uuid) -> Result<Organization, ComhairleError> {
+    let mut tx = db.begin().await?;
+
+    sqlx::query("UPDATE comhairle_user SET organization_id = NULL WHERE organization_id = $1")
+        .bind(id)
+        .execute(&mut *tx)
+        .await?;
+
+    sqlx::query("UPDATE conversation SET organization_id = NULL WHERE organization_id = $1")
+        .bind(id)
+        .execute(&mut *tx)
+        .await?;
+
+    sqlx::query(
+        "UPDATE email_template_config SET organization_id = NULL WHERE organization_id = $1",
+    )
+    .bind(id)
+    .execute(&mut *tx)
+    .await?;
+
     let (sql, values) = Query::delete()
         .from_table(OrganizationIden::Table)
         .and_where(Expr::col(OrganizationIden::Id).eq(id.to_owned()))
@@ -333,9 +512,11 @@ pub async fn delete(db: &PgPool, id: &Uuid) -> Result<Organization, ComhairleErr
         .build_sqlx(PostgresQueryBuilder);
 
     let organization = sqlx::query_as_with(&sql, values)
-        .fetch_one(db)
+        .fetch_one(&mut *tx)
         .await
         .resolve_db_err("Organization")?;
+
+    tx.commit().await?;
 
     Ok(organization)
 }
@@ -343,7 +524,11 @@ pub async fn delete(db: &PgPool, id: &Uuid) -> Result<Organization, ComhairleErr
 #[cfg(test)]
 mod tests {
     use crate::{
-        models::model_test_helpers::setup_default_app_and_session, routes::regions::dto::RegionDto,
+        models::{
+            model_test_helpers::setup_default_app_and_session,
+            users::{self, create_user},
+        },
+        routes::{auth::SignupRequest, regions::dto::RegionDto},
     };
 
     use super::*;
@@ -381,6 +566,56 @@ mod tests {
             Some("test@org.com".to_string()),
             "contact_email not persisted"
         );
+
+        Ok(())
+    }
+
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
+    async fn should_delete_organization_when_related_users_exist(
+        pool: PgPool,
+    ) -> Result<(), Box<dyn Error>> {
+        let _ = setup_default_app_and_session(&pool).await?;
+
+        let new_org = CreateOrganization {
+            name: "test_org".to_string(),
+            description: "test_org".to_string(),
+            mission: "to_pass_test".to_string(),
+            org_type: OrganizationType::NonProfit,
+            contact_email: None,
+            external_url: None,
+            user_emails: None,
+            ..Default::default()
+        };
+
+        let organization = create(&pool, &new_org, "en").await?;
+
+        let user = create_user(
+            &SignupRequest {
+                username: "test_org_user".to_string(),
+                password: "StrongPass123!".to_string(),
+                email: "test_org_user@example.com".to_string(),
+                avatar_url: None,
+            },
+            &pool,
+        )
+        .await?;
+
+        users::update_user(
+            &user.id,
+            &users::UpdateUserRequest {
+                organization_id: Some(organization.id),
+                ..Default::default()
+            },
+            &pool,
+        )
+        .await?;
+
+        let deleted_organization = delete(&pool, &organization.id).await?;
+
+        assert_eq!(deleted_organization.id, organization.id);
+
+        let updated_user = users::get_user_by_id(&user.id, &pool).await?;
+        assert_eq!(updated_user.organization_id, None);
 
         Ok(())
     }
@@ -439,6 +674,7 @@ mod tests {
             mission: "to_pass_test".to_string(),
             org_type: OrganizationType::NonProfit,
             external_url: Some("test.com".to_string()),
+            user_emails: None,
             ..Default::default()
         };
         let new_org_2 = CreateOrganization {
@@ -447,6 +683,7 @@ mod tests {
             mission: "to_pass_test".to_string(),
             org_type: OrganizationType::NonProfit,
             external_url: Some("test.com".to_string()),
+            user_emails: None,
             ..Default::default()
         };
         let new_org_3 = CreateOrganization {
@@ -455,6 +692,7 @@ mod tests {
             mission: "to_pass_test".to_string(),
             org_type: OrganizationType::NonProfit,
             external_url: Some("test.com".to_string()),
+            user_emails: None,
             ..Default::default()
         };
 
@@ -500,6 +738,8 @@ mod tests {
             contact_email: None,
             external_url: Some("test.com".to_string()),
             regions: Some(vec![region_1.id]),
+            user_emails: None,
+            organization_admin_emails: None,
         };
         let new_org_2 = CreateOrganization {
             name: "test_org_2".to_string(),
@@ -509,6 +749,8 @@ mod tests {
             contact_email: None,
             external_url: Some("test.com".to_string()),
             regions: Some(vec![region_2.id]),
+            user_emails: None,
+            organization_admin_emails: None,
         };
         let new_org_3 = CreateOrganization {
             name: "test_org_3".to_string(),
@@ -518,6 +760,8 @@ mod tests {
             contact_email: None,
             external_url: Some("test.com".to_string()),
             regions: Some(vec![region_1.id]),
+            user_emails: None,
+            organization_admin_emails: None,
         };
 
         let _ = create(&pool, &new_org_1, "en").await?;

--- a/api/src/models/permissions.rs
+++ b/api/src/models/permissions.rs
@@ -168,6 +168,7 @@ pub trait OwnedResource {
 pub enum ResourceType {
     System,
     Conversation,
+    Organization,
     #[cfg(test)]
     Test,
 }
@@ -321,6 +322,7 @@ define_owned_resource!(
 pub enum Role {
     SuperAdmin,
     Admin,
+    OrganizationAdmin,
     #[serde(rename = "content_editor")]
     #[strum(serialize = "content_editor")]
     ConversationContentEditor,
@@ -333,6 +335,7 @@ impl Role {
     pub fn resource_type(self) -> ResourceType {
         match self {
             Role::SuperAdmin | Role::Admin => ResourceType::System,
+            Role::OrganizationAdmin => ResourceType::Organization,
             Role::ConversationContentEditor => ResourceType::Conversation,
             #[cfg(test)]
             Role::Tester => ResourceType::Test,
@@ -348,6 +351,7 @@ impl Role {
                 Action::RevokePermission,
             ],
             Role::Admin => &[],
+            Role::OrganizationAdmin => &[Action::OrganizationUpdate, Action::OrganizationDelete],
             Role::ConversationContentEditor => {
                 &[Action::ConversationRead, Action::ConversationUpdate]
             }
@@ -421,16 +425,21 @@ pub enum Action {
     RevokePermission,
     ConversationRead,
     ConversationUpdate,
+    OrganizationCreate,
+    OrganizationUpdate,
+    OrganizationDelete,
 }
 
 impl Action {
     /// The resource type this action applies to.
     pub fn resource_type(self) -> ResourceType {
         match self {
-            Action::ListPermission | Action::GrantPermission | Action::RevokePermission => {
-                ResourceType::System
-            }
+            Action::ListPermission
+            | Action::GrantPermission
+            | Action::RevokePermission
+            | Action::OrganizationCreate => ResourceType::System,
             Action::ConversationRead | Action::ConversationUpdate => ResourceType::Conversation,
+            Action::OrganizationUpdate | Action::OrganizationDelete => ResourceType::Organization,
         }
     }
 

--- a/api/src/models/users.rs
+++ b/api/src/models/users.rs
@@ -258,6 +258,44 @@ pub async fn create_otp_user(user: &OtpSignupRequest, db: &PgPool) -> Result<Use
     }
 }
 
+fn organization_admin_username(email: &str) -> String {
+    let local_part = email
+        .split('@')
+        .next()
+        .unwrap_or("org_admin")
+        .chars()
+        .filter(|character| {
+            character.is_ascii_alphanumeric() || *character == '_' || *character == '-'
+        })
+        .collect::<String>();
+
+    let base = if local_part.is_empty() {
+        "org_admin".to_string()
+    } else {
+        local_part.to_lowercase()
+    };
+
+    format!("{}_{}", base, gen_id())
+}
+
+fn organization_admin_temporary_password() -> String {
+    format!("TempAdmin#{}Aa1", gen_id())
+}
+
+pub async fn create_organization_admin_user(
+    email: &str,
+    db: &PgPool,
+) -> Result<User, ComhairleError> {
+    let signup_request = SignupRequest {
+        username: organization_admin_username(email),
+        password: organization_admin_temporary_password(),
+        avatar_url: None,
+        email: email.to_string(),
+    };
+
+    create_user(&signup_request, db).await
+}
+
 async fn create_otp_user_with_username(
     email: &str,
     username: &str,
@@ -453,6 +491,42 @@ pub async fn get_user_by_username(username: &str, db: &PgPool) -> Result<User, C
         .fetch_one(db)
         .await
         .map_err(|_| ComhairleError::NoUserFound)
+}
+
+/// Return all users associated with an organization.
+pub async fn list_by_organization_id(
+    organization_id: &Uuid,
+    db: &PgPool,
+) -> Result<Vec<User>, ComhairleError> {
+    let (sql, values) = Query::select()
+        .columns(DEFAULT_COLUMNS)
+        .from(UserIden::Table)
+        .and_where(Expr::col(UserIden::OrganizationId).eq(*organization_id))
+        .build_sqlx(PostgresQueryBuilder);
+
+    sqlx::query_as_with::<_, User, _>(&sql, values)
+        .fetch_all(db)
+        .await
+        .map_err(ComhairleError::DatabaseError)
+}
+
+/// Set or clear the organization membership for a user.
+pub async fn set_user_organization_id(
+    user_id: &Uuid,
+    organization_id: Option<Uuid>,
+    db: &PgPool,
+) -> Result<User, ComhairleError> {
+    let (sql, values) = Query::update()
+        .table(UserIden::Table)
+        .value(UserIden::OrganizationId, organization_id)
+        .and_where(Expr::col(UserIden::Id).eq(*user_id))
+        .returning(Query::returning().columns(DEFAULT_COLUMNS))
+        .build_sqlx(PostgresQueryBuilder);
+
+    sqlx::query_as_with::<_, User, _>(&sql, values)
+        .fetch_one(db)
+        .await
+        .map_err(ComhairleError::DatabaseError)
 }
 
 #[derive(Debug, Deserialize, Default, Serialize, JsonSchema)]

--- a/api/src/routes/auth.rs
+++ b/api/src/routes/auth.rs
@@ -221,8 +221,8 @@ struct PasswordResetUpdateRequest {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-struct EmailLinkClaims {
-    email: Option<String>,
+pub(crate) struct EmailLinkClaims {
+    pub(crate) email: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/api/src/routes/organizations.rs
+++ b/api/src/routes/organizations.rs
@@ -1,14 +1,19 @@
 use std::sync::Arc;
 
-use aide::axum::{
-    ApiRouter,
-    routing::{delete_with, get_with, post_with, put_with},
+use aide::{
+    OperationIo,
+    axum::{
+        ApiRouter,
+        routing::{delete_with, get_with, post_with, put_with},
+    },
 };
 use axum::{
-    extract::{Json, Path, Query, State},
+    extract::{FromRequestParts, Json, Path, Query, State},
     http::StatusCode,
 };
-use tracing::instrument;
+use minijinja::context;
+use schemars::JsonSchema;
+use tracing::{instrument, warn};
 use uuid::Uuid;
 
 use crate::{
@@ -20,15 +25,250 @@ use crate::{
             PartialOrganization,
         },
         pagination::{PageOptions, PaginatedResults},
+        permissions::{
+            Action, ExtractResourceId, GrantRoleRequest, OwnedResource, RevokeRoleRequest, Role,
+            UserOrOrganizationId, grant_role, list_users_with_permission, revoke_role,
+        },
+        translations, users,
     },
     routes::{
-        auth::{RequiredAdminUser, RequiredUser},
-        organizations::dto::{LocalizedOrganizationDto, OrganizationDto},
+        auth::{EmailLinkClaims, RequiredAdminUser, RequiredUser, authorize, generate_jwt},
+        organizations::dto::{
+            CreateOrganizationResponseDto, LocalizedOrganizationDto,
+            OrganizationAdminBootstrapSummaryDto, OrganizationDto,
+        },
         translations::LocaleExtractor,
     },
 };
 
 pub mod dto;
+
+#[derive(Debug, serde::Deserialize)]
+struct OrganizationPath {
+    organization_id: Uuid,
+}
+
+#[derive(Debug, OperationIo)]
+struct OrganizationResource {
+    resource_id: Uuid,
+    owner_id: Option<Uuid>,
+}
+
+impl FromRequestParts<Arc<ComhairleState>> for OrganizationResource {
+    type Rejection = ComhairleError;
+
+    async fn from_request_parts(
+        parts: &mut axum::http::request::Parts,
+        state: &Arc<ComhairleState>,
+    ) -> Result<Self, Self::Rejection> {
+        let Path(OrganizationPath { organization_id }) =
+            Path::<OrganizationPath>::from_request_parts(parts, state)
+                .await
+                .map_err(|_| {
+                    ComhairleError::ResourceNotFound(
+                        "Path must contain an organization_id".to_string(),
+                    )
+                })?;
+
+        Ok(Self {
+            resource_id: organization_id,
+            owner_id: None,
+        })
+    }
+}
+
+impl ExtractResourceId for OrganizationResource {
+    fn resource_id(&self) -> Uuid {
+        self.resource_id
+    }
+}
+
+impl OwnedResource for OrganizationResource {
+    fn owner_id(&self) -> Option<Uuid> {
+        self.owner_id
+    }
+}
+
+#[derive(Debug, serde::Deserialize, JsonSchema)]
+struct OrganizationMemberPath {
+    organization_id: Uuid,
+    user_id: Uuid,
+}
+
+#[derive(Debug, serde::Deserialize, JsonSchema)]
+struct UpsertOrganizationUserBody {
+    email: String,
+    role: Option<OrganizationTeamRole>,
+    allow_create_user: Option<bool>,
+}
+
+#[derive(Debug, Clone, Copy, serde::Deserialize, serde::Serialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum OrganizationTeamRole {
+    Member,
+    Admin,
+}
+
+#[derive(Debug, serde::Deserialize, JsonSchema)]
+struct UpdateOrganizationMemberRoleBody {
+    role: OrganizationTeamRole,
+}
+
+#[derive(Debug, serde::Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+struct OrganizationTeamUserDto {
+    id: Uuid,
+    username: Option<String>,
+    email: Option<String>,
+    role: OrganizationTeamRole,
+}
+
+#[derive(Debug, serde::Deserialize, JsonSchema)]
+struct UpdateOrganizationBody {
+    name: Option<String>,
+    description: Option<String>,
+    mission: Option<String>,
+    org_type: Option<organization::OrganizationType>,
+    contact_email: Option<Option<String>>,
+    external_url: Option<Option<String>>,
+    regions: Option<Vec<Uuid>>,
+}
+
+#[derive(Debug, serde::Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+struct UpsertOrganizationUserResponseDto {
+    user: OrganizationTeamUserDto,
+    created_account: bool,
+    emailed: bool,
+}
+
+#[derive(Debug, serde::Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+struct OrganizationTeamResponseDto {
+    members: Vec<OrganizationTeamUserDto>,
+}
+
+async fn set_member_admin_role(
+    state: &Arc<ComhairleState>,
+    organization_id: Uuid,
+    user_id: Uuid,
+    granted_by: Uuid,
+    role: OrganizationTeamRole,
+) -> Result<(), ComhairleError> {
+    match role {
+        OrganizationTeamRole::Admin => {
+            let grant_result = grant_role(
+                state,
+                GrantRoleRequest {
+                    actor_id: UserOrOrganizationId::User(user_id),
+                    permission_triplet: Role::OrganizationAdmin.triplet(&organization_id),
+                    granted_by: &granted_by,
+                    grant_reason: "Organization team management",
+                },
+            )
+            .await;
+
+            if let Err(error) = grant_result
+                && !matches!(error, ComhairleError::RoleAlreadyGranted(_))
+            {
+                return Err(error);
+            }
+        }
+        OrganizationTeamRole::Member => {
+            let revoke_result = revoke_role(
+                state,
+                RevokeRoleRequest {
+                    actor_id: UserOrOrganizationId::User(user_id),
+                    permission_triplet: Role::OrganizationAdmin.triplet(&organization_id),
+                },
+            )
+            .await;
+
+            if let Err(error) = revoke_result
+                && !matches!(error, ComhairleError::RoleNotFound(_))
+            {
+                return Err(error);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn role_label(role: OrganizationTeamRole) -> &'static str {
+    match role {
+        OrganizationTeamRole::Member => "member",
+        OrganizationTeamRole::Admin => "administrator",
+    }
+}
+
+fn notify_team_addition(
+    state: &Arc<ComhairleState>,
+    recipient_email: &str,
+    organization_name: &str,
+    role: OrganizationTeamRole,
+) {
+    let subject = "You were added to an organization on Comhairle";
+    let admin_sign_in_link = format!("{}/auth/login?backTo=/admin", state.config.domain);
+
+    let _ = state.mailer.send_email(
+        recipient_email,
+        subject,
+        "organization_team_onboarding.html",
+        context! {
+            subject,
+            organization_name,
+            role_label => role_label(role),
+            admin_sign_in_link,
+        },
+        None,
+    );
+}
+
+async fn resolve_or_create_user_by_email(
+    state: &Arc<ComhairleState>,
+    email: &str,
+    allow_create_user: bool,
+) -> Result<(users::User, bool, bool), ComhairleError> {
+    let trimmed = email.trim().to_lowercase();
+    if trimmed.is_empty() {
+        return Err(ComhairleError::BadRequest(
+            "Email cannot be empty".to_string(),
+        ));
+    }
+
+    match users::get_user_by_email(&trimmed, &state.db).await {
+        Ok(user) => Ok((user, false, false)),
+        Err(ComhairleError::NoUserFoundForEmail(_)) => {
+            if !allow_create_user {
+                return Err(ComhairleError::NoUserFoundForEmail(trimmed));
+            }
+
+            let user = users::create_organization_admin_user(&trimmed, &state.db).await?;
+
+            let token = generate_jwt()
+                .user(&user)
+                .secret(&state.config.jwt_secret)
+                .custom_claims(EmailLinkClaims {
+                    email: user.email.clone(),
+                })
+                .duration(chrono::Duration::hours(24))
+                .call();
+            let reset_link = format!(
+                "{}/auth/password-reset/update?token={}",
+                state.config.domain, token
+            );
+
+            let emailed = state
+                .mailer
+                .send_user_account_created_email(&user.email, &user.username, reset_link)
+                .is_ok();
+
+            Ok((user, true, emailed))
+        }
+        Err(error) => Err(error),
+    }
+}
 
 #[instrument(err(Debug), skip(state))]
 async fn list(
@@ -56,7 +296,7 @@ async fn list(
 async fn get(
     State(state): State<Arc<ComhairleState>>,
     Path(organization_id): Path<Uuid>,
-    RequiredUser(user): RequiredUser,
+    RequiredUser(_user): RequiredUser,
     LocaleExtractor(locale): LocaleExtractor,
 ) -> Result<(StatusCode, Json<LocalizedOrganizationDto>), ComhairleError> {
     let organization = organization::get_localized_by_id(&state.db, &organization_id, &locale)
@@ -67,39 +307,366 @@ async fn get(
 }
 
 #[instrument(err(Debug), skip(state))]
+async fn get_team(
+    State(state): State<Arc<ComhairleState>>,
+    Path(organization_id): Path<Uuid>,
+    RequiredUser(user): RequiredUser,
+    resource: OrganizationResource,
+) -> Result<(StatusCode, Json<OrganizationTeamResponseDto>), ComhairleError> {
+    authorize(&state, &user, Action::OrganizationUpdate, &resource).await?;
+
+    let admins = list_users_with_permission(
+        &state.db,
+        Role::OrganizationAdmin.resource_type().as_ref(),
+        organization_id,
+        Some(Role::OrganizationAdmin.as_ref()),
+    )
+    .await?;
+
+    let admin_ids = admins
+        .into_iter()
+        .map(|admin| admin.id)
+        .collect::<std::collections::HashSet<_>>();
+
+    let members = users::list_by_organization_id(&organization_id, &state.db)
+        .await?
+        .into_iter()
+        .map(|member| OrganizationTeamUserDto {
+            role: if admin_ids.contains(&member.id) {
+                OrganizationTeamRole::Admin
+            } else {
+                OrganizationTeamRole::Member
+            },
+            id: member.id,
+            username: member.username,
+            email: member.email,
+        })
+        .collect();
+
+    Ok((
+        StatusCode::OK,
+        Json(OrganizationTeamResponseDto { members }),
+    ))
+}
+
+#[instrument(err(Debug), skip(state))]
+async fn add_member(
+    State(state): State<Arc<ComhairleState>>,
+    Path(organization_id): Path<Uuid>,
+    RequiredUser(user): RequiredUser,
+    resource: OrganizationResource,
+    Json(payload): Json<UpsertOrganizationUserBody>,
+) -> Result<(StatusCode, Json<UpsertOrganizationUserResponseDto>), ComhairleError> {
+    authorize(&state, &user, Action::OrganizationUpdate, &resource).await?;
+
+    let allow_create_user = payload.allow_create_user.unwrap_or(false);
+    let (resolved_user, created_account, emailed) =
+        resolve_or_create_user_by_email(&state, &payload.email, allow_create_user).await?;
+    let role = payload.role.unwrap_or(OrganizationTeamRole::Member);
+
+    let updated_user =
+        users::set_user_organization_id(&resolved_user.id, Some(organization_id), &state.db)
+            .await?;
+
+    set_member_admin_role(&state, organization_id, updated_user.id, user.id, role).await?;
+
+    if let Some(email) = updated_user.email.as_deref() {
+        let organization = organization::get_by_id(&state.db, &organization_id).await?;
+        notify_team_addition(&state, email, &organization.name, role);
+    }
+
+    Ok((
+        StatusCode::OK,
+        Json(UpsertOrganizationUserResponseDto {
+            user: OrganizationTeamUserDto {
+                id: updated_user.id,
+                username: updated_user.username,
+                email: updated_user.email,
+                role,
+            },
+            created_account,
+            emailed,
+        }),
+    ))
+}
+
+#[instrument(err(Debug), skip(state))]
+async fn update_member_role(
+    State(state): State<Arc<ComhairleState>>,
+    Path(OrganizationMemberPath {
+        organization_id,
+        user_id,
+    }): Path<OrganizationMemberPath>,
+    RequiredUser(user): RequiredUser,
+    resource: OrganizationResource,
+    Json(payload): Json<UpdateOrganizationMemberRoleBody>,
+) -> Result<StatusCode, ComhairleError> {
+    authorize(&state, &user, Action::OrganizationUpdate, &resource).await?;
+
+    let target_user = users::get_user_by_id(&user_id, &state.db).await?;
+    if !target_user
+        .organization_id
+        .is_some_and(|member_org_id| member_org_id == organization_id)
+    {
+        return Err(ComhairleError::BadRequest(
+            "User is not a member of this organization".to_string(),
+        ));
+    }
+
+    set_member_admin_role(&state, organization_id, user_id, user.id, payload.role).await?;
+
+    Ok(StatusCode::OK)
+}
+
+#[instrument(err(Debug), skip(state))]
+async fn remove_member(
+    State(state): State<Arc<ComhairleState>>,
+    Path(OrganizationMemberPath {
+        organization_id,
+        user_id,
+    }): Path<OrganizationMemberPath>,
+    RequiredUser(user): RequiredUser,
+    resource: OrganizationResource,
+) -> Result<StatusCode, ComhairleError> {
+    authorize(&state, &user, Action::OrganizationUpdate, &resource).await?;
+
+    let target_user = users::get_user_by_id(&user_id, &state.db).await?;
+
+    if target_user
+        .organization_id
+        .is_some_and(|id| id == organization_id)
+    {
+        users::set_user_organization_id(&user_id, None, &state.db).await?;
+    }
+
+    set_member_admin_role(
+        &state,
+        organization_id,
+        user_id,
+        user.id,
+        OrganizationTeamRole::Member,
+    )
+    .await?;
+
+    Ok(StatusCode::OK)
+}
+
+#[instrument(err(Debug), skip(state))]
 async fn create(
     State(state): State<Arc<ComhairleState>>,
-    RequiredAdminUser(_user): RequiredAdminUser,
+    RequiredAdminUser(user): RequiredAdminUser,
     LocaleExtractor(locale): LocaleExtractor,
     Json(payload): Json<CreateOrganization>,
-) -> Result<(StatusCode, Json<OrganizationDto>), ComhairleError> {
-    let organization = organization::create(&state.db, &payload, &locale)
-        .await?
-        .into();
+) -> Result<(StatusCode, Json<CreateOrganizationResponseDto>), ComhairleError> {
+    let created_organization = organization::create(&state.db, &payload, &locale).await?;
 
-    Ok((StatusCode::CREATED, Json(organization)))
+    grant_role(
+        &state,
+        GrantRoleRequest {
+            actor_id: UserOrOrganizationId::User(user.id),
+            permission_triplet: Role::OrganizationAdmin.triplet(&created_organization.id),
+            granted_by: &user.id,
+            grant_reason: "Organization creator bootstrap",
+        },
+    )
+    .await?;
+
+    if let Some(user_emails) = payload.user_emails.as_deref() {
+        if let Err(error) =
+            organization::add_member_emails(&state.db, &created_organization.id, user_emails).await
+        {
+            warn!(
+                "Failed to add organization members for {}: {:?}",
+                created_organization.id, error
+            );
+        }
+    }
+
+    let mut admin_bootstrap_results =
+        if let Some(admin_emails) = payload.organization_admin_emails.as_deref() {
+            organization::bootstrap_organization_admin_accounts(
+                &state.db,
+                &created_organization.id,
+                admin_emails,
+            )
+            .await
+        } else {
+            Vec::new()
+        };
+
+    for result in &mut admin_bootstrap_results {
+        if !result.assigned {
+            continue;
+        }
+
+        let Some(user_id) = result.user_id else {
+            result.assigned = false;
+            result.error = Some("Missing user id for admin assignment".to_string());
+            continue;
+        };
+
+        if let Err(error) = grant_role(
+            &state,
+            GrantRoleRequest {
+                actor_id: UserOrOrganizationId::User(user_id),
+                permission_triplet: Role::OrganizationAdmin.triplet(&created_organization.id),
+                granted_by: &user.id,
+                grant_reason: "Organization admin bootstrap",
+            },
+        )
+        .await
+        {
+            warn!(
+                "Failed to grant organization admin role for user {} and organization {}: {:?}",
+                user_id, created_organization.id, error
+            );
+            result.assigned = false;
+            result.error = Some(error.to_string());
+            continue;
+        }
+
+        let admin_user = match users::get_user_by_id(&user_id, &state.db).await {
+            Ok(user) => user,
+            Err(error) => {
+                warn!(
+                    "Failed to load organization admin user {} for onboarding email: {:?}",
+                    user_id, error
+                );
+                result.error = Some(error.to_string());
+                continue;
+            }
+        };
+
+        if result.created_account {
+            let token = generate_jwt()
+                .user(&admin_user)
+                .secret(&state.config.jwt_secret)
+                .custom_claims(EmailLinkClaims {
+                    email: admin_user.email.clone(),
+                })
+                .duration(chrono::Duration::hours(24))
+                .call();
+            let reset_link = format!(
+                "{}/auth/password-reset/update?token={}",
+                state.config.domain, token
+            );
+
+            if let Err(error) = state.mailer.send_user_account_created_email(
+                &admin_user.email,
+                &admin_user.username,
+                reset_link,
+            ) {
+                warn!(
+                    "Failed to send organization admin account created email to {}: {:?}",
+                    result.email, error
+                );
+                result.error = Some(error.to_string());
+                continue;
+            }
+
+            result.emailed = true;
+        }
+    }
+
+    let organization = created_organization.into();
+    let admin_bootstrap_summary =
+        OrganizationAdminBootstrapSummaryDto::from_results(&admin_bootstrap_results);
+
+    Ok((
+        StatusCode::CREATED,
+        Json(CreateOrganizationResponseDto {
+            organization,
+            admin_bootstrap_summary,
+        }),
+    ))
 }
 
 #[instrument(err(Debug), skip(state))]
 async fn update(
     State(state): State<Arc<ComhairleState>>,
     Path(organization_id): Path<Uuid>,
-    RequiredAdminUser(_user): RequiredAdminUser,
-    Json(organization): Json<PartialOrganization>,
+    RequiredAdminUser(user): RequiredAdminUser,
+    resource: OrganizationResource,
+    LocaleExtractor(locale): LocaleExtractor,
+    Json(payload): Json<UpdateOrganizationBody>,
 ) -> Result<(StatusCode, Json<OrganizationDto>), ComhairleError> {
-    let organization = organization::update(&state.db, &organization_id, &organization)
-        .await?
-        .into();
+    authorize(&state, &user, Action::OrganizationUpdate, &resource).await?;
+
+    let existing = organization::get_by_id(&state.db, &organization_id).await?;
+
+    if let Some(description) = payload.description.as_ref() {
+        update_localized_text_content(&state.db, &existing.description, &locale, description)
+            .await?;
+    }
+
+    if let Some(mission) = payload.mission.as_ref() {
+        update_localized_text_content(&state.db, &existing.mission, &locale, mission).await?;
+    }
+
+    let partial = PartialOrganization {
+        name: payload.name,
+        org_type: payload.org_type,
+        contact_email: payload.contact_email,
+        external_url: payload.external_url,
+        regions: payload.regions,
+    };
+
+    let organization = if partial.to_values().is_empty() {
+        existing
+    } else {
+        organization::update(&state.db, &organization_id, &partial).await?
+    }
+    .into();
 
     Ok((StatusCode::OK, Json(organization)))
+}
+
+async fn update_localized_text_content(
+    db: &sqlx::PgPool,
+    content_id: &translations::TextContentId,
+    locale: &str,
+    content: &str,
+) -> Result<(), ComhairleError> {
+    match translations::get_text_translation_by_content_and_locale(db, content_id, locale).await {
+        Ok(existing_translation) => {
+            translations::update_text_translation(
+                db,
+                &existing_translation.id,
+                &translations::UpdateTextTranslation {
+                    content: Some(content.to_string()),
+                    ..Default::default()
+                },
+            )
+            .await?;
+        }
+        Err(ComhairleError::ResourceNotFound(_)) => {
+            translations::create_text_translation(
+                db,
+                &translations::CreateTextTranslation {
+                    content_id: *content_id,
+                    locale: locale.to_string(),
+                    content: content.to_string(),
+                    ai_generated: Some(false),
+                    requires_validation: Some(false),
+                },
+            )
+            .await?;
+        }
+        Err(error) => return Err(error),
+    }
+
+    Ok(())
 }
 
 #[instrument(err(Debug), skip(state))]
 async fn delete(
     State(state): State<Arc<ComhairleState>>,
     Path(organization_id): Path<Uuid>,
-    RequiredAdminUser(_user): RequiredAdminUser,
+    RequiredAdminUser(user): RequiredAdminUser,
+    resource: OrganizationResource,
 ) -> Result<(StatusCode, Json<OrganizationDto>), ComhairleError> {
+    authorize(&state, &user, Action::OrganizationDelete, &resource).await?;
+
     let organization = organization::delete(&state.db, &organization_id)
         .await?
         .into();
@@ -132,6 +699,50 @@ pub fn router(state: Arc<ComhairleState>) -> ApiRouter {
             }),
         )
         .api_route(
+            "/{organization_id}/team",
+            get_with(get_team, |op| {
+                op.id("GetOrganizationTeam")
+                    .tag("Organizations")
+                    .summary("Get organization team")
+                    .description("Returns members and administrators for an organization")
+                    .security_requirement("JWT")
+                    .response::<200, Json<OrganizationTeamResponseDto>>()
+            }),
+        )
+        .api_route(
+            "/{organization_id}/members",
+            post_with(add_member, |op| {
+                op.id("AddOrganizationMember")
+                    .tag("Organizations")
+                    .summary("Add organization member")
+                    .description("Adds a member by email and bootstraps an account when needed")
+                    .security_requirement("JWT")
+                    .response::<200, Json<UpsertOrganizationUserResponseDto>>()
+            }),
+        )
+        .api_route(
+            "/{organization_id}/members/{user_id}",
+            delete_with(remove_member, |op| {
+                op.id("RemoveOrganizationMember")
+                    .tag("Organizations")
+                    .summary("Remove organization member")
+                    .description("Removes a user's organization membership")
+                    .security_requirement("JWT")
+                    .response::<200, ()>()
+            }),
+        )
+        .api_route(
+            "/{organization_id}/members/{user_id}/role",
+            put_with(update_member_role, |op| {
+                op.id("UpdateOrganizationMemberRole")
+                    .tag("Organizations")
+                    .summary("Update organization member role")
+                    .description("Updates organization member role between member and admin")
+                    .security_requirement("JWT")
+                    .response::<200, ()>()
+            }),
+        )
+        .api_route(
             "/",
             post_with(create, |op| {
                 op.id("CreateOrganization")
@@ -139,7 +750,7 @@ pub fn router(state: Arc<ComhairleState>) -> ApiRouter {
                     .summary("Create a new organization")
                     .description("Create a new organization")
                     .security_requirement("JWT")
-                    .response::<201, Json<OrganizationDto>>()
+                    .response::<201, Json<CreateOrganizationResponseDto>>()
             }),
         )
         .api_route(
@@ -172,9 +783,20 @@ mod tests {
     use serde_json::json;
     use sqlx::PgPool;
     use std::error::Error;
+    use uuid::Uuid;
 
-    use crate::models::{
-        model_test_helpers::setup_default_app_and_session, organization::OrganizationType,
+    use crate::{
+        error::ComhairleError,
+        mailer::MockComhairleMailer,
+        models::{
+            model_test_helpers::setup_default_app_and_session,
+            organization::OrganizationType,
+            permissions::{Role, has_resource_permission},
+            users::{create_user, get_user_by_email},
+        },
+        routes::auth::SignupRequest,
+        setup_server,
+        test_helpers::{UserSession, test_state},
     };
 
     use super::*;
@@ -194,13 +816,166 @@ mod tests {
         let body = serde_json::to_vec(&new_organization)?;
         let (status, response, _) = session.post(&app, "/organizations", body.into()).await?;
 
-        let organization: OrganizationDto = serde_json::from_value(response)?;
+        assert!(
+            status.is_success(),
+            "error response status: {status}, body: {response}"
+        );
 
-        assert!(status.is_success(), "error response status");
+        let organization: OrganizationDto = serde_json::from_value(response)?;
         assert_eq!(
             organization.org_type,
             OrganizationType::NonProfit,
             "incorrect org_type"
+        );
+
+        Ok(())
+    }
+
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
+    async fn should_bootstrap_organization_admins_and_return_summary(
+        pool: PgPool,
+    ) -> Result<(), Box<dyn Error>> {
+        let mut mailer = MockComhairleMailer::new();
+        mailer
+            .expect_send_welcome_email()
+            .once()
+            .returning(|_, _| Ok(()));
+        mailer
+            .expect_send_user_account_created_email()
+            .once()
+            .returning(|_, _, _| Ok(()));
+
+        let state = Arc::new(test_state().db(pool).mailer(Arc::new(mailer)).call()?);
+        let app = setup_server(state.clone()).await?;
+        let mut session = UserSession::new_admin();
+        session.signup(&app).await?;
+
+        let existing_admin = create_user(
+            &SignupRequest {
+                username: "existing_org_admin".to_string(),
+                password: "StrongPass123!".to_string(),
+                email: "existing-admin@example.com".to_string(),
+                avatar_url: None,
+            },
+            &state.db,
+        )
+        .await?;
+
+        let (status, response, _) = session
+            .create_organization(
+                &app,
+                json!({
+                    "name": "org_with_admins",
+                    "description": "org_with_admins",
+                    "mission": "org_with_admins",
+                    "org_type": "non_profit",
+                    "organization_admin_emails": [
+                        "existing-admin@example.com",
+                        "new-admin@example.com"
+                    ]
+                }),
+            )
+            .await?;
+
+        assert_eq!(status, StatusCode::CREATED);
+
+        let organization_id = Uuid::parse_str(
+            response
+                .get("id")
+                .and_then(|value| value.as_str())
+                .ok_or("missing id")?,
+        )?;
+
+        let summary = response
+            .get("adminBootstrapSummary")
+            .ok_or("missing adminBootstrapSummary")?;
+
+        assert_eq!(summary.get("attempted").and_then(|v| v.as_u64()), Some(2));
+        assert_eq!(summary.get("assigned").and_then(|v| v.as_u64()), Some(2));
+        assert_eq!(
+            summary.get("createdAccounts").and_then(|v| v.as_u64()),
+            Some(1)
+        );
+        assert_eq!(summary.get("emailed").and_then(|v| v.as_u64()), Some(1));
+
+        let new_admin = get_user_by_email("new-admin@example.com", &state.db).await?;
+        assert_eq!(
+            new_admin.auth_type,
+            crate::models::users::UserAuthType::EmailPassword,
+            "new organization admin should be a full email-password user"
+        );
+
+        let existing_has_permission = has_resource_permission(
+            &state,
+            Role::OrganizationAdmin.triplet(&organization_id),
+            &existing_admin.id,
+            existing_admin.organization_id.as_ref(),
+        )
+        .await?;
+        let new_has_permission = has_resource_permission(
+            &state,
+            Role::OrganizationAdmin.triplet(&organization_id),
+            &new_admin.id,
+            new_admin.organization_id.as_ref(),
+        )
+        .await?;
+
+        assert!(existing_has_permission);
+        assert!(new_has_permission);
+
+        Ok(())
+    }
+
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
+    async fn should_not_rollback_organization_when_admin_account_created_email_fails(
+        pool: PgPool,
+    ) -> Result<(), Box<dyn Error>> {
+        let mut mailer = MockComhairleMailer::new();
+        mailer
+            .expect_send_welcome_email()
+            .once()
+            .returning(|_, _| Ok(()));
+        mailer
+            .expect_send_user_account_created_email()
+            .once()
+            .returning(|_, _, _| Err(ComhairleError::WrongUserType));
+
+        let state = Arc::new(test_state().db(pool).mailer(Arc::new(mailer)).call()?);
+        let app = setup_server(state.clone()).await?;
+        let mut session = UserSession::new_admin();
+        session.signup(&app).await?;
+
+        let (status, response, _) = session
+            .create_organization(
+                &app,
+                json!({
+                    "name": "org_with_email_failure",
+                    "description": "org_with_email_failure",
+                    "mission": "org_with_email_failure",
+                    "org_type": "non_profit",
+                    "organization_admin_emails": ["new-admin-failure@example.com"]
+                }),
+            )
+            .await?;
+
+        assert_eq!(status, StatusCode::CREATED);
+        assert_eq!(
+            response.get("name").and_then(|value| value.as_str()),
+            Some("org_with_email_failure")
+        );
+
+        let summary = response
+            .get("adminBootstrapSummary")
+            .ok_or("missing adminBootstrapSummary")?;
+        assert_eq!(summary.get("attempted").and_then(|v| v.as_u64()), Some(1));
+        assert_eq!(summary.get("assigned").and_then(|v| v.as_u64()), Some(1));
+        assert_eq!(summary.get("emailed").and_then(|v| v.as_u64()), Some(0));
+        assert_eq!(
+            summary
+                .get("failures")
+                .and_then(|value| value.as_array())
+                .map(|value| !value.is_empty()),
+            Some(true)
         );
 
         Ok(())

--- a/api/src/routes/organizations/dto.rs
+++ b/api/src/routes/organizations/dto.rs
@@ -5,7 +5,9 @@ use uuid::Uuid;
 
 use crate::{
     models::{
-        organization::{LocalizedOrganization, Organization, OrganizationType},
+        organization::{
+            LocalizedOrganization, Organization, OrganizationAdminBootstrapResult, OrganizationType,
+        },
         pagination::PaginatedResults,
         translations::TextContentId,
     },
@@ -20,7 +22,7 @@ use crate::{
 /// * `updated_at`
 ///
 /// Serialized to JSON using camelCase field names for frontend (JavaScript) compatibility.
-#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct OrganizationDto {
     #[schemars(example = "example_uuid")]
@@ -31,9 +33,35 @@ pub struct OrganizationDto {
     #[schemars(example = "example_uuid")]
     pub mission: TextContentId,
     pub org_type: OrganizationType,
+    pub contact_email: Option<String>,
     pub external_url: Option<String>,
     pub regions: Vec<Uuid>,
     pub created_at: DateTime<Utc>,
+}
+
+#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct OrganizationAdminBootstrapFailureDto {
+    pub email: String,
+    pub message: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct OrganizationAdminBootstrapSummaryDto {
+    pub attempted: usize,
+    pub assigned: usize,
+    pub created_accounts: usize,
+    pub emailed: usize,
+    pub failures: Vec<OrganizationAdminBootstrapFailureDto>,
+}
+
+#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateOrganizationResponseDto {
+    #[serde(flatten)]
+    pub organization: OrganizationDto,
+    pub admin_bootstrap_summary: OrganizationAdminBootstrapSummaryDto,
 }
 
 /// Data transfer object (public API representation) for a LocalizedOrganization.
@@ -44,7 +72,7 @@ pub struct OrganizationDto {
 /// * `updated_at`
 ///
 /// Serialized to JSON using camelCase field names for frontend (JavaScript) compatibility.
-#[derive(Serialize, Deserialize, Debug, JsonSchema)]
+#[derive(Serialize, Deserialize, Debug, JsonSchema, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct LocalizedOrganizationDto {
     #[schemars(example = "example_uuid")]
@@ -55,6 +83,7 @@ pub struct LocalizedOrganizationDto {
     #[schemars(example = "example_localized_text")]
     pub mission: String,
     pub org_type: OrganizationType,
+    pub contact_email: Option<String>,
     pub external_url: Option<String>,
     pub regions: Vec<Uuid>,
     pub created_at: DateTime<Utc>,
@@ -68,9 +97,42 @@ impl From<Organization> for OrganizationDto {
             description: o.description,
             mission: o.mission,
             org_type: o.org_type,
+            contact_email: o.contact_email,
             external_url: o.external_url,
             regions: o.regions,
             created_at: o.created_at,
+        }
+    }
+}
+
+impl OrganizationAdminBootstrapSummaryDto {
+    pub fn from_results(results: &[OrganizationAdminBootstrapResult]) -> Self {
+        let attempted = results.len();
+        let assigned = results.iter().filter(|result| result.assigned).count();
+        let created_accounts = results
+            .iter()
+            .filter(|result| result.created_account)
+            .count();
+        let emailed = results.iter().filter(|result| result.emailed).count();
+        let failures = results
+            .iter()
+            .filter_map(|result| {
+                result
+                    .error
+                    .as_ref()
+                    .map(|message| OrganizationAdminBootstrapFailureDto {
+                        email: result.email.clone(),
+                        message: message.clone(),
+                    })
+            })
+            .collect();
+
+        Self {
+            attempted,
+            assigned,
+            created_accounts,
+            emailed,
+            failures,
         }
     }
 }
@@ -83,6 +145,7 @@ impl From<LocalizedOrganization> for LocalizedOrganizationDto {
             description: o.description,
             mission: o.mission,
             org_type: o.org_type,
+            contact_email: o.contact_email,
             external_url: o.external_url,
             regions: o.regions,
             created_at: o.created_at,

--- a/api/src/routes/user.rs
+++ b/api/src/routes/user.rs
@@ -21,10 +21,15 @@ use crate::{
         self,
         conversation::{ConversationFilterOptions, ConversationOrderOptions},
         media::{FromWithMedia, MediaResolver},
+        organization::{self, OrganizationFilterOptions, OrganizationOrderOptions},
         pagination::{OrderParams, PageOptions, PaginatedResults},
+        permissions::{Action, can_perform_resource_action},
         users::{UpdateUserRequest, UpgradeAccountRequest},
     },
-    routes::{conversations::dto::LocalizedConversationDto, user::dto::UserDto},
+    routes::{
+        conversations::dto::LocalizedConversationDto, organizations::dto::LocalizedOrganizationDto,
+        user::dto::UserDto,
+    },
 };
 
 pub mod dto;
@@ -178,6 +183,101 @@ pub async fn get_user_roles(
     Ok((StatusCode::OK, Json(roles)))
 }
 
+#[derive(Serialize, Deserialize, JsonSchema, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct UserOrganizationAccess {
+    pub organization: LocalizedOrganizationDto,
+    pub is_associated: bool,
+    pub can_update: bool,
+    pub can_delete: bool,
+    pub can_manage_team: bool,
+}
+
+#[derive(Serialize, Deserialize, JsonSchema, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct UserOrganizationsResponse {
+    pub organizations: Vec<UserOrganizationAccess>,
+    pub can_create_organization: bool,
+}
+
+#[instrument(err(Debug), skip(state))]
+pub async fn get_user_organizations(
+    State(state): State<Arc<ComhairleState>>,
+    RequiredAdminUser(user): RequiredAdminUser,
+    LocaleExtractor(locale): LocaleExtractor,
+) -> Result<(StatusCode, Json<UserOrganizationsResponse>), ComhairleError> {
+    let results = organization::list(
+        &state.db,
+        PageOptions {
+            offset: None,
+            limit: Some(500),
+        },
+        OrganizationFilterOptions::default(),
+        OrganizationOrderOptions::default(),
+        &locale,
+    )
+    .await?;
+
+    let all_organizations = results
+        .records
+        .into_iter()
+        .map(LocalizedOrganizationDto::from)
+        .collect::<Vec<_>>();
+
+    let mut organizations = Vec::with_capacity(all_organizations.len());
+    for organization in &all_organizations {
+        let is_associated = user
+            .organization_id
+            .is_some_and(|organization_id| organization_id == organization.id);
+
+        let can_update = can_perform_resource_action(
+            &state,
+            &organization.id,
+            Action::OrganizationUpdate,
+            &user.id,
+            user.organization_id.as_ref(),
+            None,
+        )
+        .await?;
+
+        let can_delete = can_perform_resource_action(
+            &state,
+            &organization.id,
+            Action::OrganizationDelete,
+            &user.id,
+            user.organization_id.as_ref(),
+            None,
+        )
+        .await?;
+
+        organizations.push(UserOrganizationAccess {
+            organization: organization.clone(),
+            is_associated,
+            can_update,
+            can_delete,
+            can_manage_team: can_update,
+        });
+    }
+
+    let can_create_organization = can_perform_resource_action(
+        &state,
+        &Uuid::nil(),
+        Action::OrganizationCreate,
+        &user.id,
+        user.organization_id.as_ref(),
+        None,
+    )
+    .await?;
+
+    Ok((
+        StatusCode::OK,
+        Json(UserOrganizationsResponse {
+            organizations,
+            can_create_organization,
+        }),
+    ))
+}
+
 #[instrument(err(Debug), skip(state))]
 pub async fn update_user_details(
     State(state): State<Arc<ComhairleState>>,
@@ -243,6 +343,16 @@ pub fn router(state: Arc<ComhairleState>) -> ApiRouter {
                     .description("Gets a list of the conversations a user is permitted access to")
                     .security_requirement("JWT")
                     .response::<200, Json<PaginatedResults<LocalizedConversationDto>>>()
+            }),
+        )
+        .api_route(
+            "/organizations",
+            get_with(get_user_organizations, |op| {
+                op.id("GetUserOrganizations")
+                    .tag("User")
+                    .description("Gets the organizations associated with the current user and those they can manage")
+                    .security_requirement("JWT")
+                    .response::<200, Json<UserOrganizationsResponse>>()
             }),
         )
         .api_route(

--- a/documentation/adr/0010-organization-admin-bootstrap-on-creation.md
+++ b/documentation/adr/0010-organization-admin-bootstrap-on-creation.md
@@ -1,0 +1,28 @@
+# ADR-0010: Assign Organization Administrators at organization creation with silent account bootstrap
+
+**Status:** Proposal - to be accepted
+**Date:** 2026-08-05
+
+## Context
+
+When creating an Organization in the admin dashboard, we need to assign administrative authority to specific users at creation time. This assignment must be distinct from the Organization contact email and from general member association. Some entered admin emails may not yet have user accounts.
+
+The prior magic-link-only onboarding approach reused verification behavior and produced the wrong account shape for this use case. Missing admins were being created via an OTP-style path rather than as full email-password users with a stable identity model.
+
+We considered whether to block creation and ask for confirmation before creating missing accounts, and whether to issue random passwords or magic-link sign-in. We chose non-blocking full account bootstrap plus first-login password reset to keep the creation flow fast while preserving proper account semantics.
+
+## Proposal
+
+1. Add an explicit creation input for Initial Organization Administrators (email list) that is separate from contact email and member emails.
+2. Grant each resolved user Organization Administrator permissions on the new Organization: update organization, delete organization, add members, remove members.
+3. For emails with no existing user account, auto-create full email-password accounts silently, with username generated from email local-part plus unique suffix and a generated temporary password.
+4. Grant the same Organization Administrator permissions to those new users.
+5. Send a first-login password reset email to newly created Organization Administrators only, using the password reset mechanism.
+6. First-login password reset links expire after 24 hours, and admins can resend the initial password reset email from the Organization Users surface.
+7. Organization creation is not rolled back for downstream assignment/email failures; instead return a partial-failure summary.
+
+## Consequences
+
+- We introduce a clear semantic split between Organization contact details, membership, and administrative authority.
+- Silent account bootstrap improves flow speed but requires strong audit logging and clear post-create feedback for partial failures.
+- Full account bootstrap preserves a consistent user identity model and login path, but requires secure temporary password generation and first-login reset delivery.

--- a/ui/packages/api-client/src/api.ts
+++ b/ui/packages/api-client/src/api.ts
@@ -148,6 +148,41 @@ export const PaginatedResults_for_LocalizedConversationDto = z
 export type PaginatedResults_for_LocalizedConversationDto = z.infer<
   typeof PaginatedResults_for_LocalizedConversationDto
 >;
+export const OrganizationType = z.enum(["non_profit", "governmental", "other"]);
+export type OrganizationType = z.infer<typeof OrganizationType>;
+export const LocalizedOrganizationDto = z
+  .object({
+    contactEmail: z.union([z.string(), z.null()]).optional(),
+    createdAt: z.string().datetime({ offset: true }),
+    description: z.string(),
+    externalUrl: z.union([z.string(), z.null()]).optional(),
+    id: z.string().uuid(),
+    mission: z.string(),
+    name: z.string(),
+    orgType: OrganizationType,
+    regions: z.array(z.string().uuid()),
+  })
+  .passthrough();
+export type LocalizedOrganizationDto = z.infer<typeof LocalizedOrganizationDto>;
+export const UserOrganizationsResponse = z
+  .object({
+    organizations: z.array(
+      z
+        .object({
+          canDelete: z.boolean(),
+          canManageTeam: z.boolean(),
+          canUpdate: z.boolean(),
+          isAssociated: z.boolean(),
+          organization: LocalizedOrganizationDto,
+        })
+        .passthrough()
+    ),
+    canCreateOrganization: z.boolean(),
+  })
+  .passthrough();
+export type UserOrganizationsResponse = z.infer<
+  typeof UserOrganizationsResponse
+>;
 export const UpdateUserRequest = z
   .object({
     email_verified: z.union([z.boolean(), z.null()]),
@@ -2069,21 +2104,6 @@ export const SendToUserMessage = z
   .object({ message: z.string(), user_id: z.string().uuid() })
   .passthrough();
 export type SendToUserMessage = z.infer<typeof SendToUserMessage>;
-export const OrganizationType = z.enum(["non_profit", "governmental", "other"]);
-export type OrganizationType = z.infer<typeof OrganizationType>;
-export const LocalizedOrganizationDto = z
-  .object({
-    createdAt: z.string().datetime({ offset: true }),
-    description: z.string(),
-    externalUrl: z.union([z.string(), z.null()]).optional(),
-    id: z.string().uuid(),
-    mission: z.string(),
-    name: z.string(),
-    orgType: OrganizationType,
-    regions: z.array(z.string().uuid()),
-  })
-  .passthrough();
-export type LocalizedOrganizationDto = z.infer<typeof LocalizedOrganizationDto>;
 export const PaginatedResults_for_LocalizedOrganizationDto = z
   .object({
     records: z.array(LocalizedOrganizationDto),
@@ -2095,17 +2115,42 @@ export type PaginatedResults_for_LocalizedOrganizationDto = z.infer<
 >;
 export const CreateOrganization = z
   .object({
+    contact_email: z.union([z.string(), z.null()]).optional(),
     description: z.string(),
     external_url: z.union([z.string(), z.null()]).optional(),
     mission: z.string(),
     name: z.string(),
     org_type: OrganizationType,
+    organization_admin_emails: z.union([z.array(z.string()), z.null()]).optional(),
     regions: z.union([z.array(z.string().uuid()), z.null()]).optional(),
+    user_emails: z.union([z.array(z.string()), z.null()]).optional(),
   })
   .passthrough();
 export type CreateOrganization = z.infer<typeof CreateOrganization>;
+export const OrganizationAdminBootstrapFailureDto = z
+  .object({
+    email: z.string(),
+    message: z.string(),
+  })
+  .passthrough();
+export type OrganizationAdminBootstrapFailureDto = z.infer<
+  typeof OrganizationAdminBootstrapFailureDto
+>;
+export const OrganizationAdminBootstrapSummaryDto = z
+  .object({
+    attempted: z.number().int(),
+    assigned: z.number().int(),
+    createdAccounts: z.number().int(),
+    emailed: z.number().int(),
+    failures: z.array(OrganizationAdminBootstrapFailureDto),
+  })
+  .passthrough();
+export type OrganizationAdminBootstrapSummaryDto = z.infer<
+  typeof OrganizationAdminBootstrapSummaryDto
+>;
 export const OrganizationDto = z
   .object({
+    contactEmail: z.union([z.string(), z.null()]).optional(),
     createdAt: z.string().datetime({ offset: true }),
     description: z.string().uuid(),
     externalUrl: z.union([z.string(), z.null()]).optional(),
@@ -2117,9 +2162,16 @@ export const OrganizationDto = z
   })
   .passthrough();
 export type OrganizationDto = z.infer<typeof OrganizationDto>;
+export const CreateOrganizationResponseDto = OrganizationDto.extend({
+  adminBootstrapSummary: OrganizationAdminBootstrapSummaryDto,
+}).passthrough();
+export type CreateOrganizationResponseDto = z.infer<typeof CreateOrganizationResponseDto>;
 export const PartialOrganization = z
   .object({
+    contact_email: z.union([z.string(), z.null()]),
+    description: z.union([z.string(), z.null()]),
     external_url: z.union([z.string(), z.null()]),
+    mission: z.union([z.string(), z.null()]),
     name: z.union([z.string(), z.null()]),
     org_type: z.union([OrganizationType, z.null()]),
     regions: z.union([z.array(z.string().uuid()), z.null()]),
@@ -2422,6 +2474,9 @@ export const schemas: Record<string, z.ZodType<any>> = {
   is_complete,
   limit,
   PaginatedResults_for_LocalizedConversationDto,
+  OrganizationType,
+  LocalizedOrganizationDto,
+  UserOrganizationsResponse,
   UpdateUserRequest,
   UpgradeAccountRequest,
   UserConversationPreferencesDto,
@@ -2638,8 +2693,6 @@ export const schemas: Record<string, z.ZodType<any>> = {
   BroadcastMessage,
   BroadcastResponse,
   SendToUserMessage,
-  OrganizationType,
-  LocalizedOrganizationDto,
   PaginatedResults_for_LocalizedOrganizationDto,
   CreateOrganization,
   OrganizationDto,
@@ -4442,7 +4495,7 @@ curl -X POST \
         schema: CreateOrganization,
       },
     ],
-    response: OrganizationDto,
+    response: CreateOrganizationResponseDto,
   },
   {
     method: "get",
@@ -5451,6 +5504,14 @@ This struct contains optional fields that can be updated on a TextTranslation re
       },
     ],
     response: UserDto,
+  },
+  {
+    method: "get",
+    path: "/user/organizations",
+    alias: "GetUserOrganizations",
+    description: `Gets the organizations associated with the current user and those they can manage`,
+    requestFormat: "json",
+    response: UserOrganizationsResponse,
   },
   {
     method: "get",

--- a/ui/packages/comhairle/src/lib/components/AdminNav.svelte
+++ b/ui/packages/comhairle/src/lib/components/AdminNav.svelte
@@ -11,22 +11,32 @@
 		Mail,
 		Images,
 		PanelLeftClose,
-		PanelLeftOpen
+		PanelLeftOpen,
+		Plus
 	} from 'lucide-svelte';
 	import { Button } from './ui/button';
 	import NewConversationButton from './NewConversationButton.svelte';
 	import { userInitials } from '$lib/utils';
+	import { getOrganizationSections } from '$lib/utils/organizationSections';
 	import ComhairleLogo from './ComhairleLogo.svelte';
 	import { useSidebar } from '$lib/components/ui/sidebar/context.svelte.js';
 	import SidebarResizeHandle from './SidebarResizeHandle.svelte';
 	import { useSidebarWidth } from './sidebarWidthContext.svelte.js';
 	import { EXPAND_WIDTH } from './sidebarWidth.js';
-	import type { LocalizedConversationDto, UserDto } from '@crownshy/api-client/api';
+	import type {
+		LocalizedConversationDto,
+		UserOrganizationsResponse,
+		UserDto
+	} from '@crownshy/api-client/api';
 	import { SIDEBAR_KEYBOARD_SHORTCUT } from './ui/sidebar/constants';
 
 	type Props = {
 		ownedConversations: LocalizedConversationDto[];
 		permittedConversations: LocalizedConversationDto[];
+		userOrganizations: {
+			organizations: UserOrganizationsResponse['organizations'];
+			canCreateOrganization: boolean;
+		};
 		user: UserDto;
 		path: string;
 	};
@@ -44,10 +54,16 @@
 	let user = $derived(props.user);
 	let ownedConversations = $derived(props.ownedConversations);
 	let permittedConversations = $derived(props.permittedConversations);
+	let userOrganizations = $derived(props.userOrganizations);
 	let user_initials = $derived(userInitials(user?.username ?? ''));
+	let organizationSections = $derived(getOrganizationSections(userOrganizations));
 
 	function isConversationActive(conversationId: string): boolean {
 		return path.startsWith(`/admin/conversations/${conversationId}`);
+	}
+
+	function isOrganizationActive(organizationId: string): boolean {
+		return path.startsWith(`/admin/organizations/${organizationId}`);
 	}
 </script>
 
@@ -300,13 +316,87 @@
 				</SideBar.GroupContent>
 			</SideBar.Group>
 		{/if}
+
+		{#if organizationSections.length > 0}
+			{#each organizationSections as section (section.key)}
+				<SideBar.Group
+					class="flex min-h-0 flex-1 flex-col pr-1 group-data-[collapsible=icon]:hidden"
+				>
+					<SideBar.GroupLabel class="text-sidebar-secondary text-xs font-medium">
+						{section.title}
+					</SideBar.GroupLabel>
+
+					<SideBar.GroupContent class="min-h-0 flex-1">
+						<ScrollArea.Root class="h-full pr-3" type="always">
+							<SideBar.Menu>
+								{#each section.organizations as organization (organization.id)}
+									{@const active = isOrganizationActive(organization.id)}
+									<SideBar.MenuItem>
+										<SideBar.MenuButton
+											class="text-sidebar-foreground/80 data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground h-8 w-full overflow-hidden rounded-lg p-2 data-[active=true]:font-semibold"
+											isActive={active}
+										>
+											{#snippet child({ props: btnProps })}
+												<a
+													{...btnProps}
+													href={`/admin/organizations/${organization.id}`}
+													class="hover:bg-sidebar-accent hover:text-sidebar-accent-foreground flex w-full items-center rounded-lg px-2 py-1.5 {active
+														? 'bg-sidebar-accent text-sidebar-accent-foreground font-semibold'
+														: ''}"
+												>
+													{#if organization.name.length > 29}
+														<Tooltip.Root>
+															<Tooltip.Trigger>
+																{#snippet child({
+																	props: tipProps
+																})}
+																	<span
+																		{...tipProps}
+																		class="flex-1 truncate text-left text-sm leading-4 font-medium"
+																	>
+																		{organization.name}
+																	</span>
+																{/snippet}
+															</Tooltip.Trigger>
+															<Tooltip.Content side="right">
+																{organization.name}
+															</Tooltip.Content>
+														</Tooltip.Root>
+													{:else}
+														<span
+															class="flex-1 truncate text-left text-sm leading-4 font-medium"
+														>
+															{organization.name}
+														</span>
+													{/if}
+												</a>
+											{/snippet}
+										</SideBar.MenuButton>
+									</SideBar.MenuItem>
+								{/each}
+							</SideBar.Menu>
+						</ScrollArea.Root>
+					</SideBar.GroupContent>
+				</SideBar.Group>
+			{/each}
+		{/if}
 	</SideBar.Content>
 
-	<div class="shrink-0 px-7 group-data-[collapsible=icon]:px-2">
+	<div class="flex shrink-0 flex-col gap-2 px-7 group-data-[collapsible=icon]:px-2">
 		<NewConversationButton
 			class="w-full group-data-[collapsible=icon]:h-8 group-data-[collapsible=icon]:p-0"
 			labelClass="group-data-[collapsible=icon]:hidden"
 		/>
+
+		{#if userOrganizations?.canCreateOrganization}
+			<Button
+				href="/admin/organizations/new"
+				class="w-full group-data-[collapsible=icon]:h-8 group-data-[collapsible=icon]:p-0"
+			>
+				<Plus class="size-4" />
+				<span class="group-data-[collapsible=icon]:hidden">New organization</span>
+			</Button>
+		{/if}
 	</div>
 
 	<SideBar.Footer>

--- a/ui/packages/comhairle/src/lib/utils/organizationSections.test.ts
+++ b/ui/packages/comhairle/src/lib/utils/organizationSections.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { getOrganizationSections } from './organizationSections';
+
+describe('getOrganizationSections', () => {
+	it('returns a single organizations section from backend entries', () => {
+		const sections = getOrganizationSections({
+			organizations: [
+				{
+					organization: { id: 'org-1', name: 'Org 1' } as never
+				},
+				{
+					organization: { id: 'org-2', name: 'Org 2' } as never
+				}
+			]
+		});
+
+		expect(sections.map((section) => section.key)).toEqual(['organizations']);
+		expect(sections[0]?.organizations).toEqual([
+			{ id: 'org-1', name: 'Org 1' },
+			{ id: 'org-2', name: 'Org 2' }
+		]);
+	});
+});

--- a/ui/packages/comhairle/src/lib/utils/organizationSections.ts
+++ b/ui/packages/comhairle/src/lib/utils/organizationSections.ts
@@ -1,0 +1,26 @@
+import type { LocalizedOrganizationDto } from '@crownshy/api-client/api';
+
+export type OrganizationSection = {
+	key: 'organizations';
+	title: string;
+	organizations: LocalizedOrganizationDto[];
+};
+
+export function getOrganizationSections(userOrganizations?: {
+	organizations?: {
+		organization: LocalizedOrganizationDto;
+	}[];
+}): OrganizationSection[] {
+	const organizations = userOrganizations?.organizations ?? [];
+	if (organizations.length === 0) {
+		return [];
+	}
+
+	return [
+		{
+			key: 'organizations',
+			title: 'Organizations',
+			organizations: organizations.map((entry) => entry.organization)
+		}
+	];
+}

--- a/ui/packages/comhairle/src/routes/(admin)/+layout.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/+layout.svelte
@@ -11,6 +11,7 @@
 	let { children, data }: LayoutProps = $props();
 	let ownedConversations = $derived(data.ownedConversations);
 	let permittedConversations = $derived(data.permittedConversations);
+	let userOrganizations = $derived(data.userOrganizations);
 
 	if (!data.user) {
 		loginRedirect(page.url.toString(), 'You need to be logged in to access this');
@@ -37,6 +38,10 @@
 		user={data.user}
 		ownedConversations={ownedConversations?.records ?? []}
 		permittedConversations={permittedConversations?.records ?? []}
+		userOrganizations={userOrganizations ?? {
+			organizations: [],
+			canCreateOrganization: false
+		}}
 		path={page.url.pathname}
 	/>
 	<SideBar.Inset class="min-h-0 min-w-0">

--- a/ui/packages/comhairle/src/routes/(admin)/+layout.ts
+++ b/ui/packages/comhairle/src/routes/(admin)/+layout.ts
@@ -2,19 +2,34 @@ import { notifications } from '$lib/notifications.svelte';
 import { redirect } from '@sveltejs/kit';
 import type { LayoutLoad } from './$types';
 
-export const load: LayoutLoad = async ({ parent, data }) => {
+export const load: LayoutLoad = async ({ parent, data, depends }) => {
+	depends('admin:organizations');
 	const { api } = await parent();
 
 	try {
-		const ownedConversations = await api.GetOwnedConversations();
+		const ownedConversations = await api
+			.GetOwnedConversations()
+			.catch(() => ({ records: [], total: 0 }));
 
-		const permittedConversations = await api.GetPermittedConversations({
-			queries: { role_name: 'content_editor' }
-		});
+		const permittedConversations = await api
+			.GetPermittedConversations({
+				queries: { role_name: 'content_editor' }
+			})
+			.catch(() => ({ records: [], total: 0 }));
+
+		const userOrganizations = await api.GetUserOrganizations().catch(() => ({
+			organizations: [],
+			canCreateOrganization: false
+		}));
 
 		// Forward the server-read sidebar width so the component's `data` carries it:
 		// with a universal load present, SvelteKit does not auto-merge server data.
-		return { ownedConversations, permittedConversations, sidebarWidth: data.sidebarWidth };
+		return {
+			ownedConversations,
+			permittedConversations,
+			userOrganizations,
+			sidebarWidth: data.sidebarWidth
+		};
 	} catch (e) {
 		if (e.status === 401) {
 			notifications.addFlash({ message: 'You are not authorised', priority: 'WARNING' });

--- a/ui/packages/comhairle/src/routes/(admin)/admin/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/+page.svelte
@@ -6,7 +6,7 @@
 	import { Home } from 'lucide-svelte';
 
 	let props: PageProps = $props();
-	let conversations = props.data.conversations;
+	let conversations = $derived(props.data.conversations?.records ?? []);
 </script>
 
 <svelte:head>
@@ -34,7 +34,7 @@
 		<NewConversationButton class="w-full sm:w-auto" label="Create New Conversation" />
 	</div>
 	<div class="grid w-full grid-cols-1 gap-x-2 gap-y-16 overflow-y-auto">
-		{#each conversations.records as conversation (conversation.id)}
+		{#each conversations as conversation (conversation.id)}
 			<a href={`/admin/conversations/${conversation.id}/configure`}>
 				<ConversationCard {conversation} />
 			</a>

--- a/ui/packages/comhairle/src/routes/(admin)/admin/+page.ts
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/+page.ts
@@ -1,7 +1,8 @@
 import type { PageLoad } from './$types';
 
 export const load: PageLoad = async ({ parent }) => {
-	let { ownedConversations } = await parent();
+	const parentData = await parent();
+	const ownedConversations = parentData?.ownedConversations ?? { records: [] };
 
 	return { conversations: ownedConversations };
 };

--- a/ui/packages/comhairle/src/routes/(admin)/admin/organizations/[organization_id]/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/organizations/[organization_id]/+page.svelte
@@ -1,0 +1,630 @@
+<script lang="ts">
+	import { apiClient } from '@crownshy/api-client/client';
+	import { notifications } from '$lib/notifications.svelte';
+	import { goto, invalidate } from '$app/navigation';
+	import { page } from '$app/state';
+	import * as AlertDialog from '$lib/components/ui/alert-dialog';
+	import Button from '$lib/components/ui/button/button.svelte';
+	import Input from '$lib/components/ui/input/input.svelte';
+	import Label from '$lib/components/ui/label/label.svelte';
+	import { Trash2, SquarePen, Trash } from 'lucide-svelte';
+	import type { PageData } from './$types';
+	import { tryCatchAsync } from '$lib/utils/errorHandling';
+
+	let { data }: { data: PageData } = $props();
+
+	type TeamRole = 'member' | 'admin';
+	type TeamMember = {
+		id: string;
+		username?: string | null;
+		email?: string | null;
+		role: TeamRole;
+	};
+
+	let isEditing = $state(false);
+	let isDeleting = $state(false);
+	let isSaving = $state(false);
+	let teamBusy = $state(false);
+	let confirmCreateUserOpen = $state(false);
+	let pendingCreateUser = $state<{ email: string; role: TeamRole } | null>(null);
+
+	let members = $state<TeamMember[]>(data.team.members ?? []);
+	let memberEmail = $state('');
+	let newMemberRole = $state<TeamRole>('member');
+
+	let editName = $state(data.organization?.name ?? '');
+	let editDescription = $state(data.organization?.description ?? '');
+	let editMission = $state(data.organization?.mission ?? '');
+	let editOrgType = $state<'non_profit' | 'governmental' | 'other'>(
+		(data.organization?.orgType as 'non_profit' | 'governmental' | 'other' | undefined) ??
+			'other'
+	);
+	let editContactEmail = $state(data.organization?.contactEmail ?? '');
+	let editExternalUrl = $state(data.organization?.externalUrl ?? '');
+	let editRegionIds = $state<string[]>(data.organization?.regions ?? []);
+
+	let activeTab = $derived(page.url.searchParams.get('tab') ?? 'details');
+
+	$effect(() => {
+		members = data.team.members ?? [];
+	});
+
+	async function setTab(tab: 'details' | 'team') {
+		const params = new URLSearchParams(page.url.searchParams);
+		params.set('tab', tab);
+		await goto(`?${params.toString()}`, {
+			replaceState: true,
+			noScroll: true,
+			keepFocus: true
+		});
+	}
+
+	function startEditing() {
+		editName = data.organization?.name ?? '';
+		editDescription = data.organization?.description ?? '';
+		editMission = data.organization?.mission ?? '';
+		editOrgType =
+			(data.organization?.orgType as 'non_profit' | 'governmental' | 'other' | undefined) ??
+			'other';
+		editContactEmail = data.organization?.contactEmail ?? '';
+		editExternalUrl = data.organization?.externalUrl ?? '';
+		editRegionIds = [...(data.organization?.regions ?? [])];
+		isEditing = true;
+	}
+
+	function toggleRegion(regionId: string, enabled: boolean) {
+		if (enabled) {
+			if (!editRegionIds.includes(regionId)) {
+				editRegionIds = [...editRegionIds, regionId];
+			}
+			return;
+		}
+
+		editRegionIds = editRegionIds.filter((id) => id !== regionId);
+	}
+
+	function cancelEditing() {
+		isEditing = false;
+	}
+
+	async function saveOrganization() {
+		if (!data.organization) return;
+
+		isSaving = true;
+		try {
+			await apiClient.UpdateOrganization(
+				{
+					name: editName || undefined,
+					description: editDescription || undefined,
+					mission: editMission || undefined,
+					org_type: editOrgType,
+					contact_email: editContactEmail || null,
+					external_url: editExternalUrl || null,
+					regions: editRegionIds
+				},
+				{ params: { organization_id: data.organization.id } }
+			);
+
+			notifications.send({ priority: 'INFO', message: 'Organization updated' });
+			await invalidate('organization:details');
+			isEditing = false;
+		} catch (error) {
+			console.error(error);
+			notifications.send({ priority: 'ERROR', message: 'Failed to update organization' });
+		} finally {
+			isSaving = false;
+		}
+	}
+
+	async function refreshTeam() {
+		await invalidate('organization:team');
+	}
+
+	async function addMember(allowCreateUser = false, preset?: { email: string; role: TeamRole }) {
+		const email = (preset?.email ?? memberEmail).trim();
+		const requestedRole = preset?.role ?? newMemberRole;
+		if (email.length === 0 || !data.organization) return;
+
+		teamBusy = true;
+		const response = await tryCatchAsync(async () => {
+			const result = await fetch(`/api/organizations/${data.organization.id}/members`, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({
+					email,
+					role: requestedRole,
+					allow_create_user: allowCreateUser
+				})
+			});
+
+			if (result.status === 404 && !allowCreateUser) {
+				return { requiresConfirmation: true as const };
+			}
+
+			if (!result.ok) {
+				throw new Error(`Failed to add member (${result.status})`);
+			}
+			return result.json() as Promise<{ createdAccount: boolean; emailed: boolean }>;
+		});
+
+		if (response.ok !== null && 'requiresConfirmation' in response.ok) {
+			pendingCreateUser = { email, role: requestedRole };
+			confirmCreateUserOpen = true;
+			teamBusy = false;
+			return;
+		}
+
+		if (response.err !== null) {
+			notifications.send({ priority: 'ERROR', message: 'Failed to add organization member' });
+			teamBusy = false;
+			return;
+		}
+
+		memberEmail = '';
+		newMemberRole = 'member';
+		pendingCreateUser = null;
+		confirmCreateUserOpen = false;
+		await refreshTeam();
+
+		notifications.send({
+			priority: response.ok.createdAccount && !response.ok.emailed ? 'WARNING' : 'INFO',
+			message: response.ok.createdAccount
+				? response.ok.emailed
+					? 'Member added and account created. Account setup email sent.'
+					: 'Member added and account created. Account setup email could not be sent.'
+				: 'Member added to organization'
+		});
+
+		teamBusy = false;
+	}
+
+	async function confirmCreateUser() {
+		if (!pendingCreateUser) return;
+		await addMember(true, pendingCreateUser);
+	}
+
+	async function removeMember(userId: string) {
+		if (!data.organization) return;
+
+		teamBusy = true;
+		const response = await tryCatchAsync(async () => {
+			const result = await fetch(
+				`/api/organizations/${data.organization.id}/members/${userId}`,
+				{
+					method: 'DELETE'
+				}
+			);
+			if (!result.ok) {
+				throw new Error(`Failed to remove member (${result.status})`);
+			}
+		});
+
+		if (response.err !== null) {
+			notifications.send({
+				priority: 'ERROR',
+				message: 'Failed to remove organization member'
+			});
+			teamBusy = false;
+			return;
+		}
+
+		await refreshTeam();
+		notifications.send({ priority: 'INFO', message: 'Member removed from organization' });
+		teamBusy = false;
+	}
+
+	async function updateMemberRole(userId: string, role: TeamRole) {
+		if (!data.organization) return;
+
+		teamBusy = true;
+		const response = await tryCatchAsync(async () => {
+			const result = await fetch(
+				`/api/organizations/${data.organization.id}/members/${userId}/role`,
+				{
+					method: 'PUT',
+					headers: { 'Content-Type': 'application/json' },
+					body: JSON.stringify({ role })
+				}
+			);
+			if (!result.ok) {
+				throw new Error(`Failed to update role (${result.status})`);
+			}
+		});
+
+		if (response.err !== null) {
+			notifications.send({ priority: 'ERROR', message: 'Failed to update member role' });
+			teamBusy = false;
+			return;
+		}
+
+		await refreshTeam();
+		notifications.send({ priority: 'INFO', message: 'Member role updated' });
+		teamBusy = false;
+	}
+
+	async function deleteOrganization() {
+		if (!data.organization) return;
+
+		try {
+			await apiClient.DeleteOrganization(undefined, {
+				params: { organization_id: data.organization.id }
+			});
+
+			await Promise.all([
+				invalidate('organization:details'),
+				invalidate('admin:organizations')
+			]);
+			notifications.send({ priority: 'INFO', message: 'Organization deleted' });
+			goto('/admin');
+		} catch (error) {
+			console.error(error);
+			notifications.send({ priority: 'ERROR', message: 'Failed to delete organization' });
+		} finally {
+			isDeleting = false;
+		}
+	}
+</script>
+
+<svelte:head>
+	<title>{data.organization?.name ?? 'Organization'} - Comhairle Admin</title>
+</svelte:head>
+
+<div class="flex flex-col gap-6 p-8">
+	{#if data.organization}
+		<div class="flex flex-col gap-2">
+			<div class="flex items-center justify-between">
+				<div class="flex-1">
+					<h1 class="text-3xl font-semibold">{data.organization.name}</h1>
+					{#if data.organization.description}
+						<p class="text-muted-foreground">{data.organization.description}</p>
+					{/if}
+				</div>
+
+				{#if data.canEdit || data.canDelete}
+					<div class="flex gap-2">
+						{#if data.canEdit}
+							<Button
+								variant="outline"
+								size="icon"
+								onclick={startEditing}
+								title="Edit organization"
+							>
+								<SquarePen class="h-4 w-4" />
+								<span class="sr-only">Edit organization</span>
+							</Button>
+						{/if}
+						{#if data.canDelete}
+							<Button
+								variant="destructive"
+								size="icon"
+								onclick={() => (isDeleting = true)}
+								title="Delete organization"
+							>
+								<Trash2 class="h-4 w-4" />
+								<span class="sr-only">Delete organization</span>
+							</Button>
+						{/if}
+					</div>
+				{/if}
+			</div>
+		</div>
+
+		<div class="border-b">
+			<div class="flex gap-4">
+				<button
+					type="button"
+					onclick={() => setTab('details')}
+					class={`border-b-2 px-3 py-2 text-sm font-medium ${
+						activeTab === 'details'
+							? 'border-foreground text-foreground'
+							: 'text-muted-foreground hover:text-foreground border-transparent'
+					}`}
+				>
+					Details
+				</button>
+				<button
+					type="button"
+					onclick={() => setTab('team')}
+					class={`border-b-2 px-3 py-2 text-sm font-medium ${
+						activeTab === 'team'
+							? 'border-foreground text-foreground'
+							: 'text-muted-foreground hover:text-foreground border-transparent'
+					}`}
+				>
+					Team
+				</button>
+			</div>
+		</div>
+
+		{#if activeTab === 'details'}
+			{#if isEditing}
+				<div class="rounded-lg border p-4">
+					<h2 class="mb-4 text-lg font-semibold">Edit Organization</h2>
+					<div class="flex flex-col gap-4">
+						<div class="flex flex-col gap-2">
+							<Label for="edit-name">Name</Label>
+							<Input
+								id="edit-name"
+								bind:value={editName}
+								placeholder="Organization name"
+								required
+							/>
+						</div>
+
+						<div class="flex flex-col gap-2">
+							<Label for="edit-description">Description</Label>
+							<textarea
+								id="edit-description"
+								bind:value={editDescription}
+								class="border-input bg-background min-h-24 rounded-md border px-3 py-2 text-sm"
+								placeholder="Organization description"
+							></textarea>
+						</div>
+
+						<div class="flex flex-col gap-2">
+							<Label for="edit-mission">Mission</Label>
+							<textarea
+								id="edit-mission"
+								bind:value={editMission}
+								class="border-input bg-background min-h-24 rounded-md border px-3 py-2 text-sm"
+								placeholder="Organization mission"
+							></textarea>
+						</div>
+
+						<div class="flex flex-col gap-2">
+							<Label for="edit-org-type">Type</Label>
+							<select
+								id="edit-org-type"
+								bind:value={editOrgType}
+								class="border-input bg-background h-10 rounded-md border px-3 py-2 text-sm"
+							>
+								<option value="non_profit">Non-profit</option>
+								<option value="governmental">Governmental</option>
+								<option value="other">Other</option>
+							</select>
+						</div>
+
+						<div class="flex flex-col gap-2">
+							<Label for="edit-contact">Contact Email</Label>
+							<Input
+								id="edit-contact"
+								type="email"
+								bind:value={editContactEmail}
+								placeholder="contact@example.com"
+							/>
+						</div>
+
+						<div class="flex flex-col gap-2">
+							<Label for="edit-url">External URL</Label>
+							<Input
+								id="edit-url"
+								type="url"
+								bind:value={editExternalUrl}
+								placeholder="https://example.com"
+							/>
+						</div>
+
+						<div class="flex flex-col gap-2">
+							<Label>Regions</Label>
+							<div class="grid gap-2 rounded-md border p-3 md:grid-cols-2">
+								{#if data.regions.length === 0}
+									<p class="text-muted-foreground text-sm">
+										No regions available.
+									</p>
+								{:else}
+									{#each data.regions as region}
+										<label class="flex items-center gap-2 text-sm">
+											<input
+												type="checkbox"
+												checked={editRegionIds.includes(region.id)}
+												onchange={(event) =>
+													toggleRegion(
+														region.id,
+														(event.currentTarget as HTMLInputElement)
+															.checked
+													)}
+											/>
+											{region.name}
+										</label>
+									{/each}
+								{/if}
+							</div>
+						</div>
+
+						<div class="flex justify-end gap-2">
+							<Button variant="outline" onclick={cancelEditing} disabled={isSaving}
+								>Cancel</Button
+							>
+							<Button onclick={saveOrganization} disabled={isSaving}>
+								{isSaving ? 'Saving...' : 'Save'}
+							</Button>
+						</div>
+					</div>
+				</div>
+			{:else}
+				<div class="grid gap-4 md:grid-cols-2">
+					<div class="rounded-lg border p-4">
+						<h2 class="text-lg font-semibold">Details</h2>
+						<div class="mt-3 flex flex-col gap-2 text-sm">
+							<p>
+								<span class="font-medium">Organization ID:</span>
+								{data.organization.id}
+							</p>
+							<p>
+								<span class="font-medium">Type:</span>
+								{data.organization.orgType}
+							</p>
+							{#if data.organization.mission}
+								<p>
+									<span class="font-medium">Mission:</span>
+									{data.organization.mission}
+								</p>
+							{/if}
+							{#if data.organization.regions.length > 0}
+								<p>
+									<span class="font-medium">Regions:</span>
+									{data.organization.regions
+										.map(
+											(regionId) =>
+												data.regions.find(
+													(region) => region.id === regionId
+												)?.name ?? regionId
+										)
+										.join(', ')}
+								</p>
+							{/if}
+							{#if data.organization.contactEmail}
+								<p>
+									<span class="font-medium">Contact email:</span>
+									<a
+										href="mailto:{data.organization.contactEmail}"
+										class="text-blue-600 hover:underline"
+									>
+										{data.organization.contactEmail}
+									</a>
+								</p>
+							{/if}
+							{#if data.organization.externalUrl}
+								<p>
+									<span class="font-medium">External URL:</span>
+									<a
+										href={data.organization.externalUrl}
+										target="_blank"
+										rel="noopener noreferrer"
+										class="text-blue-600 hover:underline"
+									>
+										{data.organization.externalUrl}
+									</a>
+								</p>
+							{/if}
+						</div>
+					</div>
+				</div>
+			{/if}
+		{:else if activeTab === 'team'}
+			{#if data.canManageTeam}
+				<div class="rounded-lg border p-4">
+					<h2 class="text-lg font-semibold">Members</h2>
+					<p class="text-muted-foreground mt-1 text-sm">
+						Add members and assign each member as member or admin.
+					</p>
+
+					<div class="mt-4 grid gap-2 md:grid-cols-[1fr_auto_auto]">
+						<Input
+							bind:value={memberEmail}
+							placeholder="member@example.com"
+							disabled={teamBusy}
+						/>
+						<select
+							bind:value={newMemberRole}
+							disabled={teamBusy}
+							class="border-input bg-background h-10 rounded-md border px-3 py-2 text-sm"
+						>
+							<option value="member">Member</option>
+							<option value="admin">Admin</option>
+						</select>
+						<Button
+							onclick={() => addMember()}
+							disabled={teamBusy || memberEmail.length === 0}>Add</Button
+						>
+					</div>
+
+					<div class="mt-4 overflow-x-auto">
+						<table class="w-full text-sm">
+							<thead>
+								<tr class="border-b text-left">
+									<th class="py-2">Username</th>
+									<th class="py-2">Email</th>
+									<th class="py-2">Role</th>
+									<th class="py-2 text-right">Actions</th>
+								</tr>
+							</thead>
+							<tbody>
+								{#each members as member (member.id)}
+									<tr class="border-b">
+										<td class="py-2">{member.username ?? 'Unknown user'}</td>
+										<td class="py-2">{member.email ?? 'No email'}</td>
+										<td class="py-2">
+											<select
+												value={member.role}
+												onchange={(event) =>
+													updateMemberRole(
+														member.id,
+														(event.currentTarget as HTMLSelectElement)
+															.value as TeamRole
+													)}
+												disabled={teamBusy}
+												class="border-input bg-background h-9 rounded-md border px-2 py-1 text-sm"
+											>
+												<option value="member">Member</option>
+												<option value="admin">Admin</option>
+											</select>
+										</td>
+										<td class="py-2 text-right">
+											<button
+												type="button"
+												aria-label="Remove member"
+												class="hover:bg-primary group rounded-full p-1.5"
+												onclick={() => removeMember(member.id)}
+												disabled={teamBusy}
+											>
+												<Trash
+													class="group-hover:text-primary-foreground size-4"
+												/>
+											</button>
+										</td>
+									</tr>
+								{/each}
+							</tbody>
+						</table>
+					</div>
+				</div>
+			{:else}
+				<p class="text-muted-foreground">You do not have permission to manage this team.</p>
+			{/if}
+		{/if}
+	{:else}
+		<p class="text-muted-foreground">Organization not found.</p>
+	{/if}
+</div>
+
+<AlertDialog.Root open={isDeleting}>
+	<AlertDialog.Content>
+		<AlertDialog.Header>
+			<AlertDialog.Title>Delete Organization</AlertDialog.Title>
+			<AlertDialog.Description>
+				Are you sure you want to delete <strong>{data.organization?.name}</strong>? This
+				action cannot be undone.
+			</AlertDialog.Description>
+		</AlertDialog.Header>
+		<AlertDialog.Footer>
+			<Button variant="outline" onclick={() => (isDeleting = false)}>Cancel</Button>
+			<Button variant="destructive" onclick={deleteOrganization}>Delete</Button>
+		</AlertDialog.Footer>
+	</AlertDialog.Content>
+</AlertDialog.Root>
+
+<AlertDialog.Root open={confirmCreateUserOpen}>
+	<AlertDialog.Content>
+		<AlertDialog.Header>
+			<AlertDialog.Title>Create new user account?</AlertDialog.Title>
+			<AlertDialog.Description>
+				No account exists for <strong>{pendingCreateUser?.email}</strong>. Continue to
+				create a new email/password user, send an account setup email, and add them as
+				<strong>{pendingCreateUser?.role ?? 'member'}</strong>?
+			</AlertDialog.Description>
+		</AlertDialog.Header>
+		<AlertDialog.Footer>
+			<Button
+				variant="outline"
+				onclick={() => {
+					confirmCreateUserOpen = false;
+					pendingCreateUser = null;
+				}}
+			>
+				Cancel
+			</Button>
+			<Button onclick={confirmCreateUser} disabled={teamBusy}>Create user</Button>
+		</AlertDialog.Footer>
+	</AlertDialog.Content>
+</AlertDialog.Root>

--- a/ui/packages/comhairle/src/routes/(admin)/admin/organizations/[organization_id]/+page.ts
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/organizations/[organization_id]/+page.ts
@@ -1,4 +1,5 @@
 import type { PageLoad } from './$types';
+import { apiClient } from '@crownshy/api-client/client';
 
 export const load: PageLoad = async ({ parent, params, depends, fetch }) => {
 	const { api, userOrganizations } = await parent();
@@ -33,14 +34,8 @@ export const load: PageLoad = async ({ parent, params, depends, fetch }) => {
 			}
 		}
 
-		let regions: { id: string; name: string }[] = [];
-		const regionsResponse = await fetch('/api/regions?limit=500');
-		if (regionsResponse.ok) {
-			const regionResults = (await regionsResponse.json()) as {
-				records: { id: string; name: string }[];
-			};
-			regions = regionResults.records;
-		}
+		const regionsResponse = await apiClient.ListRegions({ queries: { limit: 500 } });
+		const regions = regionsResponse.records;
 
 		return {
 			organization,

--- a/ui/packages/comhairle/src/routes/(admin)/admin/organizations/[organization_id]/+page.ts
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/organizations/[organization_id]/+page.ts
@@ -1,0 +1,63 @@
+import type { PageLoad } from './$types';
+
+export const load: PageLoad = async ({ parent, params, depends, fetch }) => {
+	const { api, userOrganizations } = await parent();
+	depends('organization:details');
+	depends('organization:team');
+	depends('organization:regions');
+
+	try {
+		const organization = await api.GetOrganization({
+			params: { organization_id: params.organization_id }
+		});
+
+		const access = (userOrganizations?.organizations ?? []).find(
+			(entry) => entry.organization.id === params.organization_id
+		);
+
+		let team: {
+			members: {
+				id: string;
+				username?: string | null;
+				email?: string | null;
+				role: 'member' | 'admin';
+			}[];
+		} = {
+			members: []
+		};
+
+		if (access?.canManageTeam) {
+			const teamResponse = await fetch(`/api/organizations/${params.organization_id}/team`);
+			if (teamResponse.ok) {
+				team = await teamResponse.json();
+			}
+		}
+
+		let regions: { id: string; name: string }[] = [];
+		const regionsResponse = await fetch('/api/regions?limit=500');
+		if (regionsResponse.ok) {
+			const regionResults = (await regionsResponse.json()) as {
+				records: { id: string; name: string }[];
+			};
+			regions = regionResults.records;
+		}
+
+		return {
+			organization,
+			regions,
+			team,
+			canEdit: access?.canUpdate ?? false,
+			canDelete: access?.canDelete ?? false,
+			canManageTeam: access?.canManageTeam ?? false
+		};
+	} catch (error) {
+		return {
+			organization: null,
+			regions: [],
+			team: { members: [] },
+			canEdit: false,
+			canDelete: false,
+			canManageTeam: false
+		};
+	}
+};

--- a/ui/packages/comhairle/src/routes/(admin)/admin/organizations/new/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/organizations/new/+page.svelte
@@ -7,40 +7,112 @@
 	import Button from '$lib/components/ui/button/button.svelte';
 	import Input from '$lib/components/ui/input/input.svelte';
 	import Label from '$lib/components/ui/label/label.svelte';
-	import type { OrganizationType } from '@crownshy/api-client/api';
+	import type { LocalizedRegionDto, OrganizationType } from '@crownshy/api-client/api';
+	import { superForm } from 'sveltekit-superforms';
+	import { zodClient } from 'sveltekit-superforms/adapters';
+	import { z } from 'zod';
 
-	let name = $state('');
-	let description = $state('');
-	let mission = $state('');
-	let orgType: OrganizationType = $state('non_profit');
-	let contactEmail = $state('');
-	let externalUrl = $state('');
-	let allRegions = $state<{ id: string; name: string }[]>([]);
-	let selectedRegions = $state<string[]>([]);
-	let userEmails = $state('');
-	let organizationAdminEmails = $state('');
+	const organizationFormSchema = z.object({
+		name: z.string().trim().min(1, 'Name is required'),
+		description: z.string().optional(),
+		mission: z.string().optional(),
+		org_type: z.enum(['non_profit', 'governmental', 'other'] as const),
+		contact_email: z.string().optional(),
+		external_url: z.string().optional(),
+		regions: z.array(z.string().uuid()).default([]),
+		user_emails: z.string().optional(),
+		organization_admin_emails: z.string().optional()
+	});
+
+	const organizationForm = superForm(
+		{
+			name: '',
+			description: '',
+			mission: '',
+			org_type: 'non_profit' as OrganizationType,
+			contact_email: '',
+			external_url: '',
+			regions: [] as string[],
+			user_emails: '',
+			organization_admin_emails: ''
+		},
+		{
+			validators: zodClient(organizationFormSchema),
+			taintedMessage: false,
+			onSubmit: async ({ cancel }) => {
+				cancel();
+				submitting = true;
+
+				const validation = await validateForm({ update: true });
+				if (!validation.valid) {
+					submitting = false;
+					return;
+				}
+
+				const response = await tryCatchAsync(() =>
+					apiClient.CreateOrganization({
+						name: $form.name,
+						description: $form.description || undefined,
+						mission: $form.mission || undefined,
+						org_type: $form.org_type,
+						contact_email: $form.contact_email || undefined,
+						external_url: $form.external_url || undefined,
+						regions: $form.regions,
+						user_emails: parseEmailList($form.user_emails ?? ''),
+						organization_admin_emails: parseEmailList(
+							$form.organization_admin_emails ?? ''
+						)
+					})
+				);
+
+				if (response.err !== null) {
+					notifications.send({
+						priority: 'ERROR',
+						message: 'Failed to create organization'
+					});
+					submitting = false;
+					return;
+				}
+
+				const organization = response.ok;
+				const summary = organization.adminBootstrapSummary;
+				const failedCount = summary.failures.length;
+
+				notifications.send({
+					priority: failedCount > 0 ? 'WARNING' : 'INFO',
+					message:
+						failedCount > 0
+							? `Organization created. ${summary.assigned} of ${summary.attempted} administrators assigned; ${failedCount} need follow-up.`
+							: 'Organization created'
+				});
+
+				submitting = false;
+				goto(`/admin/organizations/${organization.id}`);
+			}
+		}
+	);
+
+	const { form, enhance, validateForm } = organizationForm;
+
+	let allRegions = $state<LocalizedRegionDto[]>([]);
+	let submitting = $state(false);
 
 	onMount(async () => {
-		const response = await fetch('/api/regions?limit=500');
-		if (!response.ok) {
-			return;
-		}
-
-		const regionResults = (await response.json()) as {
-			records: { id: string; name: string }[];
-		};
-		allRegions = regionResults.records;
+		const response = await apiClient.ListRegions({ queries: { limit: 500 } });
+		allRegions = response.records;
 	});
 
 	function toggleRegion(regionId: string, enabled: boolean) {
+		const selectedRegionIds = new Set($form.regions);
+
 		if (enabled) {
-			if (!selectedRegions.includes(regionId)) {
-				selectedRegions = [...selectedRegions, regionId];
+			if (!selectedRegionIds.has(regionId)) {
+				$form.regions = [...selectedRegionIds, regionId];
 			}
 			return;
 		}
 
-		selectedRegions = selectedRegions.filter((id) => id !== regionId);
+		$form.regions = [...selectedRegionIds].filter((id) => id !== regionId);
 	}
 
 	function parseEmailList(value: string): string[] | undefined {
@@ -51,43 +123,6 @@
 
 		return emails.length > 0 ? emails : undefined;
 	}
-
-	async function handleSubmit(event: Event) {
-		event.preventDefault();
-
-		const response = await tryCatchAsync(() =>
-			apiClient.CreateOrganization({
-				name,
-				description,
-				mission,
-				org_type: orgType,
-				contact_email: contactEmail || undefined,
-				external_url: externalUrl || undefined,
-				regions: selectedRegions,
-				user_emails: parseEmailList(userEmails),
-				organization_admin_emails: parseEmailList(organizationAdminEmails)
-			})
-		);
-
-		if (response.err !== null) {
-			notifications.send({ priority: 'ERROR', message: 'Failed to create organization' });
-			return;
-		}
-
-		const organization = response.ok;
-		const summary = organization.adminBootstrapSummary;
-		const failedCount = summary.failures.length;
-
-		notifications.send({
-			priority: failedCount > 0 ? 'WARNING' : 'INFO',
-			message:
-				failedCount > 0
-					? `Organization created. ${summary.assigned} of ${summary.attempted} administrators assigned; ${failedCount} need follow-up.`
-					: 'Organization created'
-		});
-
-		goto(`/admin/organizations/${organization.id}`);
-	}
 </script>
 
 <svelte:head>
@@ -97,17 +132,17 @@
 <div class="flex flex-col gap-6 p-8">
 	<h1 class="text-3xl font-semibold">Create organization</h1>
 
-	<form class="flex flex-col gap-4" onsubmit={handleSubmit}>
+	<form class="flex flex-col gap-4" method="POST" use:enhance>
 		<div class="grid gap-4 md:grid-cols-2">
 			<div class="flex flex-col gap-2">
 				<Label for="name">Name</Label>
-				<Input id="name" bind:value={name} required />
+				<Input id="name" bind:value={$form.name} required />
 			</div>
 			<div class="flex flex-col gap-2">
 				<Label for="orgType">Type</Label>
 				<select
 					id="orgType"
-					bind:value={orgType}
+					bind:value={$form.org_type}
 					class="border-input bg-background h-10 rounded-md border px-3 py-2 text-sm"
 				>
 					<option value="non_profit">Non-profit</option>
@@ -119,22 +154,22 @@
 
 		<div class="flex flex-col gap-2">
 			<Label for="description">Description</Label>
-			<Input id="description" bind:value={description} />
+			<Input id="description" bind:value={$form.description} />
 		</div>
 
 		<div class="flex flex-col gap-2">
 			<Label for="mission">Mission</Label>
-			<Input id="mission" bind:value={mission} />
+			<Input id="mission" bind:value={$form.mission} />
 		</div>
 
 		<div class="flex flex-col gap-2">
 			<Label for="contactEmail">Contact email</Label>
-			<Input id="contactEmail" type="email" bind:value={contactEmail} />
+			<Input id="contactEmail" type="email" bind:value={$form.contact_email} />
 		</div>
 
 		<div class="flex flex-col gap-2">
 			<Label for="externalUrl">External URL</Label>
-			<Input id="externalUrl" type="url" bind:value={externalUrl} />
+			<Input id="externalUrl" type="url" bind:value={$form.external_url} />
 		</div>
 
 		<div class="flex flex-col gap-2">
@@ -147,7 +182,7 @@
 						<label class="flex items-center gap-2 text-sm">
 							<input
 								type="checkbox"
-								checked={selectedRegions.includes(region.id)}
+								checked={$form.regions.includes(region.id)}
 								onchange={(event) =>
 									toggleRegion(
 										region.id,
@@ -165,7 +200,7 @@
 			<Label for="userEmails">User emails to add</Label>
 			<textarea
 				id="userEmails"
-				bind:value={userEmails}
+				bind:value={$form.user_emails}
 				class="border-input bg-background min-h-24 rounded-md border px-3 py-2 text-sm"
 				placeholder="one per line or comma separated"
 			></textarea>
@@ -178,14 +213,14 @@
 			</p>
 			<textarea
 				id="organizationAdminEmails"
-				bind:value={organizationAdminEmails}
+				bind:value={$form.organization_admin_emails}
 				class="border-input bg-background min-h-24 rounded-md border px-3 py-2 text-sm"
 				placeholder="one per line or comma separated"
 			></textarea>
 		</div>
 
 		<div class="flex justify-end">
-			<Button type="submit">Create organization</Button>
+			<Button type="submit" disabled={submitting}>Create organization</Button>
 		</div>
 	</form>
 </div>

--- a/ui/packages/comhairle/src/routes/(admin)/admin/organizations/new/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/organizations/new/+page.svelte
@@ -1,0 +1,191 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { goto } from '$app/navigation';
+	import { notifications } from '$lib/notifications.svelte';
+	import { tryCatchAsync } from '$lib/utils/errorHandling';
+	import { apiClient } from '@crownshy/api-client/client';
+	import Button from '$lib/components/ui/button/button.svelte';
+	import Input from '$lib/components/ui/input/input.svelte';
+	import Label from '$lib/components/ui/label/label.svelte';
+	import type { OrganizationType } from '@crownshy/api-client/api';
+
+	let name = $state('');
+	let description = $state('');
+	let mission = $state('');
+	let orgType: OrganizationType = $state('non_profit');
+	let contactEmail = $state('');
+	let externalUrl = $state('');
+	let allRegions = $state<{ id: string; name: string }[]>([]);
+	let selectedRegions = $state<string[]>([]);
+	let userEmails = $state('');
+	let organizationAdminEmails = $state('');
+
+	onMount(async () => {
+		const response = await fetch('/api/regions?limit=500');
+		if (!response.ok) {
+			return;
+		}
+
+		const regionResults = (await response.json()) as {
+			records: { id: string; name: string }[];
+		};
+		allRegions = regionResults.records;
+	});
+
+	function toggleRegion(regionId: string, enabled: boolean) {
+		if (enabled) {
+			if (!selectedRegions.includes(regionId)) {
+				selectedRegions = [...selectedRegions, regionId];
+			}
+			return;
+		}
+
+		selectedRegions = selectedRegions.filter((id) => id !== regionId);
+	}
+
+	function parseEmailList(value: string): string[] | undefined {
+		const emails = value
+			.split(/\n|,/)
+			.map((entry) => entry.trim())
+			.filter(Boolean);
+
+		return emails.length > 0 ? emails : undefined;
+	}
+
+	async function handleSubmit(event: Event) {
+		event.preventDefault();
+
+		const response = await tryCatchAsync(() =>
+			apiClient.CreateOrganization({
+				name,
+				description,
+				mission,
+				org_type: orgType,
+				contact_email: contactEmail || undefined,
+				external_url: externalUrl || undefined,
+				regions: selectedRegions,
+				user_emails: parseEmailList(userEmails),
+				organization_admin_emails: parseEmailList(organizationAdminEmails)
+			})
+		);
+
+		if (response.err !== null) {
+			notifications.send({ priority: 'ERROR', message: 'Failed to create organization' });
+			return;
+		}
+
+		const organization = response.ok;
+		const summary = organization.adminBootstrapSummary;
+		const failedCount = summary.failures.length;
+
+		notifications.send({
+			priority: failedCount > 0 ? 'WARNING' : 'INFO',
+			message:
+				failedCount > 0
+					? `Organization created. ${summary.assigned} of ${summary.attempted} administrators assigned; ${failedCount} need follow-up.`
+					: 'Organization created'
+		});
+
+		goto(`/admin/organizations/${organization.id}`);
+	}
+</script>
+
+<svelte:head>
+	<title>Create organization - Comhairle Admin</title>
+</svelte:head>
+
+<div class="flex flex-col gap-6 p-8">
+	<h1 class="text-3xl font-semibold">Create organization</h1>
+
+	<form class="flex flex-col gap-4" onsubmit={handleSubmit}>
+		<div class="grid gap-4 md:grid-cols-2">
+			<div class="flex flex-col gap-2">
+				<Label for="name">Name</Label>
+				<Input id="name" bind:value={name} required />
+			</div>
+			<div class="flex flex-col gap-2">
+				<Label for="orgType">Type</Label>
+				<select
+					id="orgType"
+					bind:value={orgType}
+					class="border-input bg-background h-10 rounded-md border px-3 py-2 text-sm"
+				>
+					<option value="non_profit">Non-profit</option>
+					<option value="governmental">Governmental</option>
+					<option value="other">Other</option>
+				</select>
+			</div>
+		</div>
+
+		<div class="flex flex-col gap-2">
+			<Label for="description">Description</Label>
+			<Input id="description" bind:value={description} />
+		</div>
+
+		<div class="flex flex-col gap-2">
+			<Label for="mission">Mission</Label>
+			<Input id="mission" bind:value={mission} />
+		</div>
+
+		<div class="flex flex-col gap-2">
+			<Label for="contactEmail">Contact email</Label>
+			<Input id="contactEmail" type="email" bind:value={contactEmail} />
+		</div>
+
+		<div class="flex flex-col gap-2">
+			<Label for="externalUrl">External URL</Label>
+			<Input id="externalUrl" type="url" bind:value={externalUrl} />
+		</div>
+
+		<div class="flex flex-col gap-2">
+			<Label>Regions</Label>
+			<div class="grid gap-2 rounded-md border p-3 md:grid-cols-2">
+				{#if allRegions.length === 0}
+					<p class="text-muted-foreground text-sm">No regions available.</p>
+				{:else}
+					{#each allRegions as region}
+						<label class="flex items-center gap-2 text-sm">
+							<input
+								type="checkbox"
+								checked={selectedRegions.includes(region.id)}
+								onchange={(event) =>
+									toggleRegion(
+										region.id,
+										(event.currentTarget as HTMLInputElement).checked
+									)}
+							/>
+							{region.name}
+						</label>
+					{/each}
+				{/if}
+			</div>
+		</div>
+
+		<div class="flex flex-col gap-2">
+			<Label for="userEmails">User emails to add</Label>
+			<textarea
+				id="userEmails"
+				bind:value={userEmails}
+				class="border-input bg-background min-h-24 rounded-md border px-3 py-2 text-sm"
+				placeholder="one per line or comma separated"
+			></textarea>
+		</div>
+
+		<div class="flex flex-col gap-2">
+			<Label for="organizationAdminEmails">Initial organization administrators</Label>
+			<p class="text-muted-foreground text-sm">
+				These users can update or delete the organization and add or remove members.
+			</p>
+			<textarea
+				id="organizationAdminEmails"
+				bind:value={organizationAdminEmails}
+				class="border-input bg-background min-h-24 rounded-md border px-3 py-2 text-sm"
+				placeholder="one per line or comma separated"
+			></textarea>
+		</div>
+
+		<div class="flex justify-end">
+			<Button type="submit">Create organization</Button>
+		</div>
+	</form>
+</div>


### PR DESCRIPTION
Motivations:

 - We need to track organization contact emails to support a new use
   case in CivicOS.
 - We would like an easy way to be able to manage organizations via the
   admin interface.

Actions:

 - Add contact email as an optional field to the organizations data
   table and create request model.
 - Added a functional interface for now which we can improve if we want
   to make this self-serve later.