### PR TITLE
Glossary 1/4: rich-text rendering engine

### DIFF
--- a/ui/packages/comhairle/src/lib/components/RichTextEditor/ContentRenderer/ContentRenderer.svelte
+++ b/ui/packages/comhairle/src/lib/components/RichTextEditor/ContentRenderer/ContentRenderer.svelte
@@ -1,8 +1,15 @@
+<script module lang="ts">
+	// Per-instance counter so each renderer's glossary tooltip gets a unique id for
+	// aria-describedby. Increments deterministically, so SSR and hydration agree.
+	let glossaryInstance = 0;
+</script>
+
 <script lang="ts">
 	import { renderRichTextToHtml } from '$lib/utils/renderRichText';
 	import { EDITOR_HTML_ATTRIBUTES } from '../editorConfig';
 	import { cn } from '$lib/utils';
 	import type { ComhairleDocument } from '@crownshy/api-client/api';
+	import type { Glossary } from '$lib/glossary/types';
 	import PdfDocumentDialog from '$lib/components/PdfViewer/PdfDocumentDialog.svelte';
 	import '../editor-content.css';
 
@@ -13,6 +20,8 @@
 		/** Documents referenced by source-document badges, for filename and download link. */
 		availableDocuments?: ComhairleDocument[];
 		conversationId?: string;
+		/** Glossary terms to auto-tooltip in the rendered content. */
+		glossary?: Glossary;
 	};
 
 	let {
@@ -20,17 +29,23 @@
 		class: className = '',
 		minimal = false,
 		availableDocuments = [],
-		conversationId = ''
+		conversationId = '',
+		glossary = []
 	}: Props = $props();
 
 	// $derived (not onMount + an editor instance) so the content is present in the SSR
 	// markup. This used to mount a headless Tiptap editor on the client, which meant every
 	// call site painted blank until hydration, and blanked again on each remount.
 	let html = $derived(
-		renderRichTextToHtml(content, { documents: availableDocuments, conversationId })
+		renderRichTextToHtml(content, { documents: availableDocuments, conversationId, glossary })
 	);
 
 	let contentElement = $state<HTMLElement>();
+
+	// Glossary tooltip. Rendered as a single position:fixed element (below) and positioned by
+	// JS from the hovered/focused term's rect, so it escapes the article's overflow clipping.
+	let glossaryTooltipEl = $state<HTMLDivElement>();
+	const glossaryTooltipId = `glossary-tooltip-${glossaryInstance++}`;
 
 	let previewDialog = $state<{
 		open: boolean;
@@ -84,6 +99,75 @@
 		el.addEventListener('click', handleContentClick);
 		return () => el.removeEventListener('click', handleContentClick);
 	});
