### PR TITLE
Civic os places migration

### DIFF
--- a/api/migrations/20260807120000_add_region_area_and_metadata.sql
+++ b/api/migrations/20260807120000_add_region_area_and_metadata.sql
@@ -1,0 +1,26 @@
+-- Add region areas.
+CREATE TABLE region_area (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    zip_prefix TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS region_area_zip_prefix_unique_index
+ON region_area(zip_prefix);
+
+-- Add region area and metadata to regions.
+ALTER TABLE region
+ADD COLUMN region_area_id UUID REFERENCES region_area(id),
+ADD COLUMN metadata JSONB;
+
+CREATE INDEX IF NOT EXISTS region_region_area_id_index
+ON region(region_area_id);
+
+-- Add metadata to organizations.
+ALTER TABLE organization
+ADD COLUMN metadata JSONB;
+
+-- Add metadata to events.
+ALTER TABLE event
+ADD COLUMN metadata JSONB;

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -302,6 +302,7 @@ pub async fn setup_server(state: Arc<ComhairleState>) -> Result<Router<()>, Comh
             routes::organizations::router(state.clone()),
         )
         .nest_api_service("/regions", routes::regions::router(state.clone()))
+        .nest_api_service("/region_areas", routes::region_areas::router(state.clone()))
         .nest_api_service("/media", routes::media::router(state.clone()))
         .nest_api_service("/jobs", routes::jobs::router(state.clone()))
         .nest_api_service("/services", routes::services::router(state.clone()))

--- a/api/src/models.rs
+++ b/api/src/models.rs
@@ -28,6 +28,7 @@ pub mod proposal_response;
 pub mod proposal_section;
 pub mod recruitment_target;
 pub mod region;
+pub mod region_area;
 pub mod report;
 pub mod report_impact;
 pub mod resource;

