### PR TITLE
[Waves] 856 Configurable minimum proposals to review before continuing

### DIFF
--- a/api/src/tools/prioritization.rs
+++ b/api/src/tools/prioritization.rs
@@ -46,6 +46,13 @@ pub struct PrioritizationToolConfig {
     pub section_questions: Vec<Question>,
     pub randomize_order: bool,
     pub alignment_question_id: Option<Uuid>,
+    /// Minimum proposals a participant must review before they can continue to
+    /// the next step. `None` means every proposal must be reviewed, which is the
+    /// default; an admin sets a number only to loosen that. Non-positive values
+    /// are normalised back to `None` on read, and the participant UI clamps the
+    /// value to the proposal count, so the gate is always satisfiable.
+    #[serde(default)]
+    pub required_reviews: Option<i32>,
 }
 
 #[derive(Serialize, Deserialize, Debug, JsonSchema, PartialEq, Clone, TranslatableJson)]
@@ -207,6 +214,9 @@ impl ToolConfigSanitize for PrioritizationToolConfig {
             section_questions: self.section_questions.clone(),
             randomize_order: self.randomize_order,
             alignment_question_id: self.alignment_question_id,
+            // A stored zero or negative would make the gate meaningless, so treat
+            // it as unset (every proposal must be reviewed).
+            required_reviews: self.required_reviews.filter(|v| *v >= 1),
         }
     }
 }
@@ -365,6 +375,7 @@ async fn prioritization_setup(
         section_questions: vec![],
         randomize_order: false,
         alignment_question_id,
+        required_reviews: None,
     })
 }
 

--- a/api/src/tools/prioritization.rs
+++ b/api/src/tools/prioritization.rs
@@ -49,8 +49,9 @@ pub struct PrioritizationToolConfig {
     /// Minimum proposals a participant must review before they can continue to
     /// the next step. `None` means every proposal must be reviewed, which is the
     /// default; an admin sets a number only to loosen that. Non-positive values
-    /// are normalised back to `None` on read, and the participant UI clamps the
-    /// value to the proposal count, so the gate is always satisfiable.
+    /// are normalised back to `None` by `ToolConfigSanitize` on save, not on
+    /// every read, and the participant UI clamps the value to the proposal
+    /// count, so the gate is always satisfiable.
     #[serde(default)]
     pub required_reviews: Option<i32>,
 }