+
+	function showGlossaryTooltip(trigger: HTMLElement) {
+		const el = glossaryTooltipEl;
+		if (!el) return;
+		const text = trigger.getAttribute('data-glossary-tooltip');
+		if (!text) return;
+
+		el.textContent = text;
+		el.setAttribute('data-visible', 'true');
+		el.setAttribute('aria-hidden', 'false');
+		trigger.setAttribute('aria-describedby', glossaryTooltipId);
+
+		// Anchor at the term's top-centre; the CSS transform lifts and centres the box. Clamp
+		// horizontally so a term near an edge doesn't push the tooltip off-screen.
+		const rect = trigger.getBoundingClientRect();
+		const margin = 8;
+		const halfWidth = el.offsetWidth / 2;
+		const centre = rect.left + rect.width / 2;
+		const left = Math.min(
+			Math.max(centre, halfWidth + margin),
+			window.innerWidth - halfWidth - margin
+		);
+		el.style.left = `${left}px`;
+		el.style.top = `${rect.top}px`;
+	}
+
+	function hideGlossaryTooltip(trigger?: HTMLElement | null) {
+		const el = glossaryTooltipEl;
+		if (!el) return;
+		el.setAttribute('data-visible', 'false');
+		el.setAttribute('aria-hidden', 'true');
+		trigger?.removeAttribute('aria-describedby');
+	}
+
+	// Glossary terms come from {@html}, so the tooltip is driven by delegated hover/focus
+	// listeners on the wrapper rather than per-element handlers.
+	$effect(() => {
+		const el = contentElement;
+		if (!el) return;
+
+		const closestTerm = (event: Event) =>
+			(event.target as HTMLElement | null)?.closest<HTMLElement>('.glossary-term') ?? null;
+		const onOver = (event: Event) => {
+			const term = closestTerm(event);
+			if (term) showGlossaryTooltip(term);
+		};
+		const onOut = (event: Event) => {
+			const term = closestTerm(event);
+			if (term) hideGlossaryTooltip(term);
+		};
+		const onScrollResize = () => hideGlossaryTooltip();
+
+		el.addEventListener('mouseover', onOver);
+		el.addEventListener('mouseout', onOut);
+		el.addEventListener('focusin', onOver);
+		el.addEventListener('focusout', onOut);
+		// Capture so a scroll in any ancestor (the article scroll container) dismisses it.
+		window.addEventListener('scroll', onScrollResize, true);
+		window.addEventListener('resize', onScrollResize);
+
+		return () => {
+			el.removeEventListener('mouseover', onOver);
+			el.removeEventListener('mouseout', onOut);
+			el.removeEventListener('focusin', onOver);
+			el.removeEventListener('focusout', onOut);
+			window.removeEventListener('scroll', onScrollResize, true);
+			window.removeEventListener('resize', onScrollResize);
+		};
+	});
 </script>
 
 <div class="content-renderer {className}" class:content-renderer--minimal={minimal}>
@@ -102,6 +186,16 @@
 		{@html html}
 	</div>
 </div>
+
+<!-- Single shared glossary tooltip, positioned by JS. position:fixed so it escapes the
+	article's overflow clipping; text/coords are set imperatively in showGlossaryTooltip. -->
+<div
+	bind:this={glossaryTooltipEl}
+	id={glossaryTooltipId}
+	class="glossary-tooltip"
+	role="tooltip"
+	aria-hidden="true"
+></div>
 
 <PdfDocumentDialog
 	bind:open={previewDialog.open}

--- a/ui/packages/comhairle/src/lib/components/RichTextEditor/editor-content.css
+++ b/ui/packages/comhairle/src/lib/components/RichTextEditor/editor-content.css
@@ -412,3 +412,60 @@
 .editor-scroll-container::-webkit-scrollbar-thumb:hover {
 	background-color: var(--color-muted-foreground);
 }
+
+/* Glossary term (renderer view).
+ * A defined term carries a dotted underline (the dictionary/definition convention, distinct
+ * from a solid-underline link) plus a help cursor, so it reads as "hover for a definition"
+ * without an inline icon. The tooltip itself is NOT a CSS pseudo-element: ContentRenderer
+ * renders a position:fixed .glossary-tooltip and positions it by JS, so it escapes the
+ * article's overflow clipping (a z-index bump alone can't). See ContentRenderer. */
+.glossary-term {
+	cursor: help;
+	border-radius: 3px;
+	text-decoration-line: underline;
+	text-decoration-style: dotted;
+	text-decoration-color: color-mix(in srgb, var(--color-primary) 55%, transparent);
+	text-decoration-thickness: from-font;
+	text-underline-offset: 0.2em;
+}
+
+/* Hover/focus: firm up the underline to full primary and add a faint wash. */
+.glossary-term:hover {
+	text-decoration-color: var(--color-primary);
+	background: color-mix(in srgb, var(--color-primary) 12%, transparent);
+}
+
+.glossary-term:focus-visible {
+	outline: 2px solid var(--color-primary);
+	outline-offset: 1px;
+}
+
+.glossary-tooltip {
+	position: fixed;
+	z-index: 60;
+	max-width: min(20rem, 90vw);
+	padding: 0.5rem 0.75rem;
+	border-radius: 0.5rem;
+	background: var(--color-popover);
+	color: var(--color-popover-foreground);
+	border: 1px solid var(--color-border);
+	box-shadow: 0 4px 16px rgb(0 0 0 / 0.18);
+	font-size: 0.875rem;
+	line-height: 1.4;
+	text-align: left;
+	/* Anchored at the term's top-centre by JS (left/top); lift it above and centre it. */
+	transform: translate(-50%, calc(-100% - 8px));
+	pointer-events: none;
+	opacity: 0;
+	transition: opacity 120ms ease;
+}
+
+.glossary-tooltip[data-visible='true'] {
+	opacity: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.glossary-tooltip {
+		transition: none;
+	}
+}

