### PR TITLE
897 Range select (with shift) in polis statement moderation

### DIFF
--- a/ui/packages/comhairle/src/lib/tools/polis/PolisModeration.svelte
+++ b/ui/packages/comhairle/src/lib/tools/polis/PolisModeration.svelte
@@ -94,8 +94,31 @@
 	let selected = $state<Record<string, boolean>>({});
 	const selectedVisible = $derived(visible.filter((r) => selected[r.id]));
 
-	function toggleSelect(id: string, checked: boolean) {
+	// The last plainly-clicked row, used as the anchor for shift-click range
+	// selection. Ranges are computed against `visible` so they follow the current
+	// filter/search/sort order, not the raw data order.
+	let anchorId = $state<string | null>(null);
+
+	function toggleSelect(id: string, checked: boolean, range = false) {
+		// Shift-click: select every visible row between the anchor and this row
+		// (inclusive). Falls back to a plain toggle if there's no anchor or it's
+		// no longer visible (e.g. filtered out since it was clicked).
+		if (range && anchorId !== null && anchorId !== id) {
+			const order = visible.map((r) => r.id);
+			const a = order.indexOf(anchorId);
+			const b = order.indexOf(id);
+			if (a !== -1 && b !== -1) {
+				const [lo, hi] = a < b ? [a, b] : [b, a];
+				const next = { ...selected };
+				for (let i = lo; i <= hi; i++) next[order[i]] = true;
+				selected = next;
+				// Keep the anchor put so the range can be re-adjusted with another
+				// shift-click, matching standard file-list behaviour.
+				return;
+			}
+		}
 		selected = { ...selected, [id]: checked };
+		anchorId = id;
 	}
 	function toggleSelectAll(checked: boolean) {
 		const next = { ...selected };
@@ -104,6 +127,7 @@
 	}
 	function clearSelection() {
 		selected = {};
+		anchorId = null;
 	}
 
 	// Which bulk action is in flight (drives the per-button spinner); null when idle.

--- a/ui/packages/comhairle/src/lib/tools/polis/polis-moderation/StatementModerationRow.svelte
+++ b/ui/packages/comhairle/src/lib/tools/polis/polis-moderation/StatementModerationRow.svelte
@@ -19,7 +19,8 @@
 		editedFrom?: string;
 		/** Texts of the derived statements that replaced this row (if it was split). */
 		replacedBy?: string[];
-		onToggle: (checked: boolean) => void;
+		/** `range` is true when shift was held, requesting a range select. */
+		onToggle: (checked: boolean, range: boolean) => void;
 		onModerate: (status: 'accepted' | 'rejected', reason?: string) => void;
 		/** Open the split/reword dialog for this row. */
 		onSplit: () => void;
@@ -56,21 +57,32 @@
 		if (r.moderation_status === 'rejected') return 'bg-destructive';
 		return 'bg-muted-foreground/40';
 	}
+
+	// The checkbox reports toggles via `onCheckedChange`, which carries no event, so
+	// we snapshot whether shift was held on the preceding mousedown (fires before
+	// the change) to know if this should start a range select.
+	let shiftHeld = false;
 </script>
 
 <div
 	role="button"
 	tabindex="0"
 	aria-pressed={selected}
