### PR TITLE
783 Learning Assistant: open sources in the PDF viewer, with the passage highlighted

### DIFF
--- a/adaptors/ragflow/src/document.rs
+++ b/adaptors/ragflow/src/document.rs
@@ -109,6 +109,44 @@ pub async fn stop_parse(
     client.delete(&path, Some(&body), None).await
 }
 
+/// List a document's chunks. RAGFlow keeps each chunk's `positions` here (the
+/// coordinates of the passage in the source PDF) even though the stored session
+/// history strips them, so this is how we re-attach highlight coordinates on
+/// reload. See issue #783.
+pub async fn list_chunks(
+    client: &RagflowClient,
+    dataset_id: &str,
+    document_id: &str,
+    query: Option<GetQueryParams>,
+) -> Result<(StatusCode, ChunkList)> {
+    let path = format!("/datasets/{dataset_id}/documents/{document_id}/chunks");
+    let (status, value) = client.get(&path, query.as_ref(), None).await?;
+
+    let json: GetChunksResponse = serde_json::from_value(value)?;
+
+    Ok((status, json.data))
+}
+
+#[derive(Deserialize)]
+pub struct GetChunksResponse {
+    pub data: ChunkList,
+}
+
+#[derive(Serialize, Deserialize, Default)]
+pub struct ChunkList {
+    #[serde(default)]
+    pub chunks: Vec<DocumentChunk>,
+}
+
+/// A document chunk from the chunk-listing endpoint. Only the fields we need to
+/// map a citation back to its passage; RAGFlow returns more.
+#[derive(Serialize, Deserialize, Default, Clone)]
+pub struct DocumentChunk {
+    pub id: String,
+    #[serde(default)]
+    pub positions: Option<Vec<Vec<f64>>>,
+}
+
 #[derive(Serialize, Deserialize)]
 pub struct GetDocumentsResponse {
     pub code: i32,
@@ -253,6 +291,53 @@ mod tests {
             "test_doc".to_string(),
             "incorrect json response"
         );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn should_list_document_chunks_with_positions() -> Result<(), Box<dyn Error>> {
+        let mock_server = MockServer::start().await;
+        let client = RagflowClient::new(mock_server.uri(), "test_key".to_string());
+
+        Mock::given(method("GET"))
+            .and(path(format!(
+                "{}/datasets/ds1/documents/doc1/chunks",
+                client.path_prefix
+            )))
+            .and(query_param("page", "1"))
+            .and(query_param("page_size", "512"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "code": 0,
+                "data": {
+                    "chunks": [
+                        { "id": "chunk-a", "content": "…", "positions": [[8, 71, 394, 469, 484]] },
+                        { "id": "chunk-b", "content": "…" }
+                    ],
+                    "total": 2
+                }
+            })))
+            .expect(1)
+            .mount(&mock_server)
+            .await;
+
+        let query = GetQueryParams {
+            page: Some(1),
+            page_size: Some(512),
+            ..Default::default()
+        };
+        let (status, list) = list_chunks(&client, "ds1", "doc1", Some(query)).await?;
+
+        assert!(status.is_success());
+        assert_eq!(list.chunks.len(), 2);
+        assert_eq!(list.chunks[0].id, "chunk-a");
+        assert_eq!(
+            list.chunks[0].positions,
+            Some(vec![vec![8.0, 71.0, 394.0, 469.0, 484.0]]),
+            "positions parse into the highlight coordinate shape"
+        );
+        // A chunk with no positions field is fine (defaults to None).
+        assert_eq!(list.chunks[1].positions, None);
 
         Ok(())
     }

--- a/api/src/bot_service.rs
+++ b/api/src/bot_service.rs
@@ -338,6 +338,11 @@ pub struct ComhairleMessageReference {
     pub dataset_id: String,
     pub document_id: String,
     pub document_name: String,
+    /// Passage bounding boxes in the source PDF (`[page, x0, x1, top, bottom]`).
+    /// Present on live answers; re-attached from the chunk store on reload
+    /// (see issue #783). Absent for non-PDF sources.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub positions: Option<Vec<Vec<f64>>>,
 }
 
 #[derive(Serialize, Deserialize, JsonSchema, Debug, Default, Clone)]

