### PR TITLE
#834 Add optional reason when rejecting a Polis statement 

### DIFF
--- a/api/src/models/polis_statement_aux.rs
+++ b/api/src/models/polis_statement_aux.rs
@@ -426,6 +426,70 @@ pub async fn update_many(
     Ok(aux)
 }
 
+/// The `(column, value)` pairs a moderation decision writes. Both single
+/// [`moderate`] and bulk [`moderate_many`] use this so they apply identical
+/// semantics: unlike the partial-update path, `moderation_reason` is *always*
+/// written (NULL when `reason` is `None`), so accepting a statement clears any
+/// prior rejection reason (ADR-0015).
+fn moderation_values(
+    status: ModerationStatus,
+    reason: Option<&str>,
+) -> [(PolisStatementAuxIden, SimpleExpr); 2] {
+    [
+        (PolisStatementAuxIden::ModerationStatus, status.into()),
+        (
+            PolisStatementAuxIden::ModerationReason,
+            reason.map(|s| s.to_string()).into(),
+        ),
+    ]
+}
+
+/// Apply a moderation decision to a single row, setting `moderation_status`
+/// and `moderation_reason` together (see [`moderation_values`]).
+#[instrument(err(Debug))]
+pub async fn moderate(
+    db: &PgPool,
+    id: Uuid,
+    status: ModerationStatus,
+    reason: Option<&str>,
+) -> Result<PolisStatementAux, ComhairleError> {
+    let (sql, values) = Query::update()
+        .table(PolisStatementAuxIden::Table)
+        .values(moderation_values(status, reason))
+        .and_where(Expr::col(PolisStatementAuxIden::Id).eq(id))
+        .returning(Query::returning().columns(DEFAULT_COLUMNS))
+        .build_sqlx(PostgresQueryBuilder);
+
+    let aux = query_as_with(&sql, values).fetch_one(db).await?;
+
+    Ok(aux)
+}
+
+/// Apply a moderation decision to many rows in one statement, returning the
+/// updated rows (see [`moderation_values`]). An empty id slice is a no-op.
+#[instrument(err(Debug))]
+pub async fn moderate_many(
+    db: &PgPool,
+    ids: &[Uuid],
+    status: ModerationStatus,
+    reason: Option<&str>,
+) -> Result<Vec<PolisStatementAux>, ComhairleError> {
+    if ids.is_empty() {
+        return Ok(vec![]);
+    }
+
+    let (sql, values) = Query::update()
+        .table(PolisStatementAuxIden::Table)
+        .values(moderation_values(status, reason))
+        .and_where(Expr::col(PolisStatementAuxIden::Id).is_in(ids.iter().copied()))
+        .returning(Query::returning().columns(DEFAULT_COLUMNS))
+        .build_sqlx(PostgresQueryBuilder);
+
+    let aux = query_as_with(&sql, values).fetch_all(db).await?;
+
+    Ok(aux)
+}
+
 #[derive(Deserialize, Debug, JsonSchema, Default)]
 pub struct PolisStatementAuxFilterOptions {
     ids: Option<Vec<Uuid>>,

--- a/api/src/tools/polis.rs
+++ b/api/src/tools/polis.rs
@@ -771,6 +771,20 @@ pub struct ModerateStatementAuxRequest {
     pub moderation_reason: Option<String>,
 }
 
+/// The reason to persist for a moderation decision. Reject keeps the supplied
+/// reason; accept clears it (returns `None`) so a stored reason never describes
+/// a statement that is no longer rejected (ADR-0015). Shared by the single and
+/// batch handlers so the invariant lives in one place.
+fn reason_for_decision<'a>(
+    status: &ModerationStatus,
+    reason: &'a Option<String>,
+) -> Option<&'a str> {
+    match status {
+        ModerationStatus::Accepted => None,
+        _ => reason.as_deref(),
+    }
+}
+
 #[instrument(err(Debug), skip(state))]
 async fn moderate_statement_aux(
     State(state): State<Arc<ComhairleState>>,
@@ -809,12 +823,7 @@ async fn moderate_statement_aux(
         )
         .await?;
 
-    // Reject records the optional reason; accept clears any prior reason so it
-    // never describes a statement that is no longer rejected (ADR-0015).
-    let reason = match status {
-        ModerationStatus::Accepted => None,
-        _ => request.moderation_reason.as_deref(),
-    };
+    let reason = reason_for_decision(&status, &request.moderation_reason);
 
     let updated =
         models::polis_statement_aux::moderate(&state.db, statement_id, status.clone(), reason)
@@ -1041,13 +1050,9 @@ async fn moderate_statement_aux_batch(
         }
     }
 
