### PR TITLE
Fix double navigation on workflow step completion

### DIFF
--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/workflow/[workflow_id]/s/[workflow_step_id]/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/workflow/[workflow_id]/s/[workflow_step_id]/+page.svelte
@@ -15,7 +15,7 @@
 
 	import { Button } from '$lib/components/ui/button';
 	import { Spinner } from '$lib/components/ui/spinner';
-	import { goto, invalidate } from '$app/navigation';
+	import { goto } from '$app/navigation';
 	import { thank_you_page, next_workflow_step_url, workflow_step_url } from '$lib/urls';
 	import { page, navigating } from '$app/state';
 	import LearnArticleSkeleton from '$lib/tools/learn/LearnArticleSkeleton.svelte';
@@ -188,10 +188,15 @@
 					}
 				);
 
-				await invalidate('app:workflow-steps');
-
-				goto(
-					next_workflow_step_url(conversation.id, workflowStep.workflowId) + queryString
+				/** Deliberately no invalidate() in place. Marking the step done changes
+				 * what this page's own load does: a completed, non-revisitable step
+				 * redirects to /next. Invalidating here re-runs that load, the redirect
+				 * rejects the invalidate, and the catch below fires a spurious error
+				 * toast while the redirect navigates anyway. Navigating with
+				 * invalidateAll refreshes the step list at the destination instead. */
+				await goto(
+					next_workflow_step_url(conversation.id, workflowStep.workflowId) + queryString,
+					{ invalidateAll: true }
 				);
 			} else {
 				let next = workflowSteps.find((w) => w.stepOrder === workflowStep.stepOrder + 1);


### PR DESCRIPTION
Split out of #907 (the prioritization review gate for #856), where this had been committed alongside unrelated feature work.

## What was wrong

`invalidate('app:workflow-steps')` ran before `goto()` on step completion. Marking the step done changes what the page's own `load` does: a completed, non-revisitable step redirects to `/next`. Invalidating there re-runs that load, the redirect rejects the invalidate, and the `catch` fires a spurious error toast while the redirect navigates anyway. The participant saw an error on a successful completion, and the navigation ran twice.

## What changed

Dropped the `invalidate()` and navigate with `goto(..., { invalidateAll: true })`, which refreshes the step list at the destination rather than under a page that is about to redirect.

This affects every tool that completes a step, not just prioritization, which is why it sits at the bottom of the stack and can ship on its own.

Closes #909

## Stack

Merge bottom to top. This PR is the bottom, so it goes first. Use rebase or merge-commit rather than squash: squashing rewrites SHAs and will make the PRs above show duplicated commits until they are rebased.

| | PR | Branch |
|---|---|---|
| 3 | #912 Scroll to page top after each proposal submit | `prioritization-scroll-ux` |
| 2 | #907 Prioritization minimum review gate | `856/prioritization-min-review-gate` |
| 1 | **This PR** | `fix/workflow-step-double-navigation` |

The stack sits on `671/exp-with-translations` (#864).
