### PR TITLE
868 Wire up Insert Source Document in Content-tab rich fields

### DIFF
--- a/ui/packages/comhairle/src/lib/components/ConversationSupportSidebar.svelte
+++ b/ui/packages/comhairle/src/lib/components/ConversationSupportSidebar.svelte
@@ -4,7 +4,7 @@
 	import { LucideChevronRight } from 'lucide-svelte';
 	import CircleQuestionMark from '$lib/components/icons/CircleQuestionMark.svelte';
 	import ContentRenderer from '$lib/components/RichTextEditor/ContentRenderer/ContentRenderer.svelte';
-	import type { LocalizedConversationDto } from '@crownshy/api-client/api';
+	import type { ComhairleDocument, LocalizedConversationDto } from '@crownshy/api-client/api';
 	import ComhairlePrivacyPolicy from './ComhairlePrivacyPolicy.svelte';
 	import ComhairleFAQs from './ComhairleFAQs.svelte';
 	import LearningAssistant from './LearningAssistant/LearningAssistant.svelte';
@@ -12,10 +12,13 @@
 	let {
 		conversation,
 		hasKnowledgeBaseDocs = false,
+		availableDocuments = [],
 		currentStepTitle
 	}: {
 		conversation: LocalizedConversationDto;
 		hasKnowledgeBaseDocs?: boolean;
+		/** Parsed documents, so source-document badges in the FAQ/privacy tabs resolve + download. */
+		availableDocuments?: ComhairleDocument[];
 		currentStepTitle?: string;
 	} = $props();
 
