### PR TITLE
Glossary 2/4: read from metadata + show in Learn steps

### DIFF
--- a/ui/packages/comhairle/src/lib/glossary/localizedGlossary.test.ts
+++ b/ui/packages/comhairle/src/lib/glossary/localizedGlossary.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest';
+import {
+	parseLocalizedGlossary,
+	localizedGlossaryFromMetadata,
+	resolveGlossary,
+	resolveGlossaryFromMetadata
+} from './localizedGlossary';
+
+describe('parseLocalizedGlossary', () => {
+	it('keeps per-locale terms and tooltips', () => {
+		expect(
+			parseLocalizedGlossary(
+				[
+					{
+						text: { en: ['bus'], es: ['autobús'] },
+						tooltip: { en: 'A vehicle', es: 'Un vehículo' }
+					}
+				],
+				'en'
+			)
+		).toEqual([
+			{
+				text: { en: ['bus'], es: ['autobús'] },
+				tooltip: { en: 'A vehicle', es: 'Un vehículo' }
+			}
+		]);
+	});
+
+	it('treats a flat term array and a bare tooltip as the primary locale (back-compat)', () => {
+		expect(
+			parseLocalizedGlossary([{ text: ['bus', 'autobus'], tooltip: 'A vehicle' }], 'en')
+		).toEqual([{ text: { en: ['bus', 'autobus'] }, tooltip: { en: 'A vehicle' } }]);
+	});
+
+	it('trims and drops empty terms and tooltips per locale', () => {
+		expect(
+			parseLocalizedGlossary(
+				[
+					{
+						text: { en: [' bus ', ''], es: ['  '] },
+						tooltip: { en: '  A vehicle  ', es: '  ' }
+					}
+				],
+				'en'
+			)
+		).toEqual([{ text: { en: ['bus'] }, tooltip: { en: 'A vehicle' } }]);
+	});
+
+	it('drops entries with no term or no tooltip', () => {
+		expect(
+			parseLocalizedGlossary(
+				[
+					{ text: {}, tooltip: { en: 'orphan' } },
+					{ text: { en: ['bus'] }, tooltip: {} },
+					{ text: { en: ['bus'] }, tooltip: { en: 'ok' } }
+				],
+				'en'
+			)
+		).toEqual([{ text: { en: ['bus'] }, tooltip: { en: 'ok' } }]);
+	});
+
+	it.each([null, 'x', 5, {}])('returns [] for non-array %p', (value) => {
+		expect(parseLocalizedGlossary(value, 'en')).toEqual([]);
+	});
+});
+
+describe('resolveGlossary', () => {
+	const entries = [
+		{ text: { en: ['bus'], es: ['autobús'] }, tooltip: { en: 'A vehicle', es: 'Un vehículo' } }
+	];
+
+	it('picks the requested locale for both terms and tooltip', () => {
+		expect(resolveGlossary(entries, 'es', 'en')).toEqual([
+			{ text: ['autobús'], tooltip: 'Un vehículo' }
+		]);
+	});
+
+	it('falls back to the primary locale terms when the requested locale has none', () => {
+		const partial = [
+			{ text: { en: ['cookie'] }, tooltip: { en: 'A biscuit', es: 'Una galleta' } }
+		];
+		// No Spanish terms, so it matches the English term but shows the Spanish tooltip.
+		expect(resolveGlossary(partial, 'es', 'en')).toEqual([
+			{ text: ['cookie'], tooltip: 'Una galleta' }
+		]);
+	});
+
+	it('falls back to the primary tooltip when the requested locale has none', () => {
+		const partial = [{ text: { en: ['bus'], es: ['autobús'] }, tooltip: { en: 'A vehicle' } }];
+		expect(resolveGlossary(partial, 'es', 'en')).toEqual([
+			{ text: ['autobús'], tooltip: 'A vehicle' }
+		]);
+	});
+});
+
+describe('metadata helpers', () => {
+	it('resolveGlossaryFromMetadata reads and resolves in one step', () => {
+		const metadata = {
+			glossary: [
+				{
+					text: { en: ['bus'], es: ['autobús'] },
+					tooltip: { en: 'A vehicle', es: 'Un vehículo' }
+				}
+			]
+		};
+		expect(resolveGlossaryFromMetadata(metadata, 'es', 'en')).toEqual([
+			{ text: ['autobús'], tooltip: 'Un vehículo' }
+		]);
+	});
+
+	it('resolves legacy flat data against the primary locale', () => {
+		const metadata = { glossary: [{ text: ['bus'], tooltip: 'A vehicle' }] };
+		expect(resolveGlossaryFromMetadata(metadata, 'en', 'en')).toEqual([
+			{ text: ['bus'], tooltip: 'A vehicle' }
+		]);
+		expect(localizedGlossaryFromMetadata(metadata, 'en')).toEqual([
+			{ text: { en: ['bus'] }, tooltip: { en: 'A vehicle' } }
+		]);
+	});
+});