--- a/ui/packages/comhairle/src/lib/components/RichTextEditor/editorConfig.ts
+++ b/ui/packages/comhairle/src/lib/components/RichTextEditor/editorConfig.ts
@@ -11,6 +11,7 @@ import { ListItem } from '@tiptap/extension-list-item';
 import { TextStyle } from '@tiptap/extension-text-style';
 import { Underline } from '@tiptap/extension-underline';
 import { SourceDocument } from './extensions/sourceDocument';
+import { GlossaryTerm } from './extensions/glossaryTerm';
 import type { Extensions } from '@tiptap/core';
 
 export const EDITOR_HTML_ATTRIBUTES = {
@@ -83,6 +84,9 @@ export function getBaseExtensions(options: EditorConfigOptions): Extensions {
 		Iframe,
 		Audio,
 		SourceDocument,
+		// Applied to matched terms at render time by applyGlossary; lives in the shared
+		// schema so the static renderer can emit it. Harmless in the editor (no input rule).
+		GlossaryTerm,
 		TextAlign.configure({
 			types: ['heading', 'paragraph']
 		}),

--- a/ui/packages/comhairle/src/lib/components/RichTextEditor/extensions/glossaryTerm.ts
+++ b/ui/packages/comhairle/src/lib/components/RichTextEditor/extensions/glossaryTerm.ts
@@ -1,0 +1,44 @@
+import { Mark, mergeAttributes } from '@tiptap/core';
+
+/**
+ * An inline mark for a glossary term. It is never typed by an author: `applyGlossary`
+ * adds it to matched text at render time (see $lib/glossary/applyGlossary). It lives in
+ * the shared schema so `renderToHTMLString` knows how to emit it.
+ *
+ * Renders `<span class="glossary-term" data-glossary-tooltip="...">term</span>`. The
+ * tooltip itself is CSS-only (editor-content.css) so it survives the `{@html}` render
+ * path, where Svelte components can't mount.
+ */
+export const GlossaryTerm = Mark.create({
+	name: 'glossaryTerm',
+	// Not spanning, not part of any input rule: it's applied programmatically only.
+	inclusive: false,
+
+	addAttributes() {
+		return {
+			tooltip: {
+				default: null,
+				parseHTML: (element) => element.getAttribute('data-glossary-tooltip'),
+				renderHTML: (attributes) =>
+					attributes.tooltip ? { 'data-glossary-tooltip': attributes.tooltip } : {}
+			}
+		};
+	},
+
+	parseHTML() {
+		return [{ tag: 'span[data-glossary-term]' }];
+	},
+
+	renderHTML({ HTMLAttributes }) {
+		return [
+			'span',
+			mergeAttributes(HTMLAttributes, {
+				'data-glossary-term': '',
+				class: 'glossary-term',
+				// Focusable so the definition is reachable by keyboard, not only hover.
+				tabindex: '0'
+			}),
+			0
+		];
+	}
+});

--- a/ui/packages/comhairle/src/lib/glossary/applyGlossary.test.ts
+++ b/ui/packages/comhairle/src/lib/glossary/applyGlossary.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import type { JSONContent } from '@tiptap/core';
+import { applyGlossary } from './applyGlossary';
+import type { Glossary } from './types';
+
+const doc = (text: string): JSONContent => ({
+	type: 'doc',
+	content: [{ type: 'paragraph', content: [{ type: 'text', text }] }]
+});
+
+const glossary: Glossary = [
+	{ text: ['bus', 'autobus'], tooltip: 'A vehicle that carries multiple people' },
+	{ text: ['referral'], tooltip: 'When your case is passed to another team' }
+];
+
+/** Collect the text of every node carrying the glossaryTerm mark. */
+function markedTerms(node: JSONContent): string[] {
+	const out: string[] = [];
+	const walk = (n: JSONContent) => {
+		if (n.type === 'text' && n.marks?.some((m) => m.type === 'glossaryTerm') && n.text) {
+			out.push(n.text);
+		}
+		n.content?.forEach(walk);
+	};
+	walk(node);
+	return out;
+}
+
+describe('applyGlossary', () => {
+	it('marks a matching term with its tooltip', () => {
+		const result = applyGlossary(doc('Take the bus home'), glossary);
+		const para = result.content?.[0].content ?? [];
+		expect(para.map((n) => n.text)).toEqual(['Take the ', 'bus', ' home']);
+		const marked = para.find((n) => n.text === 'bus');
+		expect(marked?.marks).toEqual([
+			{ type: 'glossaryTerm', attrs: { tooltip: 'A vehicle that carries multiple people' } }
+		]);
+	});
+
+	it('matches synonyms in the same entry', () => {
+		expect(markedTerms(applyGlossary(doc('Catch the autobus'), glossary))).toEqual(['autobus']);
+	});
+
+	it('is case-insensitive but preserves the original casing', () => {
+		expect(markedTerms(applyGlossary(doc('The Bus is late'), glossary))).toEqual(['Bus']);
+	});
+
+	it('only matches whole words, not substrings', () => {
+		expect(markedTerms(applyGlossary(doc('Running a business'), glossary))).toEqual([]);
+	});
+
+	it('tooltips only the first occurrence by default', () => {
+		expect(markedTerms(applyGlossary(doc('bus then another bus'), glossary))).toEqual(['bus']);
+	});
+
+	it('tooltips every occurrence when firstOccurrenceOnly is false', () => {
+		const result = applyGlossary(doc('bus then another bus'), glossary, {
+			firstOccurrenceOnly: false
+		});
+		expect(markedTerms(result)).toEqual(['bus', 'bus']);
+	});
+
+	it('handles multiple different terms', () => {
+		const result = applyGlossary(doc('A referral onto the bus'), glossary);
+		expect(markedTerms(result)).toEqual(['referral', 'bus']);
+	});
+
+	it('leaves content untouched when the glossary is empty', () => {
+		const input = doc('Take the bus home');
+		expect(applyGlossary(input, [])).toBe(input);
+	});
+
+	it('does not mutate the input document', () => {
+		const input = doc('Take the bus home');
+		const snapshot = JSON.stringify(input);
+		applyGlossary(input, glossary);
+		expect(JSON.stringify(input)).toBe(snapshot);
+	});
+
+	it('preserves existing marks on a matched term', () => {
+		const input: JSONContent = {
+			type: 'doc',
+			content: [
+				{
+					type: 'paragraph',
+					content: [{ type: 'text', text: 'bus', marks: [{ type: 'bold' }] }]
+				}
+			]
+		};
+		const marked = applyGlossary(input, glossary).content?.[0].content?.[0];
+		expect(marked?.marks).toEqual([
+			{ type: 'bold' },
+			{ type: 'glossaryTerm', attrs: { tooltip: 'A vehicle that carries multiple people' } }
+		]);
+	});
+});

--- a/ui/packages/comhairle/src/lib/glossary/applyGlossary.ts
+++ b/ui/packages/comhairle/src/lib/glossary/applyGlossary.ts
@@ -1,0 +1,149 @@
+import type { JSONContent } from '@tiptap/core';
+import type { Glossary } from './types';
+
+export interface ApplyGlossaryOptions {
+	/**
+	 * Tooltip only the first occurrence of each term across the whole document
+	 * (keeps content from getting noisy when a term repeats). Default: true.
+	 */
+	firstOccurrenceOnly?: boolean;
+}
+
+/** The mark name applied to matched terms; must match the GlossaryTerm extension. */
+const GLOSSARY_MARK = 'glossaryTerm';
+
+function escapeRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+interface Matcher {
+	regex: RegExp;
+	/** lowercased term -> tooltip */
+	lookup: Map<string, string>;
+}
+
+/**
+ * Compiles the glossary into a single whole-word, case-insensitive regex plus a
+ * term -> tooltip lookup. Longer terms are tried first so a multi-word entry wins
+ * over one of its own words. Returns null when there is nothing to match.
+ */
+function buildMatcher(glossary: Glossary): Matcher | null {
+	const lookup = new Map<string, string>();
+	const terms: string[] = [];
+
+	for (const entry of glossary) {
+		const tooltip = entry.tooltip?.trim();
+		if (!tooltip) continue;
+		for (const raw of entry.text ?? []) {
+			const term = raw?.trim();
+			if (!term) continue;
+			const key = term.toLowerCase();
+			if (lookup.has(key)) continue;
+			lookup.set(key, tooltip);
+			terms.push(term);
+		}
+	}
+
+	if (terms.length === 0) return null;
+
+	terms.sort((a, b) => b.length - a.length);
+	const pattern = terms.map(escapeRegExp).join('|');
+	// Unicode-aware "word boundary": a term only matches when it isn't touching
+	// another letter/number/underscore, so "bus" doesn't light up inside "business".
+	const regex = new RegExp(`(?<![\\p{L}\\p{N}_])(?:${pattern})(?![\\p{L}\\p{N}_])`, 'giu');
+	return { regex, lookup };
+}
+
+function splitTextNode(
+	node: JSONContent,
+	matcher: Matcher,
+	used: Set<string>,
+	firstOccurrenceOnly: boolean
+): JSONContent[] {
+	const text = node.text;
+	if (typeof text !== 'string' || text.length === 0) return [node];
+
+	const existingMarks = node.marks ?? [];
+	// Never nest a glossary mark inside another (e.g. content that already carries one).
+	if (existingMarks.some((mark) => mark.type === GLOSSARY_MARK)) return [node];
+
+	const { regex, lookup } = matcher;
+	regex.lastIndex = 0;
+
+	const segments: JSONContent[] = [];
+	let cursor = 0;
+	let match: RegExpExecArray | null;
+
+	while ((match = regex.exec(text)) !== null) {
+		const matched = match[0];
+		const key = matched.toLowerCase();
+
+		// Guard against a zero-width match locking the loop.
+		if (matched.length === 0) {
+			regex.lastIndex += 1;
+			continue;
+		}
+
+		if (firstOccurrenceOnly && used.has(key)) continue;
+
+		const start = match.index;
+		if (start > cursor) {
+			segments.push({ ...node, text: text.slice(cursor, start) });
+		}
+
+		used.add(key);
+		segments.push({
+			...node,
+			text: matched,
+			marks: [...existingMarks, { type: GLOSSARY_MARK, attrs: { tooltip: lookup.get(key) } }]
+		});
+		cursor = start + matched.length;
+	}
+
+	if (cursor === 0) return [node];
+	if (cursor < text.length) {
+		segments.push({ ...node, text: text.slice(cursor) });
+	}
+	return segments;
+}
+
+function transformNode(
+	node: JSONContent,
+	matcher: Matcher,
+	used: Set<string>,
+	firstOccurrenceOnly: boolean
+): JSONContent[] {
+	if (node.type === 'text') {
+		return splitTextNode(node, matcher, used, firstOccurrenceOnly);
+	}
+
+	if (Array.isArray(node.content)) {
+		const content: JSONContent[] = [];
+		for (const child of node.content) {
+			content.push(...transformNode(child, matcher, used, firstOccurrenceOnly));
+		}
+		return [{ ...node, content }];
+	}
+
+	return [node];
+}
+
+/**
+ * Walks a ProseMirror document and wraps every glossary term in a `glossaryTerm`
+ * mark carrying its tooltip, so the renderer can show a definition on hover.
+ *
+ * Pure: returns a new document and never mutates the input. Applied at render time
+ * (not stored), so the same content picks up glossary edits without being re-saved.
+ */
+export function applyGlossary(
+	doc: JSONContent,
+	glossary: Glossary,
+	options: ApplyGlossaryOptions = {}
+): JSONContent {
+	const matcher = buildMatcher(glossary);
+	if (!matcher) return doc;
+
+	const firstOccurrenceOnly = options.firstOccurrenceOnly ?? true;
+	const used = new Set<string>();
+	return transformNode(doc, matcher, used, firstOccurrenceOnly)[0] ?? doc;
+}

--- a/ui/packages/comhairle/src/lib/glossary/types.ts
+++ b/ui/packages/comhairle/src/lib/glossary/types.ts
@@ -1,0 +1,34 @@
+/**
+ * A conversation glossary: a shared list of defined terms that get an automatic
+ * hover tooltip wherever they appear in rendered rich text (Learn steps for now).
+ *
+ * This is the demo shape agreed in the discussion on issue #815. It is intentionally
+ * small; conversation-level storage and a builder UI are the follow-up work.
+ */
+export interface GlossaryEntry {
+	/**
+	 * The term plus any synonyms or translated forms that should all show the same
+	 * explanation, e.g. `["bus", "autobus"]`. Matching is case-insensitive and
+	 * whole-word.
+	 */
+	text: string[];
+	/** Plain-text explanation shown on hover / focus. */
+	tooltip: string;
+}
+
+export type Glossary = GlossaryEntry[];
+
+/**
+ * The stored, translatable form of an entry: BOTH the term list and the explanation are held
+ * per locale, so a term matches in the language it's written in and shows a same-language
+ * tooltip. Resolved down to a plain `GlossaryEntry` (single locale) for rendering by
+ * resolveGlossary. See [[localizedGlossary]].
+ */
+export interface LocalizedGlossaryEntry {
+	/** Terms (and synonyms) keyed by locale code, e.g. `{ en: ["bus"], es: ["autobús"] }`. */
+	text: Record<string, string[]>;
+	/** Explanation keyed by locale code, e.g. `{ en: "...", es: "..." }`. */
+	tooltip: Record<string, string>;
+}
+
+export type LocalizedGlossary = LocalizedGlossaryEntry[];

--- a/ui/packages/comhairle/src/lib/utils/renderRichText.test.ts
+++ b/ui/packages/comhairle/src/lib/utils/renderRichText.test.ts
@@ -92,6 +92,21 @@ describe('renderRichTextToHtml', () => {
 		expect(renderRichTextToHtml('{"type":"doc","content":[{"type":"nope"}]}')).toBe('');
 	});
 
+	it('wraps glossary terms in a tooltip span when a glossary is passed', () => {
+		const html = renderRichTextToHtml(paragraph('Take the bus home'), {
+			glossary: [{ text: ['bus'], tooltip: 'A vehicle that carries people' }]
+		});
+		expect(html).toContain('data-glossary-term');
+		expect(html).toContain('data-glossary-tooltip="A vehicle that carries people"');
+		expect(html).toContain('>bus</span>');
+	});
+
+	it('leaves content unchanged when no glossary is passed', () => {
+		expect(renderRichTextToHtml(paragraph('Take the bus home'))).toBe(
+			'<p>Take the bus home</p>'
+		);
+	});
+
 	it('renders a table with header and body cells (SSR path)', () => {
 		const content = JSON.stringify({
 			type: 'doc',

--- a/ui/packages/comhairle/src/lib/utils/renderRichText.ts
+++ b/ui/packages/comhairle/src/lib/utils/renderRichText.ts
@@ -5,6 +5,8 @@ import { getBaseExtensions } from '$lib/components/RichTextEditor/editorConfig';
 import { SourceDocument } from '$lib/components/RichTextEditor/extensions/sourceDocument';
 import { CONTENT_TYPES } from '$lib/components/RichTextEditor/types';
 import { detectContentType } from './contentDetection';
+import { applyGlossary } from '$lib/glossary/applyGlossary';
+import type { Glossary } from '$lib/glossary/types';
 import type { ComhairleDocument } from '@crownshy/api-client/api';
 
 /**
@@ -14,6 +16,11 @@ import type { ComhairleDocument } from '@crownshy/api-client/api';
 export type RenderRichTextOptions = {
 	documents?: ComhairleDocument[];
 	conversationId?: string;
+	/**
+	 * Glossary terms to auto-tooltip. Matched terms get a `glossaryTerm` mark at render
+	 * time, so content picks up glossary edits without being re-saved. Empty = no-op.
+	 */
+	glossary?: Glossary;
 };
 
 function buildExtensions(documents: ComhairleDocument[], conversationId: string): AnyExtension[] {
@@ -50,7 +57,7 @@ export function renderRichTextToHtml(
 	content: string | null | undefined,
 	options: RenderRichTextOptions = {}
 ): string {
-	const { documents = [], conversationId = '' } = options;
+	const { documents = [], conversationId = '', glossary = [] } = options;
 
 	const detected = detectContentType(content);
 	if (!detected.content) return '';
@@ -58,12 +65,14 @@ export function renderRichTextToHtml(
 	const extensions = buildExtensions(documents, conversationId);
 
 	try {
-		const document =
+		const parsed =
 			detected.type === CONTENT_TYPES.JSON
 				? (detected.content as JSONContent)
 				: (new MarkdownManager({ extensions }).parse(
 						String(detected.content)
 					) as JSONContent);
+
+		const document = glossary.length > 0 ? applyGlossary(parsed, glossary) : parsed;
 
 		return renderToHTMLString({ content: document, extensions });
 	} catch (error) {


### PR DESCRIPTION
### Stack (merge bottom to top)

1. **#820 — rich-text rendering engine ← you are here**
2. #821 — read from metadata + show in Learn steps
3. #822 — CSV import + AI translation helpers
4. #823 — admin Glossary tab

---

**Stack 1 of 4** for the Learn-step glossary tooltips (#815). Merge in order.

### What this adds
The rendering engine that turns a list of defined terms into hover-tooltip'd rich text. Nothing is wired to real data yet, so this is safe to land on its own.

- `lib/glossary/types.ts` — the `Glossary` / `GlossaryEntry` shapes
- `lib/glossary/applyGlossary.ts` — a pure ProseMirror walk that wraps matched terms in a `glossaryTerm` mark (whole-word, case-insensitive, first-occurrence-only)
- `GlossaryTerm` tiptap mark + registration in `editorConfig`, so the static renderer knows how to emit it
- `renderRichText` — applies the glossary at render time (opt-in), so content picks up glossary edits without being re-saved
- `ContentRenderer` — an optional `glossary` prop plus a JS-positioned tooltip that escapes the article's overflow clipping
- `editor-content.css` — the dotted-underline term + tooltip styling

### Why it's safe
The `glossary` prop defaults to empty, so every existing caller renders exactly as before. Nothing lights up until a glossary is passed (that happens in stack 2).