+	onmousedown={(e) => {
+		// Snapshot shift for the checkbox's event-less onCheckedChange (mousedown
+		// fires first), and suppress the browser's text selection on shift-click.
+		shiftHeld = e.shiftKey;
+		if (e.shiftKey) e.preventDefault();
+	}}
 	onclick={(e) => {
 		// Ignore clicks that land on the checkbox or the accept/reject controls.
 		if (bulkWorking || (e.target as HTMLElement).closest('[data-row-control]')) return;
-		onToggle(!selected);
+		onToggle(!selected, e.shiftKey);
 	}}
 	onkeydown={(e) => {
 		if (e.key === 'Enter' || e.key === ' ') {
 			e.preventDefault();
-			if (!bulkWorking) onToggle(!selected);
+			if (!bulkWorking) onToggle(!selected, e.shiftKey);
 		}
 	}}
 	class={`border-border group relative grid cursor-pointer grid-cols-[2.5rem_3rem_minmax(0,1fr)_auto] items-center gap-4 border-b py-4 pl-4 transition-colors last:border-b-0 ${
@@ -87,7 +99,7 @@
 		<Checkbox
 			checked={selected}
 			disabled={bulkWorking}
-			onCheckedChange={(v) => onToggle(v === true)}
+			onCheckedChange={(v) => onToggle(v === true, shiftHeld)}
 			aria-label="Select statement"
 		/>
 	</div>

--- a/ui/packages/comhairle/src/lib/tools/polis/polis-moderation/StatementModerationRow.svelte
+++ b/ui/packages/comhairle/src/lib/tools/polis/polis-moderation/StatementModerationRow.svelte
@@ -58,32 +58,39 @@
 		return 'bg-muted-foreground/40';
 	}
 
-	// The checkbox reports toggles via `onCheckedChange`, which carries no event, so
-	// we snapshot whether shift was held on the preceding mousedown (fires before
-	// the change) to know if this should start a range select.
+	// Whether shift was held, for range-select. Every toggle path reads this one
+	// snapshot: we capture it in the capture phase, which runs before the checkbox's
+	// event-less `onCheckedChange` and also covers a keyboard toggle of the checkbox
+	// (Space fires no mousedown). Deliberately a plain `let`, not `$state`: it is a
+	// transient input snapshot and must not drive reactivity.
 	let shiftHeld = false;
+	const snapshotShift = (e: MouseEvent | KeyboardEvent) => {
+		shiftHeld = e.shiftKey;
+	};
 </script>
 
 <div
 	role="button"
 	tabindex="0"
 	aria-pressed={selected}
-	onmousedown={(e) => {
-		// Snapshot shift for the checkbox's event-less onCheckedChange (mousedown
-		// fires first), and suppress the browser's text selection on shift-click.
-		shiftHeld = e.shiftKey;
+	onmousedowncapture={(e) => {
+		snapshotShift(e);
+		// Suppress the browser's text selection on shift-click.
 		if (e.shiftKey) e.preventDefault();
 	}}
+	onkeydowncapture={snapshotShift}
 	onclick={(e) => {
 		// Ignore clicks that land on the checkbox or the accept/reject controls.
 		if (bulkWorking || (e.target as HTMLElement).closest('[data-row-control]')) return;
-		onToggle(!selected, e.shiftKey);
+		onToggle(!selected, shiftHeld);
 	}}
 	onkeydown={(e) => {
-		if (e.key === 'Enter' || e.key === ' ') {
-			e.preventDefault();
-			if (!bulkWorking) onToggle(!selected, e.shiftKey);
-		}
+		if (e.key !== 'Enter' && e.key !== ' ') return;
+		// Ignore keys aimed at the checkbox / accept-reject controls; those toggle
+		// themselves (the checkbox via onCheckedChange).
+		if ((e.target as HTMLElement).closest('[data-row-control]')) return;
+		e.preventDefault();
+		if (!bulkWorking) onToggle(!selected, shiftHeld);
 	}}
 	class={`border-border group relative grid cursor-pointer grid-cols-[2.5rem_3rem_minmax(0,1fr)_auto] items-center gap-4 border-b py-4 pl-4 transition-colors last:border-b-0 ${
 		selected ? 'bg-primary/5' : 'hover:bg-muted/40'

--- a/ui/packages/comhairle/src/lib/tools/polis/polis-moderation/StatementsTable.svelte
+++ b/ui/packages/comhairle/src/lib/tools/polis/polis-moderation/StatementsTable.svelte
@@ -16,7 +16,7 @@
 		pending: Record<string, boolean>;
 		/** Which bulk action is in flight, or null when idle. */
 		bulkAction: 'accepted' | 'rejected' | null;
-		onToggleSelect: (id: string, checked: boolean) => void;
+		onToggleSelect: (id: string, checked: boolean, range: boolean) => void;
 		onToggleAll: (checked: boolean) => void;
 		onClear: () => void;
 		onBulkModerate: (status: 'accepted' | 'rejected', reason?: string) => void;
@@ -141,7 +141,7 @@
 					{bulkWorking}
 					editedFrom={lineage[row.id]?.editedFrom}
 					replacedBy={lineage[row.id]?.replacedBy}
-					onToggle={(checked) => onToggleSelect(row.id, checked)}
+					onToggle={(checked, range) => onToggleSelect(row.id, checked, range)}
 					onModerate={(status, reason) => onModerate(row, status, reason)}
 					onSplit={() => onSplit(row)}
 				/>


### PR DESCRIPTION
You can now shift-click to select a range of statements in the Polis moderation table, like any normal file list. Click a row to set the anchor, then shift-click another and everything between them gets selected.

## Behaviour
- A plain click (or checkbox toggle) sets that row as the anchor.
- Shift-click selects the whole range between the anchor and the clicked row, inclusive.
- The range follows the visible order, so it stays correct under an active filter/search/sort (it's computed against the `visible` list, not the raw data).
- The anchor stays put after a range select, so you can shift-click again to grow or shrink the range.

## Notes
- Works with the keyboard too: shift is snapshotted in the capture phase, so it's correct even when the checkbox is toggled with Space (which fires no mousedown).
- Also tightened the row's keydown handler to ignore keys aimed at the checkbox /accept-reject buttons, so those no longer double-toggle the row's selection.


https://github.com/user-attachments/assets/d9398380-c7f7-4d6b-9d85-97179f9182fe