-    // Reject applies the shared reason to every row; accept clears it (ADR-0015).
-    let reason = match status {
-        ModerationStatus::Accepted => None,
-        _ => request.moderation_reason.as_deref(),
-    };
+    let reason = reason_for_decision(&status, &request.moderation_reason);
 
-    // Persist status + reason for the rows Polis accepted, in one statement.
+    // Persist status + reason for the rows that succeeded in Polis, in one statement.
     let succeeded =
         models::polis_statement_aux::moderate_many(&state.db, &succeeded_ids, status, reason)
             .await?;

--- a/api/src/tools/polis.rs
+++ b/api/src/tools/polis.rs
@@ -798,27 +798,27 @@ async fn moderate_statement_aux(
         })
         .await?;
 
+    let status: ModerationStatus = request.decision.into();
+
     client
         .moderate_comment(
             &config.poll_id,
             aux.polis_statement_id,
-            request.decision.into(),
+            status.clone(),
             &auth_cookies,
         )
         .await?;
 
-    let updated = models::polis_statement_aux::update(
-        &state.db,
-        statement_id,
-        &UpdatePolisStatementAux {
-            statement_text: None,
-            moderation_status: Some(request.decision.into()),
-            themes: None,
-            visible_statement_when_submitted: None,
-            moderation_reason: request.moderation_reason,
-        },
-    )
-    .await?;
+    // Reject records the optional reason; accept clears any prior reason so it
+    // never describes a statement that is no longer rejected (ADR-0015).
+    let reason = match status {
+        ModerationStatus::Accepted => None,
+        _ => request.moderation_reason.as_deref(),
+    };
+
+    let updated =
+        models::polis_statement_aux::moderate(&state.db, statement_id, status.clone(), reason)
+            .await?;
 
     Ok((StatusCode::OK, Json(updated)))
 }
@@ -944,6 +944,9 @@ pub struct ModerateStatementAuxBatchRequest {
     /// polis_statement_aux ids to moderate. All must belong to the same workflow step.
     pub ids: Vec<Uuid>,
     pub decision: ModerationDecisionRequest,
+    /// Optional shared reason applied to every rejected row. Ignored on accept,
+    /// which always clears the reason (ADR-0015).
+    pub moderation_reason: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, JsonSchema, Debug)]
@@ -1038,16 +1041,16 @@ async fn moderate_statement_aux_batch(
         }
     }
 
