### PR TITLE
Pin rust version to 1.95

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,3 +2,6 @@
 members = [
     "api", "comhairle_macros","adaptors/heyform-rust-sdk", "adaptors/ragflow"]
 resolver="2"
+
+[workspace.package]
+rust-version = "1.95"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ---- Chef Stage ----
-FROM rust:1.92-bookworm AS chef
+FROM rust:1.95-slim-trixie AS chef
 WORKDIR /workspace
 
 # Install cargo-chef for dependency caching

--- a/adaptors/heyform-rust-sdk/Cargo.toml
+++ b/adaptors/heyform-rust-sdk/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT"
 repository = "https://github.com/heyform/heyform"
 keywords = ["graphql", "forms", "api", "heyform"]
 categories = ["api-bindings", "web-programming"]
+rust-version = { "workspace" = true }
 
 [dependencies]
 chrono = "0.4.42"

--- a/adaptors/polis/Cargo.toml
+++ b/adaptors/polis/Cargo.toml
@@ -6,6 +6,7 @@ description = "A Rust SDK for polis"
 license = "MIT"
 repository = "https://github.com/crownshy/comhairle"
 keywords = [ "api", "polis"]
+rust-version = { "workspace" = true }
 
 [dependencies]
 reqwest = { version = "0.12", features = ["json", "cookies"] }

--- a/adaptors/ragflow/Cargo.toml
+++ b/adaptors/ragflow/Cargo.toml
@@ -2,6 +2,7 @@
 name = "ragflow"
 version = "0.1.0"
 edition = "2024"
+rust-version = { "workspace" = true }
 
 [dependencies]
 bytes = "1.11.0"

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -3,6 +3,7 @@ name = "comhairle_api"
 version = "0.1.0"
 edition = "2024"
 default-run = "comhairle_api"
+rust-version = { "workspace" = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/comhairle_macros/Cargo.toml
+++ b/comhairle_macros/Cargo.toml
@@ -2,6 +2,7 @@
 name = "comhairle-macros"
 version = "0.1.0"
 edition = "2024"
+rust-version = { "workspace" = true }
 
 [lib]
 proc-macro=true

--- a/data_model/Cargo.toml
+++ b/data_model/Cargo.toml
@@ -2,5 +2,6 @@
 name = "data_model"
 version = "0.1.0"
 edition = "2024"
+rust-version = { "workspace" = true }
 
 [dependencies]


### PR DESCRIPTION
Motivations:

 - Our current build actions are failing due to a crate minimum-rust-version incompatability. We should set the minimum rust version in-repo so that these errors surface during development.

Actions:

 - Pinned rust version to 1.95 for stability. We can update this in future if we want to bring in new lanugage features/fixes.