### PR TITLE
850 Show permitted conversations in admin dashboard

### DIFF
--- a/ui/packages/comhairle/src/routes/(admin)/admin/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/+page.svelte
@@ -6,7 +6,8 @@
 	import { Home } from 'lucide-svelte';
 
 	let props: PageProps = $props();
-	let conversations = $derived(props.data.conversations?.records ?? []);
+	let ownedConversations = $derived(props.data.ownedConversations?.records ?? []);
+	let permittedConversations = $derived(props.data.permittedConversations?.records ?? []);
 </script>
 
 <svelte:head>
@@ -33,9 +34,25 @@
 		</div>
 		<NewConversationButton class="w-full sm:w-auto" label="Create New Conversation" />
 	</div>
-	<div class="grid w-full grid-cols-1 gap-x-2 gap-y-16 overflow-y-auto">
-		{#each conversations as conversation (conversation.id)}
-			<ConversationCard {conversation} />
-		{/each}
+	<div class="flex w-full flex-col gap-11 overflow-y-auto">
+		<section class="flex flex-col gap-6">
+			<h2 class="text-muted-foreground text-base font-medium">Owned Conversations</h2>
+			<div class="grid w-full grid-cols-1 gap-x-2 gap-y-16">
+				{#each ownedConversations as conversation (conversation.id)}
+					<ConversationCard {conversation} />
+				{/each}
+			</div>
+		</section>
+
+		{#if permittedConversations.length > 0}
+			<section class="flex flex-col gap-6">
+				<h2 class="text-muted-foreground text-base font-medium">Permitted Conversations</h2>
+				<div class="grid w-full grid-cols-1 gap-x-2 gap-y-16">
+					{#each permittedConversations as conversation (conversation.id)}
+						<ConversationCard {conversation} />
+					{/each}
+				</div>
+			</section>
+		{/if}
 	</div>
 </div>

--- a/ui/packages/comhairle/src/routes/(admin)/admin/+page.ts
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/+page.ts
@@ -3,6 +3,7 @@ import type { PageLoad } from './$types';
 export const load: PageLoad = async ({ parent }) => {
 	const parentData = await parent();
 	const ownedConversations = parentData?.ownedConversations ?? { records: [] };
+	const permittedConversations = parentData?.permittedConversations ?? { records: [] };
 
-	return { conversations: ownedConversations };
+	return { ownedConversations, permittedConversations };
 };


### PR DESCRIPTION
Motivations:

- Users need to distinguish between conversations they own versus those they have permission to access.
- The admin dashboard was only showing owned conversations, hiding permitted ones.
- Better organization helps users understand their access levels and find relevant conversations.

Actions:

- Split single conversations list into ownedConversations and permittedConversations.
- Add section headers to visually separate them

Quick fix for now:
<img width="1473" height="875" alt="image" src="https://github.com/user-attachments/assets/190fd742-2590-4bfa-8071-120f523c33db" />