-    // Persist moderation_status for the rows Polis accepted, in one statement.
-    let succeeded = models::polis_statement_aux::update_many(
-        &state.db,
-        &succeeded_ids,
-        &UpdatePolisStatementAux {
-            moderation_status: Some(status),
-            ..Default::default()
-        },
-    )
-    .await?;
+    // Reject applies the shared reason to every row; accept clears it (ADR-0015).
+    let reason = match status {
+        ModerationStatus::Accepted => None,
+        _ => request.moderation_reason.as_deref(),
+    };
+
+    // Persist status + reason for the rows Polis accepted, in one statement.
+    let succeeded =
+        models::polis_statement_aux::moderate_many(&state.db, &succeeded_ids, status, reason)
+            .await?;
 
     Ok((
         StatusCode::OK,

--- a/documentation/adr/0015-reject-reason-is-a-preset-label-in-free-text.md
+++ b/documentation/adr/0015-reject-reason-is-a-preset-label-in-free-text.md
@@ -1,0 +1,82 @@
+# ADR-0015: A reject reason is an optional preset label stored as free text, not a structured code
+
+**Status:** Proposal - to be discussed with the team
+**Date:** 2026-08-13
+
+## Context
+
+When a moderator rejects a Pol.is statement there is nowhere to record *why* (#834). The
+backend already carries the storage: `polis_statement_aux.moderation_reason` is an
+`Option<String>` free-text column, and the single moderate endpoint already accepts an
+optional `moderation_reason`. The #806 split flow also writes this column, storing a
+human-readable sentence (`"Reworded/split by moderator into N statement(s)"`). So the
+column exists and is already treated as free-text prose.
+
+The originating client runs a moderation policy organised around seven rejection
+categories they code A to G, kept as a hand-maintained rejection log in an external Google
+Doc. The open question was what shape the reason should take in the product:
+
+- free text only,
+- a preset list of reasons, or
+- a per-conversation configurable list.
+
+And, if preset, whether to bake in the client's A to G letter codes or store readable
+labels.
+
+## Decision
+
+The reject reason is an **optional preset label**, chosen from a small hardcoded list,
+stored as a **human-readable string** in the existing `moderation_reason` free-text
+column. No new column, no enum, no structured code.
+
+- **Preset list (five, labels only):** Off-topic or unclear; Harmful or abusive;
+  Advertising or campaigning; Privacy or personal info; Duplicate. These are the client's
+  categories generalised, minus the ones that do not belong (see below). The list lives as
+  a shared frontend constant.
+- **Optional note.** A moderator may add a free-text note alongside a chosen label, or
+  instead of one. When both are present they serialise into the one column as
+  `"Label: note"`; chip-only stores the label; note-only stores the note.
+- **Optional overall.** Rejecting with no reason is allowed; the capture UI (a popover on
+  the reject control) never blocks a moderator who just wants the statement gone.
+- **Reject only.** Accepts are not justified; a moderation log is about what is removed.
+- **Accept clears the reason.** Because `update` treats `moderation_reason: None` as
+  "leave unchanged", accepting a previously-rejected statement explicitly sets the reason
+  to null, preserving the invariant "a reason describes why this statement is *currently*
+  rejected."
+
+Two categories from the client's policy are deliberately **not** in the list:
+
+- **Multiple themes** is handled by the #806 split flow, which auto-rejects the original
+  and writes its own reason. Offering it as a manual reject reason would invite a plain
+  reject where a split is the correct action.
+- **Illegal content** is folded into "Harmful or abusive". The genuinely-illegal-but-not-
+  abusive cases (copyright, promoting illegal activity) are rare and covered by the note.
+
+## Considered options
+
+- **Free text only** (rejected): gives the client nothing consistent to build a log from;
+  every moderator phrases the same reason differently.
+- **Structured reason code column / enum, exposing A to G** (rejected): the column is
+  already free-text prose (the split flow writes sentences into it), and a structured code
+  would fork that. It also bakes one client's internal bookkeeping (the letters) into a
+  shared tool. Readable labels stay generic, read cleanly in the UI and the eventual CSV,
+  and the client can still map a label back to their A to G in their own log.
+- **Per-conversation configurable reason list** (deferred): the flexible answer, but it
+  needs config storage, a migration and an admin UI to manage the list. Not justified by a
+  single client whose categories generalise well. Revisit if a second client needs a
+  different set.
+
+## Consequences
+
+- **Frontend-led, small backend delta.** Capture and inline display are frontend. The one
+  backend change is adding optional `moderation_reason` to the **batch** moderate request
+  and threading it through, so bulk reject can apply one shared reason to all selected
+  rows (single reject already supports it). Accept-clears-reason is a small tweak in the
+  moderate handler.
+- **The reason is internal.** It is shown to moderators inline on rejected rows, never to
+  participants.
+- **Export leans on this.** The follow-up CSV export (#892) reads `moderation_reason`
+  directly as a readable string. Keeping it human-readable, rather than a code needing a
+  lookup table, is what makes that export useful without extra machinery.
+- **The preset list will drift.** It is a constant, so changing it is a code edit. That is
+  the accepted cost of not building per-conversation configuration yet.

--- a/ui/packages/api-client/src/api.ts
+++ b/ui/packages/api-client/src/api.ts
@@ -555,6 +555,7 @@ export const ModerateStatementAuxBatchRequest = z
   .object({
     decision: ModerationDecisionRequest,
     ids: z.array(z.string().uuid()),
+    moderation_reason: z.union([z.string(), z.null()]).optional(),
   })
   .passthrough();
 export type ModerateStatementAuxBatchRequest = z.infer<

--- a/ui/packages/comhairle/src/lib/tools/polis/PolisModeration.svelte
+++ b/ui/packages/comhairle/src/lib/tools/polis/PolisModeration.svelte
@@ -110,24 +110,31 @@
 	let bulkAction = $state<'accepted' | 'rejected' | null>(null);
 	const bulkWorking = $derived(bulkAction !== null);
 
-	async function bulkModerate(status: 'accepted' | 'rejected') {
+	async function bulkModerate(status: 'accepted' | 'rejected', reason?: string) {
 		const decision = status === 'accepted' ? 'accept' : 'reject';
 		// Skip rows already in the target status.
 		const targets = selectedVisible.filter((r) => r.moderation_status !== status);
 		if (!targets.length || bulkWorking) return;
 		bulkAction = status;
 
-		// Optimistic: flip all targets at once.
+		// Optimistic: flip all targets at once, applying the shared reason (accept
+		// clears it, matching the backend, ADR-0015).
 		const ids = targets.map((t) => t.id);
 		const idSet = new Set(ids);
 		statements = statements.map((s) =>
-			idSet.has(s.id) ? { ...s, moderation_status: status } : s
+			idSet.has(s.id)
+				? { ...s, moderation_status: status, moderation_reason: reason ?? null }
+				: s
 		);
 
 		// One request: the backend logs in to Polis once, moderates every id, and
 		// reports per-row failures rather than failing the whole batch.
 		const result = await tryCatchAsync(() =>
-			apiClient.PolisModerateStatementAuxBatch({ ids, decision })
+			apiClient.PolisModerateStatementAuxBatch({
+				ids,
+				decision,
+				moderation_reason: reason ?? null
+			})
 		);
 
 		bulkAction = null;
@@ -154,27 +161,35 @@
 	// Track in-flight requests per aux row so the buttons can disable mid-call.
 	let pending = $state<Record<string, boolean>>({});
 
-	async function setStatus(row: PolisStatementAux, status: 'accepted' | 'rejected') {
+	async function setStatus(
+		row: PolisStatementAux,
+		status: 'accepted' | 'rejected',
+		reason?: string
+	) {
 		if (pending[row.id] || row.moderation_status === status) return;
 		const decision = status === 'accepted' ? 'accept' : 'reject';
 		pending = { ...pending, [row.id]: true };
 
-		// Optimistic update; roll back on failure.
-		const prevStatus = row.moderation_status;
+		// Optimistic update; roll back on failure. Accept clears any prior reason
+		// (matches the backend, ADR-0015); reject shows the new one immediately.
+		const prev = row;
 		statements = statements.map((s) =>
-			s.id === row.id ? { ...s, moderation_status: status } : s
+			s.id === row.id
+				? { ...s, moderation_status: status, moderation_reason: reason ?? null }
+				: s
 		);
 
 		const res = await tryCatchAsync(() =>
-			apiClient.PolisModerateStatementAux({ decision }, { params: { id: row.id } })
+			apiClient.PolisModerateStatementAux(
+				{ decision, moderation_reason: reason ?? null },
+				{ params: { id: row.id } }
+			)
 		);
 		pending = { ...pending, [row.id]: false };
 
 		if (res.err !== null) {
 			console.error('PolisModerateStatementAux failed', res.err);
-			statements = statements.map((s) =>
-				s.id === row.id ? { ...s, moderation_status: prevStatus } : s
-			);
+			statements = statements.map((s) => (s.id === row.id ? prev : s));
 			notifications.send({ priority: 'ERROR', message: 'Failed to update statement' });
 			return;
 		}

--- a/ui/packages/comhairle/src/lib/tools/polis/PolisModeration.svelte
+++ b/ui/packages/comhairle/src/lib/tools/polis/PolisModeration.svelte
@@ -166,6 +166,11 @@
 		status: 'accepted' | 'rejected',
 		reason?: string
 	) {
+		// If the clicked row is part of an active selection, the per-row accept/reject
+		// applies to the whole selection (same as the bulk bar). Clicking a row that
+		// isn't selected stays a single-row action.
+		if (selected[row.id]) return bulkModerate(status, reason);
+
 		if (pending[row.id] || row.moderation_status === status) return;
 		const decision = status === 'accepted' ? 'accept' : 'reject';
 		pending = { ...pending, [row.id]: true };

--- a/ui/packages/comhairle/src/lib/tools/polis/polis-moderation/RejectReasonPopover.svelte
+++ b/ui/packages/comhairle/src/lib/tools/polis/polis-moderation/RejectReasonPopover.svelte
@@ -2,6 +2,7 @@
 	import type { Snippet } from 'svelte';
 	import * as Popover from '$lib/components/ui/popover';
 	import { Button } from '$lib/components/ui/button';
+	import { Toggle } from '$lib/components/ui/toggle';
 	import { Textarea } from '$lib/components/ui/textarea';
 	import { REJECT_REASONS, composeReason } from './rejectReasons';
 
@@ -54,18 +55,14 @@
 
 			<div class="flex flex-wrap gap-2">
 				{#each REJECT_REASONS as reason (reason)}
-					<button
-						type="button"
-						aria-pressed={selected === reason}
-						onclick={() => (selected = selected === reason ? null : reason)}
-						class={`inline-flex cursor-pointer items-center rounded-full border px-3 py-1.5 text-sm transition-colors ${
-							selected === reason
-								? 'border-primary bg-primary text-primary-foreground'
-								: 'border-border bg-secondary text-secondary-foreground hover:bg-secondary/80'
-						}`}
+					<Toggle
+						size="sm"
+						pressed={selected === reason}
+						onPressedChange={(on) => (selected = on ? reason : null)}
+						class="border-border bg-secondary text-secondary-foreground data-[state=on]:border-primary data-[state=on]:bg-primary data-[state=on]:text-primary-foreground rounded-full border px-3"
 					>
 						{reason}
-					</button>
+					</Toggle>
 				{/each}
 			</div>
 

--- a/ui/packages/comhairle/src/lib/tools/polis/polis-moderation/RejectReasonPopover.svelte
+++ b/ui/packages/comhairle/src/lib/tools/polis/polis-moderation/RejectReasonPopover.svelte
@@ -1,0 +1,80 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	import * as Popover from '$lib/components/ui/popover';
+	import { Button } from '$lib/components/ui/button';
+	import { Textarea } from '$lib/components/ui/textarea';
+	import { REJECT_REASONS, composeReason } from './rejectReasons';
+
+	type Props = {
+		/** The reject control that opens the popover (rendered inside the trigger). */
+		trigger: Snippet;
+		/** Confirm the reject, passing the composed reason (undefined when blank). */
+		onConfirm: (reason: string | undefined) => void;
+		/** Heading, e.g. "Reject statement" or "Reject 3 statements". */
+		heading?: string;
+		/** When true the trigger is inert and the popover cannot open. */
+		disabled?: boolean;
+	};
+
+	let { trigger, onConfirm, heading = 'Reject statement', disabled = false }: Props = $props();
+
+	let open = $state(false);
+	// A reason is optional: the moderator can confirm with neither chip nor note.
+	let selected = $state<string | null>(null);
+	let note = $state('');
+
+	function reset() {
+		selected = null;
+		note = '';
+	}
+
+	function confirm() {
+		onConfirm(composeReason(selected, note));
+		open = false;
+	}
+</script>
+
+<Popover.Root
+	bind:open
+	onOpenChange={(o) => {
+		if (!o) reset();
+	}}
+>
+	<Popover.Trigger {disabled}>
+		{@render trigger()}
+	</Popover.Trigger>
+	<Popover.Content class="w-80" align="end">
+		<div class="flex flex-col gap-3">
+			<div class="flex flex-col gap-1">
+				<span class="text-base font-semibold">{heading}</span>
+				<span class="text-muted-foreground text-sm">
+					Add an optional reason. Only moderators see this.
+				</span>
+			</div>
+
+			<div class="flex flex-wrap gap-2">
+				{#each REJECT_REASONS as reason (reason)}
+					<button
+						type="button"
+						aria-pressed={selected === reason}
+						onclick={() => (selected = selected === reason ? null : reason)}
+						class={`inline-flex cursor-pointer items-center rounded-full border px-3 py-1.5 text-sm transition-colors ${
+							selected === reason
+								? 'border-primary bg-primary text-primary-foreground'
+								: 'border-border bg-secondary text-secondary-foreground hover:bg-secondary/80'
+						}`}
+					>
+						{reason}
+					</button>
+				{/each}
+			</div>
+
+			<Textarea bind:value={note} rows={2} placeholder="Add a note (optional)…" />
+
+			<div class="flex justify-end gap-2">
+				<Button variant="ghost" size="sm" onclick={() => (open = false)}>Cancel</Button>
+				<Button variant="destructive" size="sm" onclick={confirm}>Reject</Button>
+			</div>
+		</div>
+	</Popover.Content>
+</Popover.Root>

--- a/ui/packages/comhairle/src/lib/tools/polis/polis-moderation/StatementModerationRow.svelte
+++ b/ui/packages/comhairle/src/lib/tools/polis/polis-moderation/StatementModerationRow.svelte
@@ -8,6 +8,9 @@
 	type Props = {
 		row: PolisStatementAux;
 		selected: boolean;
+		/** How many rows are selected overall; drives whether this row's accept/reject
+		 * acts on the whole selection and how the reject popover is labelled. */
+		selectionCount: number;
 		/** This row has an accept/reject request in flight. */
 		pending: boolean;
 		/** A bulk moderation is running for the whole table. */
@@ -25,6 +28,7 @@
 	let {
 		row,
 		selected,
+		selectionCount,
 		pending,
 		bulkWorking,
 		editedFrom,
@@ -33,6 +37,16 @@
 		onModerate,
 		onSplit
 	}: Props = $props();
+
+	// When this row is part of a multi-selection, its accept/reject applies to the
+	// whole selection (the parent routes it through the bulk path), so label the
+	// controls accordingly instead of implying a single-statement action.
+	const actsOnSelection = $derived(selected && selectionCount > 1);
+	const acceptTitle = $derived(actsOnSelection ? `Accept ${selectionCount} selected` : 'Accept');
+	const rejectTitle = $derived(actsOnSelection ? `Reject ${selectionCount} selected` : 'Reject');
+	const rejectHeading = $derived(
+		actsOnSelection ? `Reject ${selectionCount} statements` : 'Reject statement'
+	);
 
 	// Left accent bar colour keyed on seed/status. Olive-green primary stands in
 	// for "accepted"; there is no dedicated success token in the theme.
@@ -123,22 +137,29 @@
 		{/if}
 		<button
 			type="button"
-			disabled={pending || bulkWorking || row.moderation_status === 'accepted'}
+			disabled={pending ||
+				bulkWorking ||
+				(!actsOnSelection && row.moderation_status === 'accepted')}
 			onclick={() => onModerate('accepted')}
-			title="Accept"
+			title={acceptTitle}
 			class="text-primary hover:bg-primary/15 inline-flex size-11 cursor-pointer items-center justify-center rounded-full transition-all hover:scale-110 active:scale-95 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:scale-100 disabled:hover:bg-transparent"
 		>
 			<Check class="size-6" />
 		</button>
 		<RejectReasonPopover
-			disabled={pending || bulkWorking || row.moderation_status === 'rejected'}
+			heading={rejectHeading}
+			disabled={pending ||
+				bulkWorking ||
+				(!actsOnSelection && row.moderation_status === 'rejected')}
 			onConfirm={(reason) => onModerate('rejected', reason)}
 		>
 			{#snippet trigger()}
 				<button
 					type="button"
-					disabled={pending || bulkWorking || row.moderation_status === 'rejected'}
-					title="Reject"
+					disabled={pending ||
+						bulkWorking ||
+						(!actsOnSelection && row.moderation_status === 'rejected')}
+					title={rejectTitle}
 					class="text-destructive hover:bg-destructive/15 inline-flex size-11 cursor-pointer items-center justify-center rounded-full transition-all hover:scale-110 active:scale-95 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:scale-100 disabled:hover:bg-transparent"
 				>
 					<X class="size-6" />

--- a/ui/packages/comhairle/src/lib/tools/polis/polis-moderation/StatementModerationRow.svelte
+++ b/ui/packages/comhairle/src/lib/tools/polis/polis-moderation/StatementModerationRow.svelte
@@ -3,6 +3,7 @@
 	import { Badge } from '$lib/components/ui/badge';
 	import { Check, Pencil, X } from '@lucide/svelte';
 	import type { PolisStatementAux } from '@crownshy/api-client/api';
+	import RejectReasonPopover from './RejectReasonPopover.svelte';
 
 	type Props = {
 		row: PolisStatementAux;
@@ -16,7 +17,7 @@
 		/** Texts of the derived statements that replaced this row (if it was split). */
 		replacedBy?: string[];
 		onToggle: (checked: boolean) => void;
-		onModerate: (status: 'accepted' | 'rejected') => void;
+		onModerate: (status: 'accepted' | 'rejected', reason?: string) => void;
 		/** Open the split/reword dialog for this row. */
 		onSplit: () => void;
 	};
@@ -100,6 +101,11 @@
 				Replaced by {replacedBy.length} statement{replacedBy.length === 1 ? '' : 's'}
 			</p>
 		{/if}
+		{#if row.moderation_status === 'rejected' && row.moderation_reason}
+			<p class="text-muted-foreground text-sm">
+				Reason: <span class="italic">{row.moderation_reason}</span>
+			</p>
+		{/if}
 	</div>
 
 	<!-- Actions -->
@@ -124,14 +130,20 @@
 		>
 			<Check class="size-6" />
 		</button>
-		<button
-			type="button"
+		<RejectReasonPopover
 			disabled={pending || bulkWorking || row.moderation_status === 'rejected'}
-			onclick={() => onModerate('rejected')}
-			title="Reject"
-			class="text-destructive hover:bg-destructive/15 inline-flex size-11 cursor-pointer items-center justify-center rounded-full transition-all hover:scale-110 active:scale-95 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:scale-100 disabled:hover:bg-transparent"
+			onConfirm={(reason) => onModerate('rejected', reason)}
 		>
-			<X class="size-6" />
-		</button>
+			{#snippet trigger()}
+				<button
+					type="button"
+					disabled={pending || bulkWorking || row.moderation_status === 'rejected'}
+					title="Reject"
+					class="text-destructive hover:bg-destructive/15 inline-flex size-11 cursor-pointer items-center justify-center rounded-full transition-all hover:scale-110 active:scale-95 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:scale-100 disabled:hover:bg-transparent"
+				>
+					<X class="size-6" />
+				</button>
+			{/snippet}
+		</RejectReasonPopover>
 	</div>
 </div>

--- a/ui/packages/comhairle/src/lib/tools/polis/polis-moderation/StatementsTable.svelte
+++ b/ui/packages/comhairle/src/lib/tools/polis/polis-moderation/StatementsTable.svelte
@@ -136,6 +136,7 @@
 				<StatementModerationRow
 					{row}
 					selected={!!selected[row.id]}
+					selectionCount={selectedCount}
 					pending={!!pending[row.id]}
 					{bulkWorking}
 					editedFrom={lineage[row.id]?.editedFrom}

--- a/ui/packages/comhairle/src/lib/tools/polis/polis-moderation/StatementsTable.svelte
+++ b/ui/packages/comhairle/src/lib/tools/polis/polis-moderation/StatementsTable.svelte
@@ -6,6 +6,7 @@
 	import { Check, X } from '@lucide/svelte';
 	import type { PolisStatementAux } from '@crownshy/api-client/api';
 	import StatementModerationRow from './StatementModerationRow.svelte';
+	import RejectReasonPopover from './RejectReasonPopover.svelte';
 
 	type Props = {
 		/** The visible (filtered + searched) statements, already ordered. */
@@ -18,8 +19,12 @@
 		onToggleSelect: (id: string, checked: boolean) => void;
 		onToggleAll: (checked: boolean) => void;
 		onClear: () => void;
-		onBulkModerate: (status: 'accepted' | 'rejected') => void;
-		onModerate: (row: PolisStatementAux, status: 'accepted' | 'rejected') => void;
+		onBulkModerate: (status: 'accepted' | 'rejected', reason?: string) => void;
+		onModerate: (
+			row: PolisStatementAux,
+			status: 'accepted' | 'rejected',
+			reason?: string
+		) => void;
 		/** Per-row lineage strings for derived statements, keyed by aux row id. */
 		lineage: Record<string, { editedFrom?: string; replacedBy?: string[] }>;
 		onSplit: (row: PolisStatementAux) => void;
@@ -71,16 +76,23 @@
 						<Check class="size-4" />
 						Approve
 					</LoadingButton>
-					<LoadingButton
-						size="sm"
-						variant="destructive"
-						loading={bulkAction === 'rejected'}
+					<RejectReasonPopover
+						heading={`Reject ${selectedCount} statement${selectedCount === 1 ? '' : 's'}`}
 						disabled={bulkWorking}
-						onclick={() => onBulkModerate('rejected')}
+						onConfirm={(reason) => onBulkModerate('rejected', reason)}
 					>
-						<X class="size-4" />
-						Reject
-					</LoadingButton>
+						{#snippet trigger()}
+							<LoadingButton
+								size="sm"
+								variant="destructive"
+								loading={bulkAction === 'rejected'}
+								disabled={bulkWorking}
+							>
+								<X class="size-4" />
+								Reject
+							</LoadingButton>
+						{/snippet}
+					</RejectReasonPopover>
 					<Button size="sm" variant="ghost" disabled={bulkWorking} onclick={onClear}>
 						Clear
 					</Button>
@@ -129,7 +141,7 @@
 					editedFrom={lineage[row.id]?.editedFrom}
 					replacedBy={lineage[row.id]?.replacedBy}
 					onToggle={(checked) => onToggleSelect(row.id, checked)}
-					onModerate={(status) => onModerate(row, status)}
+					onModerate={(status, reason) => onModerate(row, status, reason)}
 					onSplit={() => onSplit(row)}
 				/>
 			{/each}

--- a/ui/packages/comhairle/src/lib/tools/polis/polis-moderation/rejectReasons.test.ts
+++ b/ui/packages/comhairle/src/lib/tools/polis/polis-moderation/rejectReasons.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { composeReason } from './rejectReasons';
+
+describe('composeReason', () => {
+	it('combines a label and a note', () => {
+		expect(composeReason('Duplicate', 'same as #12')).toBe('Duplicate: same as #12');
+	});
+
+	it('returns the label alone when there is no note', () => {
+		expect(composeReason('Off-topic or unclear', '')).toBe('Off-topic or unclear');
+		expect(composeReason('Off-topic or unclear', '   ')).toBe('Off-topic or unclear');
+	});
+
+	it('returns the trimmed note alone when no label is chosen', () => {
+		expect(composeReason(null, '  spam  ')).toBe('spam');
+	});
+
+	it('returns undefined when neither is given, so a reason-less reject stays reason-less', () => {
+		expect(composeReason(null, '')).toBeUndefined();
+		expect(composeReason(null, '   ')).toBeUndefined();
+	});
+});

--- a/ui/packages/comhairle/src/lib/tools/polis/polis-moderation/rejectReasons.ts
+++ b/ui/packages/comhairle/src/lib/tools/polis/polis-moderation/rejectReasons.ts
@@ -1,0 +1,28 @@
+/**
+ * Preset rejection reasons offered when a moderator rejects a Polis statement
+ * (ADR-0015). Labels only, stored verbatim in `moderation_reason` as free text.
+ *
+ * "Multiple themes" is deliberately absent: splitting a statement is the correct
+ * action there, and the split flow rejects the original with its own reason.
+ * "Illegal" is folded into "Harmful or abusive"; the rare pure-illegal case goes
+ * in the note. Keep this list short: it is a fast single tap, not a taxonomy.
+ */
+export const REJECT_REASONS = [
+	'Off-topic or unclear',
+	'Harmful or abusive',
+	'Advertising or campaigning',
+	'Privacy or personal info',
+	'Duplicate'
+] as const;
+
+/**
+ * Combine the chosen preset label and an optional free-text note into the single
+ * string stored in `moderation_reason`. Returns undefined when neither is given,
+ * so a reason-less reject stays reason-less.
+ */
+export function composeReason(label: string | null, note: string): string | undefined {
+	const trimmed = note.trim();
+	if (label && trimmed) return `${label}: ${trimmed}`;
+	if (label) return label;
+	return trimmed || undefined;
+}


### PR DESCRIPTION
When an admin rejects a statement in Polis moderation there's now a place to record why. Optional, so it never slows a moderator down.

Short version: the reason is an optional preset label (five generic labels) plus an optional note, stored in the existing free-text `moderation_reason` column. Not structured codes, not per-conversation config (both considered and deferred). Rationale captured in ADR-0015.

**What's in here**

Backend
- New `moderate` / `moderate_many` model fns that write status and reason together, so accepting a statement clears any leftover reason (a reason should only ever describe a statement that's currently rejected).
- Added `moderation_reason` to the batch moderate request so bulk reject can apply one shared reason to every selected row. Single reject already supported it.
- The accept-clears-reason rule lives in one `reason_for_decision` helper now, shared by the single and batch handlers, so the invariant can't drift between them.

Frontend
- `RejectReasonPopover` opens on reject (single and bulk): pick a label, optionally add a note, confirm. Reject is now a confirm step rather than an instant click. Labels are the shared `Toggle` component rather than a hand-rolled button.
- The chosen label and note get composed into one string (`composeReason`, unit tested).
- The reason shows inline on rejected rows. Never shown to participants.
- Per-row accept/reject now respects an active selection: if the row you click is one of several selected, the action applies to the whole selection (same path as the bulk bar), and the button tooltips + reject heading say how many statements it'll affect. Clicking a row that isn't selected stays a single-row action. Split/edit is always single, unchanged.

**Out of scope / follow-up**

- CSV export of all moderated statements including reasons is filed separately as #892. That's the piece that would replace the client's hand-kept rejection log, and it reuses the existing monitor-page download pattern.
- Two smaller moderation-table polish tickets spun off while working on this: a proper loading state for CSV seed import (#896) and shift-click range selection (#897).

https://github.com/user-attachments/assets/05d90729-96f0-48c5-8b8b-7dbc692109eb

