### PR TITLE
867 Use conversation.callToAction for join button text when available

### DIFF
--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/+page.svelte
@@ -134,7 +134,7 @@
 				{#if user}
 					{#if participation}
 						<Button class="mt-5 w-full md:w-fit" variant="primaryDark" href={returnPath}
-							>{m.jump_back_in()}</Button
+							>{conversation.callToAction || m.jump_back_in()}</Button
 						>
 					{:else}
 						<Button


### PR DESCRIPTION
- The "Jump back in" button text was hardcoded and didn't respect conversation-specific call-to-action messaging.
- Conversations may want custom button text to better match their context or branding.
- The callToAction field exists on the conversation model but wasn't being used in the UI.

Actions:

- Use conversation.callToAction as primary button text when present


<img width="1440" height="874" alt="image" src="https://github.com/user-attachments/assets/588c6b96-fc69-4f74-8735-d6c5265fe417" />


Fixes #867 