--- a/api/src/bot_service/ragflow_bot.rs
+++ b/api/src/bot_service/ragflow_bot.rs
@@ -1,4 +1,8 @@
-use std::{collections::HashMap, pin::Pin, sync::Arc};
+use std::{
+    collections::{HashMap, HashSet},
+    pin::Pin,
+    sync::Arc,
+};
 
 use async_trait::async_trait;
 use axum::body::Bytes;
@@ -41,6 +45,83 @@ impl ComhairleRagBotService {
                 base_url.to_string(),
                 api_key.to_string(),
             )),
+        }
+    }
+
+    /// Re-attach passage highlight `positions` to a reloaded session's
+    /// references.
+    ///
+    /// RAGFlow's stored session history omits `positions`, but its chunk store
+    /// keeps them: they describe where a chunk sits in the document, not the
+    /// query, so the same chunk id always maps to the same boxes. We fetch each
+    /// cited document's chunks once and fill in positions by chunk id, which
+    /// fixes reloaded answers (old and new) the same way live answers already
+    /// work. Best-effort: any RAGFlow failure just leaves those references
+    /// without positions (no highlight), never a failed history load. See issue
+    /// #783.
+    async fn enrich_reference_positions(&self, session: &mut ComhairleChatSession) {
+        // Chunk-list pagination bounds. A page size this large usually means one
+        // request per document; the page cap is a runaway guard.
+        const CHUNK_PAGE_SIZE: i32 = 512;
+        const MAX_CHUNK_PAGES: i32 = 20;
+
+        let mut documents: HashSet<(String, String)> = HashSet::new();
+        for message in &session.messages {
+            let Some(refs) = &message.reference else {
+                continue;
+            };
+            for reference in refs {
+                if reference.positions.is_none() {
+                    documents.insert((reference.dataset_id.clone(), reference.document_id.clone()));
+                }
+            }
+        }
+        if documents.is_empty() {
+            return;
+        }
+
+        let mut positions_by_chunk: HashMap<String, Vec<Vec<f64>>> = HashMap::new();
+        for (dataset_id, document_id) in documents {
+            for page in 1..=MAX_CHUNK_PAGES {
+                let query = GetQueryParams {
+                    page: Some(page),
+                    page_size: Some(CHUNK_PAGE_SIZE),
+                    ..Default::default()
+                };
+                let chunks = match ragflow::document::list_chunks(
+                    &self.client,
+                    &dataset_id,
+                    &document_id,
+                    Some(query),
+                )
+                .await
+                {
+                    Ok((_, chunk_list)) => chunk_list.chunks,
+                    Err(_) => break,
+                };
+                let page_len = chunks.len();
+                for chunk in chunks {
+                    if let Some(positions) = chunk.positions {
+                        positions_by_chunk.insert(chunk.id, positions);
+                    }
+                }
+                if page_len < CHUNK_PAGE_SIZE as usize {
+                    break;
+                }
+            }
+        }
+
+        for message in &mut session.messages {
+            let Some(refs) = &mut message.reference else {
+                continue;
+            };
+            for reference in refs {
+                if reference.positions.is_none() {
+                    if let Some(positions) = positions_by_chunk.get(&reference.id) {
+                        reference.positions = Some(positions.clone());
+                    }
+                }
+            }
         }
     }
 }
@@ -363,7 +444,8 @@ impl ComhairleBotService for ComhairleRagBotService {
         let (status, chat_sessions) =
             ragflow::chat::session::list(&self.client, chat_id, Some(params)).await?;
 
-        let chat_session: ComhairleChatSession = (&chat_sessions[0]).into();
+        let mut chat_session: ComhairleChatSession = (&chat_sessions[0]).into();
+        self.enrich_reference_positions(&mut chat_session).await;
 
         Ok((status, chat_session))
     }
@@ -1005,6 +1087,8 @@ impl From<MessageReference> for ComhairleMessageReference {
             dataset_id: r.dataset_id,
             document_id: r.document_id,
             document_name: r.document_name,
+            // History omits positions; enriched from the chunk store on reload.
+            positions: None,
         }
     }
 }
@@ -1017,6 +1101,7 @@ impl From<&MessageReference> for ComhairleMessageReference {
             dataset_id: r.dataset_id.clone(),
             document_id: r.document_id.clone(),
             document_name: r.document_name.clone(),
+            positions: None,
         }
     }
 }