--- a/ui/packages/comhairle/src/lib/glossary/localizedGlossary.ts
+++ b/ui/packages/comhairle/src/lib/glossary/localizedGlossary.ts
@@ -1,0 +1,106 @@
+import type { Glossary, LocalizedGlossary, LocalizedGlossaryEntry } from './types';
+import { GLOSSARY_METADATA_KEY } from './parseGlossary';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function cleanTerms(value: unknown): string[] {
+	if (!Array.isArray(value)) return [];
+	return value
+		.filter((term): term is string => typeof term === 'string')
+		.map((term) => term.trim())
+		.filter(Boolean);
+}
+
+/**
+ * Normalizes stored glossary entries into the translatable shape, never throwing. Handles the
+ * older shapes so existing data keeps working: `text` may be a locale->terms map (current) or a
+ * flat `string[]` (taken as the primary locale's terms); `tooltip` may be a locale->string map
+ * or a bare string (taken as the primary locale's text). Empty values and entries with no term
+ * or no explanation are dropped.
+ */
+export function parseLocalizedGlossary(value: unknown, primaryLocale: string): LocalizedGlossary {
+	if (!Array.isArray(value)) return [];
+
+	const entries: LocalizedGlossaryEntry[] = [];
+	for (const raw of value) {
+		if (!isRecord(raw)) continue;
+
+		const text: Record<string, string[]> = {};
+		if (Array.isArray(raw.text)) {
+			const terms = cleanTerms(raw.text);
+			if (terms.length) text[primaryLocale] = terms;
+		} else if (isRecord(raw.text)) {
+			for (const [locale, terms] of Object.entries(raw.text)) {
+				const cleaned = cleanTerms(terms);
+				if (cleaned.length) text[locale] = cleaned;
+			}
+		}
+
+		const tooltip: Record<string, string> = {};
+		if (typeof raw.tooltip === 'string') {
+			const trimmed = raw.tooltip.trim();
+			if (trimmed) tooltip[primaryLocale] = trimmed;
+		} else if (isRecord(raw.tooltip)) {
+			for (const [locale, localeText] of Object.entries(raw.tooltip)) {
+				if (typeof localeText === 'string' && localeText.trim()) {
+					tooltip[locale] = localeText.trim();
+				}
+			}
+		}
+
+		if (Object.keys(text).length === 0 || Object.keys(tooltip).length === 0) continue;
+		entries.push({ text, tooltip });
+	}
+	return entries;
+}
+
+/** Reads the translatable glossary out of a conversation's `metadata` blob. */
+export function localizedGlossaryFromMetadata(
+	metadata: unknown,
+	primaryLocale: string
+): LocalizedGlossary {
+	if (!isRecord(metadata)) return [];
+	return parseLocalizedGlossary(metadata[GLOSSARY_METADATA_KEY], primaryLocale);
+}
+
+/**
+ * Flattens a translatable glossary to a single-locale Glossary for rendering. An entry's terms
+ * are the current locale's (falling back to the primary locale's terms when it hasn't been
+ * translated), and its tooltip is the current locale's text, falling back to the primary then
+ * to any translation. Entries with no usable term or tooltip are dropped.
+ */
+export function resolveGlossary(
+	entries: LocalizedGlossary,
+	locale: string,
+	primaryLocale: string
+): Glossary {
+	const glossary: Glossary = [];
+	for (const entry of entries) {
+		const text = entry.text[locale]?.length ? entry.text[locale] : entry.text[primaryLocale];
+		if (!text || text.length === 0) continue;
+
+		const tooltip =
+			entry.tooltip[locale] ??
+			entry.tooltip[primaryLocale] ??
+			Object.values(entry.tooltip)[0];
+		if (!tooltip) continue;
+
+		glossary.push({ text, tooltip });
+	}
+	return glossary;
+}
+
+/** Convenience: read + resolve a conversation's glossary for the participant's locale. */
+export function resolveGlossaryFromMetadata(
+	metadata: unknown,
+	locale: string,
+	primaryLocale: string
+): Glossary {
+	return resolveGlossary(
+		localizedGlossaryFromMetadata(metadata, primaryLocale),
+		locale,
+		primaryLocale
+	);
+}

