### PR TITLE
Glossary 3/4: CSV import + AI translation helpers

### DIFF
--- a/ui/packages/comhairle/src/lib/glossary/glossaryCsv.test.ts
+++ b/ui/packages/comhairle/src/lib/glossary/glossaryCsv.test.ts
@@ -27,10 +27,6 @@ describe('parseCsvRows', () => {
 			['c', 'd']
 		]);
 	});
-
-	it('strips a UTF-8 BOM', () => {
-		expect(parseCsvRows('﻿a,b')).toEqual([['a', 'b']]);
-	});
 });
 
 describe('parseGlossaryCsv', () => {
@@ -52,6 +48,11 @@ describe('parseGlossaryCsv', () => {
 			{ text: ['bus'], tooltip: 'A vehicle' },
 			{ text: ['referral'], tooltip: 'Passed to another team' }
 		]);
+	});
+
+	it('skips the header row even when the file starts with a UTF-8 BOM', () => {
+		const csv = '\ufeffTerm,Definition\nbus,A vehicle';
+		expect(parseGlossaryCsv(csv)).toEqual([{ text: ['bus'], tooltip: 'A vehicle' }]);
 	});
 
 	it('does not treat a data row as a header', () => {

--- a/ui/packages/comhairle/src/lib/glossary/glossaryCsv.test.ts
+++ b/ui/packages/comhairle/src/lib/glossary/glossaryCsv.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { parseCsvRows, parseGlossaryCsv } from './glossaryCsv';
+
+describe('parseCsvRows', () => {
+	it('splits simple rows and columns', () => {
+		expect(parseCsvRows('a,b\nc,d')).toEqual([
+			['a', 'b'],
+			['c', 'd']
+		]);
+	});
+
+	it('keeps commas inside quoted fields', () => {
+		expect(parseCsvRows('bus,"A vehicle, large"')).toEqual([['bus', 'A vehicle, large']]);
+	});
+
+	it('unescapes doubled quotes inside a quoted field', () => {
+		expect(parseCsvRows('bus,"A ""big"" vehicle"')).toEqual([['bus', 'A "big" vehicle']]);
+	});
+
+	it('keeps newlines inside quoted fields', () => {
+		expect(parseCsvRows('bus,"line one\nline two"')).toEqual([['bus', 'line one\nline two']]);
+	});
+
+	it('handles CRLF line endings and a trailing newline', () => {
+		expect(parseCsvRows('a,b\r\nc,d\r\n')).toEqual([
+			['a', 'b'],
+			['c', 'd']
+		]);
+	});
+
+	it('strips a UTF-8 BOM', () => {
+		expect(parseCsvRows('﻿a,b')).toEqual([['a', 'b']]);
+	});
+});
+
+describe('parseGlossaryCsv', () => {
+	it('maps two columns to a glossary entry', () => {
+		expect(parseGlossaryCsv('bus,A vehicle that carries people')).toEqual([
+			{ text: ['bus'], tooltip: 'A vehicle that carries people' }
+		]);
+	});
+
+	it('splits synonyms in the first column on ; or |', () => {
+		expect(parseGlossaryCsv('bus; autobus | coach,A vehicle')).toEqual([
+			{ text: ['bus', 'autobus', 'coach'], tooltip: 'A vehicle' }
+		]);
+	});
+
+	it('skips a header row', () => {
+		const csv = 'Term,Definition\nbus,A vehicle\nreferral,Passed to another team';
+		expect(parseGlossaryCsv(csv)).toEqual([
+			{ text: ['bus'], tooltip: 'A vehicle' },
+			{ text: ['referral'], tooltip: 'Passed to another team' }
+		]);
+	});
+
+	it('does not treat a data row as a header', () => {
+		expect(parseGlossaryCsv('bus,A vehicle')).toHaveLength(1);
+	});
+
+	it('keeps a definition that itself contains a comma', () => {
+		expect(parseGlossaryCsv('bus,"A large, shared vehicle"')).toEqual([
+			{ text: ['bus'], tooltip: 'A large, shared vehicle' }
+		]);
+	});
+
+	it('drops rows missing a term or a definition', () => {
+		const csv = 'bus,A vehicle\n,orphan definition\nlonely term,';
+		expect(parseGlossaryCsv(csv)).toEqual([{ text: ['bus'], tooltip: 'A vehicle' }]);
+	});
+
+	it('returns [] for empty input', () => {
+		expect(parseGlossaryCsv('')).toEqual([]);
+		expect(parseGlossaryCsv('\n\n')).toEqual([]);
+	});
+});

--- a/ui/packages/comhairle/src/lib/glossary/glossaryCsv.ts
+++ b/ui/packages/comhairle/src/lib/glossary/glossaryCsv.ts
@@ -12,8 +12,7 @@ export function parseCsvRows(text: string): string[][] {
 	let field = '';
 	let inQuotes = false;
 
-	// Skip a UTF-8 BOM if a spreadsheet exported one.
-	for (let i = text.charCodeAt(0) === 0xfeff ? 1 : 0; i < text.length; i++) {
+	for (let i = 0; i < text.length; i++) {
 		const char = text[i];
 
 		if (inQuotes) {

--- a/ui/packages/comhairle/src/lib/glossary/glossaryCsv.ts
+++ b/ui/packages/comhairle/src/lib/glossary/glossaryCsv.ts
@@ -13,9 +13,7 @@ export function parseCsvRows(text: string): string[][] {
 	let inQuotes = false;
 
 	// Skip a UTF-8 BOM if a spreadsheet exported one.
-	let i = text.charCodeAt(0) === 0xfeff ? 1 : 0;
-
-	for (; i < text.length; i++) {
+	for (let i = text.charCodeAt(0) === 0xfeff ? 1 : 0; i < text.length; i++) {
 		const char = text[i];
 
 		if (inQuotes) {

--- a/ui/packages/comhairle/src/lib/glossary/glossaryCsv.ts
+++ b/ui/packages/comhairle/src/lib/glossary/glossaryCsv.ts
@@ -1,0 +1,88 @@
+import type { Glossary } from './types';
+import { parseGlossary } from './parseGlossary';
+
+/**
+ * Parses CSV text into rows of string cells (RFC 4180: quoted fields may contain commas,
+ * newlines, and "" escaped quotes). Hand-rolled because there's no CSV dep in the repo and
+ * the glossary's two-column shape doesn't warrant adding one.
+ */
+export function parseCsvRows(text: string): string[][] {
+	const rows: string[][] = [];
+	let row: string[] = [];
+	let field = '';
+	let inQuotes = false;
+
+	// Skip a UTF-8 BOM if a spreadsheet exported one.
+	let i = text.charCodeAt(0) === 0xfeff ? 1 : 0;
+
+	for (; i < text.length; i++) {
+		const char = text[i];
+
+		if (inQuotes) {
+			if (char === '"') {
+				if (text[i + 1] === '"') {
+					field += '"';
+					i++;
+				} else {
+					inQuotes = false;
+				}
+			} else {
+				field += char;
+			}
+			continue;
+		}
+
+		if (char === '"') {
+			inQuotes = true;
+		} else if (char === ',') {
+			row.push(field);
+			field = '';
+		} else if (char === '\n') {
+			row.push(field);
+			rows.push(row);
+			row = [];
+			field = '';
+		} else if (char !== '\r') {
+			// A lone or CRLF '\r' is dropped; '\n' handles the row break.
+			field += char;
+		}
+	}
+
+	row.push(field);
+	rows.push(row);
+
+	// Drop blank lines (a trailing newline leaves an empty final row).
+	return rows.filter((cells) => !(cells.length === 1 && cells[0].trim() === ''));
+}
+
+const HEADER_TERM_NAMES = ['term', 'terms', 'word', 'words', 'phrase'];
+const HEADER_DEFINITION_NAMES = ['tooltip', 'definition', 'explanation', 'meaning', 'description'];
+
+function looksLikeHeader(cells: string[]): boolean {
+	const first = cells[0]?.trim().toLowerCase() ?? '';
+	const second = cells[1]?.trim().toLowerCase() ?? '';
+	return HEADER_TERM_NAMES.includes(first) || HEADER_DEFINITION_NAMES.includes(second);
+}
+
+/**
+ * Parses a CSV glossary. Two columns: the first holds the term plus any synonyms separated
+ * by `;` or `|` (comma is the CSV field separator, so it can't double as the synonym one);
+ * the second holds the explanation. A header row is skipped when the first row's cells look
+ * like column names. Malformed rows are dropped via parseGlossary.
+ */
+export function parseGlossaryCsv(text: string): Glossary {
+	const rows = parseCsvRows(text);
+	if (rows.length === 0) return [];
+
+	const body = looksLikeHeader(rows[0]) ? rows.slice(1) : rows;
+
+	const raw = body.map((cells) => ({
+		text: (cells[0] ?? '')
+			.split(/[;|]/)
+			.map((term) => term.trim())
+			.filter(Boolean),
+		tooltip: (cells[1] ?? '').trim()
+	}));
+
+	return parseGlossary(raw);
+}

--- a/ui/packages/comhairle/src/lib/glossary/translateGlossary.test.ts
+++ b/ui/packages/comhairle/src/lib/glossary/translateGlossary.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest';
+import { translateGlossaryToLocale } from './translateGlossary';
+
+// A fake translator that upper-cases and tags the target locale, so assertions are simple.
+const fakeTranslate = (text: string, target: string) => Promise.resolve(`${text} [${target}]`);
+
+describe('translateGlossaryToLocale', () => {
+	it('fills missing target terms and tooltip from the primary locale', async () => {
+		const glossary = [{ text: { en: ['bus', 'coach'] }, tooltip: { en: 'A vehicle' } }];
+		const result = await translateGlossaryToLocale(glossary, 'es', 'en', fakeTranslate);
+		expect(result).toEqual([
+			{
+				text: { en: ['bus', 'coach'], es: ['bus', 'coach [es]'] },
+				tooltip: { en: 'A vehicle', es: 'A vehicle [es]' }
+			}
+		]);
+	});
+
+	it('never overwrites existing target-locale text', async () => {
+		const glossary = [
+			{
+				text: { en: ['bus'], es: ['autobús'] },
+				tooltip: { en: 'A vehicle', es: 'Un vehículo' }
+			}
+		];
+		const translate = vi.fn(fakeTranslate);
+		const result = await translateGlossaryToLocale(glossary, 'es', 'en', translate);
+		expect(result).toEqual(glossary);
+		expect(translate).not.toHaveBeenCalled();
+	});
+
+	it('returns the glossary unchanged when target is the primary locale', async () => {
+		const glossary = [{ text: { en: ['bus'] }, tooltip: { en: 'A vehicle' } }];
+		const translate = vi.fn(fakeTranslate);
+		expect(await translateGlossaryToLocale(glossary, 'en', 'en', translate)).toBe(glossary);
+		expect(translate).not.toHaveBeenCalled();
+	});
+
+	it('leaves an entry unchanged when its translation throws', async () => {
+		const glossary = [{ text: { en: ['bus'] }, tooltip: { en: 'A vehicle' } }];
+		const failing = () => Promise.reject(new Error('service down'));
+		const result = await translateGlossaryToLocale(glossary, 'es', 'en', failing);
+		expect(result).toEqual([{ text: { en: ['bus'] }, tooltip: { en: 'A vehicle' } }]);
+	});
+});

--- a/ui/packages/comhairle/src/lib/glossary/translateGlossary.ts
+++ b/ui/packages/comhairle/src/lib/glossary/translateGlossary.ts
@@ -1,0 +1,60 @@
+import type { LocalizedGlossary } from './types';
+import { aiTranslateContent } from '$lib/components/Translation/translationUtils';
+
+/**
+ * Fills a target locale's missing terms and explanations by translating each entry's
+ * primary-locale text, used when a new language is added to a conversation. Returns a new
+ * glossary and never overwrites text already present in the target locale. Best-effort: an
+ * entry whose translation fails is left unchanged.
+ *
+ * `translate` is injected so this stays unit-testable; it defaults to the real AI translation.
+ */
+export async function translateGlossaryToLocale(
+	glossary: LocalizedGlossary,
+	targetLocale: string,
+	primaryLocale: string,
+	translate: (
+		text: string,
+		target: string,
+		primary: string
+	) => Promise<string> = aiTranslateContent
+): Promise<LocalizedGlossary> {
+	if (targetLocale === primaryLocale) return glossary;
+
+	const result: LocalizedGlossary = [];
+	for (const entry of glossary) {
+		const text = { ...entry.text };
+		const tooltip = { ...entry.tooltip };
+
+		const sourceTerms = entry.text[primaryLocale];
+		if (sourceTerms?.length && !entry.text[targetLocale]?.length) {
+			try {
+				const translated = await translate(
+					sourceTerms.join(', '),
+					targetLocale,
+					primaryLocale
+				);
+				const terms = translated
+					.split(',')
+					.map((term) => term.trim())
+					.filter(Boolean);
+				if (terms.length) text[targetLocale] = terms;
+			} catch {
+				// leave this entry's terms untranslated
+			}
+		}
+
+		const sourceTip = entry.tooltip[primaryLocale];
+		if (sourceTip?.trim() && !entry.tooltip[targetLocale]?.trim()) {
+			try {
+				const translated = await translate(sourceTip, targetLocale, primaryLocale);
+				if (translated.trim()) tooltip[targetLocale] = translated.trim();
+			} catch {
+				// leave this entry's explanation untranslated
+			}
+		}
+
+		result.push({ text, tooltip });
+	}
+	return result;
+}

--- a/ui/packages/comhairle/src/lib/glossary/translateGlossary.ts
+++ b/ui/packages/comhairle/src/lib/glossary/translateGlossary.ts
@@ -1,5 +1,6 @@
 import type { LocalizedGlossary } from './types';
 import { aiTranslateContent } from '$lib/components/Translation/translationUtils';
+import { tryCatchAsync } from '$lib/utils/errorHandling';
 
 /**
  * Fills a target locale's missing terms and explanations by translating each entry's
@@ -28,30 +29,26 @@ export async function translateGlossaryToLocale(
 
 		const sourceTerms = entry.text[primaryLocale];
 		if (sourceTerms?.length && !entry.text[targetLocale]?.length) {
-			try {
-				const translated = await translate(
-					sourceTerms.join(', '),
-					targetLocale,
-					primaryLocale
-				);
-				const terms = translated
+			// Best-effort: leave this entry's terms untranslated if the call fails.
+			const result = await tryCatchAsync(() =>
+				translate(sourceTerms.join(', '), targetLocale, primaryLocale)
+			);
+			if (result.err === null) {
+				const terms = result.ok
 					.split(',')
 					.map((term) => term.trim())
 					.filter(Boolean);
 				if (terms.length) text[targetLocale] = terms;
-			} catch {
-				// leave this entry's terms untranslated
 			}
 		}
 
 		const sourceTip = entry.tooltip[primaryLocale];
 		if (sourceTip?.trim() && !entry.tooltip[targetLocale]?.trim()) {
-			try {
-				const translated = await translate(sourceTip, targetLocale, primaryLocale);
-				if (translated.trim()) tooltip[targetLocale] = translated.trim();
-			} catch {
-				// leave this entry's explanation untranslated
-			}
+			// Best-effort: leave this entry's explanation untranslated if the call fails.
+			const result = await tryCatchAsync(() =>
+				translate(sourceTip, targetLocale, primaryLocale)
+			);
+			if (result.err === null && result.ok.trim()) tooltip[targetLocale] = result.ok.trim();
 		}
 
 		result.push({ text, tooltip });


### PR DESCRIPTION
### Stack (merge bottom to top)

1. #820 — rich-text rendering engine
2. #821 — read from metadata + show in Learn steps
3. **#822 — CSV import + AI translation helpers ← you are here**
4. #823 — admin Glossary tab

---

**Stack 3 of 4** for the Learn-step glossary tooltips (#815). Targets stack 2 (`815-glossary-2-learn-integration`).

### What this adds
Two pure, unit-tested helpers that the admin editor (stack 4) builds on. No UI or wiring here.

- `lib/glossary/glossaryCsv.ts` — a small RFC 4180 CSV parser plus two-column glossary import (term + synonyms in the first column, explanation in the second)
- `lib/glossary/translateGlossary.ts` — fills a target locale's missing terms and explanations by translating the primary-locale text; best-effort and non-destructive (never overwrites existing translations)

### Tests
CSV + translation unit tests pass (branch runs 73 total).

These have no consumer until stack 4 — I split them out to keep that PR focused on the Svelte UI. Fine to fold them together if you'd rather review three PRs than four; let me know.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