--- a/ui/packages/api-client/src/api.ts
+++ b/ui/packages/api-client/src/api.ts
@@ -588,6 +588,7 @@ export const ComhairleMessageReference = z
     document_id: z.string(),
     document_name: z.string(),
     id: z.string(),
+    positions: z.union([z.array(z.array(z.number())), z.null()]).optional(),
   })
   .passthrough();
 export type ComhairleMessageReference = z.infer<

--- a/ui/packages/comhairle/src/lib/api/chatSession.svelte.ts
+++ b/ui/packages/comhairle/src/lib/api/chatSession.svelte.ts
@@ -65,7 +65,11 @@ export class ChatSession {
 										content: ref.content,
 										document_id: ref.document_id,
 										document_name: ref.document_name,
-										dataset_id: ref.dataset_id
+										dataset_id: ref.dataset_id,
+										// The backend re-attaches passage positions on reload so old
+										// answers can highlight too (issue #783). The generated
+										// api-client type hasn't been regenerated for this field yet.
+										positions: (ref as { positions?: number[][] }).positions
 									}))
 								}
 							: null,

--- a/ui/packages/comhairle/src/lib/api/chatSession.svelte.ts
+++ b/ui/packages/comhairle/src/lib/api/chatSession.svelte.ts
@@ -66,10 +66,10 @@ export class ChatSession {
 										document_id: ref.document_id,
 										document_name: ref.document_name,
 										dataset_id: ref.dataset_id,
-										// The backend re-attaches passage positions on reload so old
-										// answers can highlight too (issue #783). The generated
-										// api-client type hasn't been regenerated for this field yet.
-										positions: (ref as { positions?: number[][] }).positions
+										// Re-attached from the chunk store on reload so old answers
+										// highlight too (issue #783). Normalise the API's null to
+										// undefined to match ReferenceChunk.
+										positions: ref.positions ?? undefined
 									}))
 								}
 							: null,

--- a/ui/packages/comhairle/src/lib/components/Chatbot/MessageWithReferences.svelte
+++ b/ui/packages/comhairle/src/lib/components/Chatbot/MessageWithReferences.svelte
@@ -7,9 +7,15 @@
 	interface Props {
 		content: string;
 		reference?: ChatReference | null;
+		/**
+		 * Called when an inline citation is clicked, with the exact chunk it points
+		 * at. The learning assistant uses this to open that passage in the document
+		 * viewer. When omitted, citations are hover-only.
+		 */
+		onOpenSource?: (chunk: ReferenceChunk) => void;
 	}
 
