### PR TITLE
[Waves] Prioritization: scroll to page top after each proposal submit

### DIFF
--- a/ui/packages/comhairle/src/lib/tools/prioritization/PrioritizationUser.svelte
+++ b/ui/packages/comhairle/src/lib/tools/prioritization/PrioritizationUser.svelte
@@ -63,17 +63,12 @@
 	let submitError = $state<string | null>(null);
 	let savingReview = $state(false);
 	let reviewError = $state<string | null>(null);
-	/** Top of the current-proposal view; scrolled into view after advancing so it's
-	 * clear the participant has moved on to the next proposal. */
-	let proposalTopEl = $state<HTMLDivElement | null>(null);
-
-	async function scrollToProposalTop() {
+	/** After advancing to the next proposal, return the participant to the top of
+	 * the page so the step header and progress are back in view. */
+	async function scrollToTop() {
 		await tick();
 		const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-		proposalTopEl?.scrollIntoView({
-			behavior: reduceMotion ? 'auto' : 'smooth',
-			block: 'start'
-		});
+		window.scrollTo({ top: 0, behavior: reduceMotion ? 'auto' : 'smooth' });
 	}
 
 	/** Brief success interstitial shown between proposals so a submit registers as a
@@ -340,11 +335,11 @@
 		submitAttempted = false;
 		/** Confirm the submission with a short interstitial before revealing what's next. */
 		await flashSubmittedInterstitial();
-		/** If anything is left, move on and scroll the fresh proposal to the top so the
-		 * jump to the next one is unmistakable. Otherwise let allDone surface the summary. */
+		/** If anything is left, move on and scroll back to the top of the page so the
+		 * jump to the next proposal is unmistakable. Otherwise let allDone surface the summary. */
 		if (currentIndex < proposals.length - 1) {
 			currentIndex += 1;
-			await scrollToProposalTop();
+			await scrollToTop();
 		}
 	}
 
@@ -491,7 +486,7 @@
 		</div>
 	</div>
 {:else if current}
-	<div class="space-y-6" bind:this={proposalTopEl}>
+	<div class="space-y-6">
 		<div class="space-y-2">
 			<div class="flex items-center justify-between gap-3 text-sm">
 				<span class="text-muted-foreground">

--- a/ui/packages/comhairle/src/lib/tools/prioritization/PrioritizationUser.svelte
+++ b/ui/packages/comhairle/src/lib/tools/prioritization/PrioritizationUser.svelte
@@ -335,12 +335,13 @@
 		submitAttempted = false;
 		/** Confirm the submission with a short interstitial before revealing what's next. */
 		await flashSubmittedInterstitial();
-		/** If anything is left, move on and scroll back to the top of the page so the
-		 * jump to the next proposal is unmistakable. Otherwise let allDone surface the summary. */
+		/** Move on if any proposals remain; the last submit instead flips to the
+		 * "Your answers" summary (which takes template precedence). Either way scroll
+		 * back to the top of the page so the transition is unmistakable. */
 		if (currentIndex < proposals.length - 1) {
 			currentIndex += 1;
-			await scrollToTop();
 		}
+		await scrollToTop();
 	}
 
 	function goBack() {


### PR DESCRIPTION
Split out of #907 (the prioritization review gate for #856), where this had been committed alongside the review-gate work. Stacked on top of it, so review #907 first.

## What changed

- Scroll to the page top rather than to the proposal element after a submit, so the step header and progress come back into view. This also drops the element reference that only existed to support the old behaviour.
- Scroll after every submit, whether the participant advances to the next proposal or reaches the summary. Previously the final submit left the summary mid-page.
- Respects `prefers-reduced-motion`, falling back to an instant jump.

Participant-facing UX polish rather than part of the review gate, which is why it is split out.

Closes #910

## Stack

Merge bottom to top. This PR is the top, so it goes last. Use rebase or merge-commit for the two below: squashing rewrites SHAs and will make this PR show duplicated commits until it is rebased.

| | PR | Branch |
|---|---|---|
| 3 | **This PR** | `prioritization-scroll-ux` |
| 2 | #907 Prioritization minimum review gate | `856/prioritization-min-review-gate` |
| 1 | #911 Fix double navigation on step completion | `fix/workflow-step-double-navigation` |

The stack sits on `671/exp-with-translations` (#864).