@@ -77,7 +80,11 @@
 				{#each tabs as tab (tab.value)}
 					<Tabs.Content value={tab.value} class="overflow-y-auto">
 						{#if tab.content}
-							<ContentRenderer content={tab.content} />
+							<ContentRenderer
+								content={tab.content}
+								{availableDocuments}
+								conversationId={conversation.id}
+							/>
 						{:else}
 							{@const Component = tab.fallback}
 							<Component

--- a/ui/packages/comhairle/src/lib/components/PrivacyPolicyDialog.svelte
+++ b/ui/packages/comhairle/src/lib/components/PrivacyPolicyDialog.svelte
@@ -3,15 +3,17 @@
 	import { Button } from '$lib/components/ui/button';
 	import ContentRenderer from '$lib/components/RichTextEditor/ContentRenderer/ContentRenderer.svelte';
 	import ComhairlePrivacyPolicy from './ComhairlePrivacyPolicy.svelte';
-	import type { LocalizedConversationDto } from '@crownshy/api-client/api';
+	import type { ComhairleDocument, LocalizedConversationDto } from '@crownshy/api-client/api';
 
 	type Props = {
 		conversation: LocalizedConversationDto;
 		open: boolean;
 		onAccept: () => void;
+		/** Parsed documents, so source-document badges in the short privacy policy resolve + download. */
+		availableDocuments?: ComhairleDocument[];
 	};
 
-	let { conversation, open = $bindable(), onAccept }: Props = $props();
+	let { conversation, open = $bindable(), onAccept, availableDocuments = [] }: Props = $props();
 
 	function handleAccept() {
 		open = false;
@@ -41,7 +43,11 @@
 
 		<div class="overflow-y-auto px-6 py-4">
 			{#if conversation.shortPrivacyPolicy}
-				<ContentRenderer content={conversation.shortPrivacyPolicy} />
+				<ContentRenderer
+					content={conversation.shortPrivacyPolicy}
+					{availableDocuments}
+					conversationId={conversation.id}
+				/>
 			{:else}
 				<ComhairlePrivacyPolicy
 					class="[&_h1]:text-primary [&_h2]:text-primary flex flex-col gap-4 [&_h1,&_h2,&_h3,&_h4,&_h5,&_h6]:font-bold [&_ul]:list-inside [&_ul]:list-[square]!"

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/configure/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/configure/+page.svelte
@@ -26,6 +26,7 @@
 	import { autoTranslateNewLanguage } from '$lib/components/Translation/translationUtils';
 	import { LanguageSelector } from '$lib/components/ui/language-selector';
 	import type {
+		ComhairleDocument,
 		ConversationWithTranslations,
 		MediaDto,
 		UserDto,
@@ -50,9 +51,13 @@
 			user: UserDto;
 			usersWithPermission: UserWithPermissionDto[];
 			configureTabs: { id: string; label: string }[];
+			availableDocuments: ComhairleDocument[];
 		};
 	} = $props();
 	let conversation = $derived(data.conversation);
+	// Parsed knowledge base documents, for the "Insert Source Document" control in the Content-tab
+	// rich fields (both the picker and, via the same list, the inserted badge's name/size/download).
+	let availableDocuments = $derived(data.availableDocuments);
 	let workflow = $derived(data.workflows[0]);
 	let imageMedia = $derived(data.media);
 	let permittedUsers = $derived(data.usersWithPermission);
@@ -687,6 +692,8 @@
 									placeholder="The full policy, shown on the Privacy Policy page and the 'Find out more' panel. Leave blank to use Comhairle's default."
 									primaryLocale={primaryLanguage}
 									{supportedLanguages}
+									{availableDocuments}
+									conversationId={conversation.id}
 									inputProps={props}
 								/>
 								<Form.FieldErrors />
@@ -723,6 +730,8 @@
 									placeholder="Shown in the consent dialog participants accept before joining. Leave blank to use Comhairle's default."
 									primaryLocale={primaryLanguage}
 									{supportedLanguages}
+									{availableDocuments}
+									conversationId={conversation.id}
 									inputProps={props}
 								/>
 								<Form.FieldErrors />
@@ -758,6 +767,8 @@
 									placeholder="Shown on the FAQ page and the 'Find out more' panel. Leave blank to use Comhairle's default FAQs."
 									primaryLocale={primaryLanguage}
 									{supportedLanguages}
+									{availableDocuments}
+									conversationId={conversation.id}
 									inputProps={props}
 								/>
 								<Form.FieldErrors />
@@ -794,6 +805,8 @@
 									placeholder="Shown on the thank-you page after someone finishes. Leave blank for the default 'Thank you for participating' message."
 									primaryLocale={primaryLanguage}
 									{supportedLanguages}
+									{availableDocuments}
+									conversationId={conversation.id}
 									inputProps={props}
 								/>
 								<Form.FieldErrors />

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/configure/+page.ts
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/configure/+page.ts
@@ -1,0 +1,31 @@
+import type { PageLoad } from './$types';
+import type { ComhairleDocument } from '@crownshy/api-client/api';
+
+/**
+ * The Content tab's rich fields (FAQ, thank-you, privacy policy, short privacy policy) offer an
+ * "Insert Source Document" control. It needs the conversation's parsed knowledge base documents to
+ * populate the picker, and it needs them again on the render path to resolve each badge's name/size
+ * and download link. We fetch them once here (page-scoped so unrelated conversation sub-pages don't
+ * pay for it) and only surface the DONE-parsed ones, matching the Learn step path. A failed fetch
+ * falls back to an empty list, so the picker shows its empty state rather than a raw backend error.
+ */
+export const load: PageLoad = async ({
+	parent,
+	params,
+	depends
+}): Promise<{ availableDocuments: ComhairleDocument[] }> => {
+	depends('conversation:documents');
+	const { api } = await parent();
+
+	let availableDocuments: ComhairleDocument[] = [];
+	try {
+		const documents = await api.ListDocuments({
+			params: { conversation_id: params.conversation_id }
+		});
+		availableDocuments = documents.filter((d: ComhairleDocument) => d.parse_status === 'DONE');
+	} catch (e) {
+		console.warn('failed to load conversation documents', e);
+	}
+
+	return { availableDocuments };
+};

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/+layout.ts
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/+layout.ts
@@ -1,19 +1,27 @@
 import { loginRedirect } from '$lib/urls';
 import { isRedirect, redirect } from '@sveltejs/kit';
 import type { LayoutLoad } from './$types';
-import type { LocalizedConversationDto, WorkflowDto } from '@crownshy/api-client/api';
+import type {
+	ComhairleDocument,
+	LocalizedConversationDto,
+	WorkflowDto
+} from '@crownshy/api-client/api';
 
 export const load: LayoutLoad = async ({
 	parent,
-	params
+	params,
+	depends
 }): Promise<{
 	conversation: LocalizedConversationDto;
 	workflows: WorkflowDto[];
+	availableDocuments: ComhairleDocument[];
+	hasKnowledgeBaseDocs: boolean;
 	participation: any; // TODO:
 	api: any; // TODO:
 	user: any; // TODO:
 	preview: any; // TODO:
 }> => {
+	depends('app:documents');
 	const { api, user } = await parent();
 	const conversation_id = params.conversation_id;
 	const preview = params.preview === 'preview';
@@ -29,6 +37,25 @@ export const load: LayoutLoad = async ({
 			params: { conversation_id: conversation.id }
 		});
 
+		// Parsed knowledge base documents. Hoisted to this shared ancestor (the FAQ, privacy,
+		// thank-you and landing pages, plus the workflow layout's Learning Assistant and in-content
+		// source badges) so a single fetch is the one source of truth. `hasKnowledgeBaseDocs` gates
+		// the Learning Assistant; the list resolves each source-document badge's name/size/download.
+		// A failed fetch falls back to "no documents", which safely hides the assistant and renders
+		// badges as bare labels rather than surfacing a raw backend error to participants.
+		let availableDocuments: ComhairleDocument[] = [];
+		try {
+			const documents = await api.ListDocuments({
+				params: { conversation_id: conversation.id }
+			});
+			availableDocuments = documents.filter(
+				(d: ComhairleDocument) => d.parse_status === 'DONE'
+			);
+		} catch (e) {
+			console.warn('failed to load knowledge base documents', e);
+		}
+		const hasKnowledgeBaseDocs = availableDocuments.length > 0;
+
 		let participation;
 
 		if (user) {
@@ -39,7 +66,16 @@ export const load: LayoutLoad = async ({
 			participation = null;
 		}
 
-		return { conversation, workflows, participation, api, user, preview };
+		return {
+			conversation,
+			workflows,
+			availableDocuments,
+			hasKnowledgeBaseDocs,
+			participation,
+			api,
+			user,
+			preview
+		};
 	} catch (e) {
 		if (isRedirect(e)) {
 			throw e;

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/+page.svelte
@@ -185,6 +185,7 @@
 
 			<PrivacyPolicyDialog
 				{conversation}
+				availableDocuments={data.availableDocuments}
 				bind:open={privacyPolicyOpen}
 				onAccept={handlePrivacyPolicyAccept}
 			/>

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/faq/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/faq/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { PageProps } from '../$types.js';
 	let { data }: PageProps = $props();
-	let { conversation, workflows } = data;
+	let { conversation, workflows, availableDocuments } = data;
 
 	import ContentRenderer from '$lib/components/RichTextEditor/ContentRenderer/ContentRenderer.svelte';
 	import Button from '$lib/components/ui/button/button.svelte';
@@ -14,7 +14,11 @@
 
 <div class="mx-10 mt-20 md:mx-auto md:max-w-3/5">
 	{#if conversation.faqs}
-		<ContentRenderer content={conversation.faqs} />
+		<ContentRenderer
+			content={conversation.faqs}
+			{availableDocuments}
+			conversationId={conversation.id}
+		/>
 	{/if}
 	<Button href={firstWorkflowPath}>Resume taking part</Button>
 </div>

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/privacy/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/privacy/+page.svelte
@@ -3,7 +3,7 @@
 	import ComhairlePrivacyPolicy from '$lib/components/ComhairlePrivacyPolicy.svelte';
 
 	let { data } = $props();
-	let { conversation } = data;
+	let { conversation, availableDocuments } = data;
 </script>
 
 <svelte:head>
@@ -11,7 +11,11 @@
 </svelte:head>
 
 {#if conversation.privacyPolicy}
-	<ContentRenderer content={conversation.privacyPolicy} />
+	<ContentRenderer
+		content={conversation.privacyPolicy}
+		{availableDocuments}
+		conversationId={conversation.id}
+	/>
 {:else}
 	<ComhairlePrivacyPolicy
 		class="[&_h1]:text-primary [&_h2]:text-primary flex flex-col gap-4 [&_h1,&_h2,&_h3,&_h4,&_h5,&_h6]:font-bold [&_ul]:list-inside [&_ul]:list-[square]!"

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/workflow/[workflow_id]/+layout.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/workflow/[workflow_id]/+layout.svelte
@@ -4,7 +4,7 @@
 	import type { LayoutProps } from './$types';
 
 	let { data, children }: LayoutProps = $props();
-	let { conversation, hasKnowledgeBaseDocs, workflowSteps } = $derived(data);
+	let { conversation, hasKnowledgeBaseDocs, availableDocuments, workflowSteps } = $derived(data);
 
 	// The support sidebar sits at the layout, above the per-step route, so it does not otherwise
 	// know which step the participant is on. Derive the active learn step's title from the route
@@ -20,4 +20,9 @@
 
 {@render children()}
 
-<ConversationSupportSidebar {conversation} {hasKnowledgeBaseDocs} {currentStepTitle} />
+<ConversationSupportSidebar
+	{conversation}
+	{hasKnowledgeBaseDocs}
+	{availableDocuments}
+	{currentStepTitle}
+/>

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/workflow/[workflow_id]/+layout.ts
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/workflow/[workflow_id]/+layout.ts
@@ -1,32 +1,17 @@
 import type { LayoutLoad } from './$types';
 import type {
-	ComhairleDocument,
 	LocalizedWorkflowStepDto,
 	LocalizedWorkflowStepWithProgressDto
 } from '@crownshy/api-client/api';
 
 export const load: LayoutLoad = async ({ parent, params, depends }) => {
-	const { api, conversation, preview } = await parent();
+	// Documents (the Learning Assistant gate + in-content source badges) are fetched once in the
+	// conversation [[preview]] layout, the nearest shared ancestor of every page that renders
+	// participant-facing rich content. Read them from there rather than re-fetching.
+	const { api, conversation, preview, availableDocuments, hasKnowledgeBaseDocs } = await parent();
 	const workflow_id = params.workflow_id;
 
 	depends('app:workflow-steps');
-	depends('app:documents');
-
-	// Documents power both the Learning Assistant gate and the in-content source badges.
-	// Hoisted here (the nearest shared ancestor of the step page and the support sidebar) so a
-	// single fetch is the one source of truth: the assistant is only shown when the knowledge
-	// base has at least one parsed (DONE) document. A failed fetch falls back to "no documents",
-	// which safely hides the assistant rather than surfacing a raw backend error to participants.
-	let availableDocuments: ComhairleDocument[] = [];
-	try {
-		const documents = await api.ListDocuments({
-			params: { conversation_id: conversation.id }
-		});
-		availableDocuments = documents.filter((d: ComhairleDocument) => d.parse_status === 'DONE');
-	} catch (e) {
-		console.warn('failed to load knowledge base documents', e);
-	}
-	const hasKnowledgeBaseDocs = availableDocuments.length > 0;
 
 	let workflowSteps: LocalizedWorkflowStepWithProgressDto[];
 	if (conversation.isLive) {

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/workflow/[workflow_id]/thank_you/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/workflow/[workflow_id]/thank_you/+page.svelte
@@ -14,6 +14,7 @@
 	let workflow = $derived(data.workflow);
 	let revisitableSteps = $derived(data.revisitableSteps);
 	let isPreview = $derived(data.preview);
+	let availableDocuments = $derived(data.availableDocuments);
 </script>
 
 <svelte:head>
@@ -43,7 +44,11 @@
 	{/if}
 
 	{#if conversation.thankYouMessage}
-		<ContentRenderer content={conversation.thankYouMessage} />
+		<ContentRenderer
+			content={conversation.thankYouMessage}
+			{availableDocuments}
+			conversationId={conversation.id}
+		/>
 	{/if}
 
 	{#snippet revisitStepList()}


### PR DESCRIPTION
The rich text fields on the conversation Content tab (FAQ, thank-you, privacy policy, short privacy policy) all show the **Insert Source Document** toolbar button, but clicking it always said **"No parsed documents available"** even when the conversation had parsed documents. The feature was only ever wired up for Learn steps. This hooks it up for the Content tab too, on both the admin editor and the participant-facing render.

### What changed

**Admin side: fill the picker**
- New `configure/+page.ts` load that fetches the conversation's `DONE`-parsed documents (`depends('conversation:documents')`). Kept it page-scoped so other conversation sub-pages don't pay for a fetch they don't use.
- The configure page passes `availableDocuments` + `conversationId` into all four rich fields. Call-to-action is a plain field so it's left alone.

**Participant side: render it properly**
- An inserted badge only stores a `documentId`; it needs the documents map + `conversationId` to show the right name/size and build a working download link. None of the render paths were passing those.
- Hoisted the documents fetch up to the shared `[[preview]]/+layout.ts` so there's one source of truth, and pointed the workflow layout at it via `parent()` instead of re-fetching.
- Fed `availableDocuments` + `conversationId` into every render site: FAQ page, privacy page, thank-you page, the "Find out more" panel, and the consent dialog's short privacy policy.


<img width="1192" height="829" alt="image" src="https://github.com/user-attachments/assets/60cb3031-eb8d-45c5-a52f-0e648f8c26f2" />
<img width="1165" height="871" alt="image" src="https://github.com/user-attachments/assets/472fba9c-e470-45d3-98c1-0ca5c824fcf7" />
<img width="1469" height="887" alt="image" src="https://github.com/user-attachments/assets/b2c167bd-e622-41df-a32b-bdc1d419250e" />