-	let { content, reference = null }: Props = $props();
+	let { content, reference = null, onOpenSource }: Props = $props();
 
 	// Parse content and extract reference markers [ID:X]
 	function parseContentWithReferences(
@@ -48,26 +54,32 @@
 </script>
 
 <span class="message-with-refs">
-	{#each parsedContent as part}
+	{#each parsedContent as part, i (i)}
 		{#if part.type === 'text'}
 			{part.value}
 		{:else}
 			{@const chunk = getChunkById(part.value)}
 			{#if chunk}
 				<HoverCard.Root openDelay={200} closeDelay={100}>
-					<HoverCard.Trigger class="inline-flex items-center">
-						<span
-							class="text-chat-primary bg-chat-primary-lighter hover:bg-chat-primary-light mx-0.5 inline-flex h-4 w-4 cursor-pointer items-center justify-center rounded-full text-[10px] font-medium transition-colors"
-						>
-							<Info class="h-3 w-3" />
-						</span>
+					<HoverCard.Trigger>
+						{#snippet child({ props })}
+							<button
+								{...props}
+								type="button"
+								title="Open source"
+								onclick={() => onOpenSource?.(chunk)}
+								class="text-chat-primary bg-chat-primary-lighter hover:bg-chat-primary-light mx-0.5 inline-flex h-4 w-4 cursor-pointer items-center justify-center rounded-full align-baseline text-[10px] font-medium transition-colors"
+							>
+								<Info class="h-3 w-3" />
+							</button>
+						{/snippet}
 					</HoverCard.Trigger>
 					<HoverCard.Content
 						class="bg-chat-bubble border-chat-border max-h-96 w-96 overflow-y-auto rounded-lg border p-0 shadow-lg"
 						side="top"
 						sideOffset={8}
 					>
-						<ReferencePopoverContent {chunk} />
+						<ReferencePopoverContent {chunk} {onOpenSource} />
 					</HoverCard.Content>
 				</HoverCard.Root>
 			{:else}

--- a/ui/packages/comhairle/src/lib/components/Chatbot/ReferencePopoverContent.svelte
+++ b/ui/packages/comhairle/src/lib/components/Chatbot/ReferencePopoverContent.svelte
@@ -1,12 +1,17 @@
 <script lang="ts">
-	import { ChevronDown, ChevronUp } from 'lucide-svelte';
+	import { ChevronDown, ChevronUp, FileText } from 'lucide-svelte';
 	import type { ReferenceChunk } from '$lib/api/chatClient.svelte';
 
 	interface Props {
 		chunk: ReferenceChunk;
+		/**
+		 * When provided, the footer action opens this chunk in the document viewer
+		 * instead of expanding the (raw, often messy) extracted text inline.
+		 */
+		onOpenSource?: (chunk: ReferenceChunk) => void;
 	}
 
-	let { chunk }: Props = $props();
+	let { chunk, onOpenSource }: Props = $props();
 	let isExpanded = $state(false);
 
 	function stripHtml(text: string): string {
@@ -18,8 +23,12 @@
 
 	const strippedContent = $derived(stripHtml(chunk.content));
 	const isTruncatable = $derived(strippedContent.length > 300);
+	// With a viewer available we always keep the preview short; "Open in document"
+	// is the way to read the full passage, so the inline expand is only a fallback.
 	const displayContent = $derived(
-		isExpanded || !isTruncatable ? strippedContent : strippedContent.slice(0, 300) + '...'
+		(isExpanded && !onOpenSource) || !isTruncatable
+			? strippedContent
+			: strippedContent.slice(0, 300) + '...'
 	);
 </script>
 
@@ -55,9 +64,19 @@
 		{displayContent}
 	</div>
 
-	<!-- See more/less button -->
-	{#if isTruncatable}
+	<!-- Footer action: open the real document, or (fallback) expand the text inline. -->
+	{#if onOpenSource}
 		<button
+			type="button"
+			onclick={() => onOpenSource?.(chunk)}
+			class="text-chat-primary hover:text-chat-primary-dark mt-2 inline-flex items-center gap-1 text-xs font-medium transition-colors"
+		>
+			<FileText class="h-3 w-3" />
+			Open in document
+		</button>
+	{:else if isTruncatable}
+		<button
+			type="button"
 			onclick={() => (isExpanded = !isExpanded)}
 			class="text-chat-primary hover:text-chat-primary-dark mt-2 inline-flex items-center gap-1 text-xs font-medium transition-colors"
 		>

--- a/ui/packages/comhairle/src/lib/components/LearningAssistant/LearningAssistant.svelte
+++ b/ui/packages/comhairle/src/lib/components/LearningAssistant/LearningAssistant.svelte
@@ -4,7 +4,8 @@
 	import { getChatSession, type ChatMessage } from '$lib/api/chatSession.svelte';
 	import type { ChatReference, ReferenceChunk } from '$lib/api/chatClient.svelte';
 	import MessageWithReferences from '$lib/components/Chatbot/MessageWithReferences.svelte';
-	import * as Dialog from '$lib/components/ui/dialog';
+	import PdfDocumentDialog from '$lib/components/PdfViewer/PdfDocumentDialog.svelte';
+	import { highlightsFromPositions } from '$lib/components/PdfViewer/highlights';
 	import LearningAssistantSkeleton from './LearningAssistantSkeleton.svelte';
 
 	type QA = {
@@ -37,6 +38,7 @@
 	let focused = $state(false);
 	let inputRef = $state<HTMLInputElement | null>(null);
 	let activeChunk = $state<ReferenceChunk | null>(null);
+	let viewerOpen = $state(false);
 	let initStartedFor = $state<string | null>(null);
 	/** Manual overrides for collapsed state, keyed by QA id. Unset → use default. */
 	let expandedOverrides = $state<Record<string, boolean>>({});
@@ -147,6 +149,43 @@
 		focused = true;
 		tick().then(() => inputRef?.focus());
 	}
+
+	const IMAGE_EXTENSIONS = ['.jpg', '.jpeg', '.png', '.gif', '.webp', '.bmp', '.svg', '.avif'];
+
+	function previewKind(fileName: string): 'pdf' | 'image' | 'docx' {
+		const lower = fileName.toLowerCase();
+		if (lower.endsWith('.doc') || lower.endsWith('.docx')) return 'docx';
+		if (IMAGE_EXTENSIONS.some((ext) => lower.endsWith(ext))) return 'image';
+		return 'pdf';
+	}
+
+	function openSource(chunk: ReferenceChunk) {
+		activeChunk = chunk;
+		viewerOpen = true;
+	}
+
+	/**
+	 * Turn the selected source chunk into props for the document viewer: the
+	 * download URL doubles as the viewer src, and RAGFlow `positions` (present on
+	 * freshly-asked answers) become passage highlights on the right page. Reloaded
+	 * answers carry no positions, so those just open the document with no
+	 * highlight.
+	 */
+	let activeSource = $derived.by(() => {
+		const chunk = activeChunk;
+		if (!chunk) return null;
+		const kind = previewKind(chunk.document_name);
+		const href = `/api/conversation/${conversationId}/documents/${chunk.document_id}/download`;
+		const highlights = kind === 'pdf' ? highlightsFromPositions(chunk.positions) : [];
+		return {
+			kind,
+			src: href,
+			downloadHref: href,
+			name: chunk.document_name,
+			highlights,
+			page: highlights[0]?.page ?? null
+		};
+	});
 
 	function uniqueDocsFromReference(ref: ChatReference | null): ReferenceChunk[] {
 		if (!ref?.chunks?.length) return [];
@@ -332,6 +371,7 @@
 												<MessageWithReferences
 													content={qa.answer}
 													reference={qa.reference}
+													onOpenSource={openSource}
 												/>
 												{#if qa.streaming}
 													<span
@@ -372,8 +412,7 @@
 															<button
 																type="button"
 																class="border-border bg-muted/40 hover:bg-primary hover:text-primary-foreground hover:border-primary text-foreground inline-flex max-w-full items-center gap-1.5 rounded-md border px-2 py-1 text-xs font-medium transition-colors"
-																onclick={() =>
-																	(activeChunk = chunk)}
+																onclick={() => openSource(chunk)}
 															>
 																<FileText
 																	class="h-3 w-3 shrink-0"
@@ -404,28 +443,14 @@
 	</div>
 {/if}
 
-<!-- Source chunk modal -->
-<Dialog.Root open={!!activeChunk} onOpenChange={(o) => !o && (activeChunk = null)}>
-	<Dialog.Content class="max-w-xl">
-		{#if activeChunk}
-			<Dialog.Header>
-				<Dialog.Title class="flex items-start gap-2">
-					<FileText class="text-primary mt-1 h-4 w-4 shrink-0" />
-					<span>{activeChunk.document_name}</span>
-				</Dialog.Title>
-			</Dialog.Header>
-			<div
-				class="text-foreground/90 max-h-[55vh] overflow-y-auto text-sm leading-relaxed whitespace-pre-wrap"
-			>
-				{activeChunk.content
-					.replace(/<[^>]*>/g, ' ')
-					.replace(/\s+/g, ' ')
-					.trim()}
-			</div>
-			<p class="text-muted-foreground border-border border-t pt-3 text-xs">
-				This excerpt was retrieved from the document above and may not reflect its full
-				content.
-			</p>
-		{/if}
-	</Dialog.Content>
-</Dialog.Root>
+<!-- Source document: opens the real PDF (or Word/image) in the shared viewer,
+     with the retrieved passage highlighted when position data is available. -->
+<PdfDocumentDialog
+	bind:open={viewerOpen}
+	kind={activeSource?.kind ?? 'pdf'}
+	src={activeSource?.src ?? null}
+	name={activeSource?.name ?? 'Document'}
+	downloadHref={activeSource?.downloadHref ?? null}
+	highlights={activeSource?.highlights ?? []}
+	page={activeSource?.page ?? null}
+/>

--- a/ui/packages/comhairle/src/lib/components/PdfViewer/PdfDocumentDialog.svelte
+++ b/ui/packages/comhairle/src/lib/components/PdfViewer/PdfDocumentDialog.svelte
@@ -4,6 +4,9 @@
 	import DownloadIcon from '@lucide/svelte/icons/download';
 	import * as Dialog from '$lib/components/ui/dialog';
 	import { Button } from '$lib/components/ui/button';
+	import type { PdfHighlight } from './highlights';
+
+	type PdfViewerProps = { src: string; highlights?: PdfHighlight[]; initialPage?: number | null };
 
 	type Props = {
 		open: boolean;
@@ -11,6 +14,10 @@
 		name?: string;
 		downloadHref?: string | null;
 		kind?: 'pdf' | 'image' | 'docx';
+		/** Passage rectangles to shade (PDF only). */
+		highlights?: PdfHighlight[];
+		/** Page to open on (1-based, PDF only). */
+		page?: number | null;
 	};
 
 	let {
@@ -18,19 +25,21 @@
 		src,
 		name = 'Document',
 		downloadHref = null,
-		kind = 'pdf'
+		kind = 'pdf',
+		highlights = [],
+		page = null
 	}: Props = $props();
 
 	// pdfjs-dist (~1MB) and mammoth (~500KB) are heavy and not SSR-safe, so the
 	// viewers are loaded lazily in the browser the first time a document is opened.
-	let PdfViewer = $state<Component<{ src: string }> | null>(null);
+	let PdfViewer = $state<Component<PdfViewerProps> | null>(null);
 	let DocxViewer = $state<Component<{ src: string }> | null>(null);
 
 	$effect(() => {
 		if (!browser || !open) return;
 		if (kind === 'pdf' && !PdfViewer) {
 			import('./PdfViewer.svelte').then((m) => {
-				PdfViewer = m.default as unknown as Component<{ src: string }>;
+				PdfViewer = m.default as unknown as Component<PdfViewerProps>;
 			});
 		} else if (kind === 'docx' && !DocxViewer) {
 			import('./DocxViewer.svelte').then((m) => {
@@ -73,7 +82,7 @@
 				{:else if kind === 'docx' && DocxViewer}
 					<DocxViewer {src} />
 				{:else if kind === 'pdf' && PdfViewer}
-					<PdfViewer {src} />
+					<PdfViewer {src} {highlights} initialPage={page} />
 				{:else}
 					<div
 						class="text-muted-foreground flex h-full items-center justify-center text-sm"

--- a/ui/packages/comhairle/src/lib/components/PdfViewer/PdfViewer.svelte
+++ b/ui/packages/comhairle/src/lib/components/PdfViewer/PdfViewer.svelte
@@ -8,6 +8,7 @@
 	import ChevronRightIcon from '@lucide/svelte/icons/chevron-right';
 	import MinusIcon from '@lucide/svelte/icons/minus';
 	import PlusIcon from '@lucide/svelte/icons/plus';
+	import type { PdfHighlight } from './highlights';
 
 	pdfjsLib.GlobalWorkerOptions.workerSrc = new URL(
 		'pdfjs-dist/build/pdf.worker.min.mjs',
@@ -18,9 +19,19 @@
 
 	type Props = {
 		src: string;
+		/** Passage rectangles to shade, in PDF points (see {@link PdfHighlight}). */
+		highlights?: PdfHighlight[];
+		/**
+		 * Page to scroll to when the document first renders (1-based). Defaults to
+		 * the first highlighted page when `highlights` is set.
+		 */
+		initialPage?: number | null;
 	};
 
-	let { src }: Props = $props();
+	let { src, highlights = [], initialPage = null }: Props = $props();
+
+	const highlightsForPage = (pageNumber: number) =>
+		highlights.filter((h) => h.page === pageNumber);
 
 	const MIN_ZOOM = 0.25;
 	const MAX_ZOOM = 4;
@@ -40,6 +51,11 @@
 	let resizeTick = $state(0);
 	let loading = $state(true);
 	let error = $state<string | null>(null);
+	// True once a full render pass has completed, so page wrappers have their real
+	// height and an auto-jump lands on the right place. Reset when `src` changes.
+	let renderedOnce = $state(false);
+	// Guards the one-shot auto-jump, keyed by `src` + target page.
+	let jumpedFor = $state<string | null>(null);
 
 	let doc: PDFDocumentProxy | null = null;
 	let renderTasks: RenderTask[] = [];
@@ -140,10 +156,12 @@
 
 			if (textDiv) await renderTextLayer(page, textDiv, viewport, scale, gen);
 		}
+
+		if (gen === renderGen) renderedOnce = true;
 	}
 
-	function goToPage(pageNumber: number) {
-		pageWrappers[pageNumber - 1]?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+	function goToPage(pageNumber: number, behavior: 'smooth' | 'auto' = 'smooth') {
+		pageWrappers[pageNumber - 1]?.scrollIntoView({ behavior, block: 'start' });
 	}
 
 	function zoomIn() {
@@ -163,6 +181,7 @@
 		numPages = 0;
 		currentPage = 1;
 		userZoom = 1;
+		renderedOnce = false;
 
 		let cancelled = false;
 		const task = pdfjsLib.getDocument(url);
@@ -223,6 +242,21 @@
 			clearTimeout(timer);
 			observer.disconnect();
 		};
+	});
+
+	// Auto-scroll to the passage once the document has rendered. Runs once per
+	// src/target (guarded by `jumpedFor`) so it doesn't fight the user's own
+	// scrolling on zoom or resize. Instant jump, not smooth, so a deep target
+	// page doesn't animate through everything above it.
+	$effect(() => {
+		if (!renderedOnce || !scrollContainer) return;
+		const target =
+			initialPage ?? (highlights.length ? Math.min(...highlights.map((h) => h.page)) : null);
+		if (!target) return;
+		const key = `${src}:${target}`;
+		if (jumpedFor === key) return;
+		jumpedFor = key;
+		goToPage(target, 'auto');
 	});
 
 	// Track which page is most visible so the toolbar counter stays accurate.
@@ -321,6 +355,14 @@
 				<div class="pdf-page" data-page={i + 1} bind:this={pageWrappers[i]}>
 					<canvas bind:this={canvases[i]}></canvas>
 					<div class="textLayer" bind:this={textLayers[i]}></div>
+					{#each highlightsForPage(i + 1) as h, hi (hi)}
+						<div
+							class="pdf-highlight"
+							style="left: {h.left * renderedScale}px; top: {h.top *
+								renderedScale}px; width: {h.width *
+								renderedScale}px; height: {h.height * renderedScale}px;"
+						></div>
+					{/each}
 				</div>
 			{/each}
 		{/if}
@@ -385,6 +427,16 @@
 
 	.pdf-page canvas {
 		display: block;
+	}
+
+	/* Passage highlight. mix-blend-multiply keeps the underlying text legible
+	   (the page is always on white), so the amber reads as a marker-pen tint. */
+	.pdf-highlight {
+		position: absolute;
+		background-color: rgba(250, 204, 21, 0.4);
+		mix-blend-mode: multiply;
+		border-radius: 2px;
+		pointer-events: none;
 	}
 
 	.pdf-message {

--- a/ui/packages/comhairle/src/lib/components/PdfViewer/highlights.test.ts
+++ b/ui/packages/comhairle/src/lib/components/PdfViewer/highlights.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { highlightsFromPositions } from './highlights';
+
+describe('highlightsFromPositions', () => {
+	it('returns an empty array for missing or empty input', () => {
+		expect(highlightsFromPositions(undefined)).toEqual([]);
+		expect(highlightsFromPositions(null)).toEqual([]);
+		expect(highlightsFromPositions([])).toEqual([]);
+	});
+
+	it('maps [page, x0, x1, top, bottom] to a rectangle', () => {
+		// One RAGFlow line box from a real chunk payload.
+		expect(highlightsFromPositions([[8, 71, 394, 469, 484]])).toEqual([
+			{ page: 8, left: 71, top: 469, width: 323, height: 15 }
+		]);
+	});
+
+	it('keeps the page number as-is (1-based, matching the viewer)', () => {
+		const [h] = highlightsFromPositions([[1, 49, 430, 136, 223]]);
+		expect(h.page).toBe(1);
+	});
+
+	it('skips malformed rows instead of throwing', () => {
+		expect(
+			highlightsFromPositions([
+				[8, 71, 394],
+				[2, 70, 500, 380, 395]
+			])
+		).toEqual([{ page: 2, left: 70, top: 380, width: 430, height: 15 }]);
+	});
+
+	it('clamps negative width/height to zero', () => {
+		const [h] = highlightsFromPositions([[3, 400, 100, 500, 480]]);
+		expect(h.width).toBe(0);
+		expect(h.height).toBe(0);
+	});
+});

--- a/ui/packages/comhairle/src/lib/components/PdfViewer/highlights.ts
+++ b/ui/packages/comhairle/src/lib/components/PdfViewer/highlights.ts
@@ -1,0 +1,37 @@
+/**
+ * A highlight rectangle over a PDF page, expressed in PDF point coordinates
+ * (1pt units, origin top-left). `page` is 1-based to match the viewer's page
+ * numbering.
+ */
+export type PdfHighlight = {
+	page: number;
+	left: number;
+	top: number;
+	width: number;
+	height: number;
+};
+
+/**
+ * Convert RAGFlow chunk `positions` into highlight rectangles.
+ *
+ * Each entry is `[page, x0, x1, top, bottom]` in PDF points with a top-left
+ * origin, and corresponds to one line of the retrieved passage. Pages are
+ * 1-based, matching {@link PdfHighlight.page} and the viewer. Malformed rows
+ * (fewer than 5 numbers) are skipped rather than throwing.
+ */
+export function highlightsFromPositions(positions: number[][] | undefined | null): PdfHighlight[] {
+	if (!positions?.length) return [];
+	const out: PdfHighlight[] = [];
+	for (const p of positions) {
+		if (p.length < 5) continue;
+		const [page, x0, x1, top, bottom] = p;
+		out.push({
+			page,
+			left: x0,
+			top,
+			width: Math.max(x1 - x0, 0),
+			height: Math.max(bottom - top, 0)
+		});
+	}
+	return out;
+}


### PR DESCRIPTION
Source citations in the learning assistant now open the real document in the PDF viewer, scrolled to the passage and highlighted, instead of a stripped-text modal. Works for fresh and reloaded answers alike.


## What

- **Source badges** under an answer open the real PDF in the existing viewer, on the right page with an amber highlight over the passage.
- **Inline ⓘ citations** are clickable too, each opening its own exact chunk's passage (more precise than the per-document badge).
- The **hover popover** now shows a short preview plus an "Open in document" action, replacing the old "See more" that just expanded raw extraction text.
- Highlighting works on **reload as well as live**, including answers created before this change.

## How the reload part works

Live answers carry passage coordinates (`positions`) over the stream, but RAGFlow's stored session history strips them, which is why reloaded answers couldn't highlight. Positions are a static property of a chunk (where it sits in the document, keyed by its stable id), not of the question, so on history load the backend re-fetches them from RAGFlow's chunk store and re-attaches them by chunk id. That fixes every old answer retroactively, not just new ones. It's best-effort: if the chunk lookup fails, you just get no highlight, never a broken load. Cost is one RAGFlow call per cited document on reload (paginated, capped).

## Main pieces

- **Viewer**: `PdfViewer` gains a highlight overlay + jump-to-page; `PdfDocumentDialog` threads `highlights`/`page` through; new `highlights.ts` converts RAGFlow `positions` to rectangles (with unit tests).
- **Citations**: `LearningAssistant` opens the viewer from badges and inline citations; `MessageWithReferences` / `ReferencePopoverContent` make citations clickable.
- **Reload positions**: adaptor `list_chunks` + backend `enrich_reference_positions` re-attach positions on history load; `positions` added to the reference type; frontend carries it through.

## Notes

- Page numbers are treated as 1-based (matches RAGFlow's payloads). Worth an eyeball, but it's a one-line flip in the converter if ever off.
- Adds `positions` to the reference type, so the regenerated `@crownshy/api-client` (`api.ts`) is included in this PR. `open-api-spec.json` is gitignored, so it's not part of the diff.
- Enrichment is best-effort by design: a RAGFlow chunk-lookup failure degrades to "no highlight," never a failed history load.

Old:
<img width="996" height="711" alt="image" src="https://github.com/user-attachments/assets/43135c00-5459-4d65-9194-4aa209fc8728" />

New (actually use the pdf viewer)

<img width="834" height="421" alt="image" src="https://github.com/user-attachments/assets/952bb42a-6a55-4526-8f85-7bc9a9c52170" />