--- a/api/src/models/conversation.rs
+++ b/api/src/models/conversation.rs
@@ -568,7 +568,7 @@ pub async fn patch_metadata(
 
     let conversation = sqlx::query_as::<_, Conversation>(
         "UPDATE conversation
-            SET metadata = metadata || $1::jsonb,
+            SET metadata = COALESCE(metadata, '{}'::jsonb) || $1::jsonb,
                 updated_at = NOW()
             WHERE id = $2
             RETURNING *",

--- a/api/src/models/event.rs
+++ b/api/src/models/event.rs
@@ -177,6 +177,7 @@ pub struct Event {
     pub format: EventFormat,
     #[partially(transparent)]
     pub location: Option<EventLocation>,
+    pub metadata: Option<serde_json::Value>,
     #[partially(omit)]
     pub created_at: DateTime<Utc>,
     #[partially(omit)]
@@ -324,7 +325,7 @@ impl LocalizedEvent {
     }
 }
 
-const DEFAULT_COLUMNS: [EventIden; 16] = [
+const DEFAULT_COLUMNS: [EventIden; 17] = [
     EventIden::Id,
     EventIden::Name,
     EventIden::Description,
@@ -338,6 +339,7 @@ const DEFAULT_COLUMNS: [EventIden; 16] = [
     EventIden::BreakoutPlan,
     EventIden::DefaultTimeZone,
     EventIden::Location,
+    EventIden::Metadata,
     EventIden::Format,
     EventIden::CreatedAt,
     EventIden::UpdatedAt,
@@ -479,6 +481,9 @@ impl PartialEvent {
         if let Some(value) = &self.default_time_zone {
             values.push((EventIden::DefaultTimeZone, value.into()));
         }
+        if let Some(value) = &self.metadata {
+            values.push((EventIden::Metadata, value.clone().into()));
+        }
 
         values
     }
@@ -506,6 +511,56 @@ pub async fn update(
     let event = sqlx::query_as_with::<_, Event, _>(&sql, values)
         .fetch_one(db)
         .await?;
+
+    Ok(event)
+}
+
+/// Get the event's `metadata` jsonb column.
+#[instrument(err(Debug), skip(db))]
+pub async fn get_metadata(
+    db: &PgPool,
+    id: &Uuid,
+) -> Result<Option<serde_json::Value>, ComhairleError> {
+    let query = Query::select()
+        .columns([EventIden::Metadata].map(|col| (EventIden::Table, col)))
+        .from(EventIden::Table)
+        .and_where(Expr::col((EventIden::Table, EventIden::Id)).eq(id.to_owned()))
+        .to_owned();
+
+    let (sql, values) = query.build_sqlx(PostgresQueryBuilder);
+
+    let (metadata,) = sqlx::query_as_with::<_, (Option<serde_json::Value>,), _>(&sql, values)
+        .fetch_one(db)
+        .await?;
+
+    Ok(metadata)
+}
+
+/// Merge the supplied object into the event's `metadata` jsonb column at the
+/// top level. Existing keys are overwritten by the patch.
+pub async fn patch_metadata(
+    db: &PgPool,
+    id: &Uuid,
+    patch: serde_json::Value,
+) -> Result<Event, ComhairleError> {
+    if !patch.is_object() {
+        return Err(ComhairleError::BadRequest(
+            "metadata patch must be a JSON object".into(),
+        ));
+    }
+
+    let event = sqlx::query_as::<_, Event>(
+        "UPDATE event
+            SET metadata = COALESCE(metadata, '{}'::jsonb) || $1::jsonb,
+                updated_at = NOW()
+            WHERE id = $2
+            RETURNING *",
+    )
+    .bind(patch)
+    .bind(id)
+    .fetch_one(db)
+    .await
+    .resolve_db_err("Event")?;
 
     Ok(event)
 }

--- a/api/src/models/organization.rs
+++ b/api/src/models/organization.rs
@@ -6,7 +6,7 @@ use sea_query::{Expr, PostgresQueryBuilder, Query, SelectStatement, enum_def};
 use sea_query_binder::SqlxBinder;
 use serde::{Deserialize, Serialize};
 use sqlx::{PgPool, prelude::FromRow, query_as_with};
-use std::collections::HashSet;
+use std::{collections::HashSet, sync::Arc};
 use tracing::instrument;
 use uuid::Uuid;
 
@@ -14,6 +14,7 @@ use uuid::Uuid;
 use fake::Dummy;
 
 use crate::{
+    ComhairleState,
     error::ComhairleError,
     models::{
         SqlxResultExt,
@@ -38,6 +39,7 @@ pub struct Organization {
     pub contact_email: Option<String>,
     pub external_url: Option<String>,
     pub regions: Vec<Uuid>,
+    pub metadata: Option<serde_json::Value>,
     #[partially(omit)]
     pub created_at: DateTime<Utc>,
     #[partially(omit)]
@@ -77,7 +79,7 @@ impl std::fmt::Display for OrganizationType {
     }
 }
 
-const DEFAULT_COLUMNS: [OrganizationIden; 10] = [
+const DEFAULT_COLUMNS: [OrganizationIden; 11] = [
     OrganizationIden::Id,
     OrganizationIden::Name,
     OrganizationIden::Description,
@@ -86,6 +88,7 @@ const DEFAULT_COLUMNS: [OrganizationIden; 10] = [
     OrganizationIden::ContactEmail,
     OrganizationIden::ExternalUrl,
     OrganizationIden::Regions,
+    OrganizationIden::Metadata,
     OrganizationIden::CreatedAt,
     OrganizationIden::UpdatedAt,
 ];
@@ -234,9 +237,8 @@ pub async fn add_member_emails(
     Ok(())
 }
 
-#[instrument]
 pub async fn bootstrap_organization_admin_accounts(
-    db: &PgPool,
+    state: &Arc<ComhairleState>,
     organization_id: &Uuid,
     admin_emails: &[String],
 ) -> Vec<OrganizationAdminBootstrapResult> {
@@ -253,11 +255,11 @@ pub async fn bootstrap_organization_admin_accounts(
         }
 
         let mut created_account = false;
-        let user = match users::get_user_by_email(&trimmed, db).await {
+        let user = match users::get_user_by_email(&trimmed, &state.db).await {
             Ok(user) => user,
             Err(ComhairleError::NoUserFoundForEmail(_)) => {
                 created_account = true;
-                match users::create_organization_admin_user(&trimmed, db).await {
+                match users::create_organization_admin_user(state, &trimmed).await {
                     Ok(user) => user,
                     Err(error) => {
                         tracing::warn!(
@@ -294,7 +296,7 @@ pub async fn bootstrap_organization_admin_accounts(
             ..Default::default()
         };
 
-        if let Err(error) = users::update_user(&user.id, &update_request, db).await {
+        if let Err(error) = users::update_user(&user.id, &update_request, &state.db).await {
             tracing::warn!(
                 "Failed to associate admin user {} with organization {}: {:?}",
                 user.id,
@@ -345,6 +347,9 @@ impl PartialOrganization {
         if let Some(value) = &self.regions {
             values.push((OrganizationIden::Regions, value.clone().into()));
         }
+        if let Some(value) = &self.metadata {
+            values.push((OrganizationIden::Metadata, value.clone().into()));
+        }
 
         values
     }
@@ -370,6 +375,54 @@ pub async fn update(
         .build_sqlx(PostgresQueryBuilder);
 
     let organization = sqlx::query_as_with(&sql, values).fetch_one(db).await?;
+
+    Ok(organization)
+}
+
+/// Get the organization's `metadata` jsonb column
+#[instrument(err(Debug), skip(db))]
+pub async fn get_metadata(
+    db: &PgPool,
+    id: &Uuid,
+) -> Result<Option<serde_json::Value>, ComhairleError> {
+    let (sql, values) = Query::select()
+        .columns([OrganizationIden::Metadata])
+        .from(OrganizationIden::Table)
+        .and_where(Expr::col((OrganizationIden::Table, OrganizationIden::Id)).eq(id.to_owned()))
+        .build_sqlx(PostgresQueryBuilder);
+
+    let (metadata,) = query_as_with::<_, (Option<serde_json::Value>,), _>(&sql, values)
+        .fetch_one(db)
+        .await?;
+
+    Ok(metadata)
+}
+
+/// Merge the supplied object into the organization's `metadata` jsonb column
+/// at the top level. Existing keys are overwritten by the patch.
+pub async fn patch_metadata(
+    db: &PgPool,
+    id: &Uuid,
+    patch: serde_json::Value,
+) -> Result<Organization, ComhairleError> {
+    if !patch.is_object() {
+        return Err(ComhairleError::BadRequest(
+            "metadata patch must be a JSON object".into(),
+        ));
+    }
+
+    let organization = sqlx::query_as::<_, Organization>(
+        "UPDATE organization
+            SET metadata = COALESCE(metadata, '{}'::jsonb) || $1::jsonb,
+                updated_at = NOW()
+            WHERE id = $2
+            RETURNING *",
+    )
+    .bind(patch)
+    .bind(id)
+    .fetch_one(db)
+    .await
+    .resolve_db_err("Organization")?;
 
     Ok(organization)
 }

--- a/api/src/models/permissions.rs
+++ b/api/src/models/permissions.rs
@@ -351,7 +351,11 @@ impl Role {
                 Action::RevokePermission,
             ],
             Role::Admin => &[],
-            Role::OrganizationAdmin => &[Action::OrganizationUpdate, Action::OrganizationDelete],
+            Role::OrganizationAdmin => &[
+                Action::OrganizationRead,
+                Action::OrganizationUpdate,
+                Action::OrganizationDelete,
+            ],
             Role::ConversationContentEditor => {
                 &[Action::ConversationRead, Action::ConversationUpdate]
             }
@@ -425,6 +429,7 @@ pub enum Action {
     RevokePermission,
     ConversationRead,
     ConversationUpdate,
+    OrganizationRead,
     OrganizationCreate,
     OrganizationUpdate,
     OrganizationDelete,
@@ -439,7 +444,9 @@ impl Action {
             | Action::RevokePermission
             | Action::OrganizationCreate => ResourceType::System,
             Action::ConversationRead | Action::ConversationUpdate => ResourceType::Conversation,
-            Action::OrganizationUpdate | Action::OrganizationDelete => ResourceType::Organization,
+            Action::OrganizationRead | Action::OrganizationUpdate | Action::OrganizationDelete => {
+                ResourceType::Organization
+            }
         }
     }
 

--- a/api/src/models/region.rs
+++ b/api/src/models/region.rs
@@ -32,9 +32,11 @@ pub struct Region {
     pub name: TextContentId,
     #[partially(omit)]
     pub description: TextContentId,
+    pub region_area_id: Option<Uuid>,
     pub region_type: RegionType,
     #[partially(transparent)]
     pub official_id: Option<String>,
+    pub metadata: Option<serde_json::Value>,
     #[partially(omit)]
     pub created_at: DateTime<Utc>,
     #[partially(omit)]
@@ -71,12 +73,14 @@ impl std::fmt::Display for RegionType {
     }
 }
 
-const DEFAULT_COLUMNS: [RegionIden; 7] = [
+const DEFAULT_COLUMNS: [RegionIden; 9] = [
     RegionIden::Id,
     RegionIden::Name,
     RegionIden::Description,
+    RegionIden::RegionAreaId,
     RegionIden::RegionType,
     RegionIden::OfficialId,
+    RegionIden::Metadata,
     RegionIden::CreatedAt,
     RegionIden::UpdatedAt,
 ];
@@ -143,11 +147,17 @@ pub async fn create(
 impl PartialRegion {
     pub fn to_values(&self) -> Vec<(RegionIden, sea_query::SimpleExpr)> {
         let mut values = vec![];
+        if let Some(value) = &self.region_area_id {
+            values.push((RegionIden::RegionAreaId, (*value).into()));
+        }
         if let Some(value) = &self.region_type {
             values.push((RegionIden::RegionType, value.clone().into()));
         }
         if let Some(value) = &self.official_id {
             values.push((RegionIden::OfficialId, value.into()));
+        }
+        if let Some(value) = &self.metadata {
+            values.push((RegionIden::Metadata, value.clone().into()));
         }
 
         values
@@ -174,6 +184,53 @@ pub async fn update(
         .build_sqlx(PostgresQueryBuilder);
 
     let region = query_as_with(&sql, values).fetch_one(db).await?;
+
+    Ok(region)
+}
+
+/// Get the metadata for a region by its ID.
+#[instrument(err(Debug), skip(db))]
+pub async fn get_metadata(
+    db: &PgPool,
+    id: &Uuid,
+) -> Result<Option<serde_json::Value>, ComhairleError> {
+    let (sql, values) = Query::select()
+        .columns([RegionIden::Metadata])
+        .from(RegionIden::Table)
+        .and_where(Expr::col(RegionIden::Id).eq(id.to_owned()))
+        .build_sqlx(PostgresQueryBuilder);
+
+    let (metadata,) = query_as_with(&sql, values).fetch_one(db).await?;
+
+    Ok(metadata)
+}
+
+/// Merge the supplied object into the region's `metadata` jsonb column at
+/// the top level. Existing keys are overwritten by the patch, keys not present
+/// in the patch are left untouched.
+pub async fn patch_metadata(
+    db: &PgPool,
+    id: &Uuid,
+    patch: serde_json::Value,
+) -> Result<Region, ComhairleError> {
+    if !patch.is_object() {
+        return Err(ComhairleError::BadRequest(
+            "metadata patch must be a JSON object".into(),
+        ));
+    }
+
+    let region = sqlx::query_as::<_, Region>(
+        "UPDATE region
+            SET metadata = COALESCE(metadata, '{}'::jsonb) || $1::jsonb,
+                updated_at = NOW()
+            WHERE id = $2
+            RETURNING *",
+    )
+    .bind(patch)
+    .bind(id)
+    .fetch_one(db)
+    .await
+    .resolve_db_err("Region")?;
 
     Ok(region)
 }
@@ -280,6 +337,22 @@ pub async fn get_localized_by_id(
 }
 
 #[instrument(err(Debug))]
+pub async fn get_by_id(db: &PgPool, id: &Uuid) -> Result<Region, ComhairleError> {
+    let (sql, values) = Query::select()
+        .columns(DEFAULT_COLUMNS)
+        .from(RegionIden::Table)
+        .and_where(Expr::col(RegionIden::Id).eq(id.to_owned()))
+        .build_sqlx(PostgresQueryBuilder);
+
+    let region = query_as_with(&sql, values)
+        .fetch_one(db)
+        .await
+        .resolve_db_err("Region")?;
+
+    Ok(region)
+}
+
+#[instrument(err(Debug))]
 pub async fn delete(db: &PgPool, id: &Uuid) -> Result<Region, ComhairleError> {
     let (sql, values) = Query::delete()
         .from_table(RegionIden::Table)
@@ -359,6 +432,7 @@ mod tests {
         let update_region = PartialRegion {
             region_type: Some(RegionType::Custom),
             official_id: Some("G1".to_string()),
+            ..Default::default()
         };
         let updated_region = update(&pool, &region.id, &update_region).await?;
 

--- a/api/src/models/region_area.rs
+++ b/api/src/models/region_area.rs
@@ -1,0 +1,136 @@
+use chrono::{DateTime, Utc};
+use partially::Partial;
+use schemars::JsonSchema;
+use sea_query::{Expr, PostgresQueryBuilder, Query, enum_def};
+use sea_query_binder::SqlxBinder;
+use serde::{Deserialize, Serialize};
+use sqlx::{PgPool, prelude::FromRow};
+use uuid::Uuid;
+
+use crate::{error::ComhairleError, models::SqlxResultExt};
+
+#[derive(Partial, Debug, Deserialize, Serialize, FromRow, Clone, JsonSchema)]
+#[enum_def(table_name = "region_area")]
+#[partially(derive(Deserialize, Debug, JsonSchema, Default))]
+pub struct RegionArea {
+    #[partially(omit)]
+    pub id: Uuid,
+    pub zip_prefix: String,
+    #[partially(omit)]
+    pub created_at: DateTime<Utc>,
+    #[partially(omit)]
+    pub updated_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+pub struct CreateRegionArea {
+    pub zip_prefix: String,
+}
+
+const DEFAULT_COLUMNS: [RegionAreaIden; 4] = [
+    RegionAreaIden::Id,
+    RegionAreaIden::ZipPrefix,
+    RegionAreaIden::CreatedAt,
+    RegionAreaIden::UpdatedAt,
+];
+
+pub async fn create(
+    db: &PgPool,
+    create_request: &CreateRegionArea,
+) -> Result<RegionArea, ComhairleError> {
+    let (sql, values) = Query::insert()
+        .into_table(RegionAreaIden::Table)
+        .columns([RegionAreaIden::ZipPrefix])
+        .values([create_request.zip_prefix.clone().into()])
+        .expect("region_area create values should be valid")
+        .returning(Query::returning().columns(DEFAULT_COLUMNS))
+        .build_sqlx(PostgresQueryBuilder);
+
+    let area = sqlx::query_as_with::<_, RegionArea, _>(&sql, values)
+        .fetch_one(db)
+        .await?;
+
+    Ok(area)
+}
+
+pub async fn get_by_id(db: &PgPool, id: &Uuid) -> Result<RegionArea, ComhairleError> {
+    let (sql, values) = Query::select()
+        .columns(DEFAULT_COLUMNS)
+        .from(RegionAreaIden::Table)
+        .and_where(Expr::col(RegionAreaIden::Id).eq(*id))
+        .build_sqlx(PostgresQueryBuilder);
+
+    let area = sqlx::query_as_with::<_, RegionArea, _>(&sql, values)
+        .fetch_one(db)
+        .await
+        .resolve_db_err("Region Area")?;
+
+    Ok(area)
+}
+
+pub async fn list(db: &PgPool) -> Result<Vec<RegionArea>, ComhairleError> {
+    let (sql, values) = Query::select()
+        .columns(DEFAULT_COLUMNS)
+        .from(RegionAreaIden::Table)
+        .order_by(RegionAreaIden::ZipPrefix, sea_query::Order::Asc)
+        .build_sqlx(PostgresQueryBuilder);
+
+    let areas = sqlx::query_as_with::<_, RegionArea, _>(&sql, values)
+        .fetch_all(db)
+        .await?;
+
+    Ok(areas)
+}
+
+pub async fn update(
+    db: &PgPool,
+    id: &Uuid,
+    update_request: &PartialRegionArea,
+) -> Result<RegionArea, ComhairleError> {
+    let mut query = Query::update()
+        .table(RegionAreaIden::Table)
+        .and_where(Expr::col(RegionAreaIden::Id).eq(*id))
+        .to_owned();
+
+    let mut has_updates = false;
+    if let Some(value) = &update_request.zip_prefix {
+        query = query
+            .value(RegionAreaIden::ZipPrefix, value.clone())
+            .to_owned();
+        has_updates = true;
+    }
+
+    if !has_updates {
+        return get_by_id(db, id).await;
+    }
+
+    query = query
+        .value(RegionAreaIden::UpdatedAt, Utc::now())
+        .to_owned();
+
+    let (sql, values) = query
+        .returning(Query::returning().columns(DEFAULT_COLUMNS))
+        .build_sqlx(PostgresQueryBuilder);
+
+    let area = sqlx::query_as_with::<_, RegionArea, _>(&sql, values)
+        .fetch_one(db)
+        .await
+        .resolve_db_err("Region Area")?;
+
+    Ok(area)
+}
+
+pub async fn delete(db: &PgPool, id: &Uuid) -> Result<RegionArea, ComhairleError> {
+    let (sql, values) = Query::delete()
+        .from_table(RegionAreaIden::Table)
+        .and_where(Expr::col(RegionAreaIden::Id).eq(*id))
+        .returning(Query::returning().columns(DEFAULT_COLUMNS))
+        .build_sqlx(PostgresQueryBuilder);
+
+    let area = sqlx::query_as_with::<_, RegionArea, _>(&sql, values)
+        .fetch_one(db)
+        .await
+        .resolve_db_err("Region Area")?;
+
+    Ok(area)
+}

--- a/api/src/models/users.rs
+++ b/api/src/models/users.rs
@@ -1,11 +1,13 @@
-use std::fmt;
+use std::{fmt, sync::Arc};
 
 use crate::{
+    ComhairleState,
     error::ComhairleError,
     models::{
         pagination::{Order, PageOptions, PaginatedResults},
         permissions::{
-            ResourcePermissionIden, ResourceType as PermissionResourceType, Role as PermissionRole,
+            self, GrantRoleRequest, ResourcePermissionIden, ResourceType as PermissionResourceType,
+            Role as PermissionRole, grant_role,
         },
     },
     routes::auth::{OtpSignupRequest, SignupRequest, hash_pw, validate_password_strength},
@@ -283,8 +285,8 @@ fn organization_admin_temporary_password() -> String {
 }
 
 pub async fn create_organization_admin_user(
+    state: &Arc<ComhairleState>,
     email: &str,
-    db: &PgPool,
 ) -> Result<User, ComhairleError> {
     let signup_request = SignupRequest {
         username: organization_admin_username(email),
@@ -293,7 +295,21 @@ pub async fn create_organization_admin_user(
         email: email.to_string(),
     };
 
-    create_user(&signup_request, db).await
+    let user = create_user(&signup_request, &state.db).await?;
+
+    // Grant the user the admin role so that they can use the admin interface
+    let _ = grant_role(
+        state,
+        GrantRoleRequest {
+            actor_id: permissions::UserOrOrganizationId::User(user.id),
+            granted_by: &user.id,
+            grant_reason: "Admin user created for organization",
+            permission_triplet: permissions::Role::Admin.system_triplet(),
+        },
+    )
+    .await?;
+
+    Ok(user)
 }
 
 async fn create_otp_user_with_username(

--- a/api/src/routes.rs
+++ b/api/src/routes.rs
@@ -15,6 +15,7 @@ pub mod notifications;
 pub mod organizations;
 pub mod permissions;
 pub mod recruitment_targets;
+pub mod region_areas;
 pub mod regions;
 pub mod report_impacts;
 pub mod reports;

--- a/api/src/routes/events.rs
+++ b/api/src/routes/events.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use aide::axum::{
     ApiRouter,
-    routing::{delete_with, get_with, post_with, put_with},
+    routing::{delete_with, get_with, patch_with, post_with, put_with},
 };
 use axum::{
     extract::{Json, Path, Query, State},
@@ -138,6 +138,31 @@ async fn update(
     Ok((StatusCode::OK, Json(event)))
 }
 
+///  Get an event's `metadata` jsonb column.
+#[instrument(err(Debug), skip(state))]
+async fn get_event_metadata(
+    State(state): State<Arc<ComhairleState>>,
+    Path((_conversation_id, event_id)): Path<(Uuid, Uuid)>,
+    RequiredAdminUser(_user): RequiredAdminUser,
+) -> Result<(StatusCode, Json<Option<serde_json::Value>>), ComhairleError> {
+    let metadata = event::get_metadata(&state.db, &event_id).await?;
+    Ok((StatusCode::OK, Json(metadata)))
+}
+
+/// Shallow-merge the request body into the event's `metadata` jsonb column.
+#[instrument(err(Debug), skip(state))]
+async fn patch_event_metadata(
+    State(state): State<Arc<ComhairleState>>,
+    Path((_conversation_id, event_id)): Path<(Uuid, Uuid)>,
+    RequiredAdminUser(_user): RequiredAdminUser,
+    Json(patch): Json<serde_json::Value>,
+) -> Result<(StatusCode, Json<EventDto>), ComhairleError> {
+    let event = event::patch_metadata(&state.db, &event_id, patch).await?;
+    let event: EventDto = event.into();
+
+    Ok((StatusCode::OK, Json(event)))
+}
+
 #[instrument(err(Debug), skip(state))]
 async fn delete(
     State(state): State<Arc<ComhairleState>>,
@@ -258,6 +283,28 @@ pub fn router(state: Arc<ComhairleState>) -> ApiRouter {
                     .tag("Events")
                     .summary("Update an event")
                     .description("Update an event")
+                    .security_requirement("JWT")
+                    .response::<200, Json<EventDto>>()
+
+        }))
+        .api_route("/{event_id}/metadata",
+            get_with(get_event_metadata, |op| {
+                op.id("GetEventMetadata")
+                    .tag("Events")
+                    .summary("Get event metadata")
+                    .description("Get event metadata")
+                    .security_requirement("JWT")
+                    .response::<200, Json<Option<serde_json::Value>>>()
+
+        }))
+        .api_route("/{event_id}/metadata",
+            patch_with(patch_event_metadata, |op| {
+                op.id("PatchEventMetadata")
+                    .tag("Events")
+                    .summary("Shallow-merge event metadata")
+                    .description(
+                        "Merge a JSON object into event.metadata at the top level using jsonb concatenation",
+                    )
                     .security_requirement("JWT")
                     .response::<200, Json<EventDto>>()
 

--- a/api/src/routes/events/dto.rs
+++ b/api/src/routes/events/dto.rs
@@ -41,6 +41,7 @@ pub struct EventDto {
     pub video_meeting_id: Option<Uuid>,
     pub agenda: EventAgenda,
     pub location: Option<EventLocation>,
+    pub metadata: Option<serde_json::Value>,
     pub format: EventFormat,
     pub created_at: DateTime<Utc>,
 }
@@ -72,6 +73,7 @@ pub struct LocalizedEventDto {
     pub video_meeting_id: Option<Uuid>,
     pub agenda: EventAgenda,
     pub location: Option<EventLocation>,
+    pub metadata: Option<serde_json::Value>,
     pub format: EventFormat,
     pub created_at: DateTime<Utc>,
 }
@@ -90,6 +92,7 @@ impl From<Event> for EventDto {
             video_meeting_id: e.video_meeting_id,
             agenda: e.agenda,
             location: e.location,
+            metadata: e.metadata,
             format: e.format,
             created_at: e.created_at,
         }
@@ -111,6 +114,7 @@ impl From<LocalizedEventWithAttendance> for LocalizedEventDto {
             video_meeting_id: e.event.video_meeting_id,
             agenda: e.event.agenda,
             location: e.event.location,
+            metadata: e.event.metadata,
             format: e.event.format,
             current_attendance: Some(e.current_attendance),
         }
@@ -132,6 +136,7 @@ impl From<LocalizedEvent> for LocalizedEventDto {
             video_meeting_id: e.video_meeting_id,
             agenda: e.agenda,
             location: e.location,
+            metadata: e.metadata,
             format: e.format,
             current_attendance: None,
         }

--- a/api/src/routes/organizations.rs
+++ b/api/src/routes/organizations.rs
@@ -4,7 +4,7 @@ use aide::{
     OperationIo,
     axum::{
         ApiRouter,
-        routing::{delete_with, get_with, post_with, put_with},
+        routing::{delete_with, get_with, patch_with, post_with, put_with},
     },
 };
 use axum::{
@@ -132,6 +132,7 @@ struct UpdateOrganizationBody {
     contact_email: Option<Option<String>>,
     external_url: Option<Option<String>>,
     regions: Option<Vec<Uuid>>,
+    metadata: Option<serde_json::Value>,
 }
 
 #[derive(Debug, serde::Serialize, JsonSchema)]
@@ -244,7 +245,7 @@ async fn resolve_or_create_user_by_email(
                 return Err(ComhairleError::NoUserFoundForEmail(trimmed));
             }
 
-            let user = users::create_organization_admin_user(&trimmed, &state.db).await?;
+            let user = users::create_organization_admin_user(state, &trimmed).await?;
 
             let token = generate_jwt()
                 .user(&user)
@@ -485,7 +486,7 @@ async fn create(
     let mut admin_bootstrap_results =
         if let Some(admin_emails) = payload.organization_admin_emails.as_deref() {
             organization::bootstrap_organization_admin_accounts(
-                &state.db,
+                &state,
                 &created_organization.id,
                 admin_emails,
             )
@@ -609,6 +610,7 @@ async fn update(
         contact_email: payload.contact_email,
         external_url: payload.external_url,
         regions: payload.regions,
+        metadata: payload.metadata.into(),
     };
 
     let organization = if partial.to_values().is_empty() {
@@ -617,6 +619,40 @@ async fn update(
         organization::update(&state.db, &organization_id, &partial).await?
     }
     .into();
+
+    Ok((StatusCode::OK, Json(organization)))
+}
+
+/// Get the organization's `metadata` jsonb column.
+#[instrument(err(Debug), skip(state))]
+async fn get_metadata(
+    State(state): State<Arc<ComhairleState>>,
+    Path(organization_id): Path<Uuid>,
+    RequiredAdminUser(_user): RequiredAdminUser,
+    resource: OrganizationResource,
+) -> Result<(StatusCode, Json<Option<serde_json::Value>>), ComhairleError> {
+    authorize(&state, &_user, Action::OrganizationRead, &resource).await?;
+
+    let metadata = organization::get_metadata(&state.db, &organization_id).await?;
+
+    Ok((StatusCode::OK, Json(metadata)))
+}
+
+/// Shallow-merge the request body into the organization's `metadata` jsonb
+/// column. The body must be a JSON object.
+#[instrument(err(Debug), skip(state))]
+async fn patch_metadata(
+    State(state): State<Arc<ComhairleState>>,
+    Path(organization_id): Path<Uuid>,
+    RequiredAdminUser(user): RequiredAdminUser,
+    resource: OrganizationResource,
+    Json(patch): Json<serde_json::Value>,
+) -> Result<(StatusCode, Json<OrganizationDto>), ComhairleError> {
+    authorize(&state, &user, Action::OrganizationUpdate, &resource).await?;
+
+    let organization = organization::patch_metadata(&state.db, &organization_id, patch)
+        .await?
+        .into();
 
     Ok((StatusCode::OK, Json(organization)))
 }
@@ -760,6 +796,30 @@ pub fn router(state: Arc<ComhairleState>) -> ApiRouter {
                     .tag("Organizations")
                     .summary("Update an organization")
                     .description("Update an organization")
+                    .security_requirement("JWT")
+                    .response::<200, Json<OrganizationDto>>()
+            }),
+        )
+        .api_route(
+            "/{organization_id}/metadata",
+            get_with(get_metadata, |op| {
+                op.id("GetOrganizationMetadata")
+                    .tag("Organizations")
+                    .summary("Get organization metadata")
+                    .description("Get organization metadata")
+                    .security_requirement("JWT")
+                    .response::<200, Json<Option<serde_json::Value>>>()
+            }),
+        )
+        .api_route(
+            "/{organization_id}/metadata",
+            patch_with(patch_metadata, |op| {
+                op.id("PatchOrganizationMetadata")
+                    .tag("Organizations")
+                    .summary("Shallow-merge organization metadata")
+                    .description(
+                        "Merge a JSON object into organization.metadata at the top level using jsonb concatenation",
+                    )
                     .security_requirement("JWT")
                     .response::<200, Json<OrganizationDto>>()
             }),

--- a/api/src/routes/organizations/dto.rs
+++ b/api/src/routes/organizations/dto.rs
@@ -36,6 +36,7 @@ pub struct OrganizationDto {
     pub contact_email: Option<String>,
     pub external_url: Option<String>,
     pub regions: Vec<Uuid>,
+    pub metadata: Option<serde_json::Value>,
     pub created_at: DateTime<Utc>,
 }
 
@@ -86,6 +87,7 @@ pub struct LocalizedOrganizationDto {
     pub contact_email: Option<String>,
     pub external_url: Option<String>,
     pub regions: Vec<Uuid>,
+    pub metadata: Option<serde_json::Value>,
     pub created_at: DateTime<Utc>,
 }
 
@@ -100,6 +102,7 @@ impl From<Organization> for OrganizationDto {
             contact_email: o.contact_email,
             external_url: o.external_url,
             regions: o.regions,
+            metadata: o.metadata,
             created_at: o.created_at,
         }
     }
@@ -148,6 +151,7 @@ impl From<LocalizedOrganization> for LocalizedOrganizationDto {
             contact_email: o.contact_email,
             external_url: o.external_url,
             regions: o.regions,
+            metadata: o.metadata,
             created_at: o.created_at,
         }
     }

--- a/api/src/routes/region_areas.rs
+++ b/api/src/routes/region_areas.rs
@@ -1,0 +1,133 @@
+use std::sync::Arc;
+
+use aide::axum::{
+    ApiRouter,
+    routing::{delete_with, get_with, post_with, put_with},
+};
+use axum::{
+    Json,
+    extract::{Path, State},
+    http::StatusCode,
+};
+use uuid::Uuid;
+
+use crate::{
+    ComhairleState,
+    error::ComhairleError,
+    models::region_area::{self, CreateRegionArea, PartialRegionArea},
+    routes::{auth::RequiredAdminUser, region_areas::dto::RegionAreaDto},
+};
+
+pub mod dto;
+
+async fn create_region_area(
+    State(state): State<Arc<ComhairleState>>,
+    RequiredAdminUser(_user): RequiredAdminUser,
+    Json(create_request): Json<CreateRegionArea>,
+) -> Result<(StatusCode, Json<RegionAreaDto>), ComhairleError> {
+    let area = region_area::create(&state.db, &create_request)
+        .await?
+        .into();
+    Ok((StatusCode::CREATED, Json(area)))
+}
+
+async fn list_region_areas(
+    State(state): State<Arc<ComhairleState>>,
+    RequiredAdminUser(_user): RequiredAdminUser,
+) -> Result<(StatusCode, Json<Vec<RegionAreaDto>>), ComhairleError> {
+    let areas = region_area::list(&state.db)
+        .await?
+        .into_iter()
+        .map(Into::into)
+        .collect();
+    Ok((StatusCode::OK, Json(areas)))
+}
+
+async fn get_region_area(
+    State(state): State<Arc<ComhairleState>>,
+    Path(region_area_id): Path<Uuid>,
+    RequiredAdminUser(_user): RequiredAdminUser,
+) -> Result<(StatusCode, Json<RegionAreaDto>), ComhairleError> {
+    let area = region_area::get_by_id(&state.db, &region_area_id)
+        .await?
+        .into();
+    Ok((StatusCode::OK, Json(area)))
+}
+
+async fn update_region_area(
+    State(state): State<Arc<ComhairleState>>,
+    Path(region_area_id): Path<Uuid>,
+    RequiredAdminUser(_user): RequiredAdminUser,
+    Json(update_request): Json<PartialRegionArea>,
+) -> Result<(StatusCode, Json<RegionAreaDto>), ComhairleError> {
+    let area = region_area::update(&state.db, &region_area_id, &update_request)
+        .await?
+        .into();
+    Ok((StatusCode::OK, Json(area)))
+}
+
+async fn delete_region_area(
+    State(state): State<Arc<ComhairleState>>,
+    Path(region_area_id): Path<Uuid>,
+    RequiredAdminUser(_user): RequiredAdminUser,
+) -> Result<(StatusCode, Json<RegionAreaDto>), ComhairleError> {
+    let area = region_area::delete(&state.db, &region_area_id)
+        .await?
+        .into();
+    Ok((StatusCode::OK, Json(area)))
+}
+
+pub fn router(state: Arc<ComhairleState>) -> ApiRouter {
+    ApiRouter::new()
+        .api_route(
+            "/",
+            post_with(create_region_area, |op| {
+                op.id("CreateRegionArea")
+                    .tag("Region Areas")
+                    .security_requirement("JWT")
+                    .summary("Create a region area")
+                    .response::<201, Json<RegionAreaDto>>()
+            }),
+        )
+        .api_route(
+            "/",
+            get_with(list_region_areas, |op| {
+                op.id("ListRegionAreas")
+                    .tag("Region Areas")
+                    .security_requirement("JWT")
+                    .summary("List region areas")
+                    .response::<200, Json<Vec<RegionAreaDto>>>()
+            }),
+        )
+        .api_route(
+            "/{region_area_id}",
+            get_with(get_region_area, |op| {
+                op.id("GetRegionArea")
+                    .tag("Region Areas")
+                    .security_requirement("JWT")
+                    .summary("Get a region area by id")
+                    .response::<200, Json<RegionAreaDto>>()
+            }),
+        )
+        .api_route(
+            "/{region_area_id}",
+            put_with(update_region_area, |op| {
+                op.id("UpdateRegionArea")
+                    .tag("Region Areas")
+                    .security_requirement("JWT")
+                    .summary("Update a region area")
+                    .response::<200, Json<RegionAreaDto>>()
+            }),
+        )
+        .api_route(
+            "/{region_area_id}",
+            delete_with(delete_region_area, |op| {
+                op.id("DeleteRegionArea")
+                    .tag("Region Areas")
+                    .security_requirement("JWT")
+                    .summary("Delete a region area")
+                    .response::<200, Json<RegionAreaDto>>()
+            }),
+        )
+        .with_state(state)
+}

--- a/api/src/routes/region_areas/dto.rs
+++ b/api/src/routes/region_areas/dto.rs
@@ -1,0 +1,24 @@
+use chrono::{DateTime, Utc};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::models::region_area::RegionArea;
+
+#[derive(Serialize, Deserialize, JsonSchema, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct RegionAreaDto {
+    pub id: Uuid,
+    pub zip_prefix: String,
+    pub created_at: DateTime<Utc>,
+}
+
+impl From<RegionArea> for RegionAreaDto {
+    fn from(area: RegionArea) -> Self {
+        Self {
+            id: area.id,
+            zip_prefix: area.zip_prefix,
+            created_at: area.created_at,
+        }
+    }
+}

--- a/api/src/routes/regions.rs
+++ b/api/src/routes/regions.rs
@@ -2,12 +2,14 @@ use std::sync::Arc;
 
 use aide::axum::{
     ApiRouter,
-    routing::{delete_with, get_with, post_with, put_with},
+    routing::{delete_with, get_with, patch_with, post_with, put_with},
 };
 use axum::{
     extract::{Json, Path, Query, State},
     http::StatusCode,
 };
+use schemars::JsonSchema;
+use serde::Serialize;
 use tracing::instrument;
 use uuid::Uuid;
 
@@ -17,6 +19,7 @@ use crate::{
     models::{
         pagination::{PageOptions, PaginatedResults},
         region::{self, CreateRegion, PartialRegion, RegionFilterOptions, RegionOrderOptions},
+        region_area,
     },
     routes::{
         auth::{RequiredAdminUser, RequiredUser},
@@ -26,6 +29,14 @@ use crate::{
 };
 
 pub mod dto;
+
+#[derive(Debug, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+struct PublicRegionRoutingDto {
+    id: Uuid,
+    slug: String,
+    zip_prefix: Option<String>,
+}
 
 #[instrument(err(Debug), skip(state))]
 async fn list(
@@ -87,6 +98,32 @@ async fn update(
     Ok((StatusCode::OK, Json(region)))
 }
 
+/// Get the region's `metadata` jsonb column.
+#[instrument(err(Debug), skip(state))]
+async fn get_region_metadata(
+    State(state): State<Arc<ComhairleState>>,
+    Path(region_id): Path<Uuid>,
+    RequiredAdminUser(_user): RequiredAdminUser,
+) -> Result<(StatusCode, Json<Option<serde_json::Value>>), ComhairleError> {
+    let metadata = region::get_metadata(&state.db, &region_id).await?;
+
+    Ok((StatusCode::OK, Json(metadata)))
+}
+
+/// Shallow-merge the request body into the region's `metadata` jsonb column.
+#[instrument(err(Debug), skip(state))]
+async fn patch_region_metadata(
+    State(state): State<Arc<ComhairleState>>,
+    Path(region_id): Path<Uuid>,
+    RequiredAdminUser(_user): RequiredAdminUser,
+    Json(patch): Json<serde_json::Value>,
+) -> Result<(StatusCode, Json<RegionDto>), ComhairleError> {
+    let region = region::patch_metadata(&state.db, &region_id, patch).await?;
+    let region: RegionDto = region.into();
+
+    Ok((StatusCode::OK, Json(region)))
+}
+
 #[instrument(err(Debug), skip(state))]
 async fn delete(
     State(state): State<Arc<ComhairleState>>,
@@ -140,6 +177,30 @@ pub fn router(state: Arc<ComhairleState>) -> ApiRouter {
                     .tag("Regions")
                     .summary("Update a region")
                     .description("Update a region")
+                    .security_requirement("JWT")
+                    .response::<200, Json<RegionDto>>()
+            }),
+        )
+        .api_route(
+            "/{region_id}/metadata",
+            get_with(get_region_metadata, |op| {
+                op.id("GetRegionMetadata")
+                    .tag("Regions")
+                    .summary("Get region metadata")
+                    .description("Get region metadata")
+                    .security_requirement("JWT")
+                    .response::<200, Json<Option<serde_json::Value>>>()
+            }),
+        )
+        .api_route(
+            "/{region_id}/metadata",
+            patch_with(patch_region_metadata, |op| {
+                op.id("PatchRegionMetadata")
+                    .tag("Regions")
+                    .summary("Shallow-merge region metadata")
+                    .description(
+                        "Merge a JSON object into region.metadata at the top level using jsonb concatenation",
+                    )
                     .security_requirement("JWT")
                     .response::<200, Json<RegionDto>>()
             }),

--- a/api/src/routes/regions/dto.rs
+++ b/api/src/routes/regions/dto.rs
@@ -29,8 +29,10 @@ pub struct RegionDto {
     pub name: TextContentId,
     #[schemars(example = "example_uuid")]
     pub description: TextContentId,
+    pub region_area_id: Option<Uuid>,
     pub region_type: RegionType,
     pub official_id: Option<String>,
+    pub metadata: Option<serde_json::Value>,
     pub created_at: DateTime<Utc>,
 }
 
@@ -51,8 +53,10 @@ pub struct LocalizedRegionDto {
     pub name: String,
     #[schemars(example = "example_localized_text")]
     pub description: String,
+    pub region_area_id: Option<Uuid>,
     pub region_type: RegionType,
     pub official_id: Option<String>,
+    pub metadata: Option<serde_json::Value>,
     pub created_at: DateTime<Utc>,
 }
 
@@ -62,8 +66,10 @@ impl From<Region> for RegionDto {
             id: o.id,
             name: o.name,
             description: o.description,
+            region_area_id: o.region_area_id,
             region_type: o.region_type,
             official_id: o.official_id,
+            metadata: o.metadata,
             created_at: o.created_at,
         }
     }
@@ -75,8 +81,10 @@ impl From<LocalizedRegion> for LocalizedRegionDto {
             id: o.id,
             name: o.name,
             description: o.description,
+            region_area_id: o.region_area_id,
             region_type: o.region_type,
             official_id: o.official_id,
+            metadata: o.metadata,
             created_at: o.created_at,
         }
     }

--- a/ui/packages/api-client/src/api.ts
+++ b/ui/packages/api-client/src/api.ts
@@ -157,6 +157,7 @@ export const LocalizedOrganizationDto = z
     description: z.string(),
     externalUrl: z.union([z.string(), z.null()]).optional(),
     id: z.string().uuid(),
+    metadata: z.unknown().optional(),
     mission: z.string(),
     name: z.string(),
     orgType: OrganizationType,
@@ -1832,6 +1833,7 @@ export const LocalizedEventDto = z
     format: EventFormat,
     id: z.string().uuid(),
     location: z.union([EventLocation, z.null()]).optional(),
+    metadata: z.unknown().optional(),
     name: z.string(),
     signupMode: z.string(),
     startTime: z.string().datetime({ offset: true }),
@@ -1870,6 +1872,7 @@ export const EventDto = z
     format: EventFormat,
     id: z.string().uuid(),
     location: z.union([EventLocation, z.null()]).optional(),
+    metadata: z.unknown().optional(),
     name: z.string().uuid(),
     signupMode: z.string(),
     startTime: z.string().datetime({ offset: true }),
@@ -1915,6 +1918,7 @@ export const EventWithTranslations = z
     format: EventFormat,
     id: z.string().uuid(),
     location: z.union([EventLocation, z.null()]).optional(),
+    metadata: z.unknown().optional(),
     name: z.string(),
     signupMode: z.string(),
     startTime: z.string().datetime({ offset: true }),
@@ -1938,6 +1942,7 @@ export const PartialEvent = z
     end_time: z.union([z.string(), z.null()]),
     format: z.union([EventFormat, z.null()]),
     location: z.union([EventLocation, z.null()]),
+    metadata: z.unknown(),
     name: z.union([z.string(), z.null()]),
     signup_mode: z.union([z.string(), z.null()]),
     start_time: z.union([z.string(), z.null()]),
@@ -2156,6 +2161,7 @@ export const CreateOrganizationResponseDto = z
     description: z.string().uuid(),
     externalUrl: z.union([z.string(), z.null()]).optional(),
     id: z.string().uuid(),
+    metadata: z.unknown().optional(),
     mission: z.string().uuid(),
     name: z.string(),
     orgType: OrganizationType,
@@ -2170,6 +2176,7 @@ export const UpdateOrganizationBody = z
     contact_email: z.union([z.string(), z.null()]),
     description: z.union([z.string(), z.null()]),
     external_url: z.union([z.string(), z.null()]),
+    metadata: z.unknown(),
     mission: z.union([z.string(), z.null()]),
     name: z.union([z.string(), z.null()]),
     org_type: z.union([OrganizationType, z.null()]),
@@ -2185,6 +2192,7 @@ export const OrganizationDto = z
     description: z.string().uuid(),
     externalUrl: z.union([z.string(), z.null()]).optional(),
     id: z.string().uuid(),
+    metadata: z.unknown().optional(),
     mission: z.string().uuid(),
     name: z.string(),
     orgType: OrganizationType,
@@ -2242,8 +2250,10 @@ export const LocalizedRegionDto = z
     created_at: z.string().datetime({ offset: true }),
     description: z.string(),
     id: z.string().uuid(),
+    metadata: z.unknown().optional(),
     name: z.string(),
     official_id: z.union([z.string(), z.null()]).optional(),
+    region_area_id: z.union([z.string(), z.null()]).optional(),
     region_type: RegionType,
   })
   .passthrough();
@@ -2268,20 +2278,41 @@ export const RegionDto = z
     created_at: z.string().datetime({ offset: true }),
     description: z.string().uuid(),
     id: z.string().uuid(),
+    metadata: z.unknown().optional(),
     name: z.string().uuid(),
     official_id: z.union([z.string(), z.null()]).optional(),
+    region_area_id: z.union([z.string(), z.null()]).optional(),
     region_type: RegionType,
   })
   .passthrough();
 export type RegionDto = z.infer<typeof RegionDto>;
 export const PartialRegion = z
   .object({
+    metadata: z.unknown(),
     official_id: z.union([z.string(), z.null()]),
+    region_area_id: z.union([z.string(), z.null()]),
     region_type: z.union([RegionType, z.null()]),
   })
   .partial()
   .passthrough();
 export type PartialRegion = z.infer<typeof PartialRegion>;
+export const RegionAreaDto = z
+  .object({
+    createdAt: z.string().datetime({ offset: true }),
+    id: z.string().uuid(),
+    zipPrefix: z.string(),
+  })
+  .passthrough();
+export type RegionAreaDto = z.infer<typeof RegionAreaDto>;
+export const CreateRegionArea = z
+  .object({ zip_prefix: z.string() })
+  .passthrough();
+export type CreateRegionArea = z.infer<typeof CreateRegionArea>;
+export const PartialRegionArea = z
+  .object({ zip_prefix: z.union([z.string(), z.null()]) })
+  .partial()
+  .passthrough();
+export type PartialRegionArea = z.infer<typeof PartialRegionArea>;
 export const MediaContentType = z.enum([
   "image/jpeg",
   "image/png",
@@ -2773,6 +2804,9 @@ export const schemas: Record<string, z.ZodType<any>> = {
   CreateRegion,
   RegionDto,
   PartialRegion,
+  RegionAreaDto,
+  CreateRegionArea,
+  PartialRegionArea,
   MediaContentType,
   content_type,
   MediaDto,
@@ -3569,6 +3603,29 @@ curl -X POST \
     alias: "SeedEventBreakoutPlan",
     requestFormat: "json",
     response: BreakoutPlanDto,
+  },
+  {
+    method: "get",
+    path: "/conversation/:conversation_id/events/:event_id/metadata",
+    alias: "GetEventMetadata",
+    description: `Get event metadata`,
+    requestFormat: "json",
+    response: z.unknown(),
+  },
+  {
+    method: "patch",
+    path: "/conversation/:conversation_id/events/:event_id/metadata",
+    alias: "PatchEventMetadata",
+    description: `Merge a JSON object into event.metadata at the top level using jsonb concatenation`,
+    requestFormat: "json",
+    parameters: [
+      {
+        name: "body",
+        type: "Body",
+        schema: z.unknown(),
+      },
+    ],
+    response: EventDto,
   },
   {
     method: "get",
@@ -4660,6 +4717,29 @@ curl -X POST \
   },
   {
     method: "get",
+    path: "/organizations/:organization_id/metadata",
+    alias: "GetOrganizationMetadata",
+    description: `Get organization metadata`,
+    requestFormat: "json",
+    response: z.unknown(),
+  },
+  {
+    method: "patch",
+    path: "/organizations/:organization_id/metadata",
+    alias: "PatchOrganizationMetadata",
+    description: `Merge a JSON object into organization.metadata at the top level using jsonb concatenation`,
+    requestFormat: "json",
+    parameters: [
+      {
+        name: "body",
+        type: "Body",
+        schema: z.unknown(),
+      },
+    ],
+    response: OrganizationDto,
+  },
+  {
+    method: "get",
     path: "/organizations/:organization_id/team",
     alias: "GetOrganizationTeam",
     description: `Returns members and administrators for an organization`,
@@ -4854,6 +4934,55 @@ curl -X POST \
   },
   {
     method: "get",
+    path: "/region_areas",
+    alias: "ListRegionAreas",
+    requestFormat: "json",
+    response: z.array(RegionAreaDto),
+  },
+  {
+    method: "post",
+    path: "/region_areas",
+    alias: "CreateRegionArea",
+    requestFormat: "json",
+    parameters: [
+      {
+        name: "body",
+        type: "Body",
+        schema: z.object({ zip_prefix: z.string() }).passthrough(),
+      },
+    ],
+    response: RegionAreaDto,
+  },
+  {
+    method: "get",
+    path: "/region_areas/:region_area_id",
+    alias: "GetRegionArea",
+    requestFormat: "json",
+    response: RegionAreaDto,
+  },
+  {
+    method: "put",
+    path: "/region_areas/:region_area_id",
+    alias: "UpdateRegionArea",
+    requestFormat: "json",
+    parameters: [
+      {
+        name: "body",
+        type: "Body",
+        schema: PartialRegionArea,
+      },
+    ],
+    response: RegionAreaDto,
+  },
+  {
+    method: "delete",
+    path: "/region_areas/:region_area_id",
+    alias: "DeleteRegionArea",
+    requestFormat: "json",
+    response: RegionAreaDto,
+  },
+  {
+    method: "get",
     path: "/regions",
     alias: "ListRegions",
     description: `Paginated list of regions with optional ordering`,
@@ -4931,6 +5060,29 @@ curl -X POST \
     alias: "DeleteRegion",
     description: `Delete a region`,
     requestFormat: "json",
+    response: RegionDto,
+  },
+  {
+    method: "get",
+    path: "/regions/:region_id/metadata",
+    alias: "GetRegionMetadata",
+    description: `Get region metadata`,
+    requestFormat: "json",
+    response: z.unknown(),
+  },
+  {
+    method: "patch",
+    path: "/regions/:region_id/metadata",
+    alias: "PatchRegionMetadata",
+    description: `Merge a JSON object into region.metadata at the top level using jsonb concatenation`,
+    requestFormat: "json",
+    parameters: [
+      {
+        name: "body",
+        type: "Body",
+        schema: z.unknown(),
+      },
+    ],
     response: RegionDto,
   },
   {


### PR DESCRIPTION
Motivation:

- We would like to migrate our regions.ts data to the database soon in
       civic_os and we will need appropriate data fields to handle the new
       data.

Actions:

- Created regions_area table which will hold zipcode areas for now, but may be migrated to use generic PostGIS geometry in the future.
- Added metadata fields to regions, organizations and events to support extra civic_os use cases.