--- a/ui/packages/comhairle/src/lib/glossary/parseGlossary.test.ts
+++ b/ui/packages/comhairle/src/lib/glossary/parseGlossary.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { parseGlossary, glossaryFromMetadata } from './parseGlossary';
+
+describe('parseGlossary', () => {
+	it('keeps well-formed entries', () => {
+		expect(parseGlossary([{ text: ['bus', 'autobus'], tooltip: 'A vehicle' }])).toEqual([
+			{ text: ['bus', 'autobus'], tooltip: 'A vehicle' }
+		]);
+	});
+
+	it('trims terms and tooltip and drops blank terms', () => {
+		expect(parseGlossary([{ text: [' bus ', '', '  '], tooltip: '  A vehicle  ' }])).toEqual([
+			{ text: ['bus'], tooltip: 'A vehicle' }
+		]);
+	});
+
+	it('drops entries with no usable term or no tooltip', () => {
+		expect(
+			parseGlossary([
+				{ text: [], tooltip: 'orphan' },
+				{ text: ['bus'], tooltip: '' },
+				{ text: ['bus'], tooltip: 'ok' }
+			])
+		).toEqual([{ text: ['bus'], tooltip: 'ok' }]);
+	});
+
+	it('ignores non-string terms and malformed rows', () => {
+		expect(
+			parseGlossary([{ text: ['bus', 3, null], tooltip: 'A vehicle' }, 'nope', 42, null])
+		).toEqual([{ text: ['bus'], tooltip: 'A vehicle' }]);
+	});
+
+	it.each([null, undefined, 'string', 42, {}])('returns [] for non-array %p', (value) => {
+		expect(parseGlossary(value)).toEqual([]);
+	});
+});
+
+describe('glossaryFromMetadata', () => {
+	it('reads the glossary key out of a metadata object', () => {
+		const metadata = { glossary: [{ text: ['bus'], tooltip: 'A vehicle' }], other: 1 };
+		expect(glossaryFromMetadata(metadata)).toEqual([{ text: ['bus'], tooltip: 'A vehicle' }]);
+	});
+
+	it.each([null, undefined, 'x', 5, {}, { glossary: null }])(
+		'returns [] when there is no valid glossary (%p)',
+		(metadata) => {
+			expect(glossaryFromMetadata(metadata)).toEqual([]);
+		}
+	);
+});