--- a/documentation/adr/0015-prioritization-review-gate-defaults-to-all-proposals.md
+++ b/documentation/adr/0015-prioritization-review-gate-defaults-to-all-proposals.md
@@ -1,0 +1,66 @@
+# ADR-0015: The prioritization review gate defaults to all proposals
+
+**Status:** accepted
+**Date:** 2026-08-17
+
+## Context
+
+[Issue #856](https://github.com/crown-shy/comhairle/issues/856) asked for a prioritization step
+that participants do not have to complete in full: a configurable **minimum number of proposals a
+participant must review** before the step's "Next" unlocks, roughly the Polis / Thinking Space
+model. The issue proposed "a sensible default of 1", i.e. out of the box a participant would only
+need to review one proposal before moving on.
+
+Before this change the participant gate was `allDone`: every proposal had to be submitted before
+the step would let anyone continue. There was no "minimum N" concept at all.
+
+Taking the issue's default literally would have **silently loosened every prioritization step that
+already exists**. A step configured before this feature landed carries no `required_reviews` value,
+so on deploy every one of them would drop from "review all 9 proposals" to "review 1", with no
+admin action and no signal in the Manage UI that anything had changed. The only partner asking for
+the feature (Waves) wants the value set to 1 on their own steps, which they can do explicitly.
+
+## Decision
+
+**Unset means all proposals. An admin sets a number only to loosen the gate.**
+
+- `PrioritizationToolConfig.required_reviews` is `Option<i32>`, defaulting to `None`
+  ([api/src/tools/prioritization.rs](../../api/src/tools/prioritization.rs)). `None` is not "1", it
+  is "every proposal".
+- The participant gate resolves `None` to `proposals.length`, so behaviour with no config is
+  byte-for-byte the old `allDone`
+  ([PrioritizationUser.svelte](../../ui/packages/comhairle/src/lib/tools/prioritization/PrioritizationUser.svelte)).
+- A set value is floored at 1 and clamped to the proposal count, so an admin cannot configure a
+  gate that no participant can satisfy (e.g. "review 20" on a 9-proposal step).
+- Non-positive stored values normalise back to `None` in `sanitize()`, so a hand-edited or
+  legacy-bad config fails closed (review all) rather than open (review none).
+- In the Manage UI the field is a number input with placeholder **All**; blank clears back to
+  `undefined`. Blank is a first-class value, not an error state.
+
+This is a deliberate inversion of the default stated in #856. The configurability the issue asked
+for is delivered in full; only the value you get when you configure nothing differs.
+
+## Consequences
+
+- Existing prioritization steps are unaffected by the deploy. No conversation changes behaviour
+  until an admin types a number.
+- Waves gets what they asked for by setting the field to 1 on their steps, which is one input away.
+- The tri-state (blank = all, N = minimum, and the floor/clamp) has to be explained in the Manage
+  UI copy, since "leave blank for the stricter behaviour" is not guessable. The field's description
+  says so directly.
+- The field is named `required_reviews`, **not** `required_votes` as the Polis tool names its
+  equivalent. Prioritization has no votes: participants review and submit proposals, and the issue
+  thread settled on "review" for the participant-facing copy. Reusing the Polis noun would have put
+  the same key with two different defaults (Polis falls back to 10) in two tool configs.
+
+## Alternatives considered
+
+- **Default of 1, as written in the issue.** Rejected for the silent-loosening problem above. A
+  gate that weakens itself on deploy is the wrong direction to fail in for a consultation tool.
+- **Backfill every existing step with `required_reviews = <its proposal count>` in a migration.**
+  Equivalent behaviour, but it freezes the count at migration time: adding a tenth proposal later
+  would leave the gate at 9. Resolving `None` at gate time tracks the proposal list.
+- **Make the step's `required` flag do this job.** `required` is a workflow-level concept that
+  shows the "Skip this step" button and bypasses the tool entirely. It is orthogonal: `required`
+  controls whether you may skip the step wholesale, `required_reviews` controls how much
+  engagement counts as finishing it. Both can be set, and they compose the way they do for Polis.

--- a/ui/packages/comhairle/src/lib/tools/prioritization/PrioritizationManage.svelte
+++ b/ui/packages/comhairle/src/lib/tools/prioritization/PrioritizationManage.svelte
@@ -224,7 +224,9 @@
 	 * can continue. Blank (or invalid) input means "all proposals", the default, and
 	 * is stored as undefined so clearing the field restores it. A set value floors at
 	 * 1; the participant gate clamps to the proposal count, so there is no upper bound
-	 * to enforce here. Debounced on input, matching PolisManage's identical field. */
+	 * to enforce here. Debounced on input. PolisManage's field looks identical but
+	 * handles blank input differently: it returns early and keeps the previous value,
+	 * where clearing this one deliberately restores the default. */
 	const saveRequiredReviews = useDebounce(async (raw: string) => {
 		const parsed = Number.parseInt(raw.trim(), 10);
 		const next = Number.isFinite(parsed) && parsed >= 1 ? parsed : undefined;
@@ -483,7 +485,8 @@
 				<Label for="requiredReviews" class="font-medium">Minimum proposals to review</Label>
 				<p class="text-muted-foreground text-sm">
 					How many proposals a participant must review before they can continue to the
-					next step. Leave blank to require all proposals.
+					next step. Leave blank to require all proposals.{#if store.proposals.length > 0}
+						A number above {store.proposals.length} counts as all of them.{/if}
 				</p>
 			</div>
 			<Input
@@ -491,6 +494,7 @@
 				name="requiredReviews"
 				type="number"
 				min="1"
+				max={store.proposals.length > 0 ? store.proposals.length : undefined}
 				step="1"
 				placeholder="All"
 				class="w-24"

--- a/ui/packages/comhairle/src/lib/tools/prioritization/PrioritizationManage.svelte
+++ b/ui/packages/comhairle/src/lib/tools/prioritization/PrioritizationManage.svelte
@@ -2,6 +2,8 @@
 	import { Button } from '$lib/components/ui/button';
 	import { Badge } from '$lib/components/ui/badge';
 	import { Switch } from '$lib/components/ui/switch';
+	import Input from '$lib/components/ui/input/input.svelte';
+	import Label from '$lib/components/ui/label/label.svelte';
 	import * as Card from '$lib/components/ui/card';
 	import * as AlertDialog from '$lib/components/ui/alert-dialog';
 	import { Plus, Pencil, Trash2, LoaderCircle, GripVertical } from 'lucide-svelte';
@@ -21,6 +23,7 @@
 	} from './types';
 	import * as Select from '$lib/components/ui/select';
 	import Spinner from '$lib/components/ui/spinner/spinner.svelte';
+	import { useDebounce } from 'runed';
 	import { type ConversationWithTranslations } from '@crownshy/api-client/api';
 
 	let {
@@ -67,6 +70,11 @@
 	let deletingQuestionInFlight = $state(false);
 	let randomizeSaving = $state(false);
 
+	/** Local mirror of the required-review count. Writable $derived: tracks the
+	 * saved config but holds the admin's in-progress edit until the source changes.
+	 * Undefined (blank input) means "all proposals", the default. */
+	let requiredReviewsInput = $derived(toolConfig.requiredReviews);
+
 	/** Per-section question editor/delete state (mirrors the proposal-question flow). */
 	let sectionQuestionEditorOpen = $state(false);
 	let sectionQuestionDeleteOpen = $state(false);
@@ -88,12 +96,7 @@
 	async function commitQuestionOrder(next: DraftQuestion[]) {
 		savingOrder = true;
 		try {
-			await store.saveToolConfig({
-				questions: next,
-				sectionQuestions,
-				randomizeOrder: toolConfig.randomizeOrder,
-				alignmentQuestionId: toolConfig.alignmentQuestionId
-			});
+			await store.saveToolConfig({ ...toolConfig, questions: next });
 		} catch {
 			/** saveToolConfig surfaces an error toast. Revert local view to the upstream order. */
 			localQuestions = questions;
@@ -105,12 +108,7 @@
 	async function commitSectionQuestionOrder(next: DraftQuestion[]) {
 		savingSectionOrder = true;
 		try {
-			await store.saveToolConfig({
-				questions,
-				sectionQuestions: next,
-				randomizeOrder: toolConfig.randomizeOrder,
-				alignmentQuestionId: toolConfig.alignmentQuestionId
-			});
+			await store.saveToolConfig({ ...toolConfig, sectionQuestions: next });
 		} catch {
 			localSectionQuestions = sectionQuestions;
 		} finally {
@@ -171,12 +169,7 @@
 		deletingQuestionInFlight = true;
 		try {
 			const next = questions.filter((q) => q.id !== selectedQuestionId);
-			await store.saveToolConfig({
-				questions: next,
-				sectionQuestions,
-				randomizeOrder: toolConfig.randomizeOrder,
-				alignmentQuestionId: toolConfig.alignmentQuestionId
-			});
+			await store.saveToolConfig({ ...toolConfig, questions: next });
 			questionDeleteOpen = false;
 			selectedQuestionId = null;
 		} catch {
@@ -206,12 +199,7 @@
 		deletingSectionQuestionInFlight = true;
 		try {
 			const next = sectionQuestions.filter((q) => q.id !== selectedSectionQuestionId);
-			await store.saveToolConfig({
-				questions,
-				sectionQuestions: next,
-				randomizeOrder: toolConfig.randomizeOrder,
-				alignmentQuestionId: toolConfig.alignmentQuestionId
-			});
+			await store.saveToolConfig({ ...toolConfig, sectionQuestions: next });
 			sectionQuestionDeleteOpen = false;
 			selectedSectionQuestionId = null;
 		} catch {
@@ -224,18 +212,28 @@
 	async function toggleRandomize(checked: boolean) {
 		randomizeSaving = true;
 		try {
-			await store.saveToolConfig({
-				questions,
-				sectionQuestions,
-				randomizeOrder: checked,
-				alignmentQuestionId: toolConfig.alignmentQuestionId
-			});
+			await store.saveToolConfig({ ...toolConfig, randomizeOrder: checked });
 		} catch {
 			/** store.saveToolConfig surfaces an error toast. */
 		} finally {
 			randomizeSaving = false;
 		}
 	}
+
+	/** Persist the minimum number of proposals a participant must review before they
+	 * can continue. Blank (or invalid) input means "all proposals", the default, and
+	 * is stored as undefined so clearing the field restores it. A set value floors at
+	 * 1; the participant gate clamps to the proposal count, so there is no upper bound
+	 * to enforce here. Debounced on input, matching PolisManage's identical field. */
+	const saveRequiredReviews = useDebounce(async (raw: string) => {
+		const parsed = Number.parseInt(raw.trim(), 10);
+		const next = Number.isFinite(parsed) && parsed >= 1 ? parsed : undefined;
+		try {
+			await store.saveToolConfig({ ...toolConfig, requiredReviews: next });
+		} catch {
+			/** store.saveToolConfig surfaces an error toast. */
+		}
+	}, 500);
 
 	function describeType(type: DraftQuestionType): string {
 		switch (type.kind) {
@@ -267,12 +265,7 @@
 	let savingAlignmentQuestion = $state(false);
 	async function setAlignmentQuestion(value: string) {
 		savingAlignmentQuestion = true;
-		await store.saveToolConfig({
-			questions,
-			sectionQuestions,
-			randomizeOrder: toolConfig.randomizeOrder,
-			alignmentQuestionId: value
-		});
+		await store.saveToolConfig({ ...toolConfig, alignmentQuestionId: value });
 		savingAlignmentQuestion = false;
 	}
 </script>
@@ -482,6 +475,27 @@
 				checked={toolConfig.randomizeOrder}
 				disabled={randomizeSaving}
 				onCheckedChange={toggleRandomize}
+			/>
+		</div>
+
+		<div class="bg-card flex items-center justify-between gap-4 rounded-md border p-3">
+			<div>
+				<Label for="requiredReviews" class="font-medium">Minimum proposals to review</Label>
+				<p class="text-muted-foreground text-sm">
+					How many proposals a participant must review before they can continue to the
+					next step. Leave blank to require all proposals.
+				</p>
+			</div>
+			<Input
+				id="requiredReviews"
+				name="requiredReviews"
+				type="number"
+				min="1"
+				step="1"
+				placeholder="All"
+				class="w-24"
+				bind:value={requiredReviewsInput}
+				oninput={(e) => saveRequiredReviews((e.currentTarget as HTMLInputElement).value)}
 			/>
 		</div>
 

--- a/ui/packages/comhairle/src/lib/tools/prioritization/PrioritizationUser.svelte
+++ b/ui/packages/comhairle/src/lib/tools/prioritization/PrioritizationUser.svelte
@@ -40,6 +40,9 @@
 	const toolConfig = $derived(
 		api.resolveToolConfig<string>(workflowStep, conversation.isLive ?? false)
 	);
+	/** Whether the participant can return to this step later — drives the "come
+	 * back to review more" reassurance when they move on before finishing. */
+	const canRevisit = $derived(workflowStep.canRevisit ?? false);
 
 	let proposals = $state<LocalizedProposal[]>([]);
 	let answers = $state<Record<string, Record<string, number | string>>>({}); // proposalId → questionId → value
@@ -623,7 +626,19 @@
 				</Button>
 			{/if}
 		</div>
-		{#if !canContinue && requiredReviews > 0}
+		{#if canContinue}
+			<div
+				class="flex flex-col gap-2 border-t pt-4 sm:flex-row sm:items-center sm:justify-between"
+			>
+				<p class="text-muted-foreground text-sm">
+					You've reviewed enough to move on. Continue to the next step, or keep reviewing.{#if canRevisit}
+						You can always come back to review more later.{/if}
+				</p>
+				<Button variant="outline" class="shrink-0" onclick={onDone} disabled={submitting}>
+					Continue to next step <ArrowRight class="ml-2 h-4 w-4" />
+				</Button>
+			</div>
+		{:else if requiredReviews > 0}
 			<p class="text-muted-foreground text-right text-sm">
 				Reviewed {submittedIds.size} of {requiredReviews}. Review {reviewsRemaining} more proposal{reviewsRemaining >
 				1

--- a/ui/packages/comhairle/src/lib/tools/prioritization/PrioritizationUser.svelte
+++ b/ui/packages/comhairle/src/lib/tools/prioritization/PrioritizationUser.svelte
@@ -24,12 +24,16 @@
 		workflowStep,
 		conversation,
 		participantId = '',
-		onDone
+		onDone,
+		onCanContinueChange
 	}: {
 		workflowStep: WorkflowStepInput;
 		conversation: ConversationInput;
 		participantId?: string;
 		onDone: () => void;
+		/** Drives the host step's top-nav "Next": true once the participant has
+		 * reviewed the minimum number of proposals. Mirrors Polis / Thinking Space. */
+		onCanContinueChange?: (canContinue: boolean) => void;
 	} = $props();
 
 	const stepId = $derived(workflowStep.id);
@@ -220,6 +224,27 @@
 	let showRequiredErrors = $derived(submitAttempted && missingKeys.size > 0);
 
 	let allDone = $derived(proposals.length > 0 && proposals.every((p) => submittedIds.has(p.id)));
+
+	/** Minimum proposals a participant must review before they can continue. Unset
+	 * means "all proposals", which is the default; an admin sets a number only to
+	 * loosen that. A set value is clamped to the number of proposals that exist, so
+	 * an over-set minimum can never leave the participant unable to advance. */
+	let requiredReviews = $derived(
+		proposals.length === 0
+			? 0
+			: toolConfig.requiredReviews == null
+				? proposals.length
+				: Math.min(Math.max(toolConfig.requiredReviews, 1), proposals.length)
+	);
+	/** The gate: has the participant reviewed at least the minimum? */
+	let canContinue = $derived(submittedIds.size >= requiredReviews);
+	let reviewsRemaining = $derived(Math.max(requiredReviews - submittedIds.size, 0));
+
+	/** Drive the host step's top-nav "Next". Runs on load too, so a returning
+	 * participant who already met the minimum can continue immediately. */
+	$effect(() => {
+		onCanContinueChange?.(canContinue);
+	});
 
 	function setAnswer(proposalId: string, questionId: string, value: number | string) {
 		const next = { ...(answers[proposalId] ?? {}), [questionId]: value };
@@ -598,6 +623,14 @@
 				</Button>
 			{/if}
 		</div>
+		{#if !canContinue && requiredReviews > 0}
+			<p class="text-muted-foreground text-right text-sm">
+				Reviewed {submittedIds.size} of {requiredReviews}. Review {reviewsRemaining} more proposal{reviewsRemaining >
+				1
+					? 's'
+					: ''} to continue to the next step.
+			</p>
+		{/if}
 		{#if showRequiredErrors}
 			<p class="text-destructive text-right text-sm">
 				Please answer the highlighted question{missingKeys.size > 1 ? 's' : ''} before continuing.

--- a/ui/packages/comhairle/src/lib/tools/prioritization/PrioritizationUser.svelte
+++ b/ui/packages/comhairle/src/lib/tools/prioritization/PrioritizationUser.svelte
@@ -11,6 +11,7 @@
 	import ContentRenderer from '$lib/components/RichTextEditor/ContentRenderer/ContentRenderer.svelte';
 	import QuestionField from './components/QuestionField.svelte';
 	import * as api from './prioritizationApi';
+	import { requiredReviewCount, canLeaveStep } from './reviewGate';
 	import type {
 		ConversationInput,
 		LocalizedProposal,
@@ -20,13 +21,7 @@
 	} from './types';
 	import { SvelteSet } from 'svelte/reactivity';
 
-	let {
-		workflowStep,
-		conversation,
-		participantId = '',
-		onDone,
-		onCanContinueChange
-	}: {
+	type Props = {
 		workflowStep: WorkflowStepInput;
 		conversation: ConversationInput;
 		participantId?: string;
@@ -34,13 +29,21 @@
 		/** Drives the host step's top-nav "Next": true once the participant has
 		 * reviewed the minimum number of proposals. Mirrors Polis / Thinking Space. */
 		onCanContinueChange?: (canContinue: boolean) => void;
-	} = $props();
+	};
+
+	let {
+		workflowStep,
+		conversation,
+		participantId = '',
+		onDone,
+		onCanContinueChange
+	}: Props = $props();
 
 	const stepId = $derived(workflowStep.id);
 	const toolConfig = $derived(
 		api.resolveToolConfig<string>(workflowStep, conversation.isLive ?? false)
 	);
-	/** Whether the participant can return to this step later — drives the "come
+	/** Whether the participant can return to this step later. Drives the "come
 	 * back to review more" reassurance when they move on before finishing. */
 	const canRevisit = $derived(workflowStep.canRevisit ?? false);
 
@@ -228,19 +231,18 @@
 
 	let allDone = $derived(proposals.length > 0 && proposals.every((p) => submittedIds.has(p.id)));
 
-	/** Minimum proposals a participant must review before they can continue. Unset
-	 * means "all proposals", which is the default; an admin sets a number only to
-	 * loosen that. A set value is clamped to the number of proposals that exist, so
-	 * an over-set minimum can never leave the participant unable to advance. */
 	let requiredReviews = $derived(
-		proposals.length === 0
-			? 0
-			: toolConfig.requiredReviews == null
-				? proposals.length
-				: Math.min(Math.max(toolConfig.requiredReviews, 1), proposals.length)
+		requiredReviewCount(toolConfig.requiredReviews, proposals.length)
 	);
-	/** The gate: has the participant reviewed at least the minimum? */
-	let canContinue = $derived(submittedIds.size >= requiredReviews);
+	/** The gate. Closed until proposals load, so a fast participant cannot click
+	 * past the step before there is anything to review. */
+	let canContinue = $derived(
+		canLeaveStep({
+			reviewedCount: submittedIds.size,
+			requiredReviews,
+			proposalsLoaded: loadState.kind === 'ready'
+		})
+	);
 	let reviewsRemaining = $derived(Math.max(requiredReviews - submittedIds.size, 0));
 
 	/** Drive the host step's top-nav "Next". Runs on load too, so a returning
@@ -630,7 +632,7 @@
 			<div
 				class="flex flex-col gap-2 border-t pt-4 sm:flex-row sm:items-center sm:justify-between"
 			>
-				<p class="text-muted-foreground text-sm">
+				<p class="text-muted-foreground text-base">
 					You've reviewed enough to move on. Continue to the next step, or keep reviewing.{#if canRevisit}
 						You can always come back to review more later.{/if}
 				</p>
@@ -639,7 +641,7 @@
 				</Button>
 			</div>
 		{:else if requiredReviews > 0}
-			<p class="text-muted-foreground text-right text-sm">
+			<p class="text-muted-foreground text-right text-base">
 				Reviewed {submittedIds.size} of {requiredReviews}. Review {reviewsRemaining} more proposal{reviewsRemaining >
 				1
 					? 's'

--- a/ui/packages/comhairle/src/lib/tools/prioritization/components/QuestionEditorDialog.svelte
+++ b/ui/packages/comhairle/src/lib/tools/prioritization/components/QuestionEditorDialog.svelte
@@ -256,10 +256,9 @@
 					: [...existing, next];
 
 			await store.saveToolConfig({
+				...toolConfig,
 				questions: target === 'section' ? toolConfig.questions : updated,
-				sectionQuestions: target === 'section' ? updated : toolConfig.sectionQuestions,
-				randomizeOrder: toolConfig.randomizeOrder,
-				alignmentQuestionId: toolConfig.alignmentQuestionId
+				sectionQuestions: target === 'section' ? updated : toolConfig.sectionQuestions
 			});
 			onOpenChange(false);
 		} catch (e) {

--- a/ui/packages/comhairle/src/lib/tools/prioritization/prioritizationApi.ts
+++ b/ui/packages/comhairle/src/lib/tools/prioritization/prioritizationApi.ts
@@ -105,6 +105,7 @@ export function resolveToolConfig<TText>(
 				questions?: unknown[];
 				randomize_order?: boolean;
 				alignment_question_id?: string;
+				required_reviews?: number | null;
 		  }
 		| null
 		| undefined;
@@ -120,7 +121,8 @@ export function resolveToolConfig<TText>(
 		questions: (raw.questions ?? []).map(normaliseQuestion<TText>),
 		sectionQuestions: (withSections.section_questions ?? []).map(normaliseQuestion<TText>),
 		randomizeOrder: Boolean(raw.randomize_order),
-		alignmentQuestionId: raw.alignment_question_id
+		alignmentQuestionId: raw.alignment_question_id,
+		requiredReviews: raw.required_reviews ?? undefined
 	};
 }
 
@@ -238,7 +240,8 @@ export async function updateToolConfig(opts: {
 		questions: opts.toolConfig.questions.map(denormaliseQuestion),
 		sectionQuestions: opts.toolConfig.sectionQuestions.map(denormaliseQuestion),
 		randomizeOrder: opts.toolConfig.randomizeOrder,
-		alignmentQuestionId: opts.toolConfig.alignmentQuestionId
+		alignmentQuestionId: opts.toolConfig.alignmentQuestionId,
+		requiredReviews: opts.toolConfig.requiredReviews
 	});
 }
 
@@ -251,13 +254,15 @@ async function putToolConfig(opts: {
 	sectionQuestions: ApiQuestion[];
 	randomizeOrder: boolean;
 	alignmentQuestionId?: string;
+	requiredReviews?: number;
 }): Promise<void> {
 	const payload = {
 		type: 'prioritization' as const,
 		questions: opts.questions,
 		section_questions: opts.sectionQuestions,
 		randomize_order: opts.randomizeOrder,
-		...(opts.alignmentQuestionId && { alignment_question_id: opts.alignmentQuestionId })
+		...(opts.alignmentQuestionId && { alignment_question_id: opts.alignmentQuestionId }),
+		...(opts.requiredReviews != null && { required_reviews: opts.requiredReviews })
 	};
 	const body: PartialWorkflowStep = opts.isLive
 		? { tool_config: payload }

--- a/ui/packages/comhairle/src/lib/tools/prioritization/reviewGate.test.ts
+++ b/ui/packages/comhairle/src/lib/tools/prioritization/reviewGate.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { requiredReviewCount, canLeaveStep } from './reviewGate';
+
+describe('requiredReviewCount', () => {
+	it('requires every proposal when the admin has set no minimum', () => {
+		expect(requiredReviewCount(null, 9)).toBe(9);
+		expect(requiredReviewCount(undefined, 9)).toBe(9);
+	});
+
+	it('uses the configured minimum when it loosens the default', () => {
+		expect(requiredReviewCount(3, 9)).toBe(3);
+	});
+
+	it('clamps a minimum set above the number of proposals', () => {
+		expect(requiredReviewCount(20, 9)).toBe(9);
+	});
+
+	it('treats a non-positive minimum as one proposal', () => {
+		expect(requiredReviewCount(0, 9)).toBe(1);
+		expect(requiredReviewCount(-4, 9)).toBe(1);
+	});
+
+	it('requires nothing when the step has no proposals', () => {
+		expect(requiredReviewCount(null, 0)).toBe(0);
+		expect(requiredReviewCount(3, 0)).toBe(0);
+	});
+});
+
+describe('canLeaveStep', () => {
+	it('stays closed while proposals are still loading', () => {
+		expect(canLeaveStep({ reviewedCount: 0, requiredReviews: 0, proposalsLoaded: false })).toBe(
+			false
+		);
+	});
+
+	it('stays closed when the participant is short of the minimum', () => {
+		expect(canLeaveStep({ reviewedCount: 2, requiredReviews: 3, proposalsLoaded: true })).toBe(
+			false
+		);
+	});
+
+	it('opens once the minimum is met', () => {
+		expect(canLeaveStep({ reviewedCount: 3, requiredReviews: 3, proposalsLoaded: true })).toBe(
+			true
+		);
+	});
+
+	it('opens when the participant has reviewed more than the minimum', () => {
+		expect(canLeaveStep({ reviewedCount: 9, requiredReviews: 3, proposalsLoaded: true })).toBe(
+			true
+		);
+	});
+
+	it('opens on a loaded step that has no proposals to review', () => {
+		expect(canLeaveStep({ reviewedCount: 0, requiredReviews: 0, proposalsLoaded: true })).toBe(
+			true
+		);
+	});
+});

--- a/ui/packages/comhairle/src/lib/tools/prioritization/reviewGate.ts
+++ b/ui/packages/comhairle/src/lib/tools/prioritization/reviewGate.ts
@@ -1,0 +1,49 @@
+/** The rule deciding when a participant may leave the prioritization step.
+ *
+ * Kept out of the component so it can be tested directly: it is the whole
+ * contract between the admin's `required_reviews` config and the step's
+ * top-nav "Next", and getting it wrong either strands participants or lets
+ * them skip the step entirely.
+ */
+
+/**
+ * How many proposals the participant must review before they can continue.
+ *
+ * An unset minimum means every proposal, which is the default (ADR-0015). A
+ * configured minimum only ever loosens that, and is clamped to the proposals
+ * that actually exist so an over-set minimum can never strand the participant
+ * on a step they cannot finish.
+ *
+ * A step with no proposals requires nothing. Callers must not read that as
+ * "the gate is open": while proposals are still loading the count is also 0,
+ * which is why `canLeaveStep` takes `proposalsLoaded` separately.
+ */
+export function requiredReviewCount(
+	configured: number | null | undefined,
+	proposalCount: number
+): number {
+	if (proposalCount === 0) return 0;
+	if (configured == null) return proposalCount;
+	if (configured < 1) return 1;
+	return Math.min(configured, proposalCount);
+}
+
+/**
+ * Whether the participant has met the minimum and may move on.
+ *
+ * `proposalsLoaded` is load-bearing. Before proposals arrive the required
+ * count is 0, so a plain `reviewed >= required` would open the gate on mount
+ * and let a fast participant click straight past the step.
+ */
+export function canLeaveStep({
+	reviewedCount,
+	requiredReviews,
+	proposalsLoaded
+}: {
+	reviewedCount: number;
+	requiredReviews: number;
+	proposalsLoaded: boolean;
+}): boolean {
+	if (!proposalsLoaded) return false;
+	return reviewedCount >= requiredReviews;
+}

--- a/ui/packages/comhairle/src/lib/tools/prioritization/types.ts
+++ b/ui/packages/comhairle/src/lib/tools/prioritization/types.ts
@@ -122,6 +122,9 @@ export type WorkflowStepInput = {
 	id: string;
 	toolConfig?: unknown;
 	previewToolConfig?: unknown;
+	/** Whether participants may return to this step after completing it. Used to
+	 * reassure them they can review the remaining proposals later. */
+	canRevisit?: boolean;
 };
 
 export type ConversationInput = {

--- a/ui/packages/comhairle/src/lib/tools/prioritization/types.ts
+++ b/ui/packages/comhairle/src/lib/tools/prioritization/types.ts
@@ -79,6 +79,11 @@ export type ToolConfig<TText> = {
 	sectionQuestions: Question<TText>[];
 	randomizeOrder: boolean;
 	alignmentQuestionId: string;
+	/** Minimum proposals a participant must review before they can continue to the
+	 * next step. Unset means every proposal must be reviewed, which is the default;
+	 * an admin sets a number only to loosen that. Clamped to the proposal count at
+	 * gate time so the bar is never impossible. */
+	requiredReviews?: number;
 };
 
 /** ---------------------------- **/

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/workflow/[workflow_id]/s/[workflow_step_id]/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/workflow/[workflow_id]/s/[workflow_step_id]/+page.svelte
@@ -371,6 +371,7 @@
 								}}
 								participantId={user.id}
 								onDone={stepComplete}
+								onCanContinueChange={handleCanContinueChange}
 							/>
 						{/key}
 					{/if}

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/workflow/[workflow_id]/s/[workflow_step_id]/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/workflow/[workflow_id]/s/[workflow_step_id]/+page.svelte
@@ -370,6 +370,7 @@
 								}}
 								participantId={user.id}
 								onDone={stepComplete}
+								onCanContinueChange={handleCanContinueChange}
 							/>
 						{/key}
 					{/if}


### PR DESCRIPTION
Implements #856. The prioritization step becomes skippable, gated on a configurable minimum number of proposals a participant must review before they can continue.

## What changed

**Config.** New `required_reviews: Option<i32>` on `PrioritizationToolConfig`, with a matching admin field in the Manage UI. Debounced save, bounded by `min`/`max` to the proposals that actually exist, and the description tells the admin that a number above that count means all of them.

**The gate.** Lives in `reviewGate.ts` as two pure functions with unit tests rather than inline in the component, because it is the whole contract between the admin's config and the step's Next button:

- `requiredReviewCount(configured, proposalCount)` resolves the admin setting against reality. Unset means every proposal. A set value is clamped to the proposals that exist, so an over-set minimum can never strand a participant on a step they cannot finish.
- `canLeaveStep({ reviewedCount, requiredReviews, proposalsLoaded })` is the gate. `proposalsLoaded` is load-bearing: before proposals arrive the required count is 0, so a plain `reviewed >= required` would open the gate on mount and let a fast participant click straight past the step.

**Default.** Unset means *all* proposals, not 1. This inverts what #856 proposed. Reasoning is in ADR-0015: defaulting to 1 would silently loosen every prioritization step that already exists. The cost is that Waves now has to set 1 by hand, which is worth a product confirmation before this merges.

## Split out of this PR

Two things had been committed onto this branch that were not part of #856:

- The workflow-step double-navigation fix, now #911 below this in the stack.
- The scroll-to-top UX change, now #912 above it.

## Follow-ups, not addressed here

- #913, a pre-existing `$effect` race in the shared step page that can leave Next stuck disabled. Affects every gated tool, so it was left out rather than widening this PR.
- #914, the disabled Next giving no reason when the gate is unmet. The requirement copy exists but sits in the proposal card rather than next to the button, and moving it is a design call on shared `StepHeader`.

## Stack

Merge bottom to top. Use rebase or merge-commit for the lower two: squashing rewrites SHAs and will make the PRs above show duplicated commits until they are rebased.

| | PR | Branch |
|---|---|---|
| 3 | #912 Scroll to page top after each proposal submit | `prioritization-scroll-ux` |
| 2 | **This PR** | `856/prioritization-min-review-gate` |
| 1 | #911 Fix double navigation on step completion | `fix/workflow-step-double-navigation` |

The stack sits on `671/exp-with-translations` (#864).