--- a/ui/packages/comhairle/src/lib/glossary/parseGlossary.ts
+++ b/ui/packages/comhairle/src/lib/glossary/parseGlossary.ts
@@ -1,0 +1,40 @@
+import type { Glossary, GlossaryEntry } from './types';
+
+/** The key the glossary lives under in a conversation's `metadata` jsonb blob. */
+export const GLOSSARY_METADATA_KEY = 'glossary';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null;
+}
+
+/**
+ * Coerces an untyped value (the glossary comes out of `metadata`, typed `unknown`) into a
+ * valid Glossary, dropping anything malformed. Never throws, so bad stored data degrades to
+ * "no tooltips" rather than a render crash.
+ */
+export function parseGlossary(value: unknown): Glossary {
+	if (!Array.isArray(value)) return [];
+
+	const entries: GlossaryEntry[] = [];
+	for (const raw of value) {
+		if (!isRecord(raw)) continue;
+
+		const tooltip = typeof raw.tooltip === 'string' ? raw.tooltip.trim() : '';
+		const text = Array.isArray(raw.text)
+			? raw.text
+					.filter((term): term is string => typeof term === 'string')
+					.map((term) => term.trim())
+					.filter(Boolean)
+			: [];
+
+		if (!tooltip || text.length === 0) continue;
+		entries.push({ text, tooltip });
+	}
+	return entries;
+}
+
+/** Reads the glossary out of a conversation's `metadata` blob (`conversation.metadata`). */
+export function glossaryFromMetadata(metadata: unknown): Glossary {
+	if (!isRecord(metadata)) return [];
+	return parseGlossary(metadata[GLOSSARY_METADATA_KEY]);
+}

--- a/ui/packages/comhairle/src/lib/tools/learn/LearnUI.svelte
+++ b/ui/packages/comhairle/src/lib/tools/learn/LearnUI.svelte
@@ -15,6 +15,7 @@
 	import LearningAssistant from '$lib/components/LearningAssistant/LearningAssistant.svelte';
 	import LearnArticleSkeleton from './LearnArticleSkeleton.svelte';
 	import { delayedFlag } from '$lib/utils/delayedFlag.svelte';
+	import { resolveGlossaryFromMetadata } from '$lib/glossary/localizedGlossary';
 
 	let {
 		pages,
@@ -52,6 +53,16 @@
 		(currentPage ?? []).filter((p) => p.lang === getLocale())
 	);
 	let content = $derived(currentPageTranslation[0]?.content);
+	// Glossary is stored on the conversation's metadata jsonb (edited in the admin Configure ->
+	// Glossary tab); terms get an auto tooltip in the rendered article, resolved to the
+	// participant's current locale (falling back to the conversation's primary locale).
+	let glossary = $derived(
+		resolveGlossaryFromMetadata(
+			conversation?.metadata,
+			getLocale(),
+			conversation?.primaryLocale ?? 'en'
+		)
+	);
 	let isLastPage = $derived(currentPageNo === pages.length - 1);
 	let pageHeading = $derived(
 		(currentPageTranslation[0] as { title?: string } | undefined)?.title ?? ''
@@ -112,7 +123,12 @@
 		<LearnArticleSkeleton />
 	{:else if content}
 		<article class="prose mx-auto w-full grow overflow-y-auto">
-			<ContentRenderer {content} {availableDocuments} conversationId={conversation?.id} />
+			<ContentRenderer
+				{content}
+				{availableDocuments}
+				conversationId={conversation?.id}
+				{glossary}
+			/>
 		</article>
 	{:else}
 		<h1>Sorry this page is currently not avaliable in this language</h1>


### PR DESCRIPTION
### Stack (merge bottom to top)

1. #820 — rich-text rendering engine
2. **#821 — read from metadata + show in Learn steps ← you are here**
3. #822 — CSV import + AI translation helpers
4. #823 — admin Glossary tab

---

**Stack 2 of 4** for the Learn-step glossary tooltips (#815). Targets stack 1 (`815-glossary-1-render-engine`); review/merge that one first.

### What this adds
Wires the engine from stack 1 to real conversation data for participants.

- `lib/glossary/parseGlossary.ts` — coerces the untyped conversation `metadata` blob into a valid `Glossary`, degrading malformed data to "no tooltips" instead of a render crash. Exports `GLOSSARY_METADATA_KEY`.
- `lib/glossary/localizedGlossary.ts` — holds terms and explanations per locale and resolves down to the participant's current locale, falling back to the conversation's primary locale
- `LearnUI.svelte` — reads the glossary off `conversation.metadata` and passes it to `ContentRenderer`

### Effect
After this, a glossary stored on a conversation shows tooltips in that conversation's Learn steps, in the participant's language. There's no editor yet, so the glossary would have to be written into `metadata` by hand until stack 4.

### Tests
Parse + localized-resolve unit tests pass (branch runs 56 total).

Shout if you want more detail on the locale fallback logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
