### PR TITLE
752/preassigned breakout rooms

### DIFF
--- a/ui/packages/comhairle/src/lib/components/LiveEvent/CreateBreakoutDialog.svelte
+++ b/ui/packages/comhairle/src/lib/components/LiveEvent/CreateBreakoutDialog.svelte
@@ -7,7 +7,6 @@
 	interface Props {
 		open: boolean;
 		participants: VideoCallParticipant[];
-		breakoutRoomPlan?: { participants: string[] }[];
 		defaultMaxPerRoom?: number;
 		defaultDuration?: number;
 		/** When provided, the dialog opens with this layout instead of auto-distributing. */
@@ -32,7 +31,6 @@
 	let {
 		open = $bindable(),
 		participants,
-		breakoutRoomPlan,
 		defaultMaxPerRoom = 4,
 		defaultDuration = 10,
 		initialAssignments,
@@ -68,8 +66,6 @@
 			if (initialAssignments && initialAssignments.length > 0) {
 				// Preserve a pre-existing plan rather than reshuffling it away.
 				roomAssignments = initialAssignments.map((room) => [...room]);
-			} else if (participants.length > 0 && breakoutRoomPlan && breakoutRoomPlan.length > 0) {
-				roomAssignments = renderPreassignedRooms(participants, breakoutRoomPlan);
 			} else if (participants.length > 0) {
 				distributeParticipants();
 			} else {
@@ -110,28 +106,6 @@
 			[result[i], result[j]] = [result[j], result[i]];
 		}
 		return result;
-	}
-
-	function renderPreassignedRooms(
-		participants: VideoCallParticipant[],
-		preassignedRooms: { participants: string[] }[]
-	): VideoCallParticipant[][] {
-		const roomIndexByUserId = new Map<string, number>();
-		preassignedRooms.forEach((room, index) => {
-			room.participants.forEach((userId) => roomIndexByUserId.set(userId, index));
-		});
-
-		const roomAssignments: VideoCallParticipant[][] = preassignedRooms.map(() => []);
-
-		participants.forEach((p) => {
-			const roomIndex = roomIndexByUserId.get(p.user_id);
-
-			if (roomIndex !== undefined) {
-				roomAssignments[roomIndex].push(p);
-			}
-		});
-
-		return roomAssignments;
 	}
 
 	function distributeParticipants() {

--- a/ui/packages/comhairle/src/lib/components/LiveEvent/CreateBreakoutDialog.svelte
+++ b/ui/packages/comhairle/src/lib/components/LiveEvent/CreateBreakoutDialog.svelte
@@ -7,6 +7,7 @@
 	interface Props {
 		open: boolean;
 		participants: VideoCallParticipant[];
+		breakoutRoomPlan?: { participants: string[] }[];
 		defaultMaxPerRoom?: number;
 		defaultDuration?: number;
 		/** When provided, the dialog opens with this layout instead of auto-distributing. */
@@ -31,6 +32,7 @@
 	let {
 		open = $bindable(),
 		participants,
+		breakoutRoomPlan,
 		defaultMaxPerRoom = 4,
 		defaultDuration = 10,
 		initialAssignments,
@@ -66,6 +68,8 @@
 			if (initialAssignments && initialAssignments.length > 0) {
 				// Preserve a pre-existing plan rather than reshuffling it away.
 				roomAssignments = initialAssignments.map((room) => [...room]);
+			} else if (participants.length > 0 && breakoutRoomPlan && breakoutRoomPlan.length > 0) {
+				roomAssignments = renderPreassignedRooms(participants, breakoutRoomPlan);
 			} else if (participants.length > 0) {
 				distributeParticipants();
 			} else {
@@ -106,6 +110,28 @@
 			[result[i], result[j]] = [result[j], result[i]];
 		}
 		return result;
+	}
+
+	function renderPreassignedRooms(
+		participants: VideoCallParticipant[],
+		preassignedRooms: { participants: string[] }[]
+	): VideoCallParticipant[][] {
+		const roomIndexByUserId = new Map<string, number>();
+		preassignedRooms.forEach((room, index) => {
+			room.participants.forEach((userId) => roomIndexByUserId.set(userId, index));
+		});
+
+		const roomAssignments: VideoCallParticipant[][] = preassignedRooms.map(() => []);
+
+		participants.forEach((p) => {
+			const roomIndex = roomIndexByUserId.get(p.user_id);
+
+			if (roomIndex !== undefined) {
+				roomAssignments[roomIndex].push(p);
+			}
+		});
+
+		return roomAssignments;
 	}
 
 	function distributeParticipants() {

--- a/ui/packages/comhairle/src/lib/services/videoCallService.svelte.ts
+++ b/ui/packages/comhairle/src/lib/services/videoCallService.svelte.ts
@@ -119,25 +119,14 @@ export class VideoCallService {
 	}
 
 	private handleStateUpdate(state: VideoCallState) {
-		console.log('Video call state updated:', state);
-		console.log(
-			'[BREAKOUT-SVC] breakout_rooms:',
-			state.breakout_rooms?.length,
-			'breakout_session:',
-			state.breakout_session,
-			'participants:',
-			Object.keys(state.participants ?? {})
-		);
 		this._currentCallState = state;
 	}
 
 	private handleBroadcastMessage(data: BroadcastMessage) {
-		console.log('Received broadcast message:', data.message);
 		this._lastBroadcastMessage = data.message;
 	}
 
 	private handleAgendaUpdate(agenda: EventAgendaItem[]) {
-		console.log('[BREAKOUT-SVC] agenda updated:', agenda?.length, 'items');
 		this._agenda = agenda;
 	}
 

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/events/[event_id]/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/events/[event_id]/+page.svelte
@@ -645,7 +645,7 @@
 		<EmailInvitesList {emailInvites} inviteLink={InviteLink} />
 	</div>
 {:else if activeTab === 'breakout'}
-	<EventBreakoutRooms conversation_id={conversation.id} event_id={event.id} />
+	<EventBreakoutRooms conversation_id={conversation.id} event_id={event.id} {attendees} />
 {:else if activeTab === 'recordings'}
 	<EventRecordings conversation_id={conversation.id} event_id={event.id} {recordings} />
 {/if}

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/events/[event_id]/EventBreakoutRooms.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/events/[event_id]/EventBreakoutRooms.svelte
@@ -4,14 +4,14 @@
 	import { Button } from '$lib/components/ui/button';
 	import { notifications } from '$lib/notifications.svelte';
 	import { apiClient } from '@crownshy/api-client/client';
-	import type { BreakoutPlanDto, EventAttendanceDto } from '@crownshy/api-client/api';
+	import type { BreakoutPlanDto, EventAttendanceEtx } from '@crownshy/api-client/api';
 	import CreateBreakoutDialog from '$lib/components/LiveEvent/CreateBreakoutDialog.svelte';
 	import type { VideoCallParticipant } from '$lib/services/videoCallService.svelte';
 
 	type Props = {
 		conversation_id: string;
 		event_id: string;
-		attendees: (EventAttendanceDto & { email?: string })[];
+		attendees: EventAttendanceEtx[];
 	};
 
 	let { conversation_id, event_id, attendees }: Props = $props();

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/events/[event_id]/EventBreakoutRooms.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/events/[event_id]/EventBreakoutRooms.svelte
@@ -4,16 +4,17 @@
 	import { Button } from '$lib/components/ui/button';
 	import { notifications } from '$lib/notifications.svelte';
 	import { apiClient } from '@crownshy/api-client/client';
-	import type { BreakoutPlanDto } from '@crownshy/api-client/api';
+	import type { BreakoutPlanDto, EventAttendanceDto } from '@crownshy/api-client/api';
 	import CreateBreakoutDialog from '$lib/components/LiveEvent/CreateBreakoutDialog.svelte';
 	import type { VideoCallParticipant } from '$lib/services/videoCallService.svelte';
 
 	type Props = {
 		conversation_id: string;
 		event_id: string;
+		attendees: (EventAttendanceDto & { email?: string })[];
 	};
 
-	let { conversation_id, event_id }: Props = $props();
+	let { conversation_id, event_id, attendees }: Props = $props();
 
 	let plan = $state<BreakoutPlanDto | null>(null);
 	let loading = $state(true);
@@ -180,7 +181,11 @@
 
 <CreateBreakoutDialog
 	bind:open={dialogOpen}
-	participants={[]}
+	participants={attendees.map((a) => ({
+		user_id: a.userId,
+		username: a.email ?? a.userId,
+		role: a.role
+	}))}
 	initialAssignments={dialogAssignments}
 	moderatorIds={dialogModeratorIds}
 	enableModerators={true}

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
@@ -176,15 +176,6 @@
 		} else {
 			phase = 'lobby';
 		}
-		console.log(
-			'[BREAKOUT] meetingPhase:',
-			phase,
-			'{ callStatus:',
-			callStatus,
-			', hasJoinedCall:',
-			hasJoinedCall,
-			'}'
-		);
 		return phase;
 	});
 
@@ -269,18 +260,12 @@
 			const nonMainRoomCount = Object.values(jitsiBreakoutRooms).filter(
 				(r: any) => !r.isMainRoom
 			).length;
-			console.log('[BREAKOUT] Checking rooms ready:', {
-				nonMainRoomCount,
-				expectedRooms: breakoutRooms.length || mockBreakoutRooms.length,
-				breakoutRoomsReady
-			});
 			// Set ready when Jitsi has created the expected number of rooms
 			if (
 				nonMainRoomCount > 0 &&
 				nonMainRoomCount >= (breakoutRooms.length || mockBreakoutRooms.length)
 			) {
 				if (!breakoutRoomsReady) {
-					console.log('[BREAKOUT] Breakout rooms are now ready!');
 					breakoutRoomsReady = true;
 				}
 			}
@@ -327,7 +312,6 @@
 	// Auto-join when call is in progress (moderator started it)
 	$effect(() => {
 		if (callStatus === 'InProgress' && !hasJoinedCall) {
-			console.log('[BREAKOUT] Auto-joining into call, isModerator:', isModerator);
 			hasJoinedCall = true;
 		}
 	});
@@ -355,13 +339,6 @@
 
 	// Auto-enter participants into their assigned breakout room
 	$effect(() => {
-		console.log('[BREAKOUT] auto-enter effect:', {
-			isBreakoutActive,
-			isModerator,
-			breakoutRoomsReady,
-			roomContext: typeof roomContext === 'string' ? roomContext : roomContext,
-			userId: user?.id
-		});
 		if (
 			isBreakoutActive &&
 			!isModerator &&
@@ -369,16 +346,10 @@
 			typeof roomContext === 'string'
 		) {
 			const assignedRoom = user ? videoCallService.getUserBreakoutRoom(user.id) : null;
-			console.log(
-				'[BREAKOUT] Participant auto-entering breakout room:',
-				assignedRoom,
-				'(fallback 0)'
-			);
 			// Use assigned room from backend, or default to room 0 for mock testing
 			handleEnterBreakoutRoom(assignedRoom ?? 0);
 		}
 		if (!isBreakoutActive && typeof roomContext !== 'string' && !isModerator) {
-			console.log('[BREAKOUT] Breakout ended — returning participant to main room');
 			roomContext = 'plenary';
 			// Jitsi automatically moves participants back when rooms are removed
 		}
@@ -393,15 +364,12 @@
 
 		const assignedRoom = videoCallService.getUserBreakoutRoom(user.id);
 		const tracked = untrack(() => trackedRoomIndex);
-		console.log('[BREAKOUT] reassignment check:', { assignedRoom, tracked });
 
 		if (tracked === null && assignedRoom !== null) {
 			// First assignment — just start tracking
-			console.log('[BREAKOUT] First assignment, tracking room:', assignedRoom);
 			trackedRoomIndex = assignedRoom;
 		} else if (assignedRoom !== null && assignedRoom !== tracked && tracked !== null) {
 			// Room changed mid-session — moderator moved us
-			console.log('[BREAKOUT] Room CHANGED by moderator:', tracked, '→', assignedRoom);
 			handleEnterBreakoutRoom(assignedRoom);
 			pushNotice({ message: `You've been moved to Breakout room #${assignedRoom + 1}` });
 			trackedRoomIndex = assignedRoom;
@@ -558,11 +526,6 @@
 		durationMinutes: number;
 		roomAssignments: VideoCallParticipant[][];
 	}) {
-		console.log('[BREAKOUT] handleCreateBreakout:', {
-			maxPerRoom: config.maxPerRoom,
-			durationMinutes: config.durationMinutes,
-			roomCount: config.roomAssignments.length
-		});
 		// Send explicit room assignments so backend uses the dialog's distribution
 		const roomAssignments = config.roomAssignments.map((room) => room.map((p) => p.user_id));
 		videoCallService.assignBreakoutRooms(eventId, config.maxPerRoom, roomAssignments);
@@ -589,43 +552,21 @@
 	}
 
 	function handleEnterBreakoutRoom(roomIndex: number) {
-		console.log(
-			'[BREAKOUT] handleEnterBreakoutRoom:',
-			roomIndex,
-			'| isModerator:',
-			isModerator,
-			'| current roomContext:',
-			roomContext,
-			'| breakoutRoomsReady:',
-			breakoutRoomsReady
-		);
-
 		if (!breakoutRoomsReady) {
 			console.warn(
 				'[BREAKOUT] Attempted to enter room before Jitsi breakout rooms are ready'
 			);
 		}
 
-		console.log('[BREAKOUT] Current jitsiBreakoutRooms state:', jitsiBreakoutRooms);
-		console.log('[BREAKOUT] All rooms:', Object.values(jitsiBreakoutRooms));
-
 		roomContext = {
 			type: 'breakout',
 			roomIndex,
 			roomName: `Breakout room #${roomIndex + 1}`
 		};
-		console.log('[BREAKOUT] roomContext NOW:', roomContext);
 
 		// Use Jitsi's native breakout room API to switch rooms
 		const jitsiRoomId = getJitsiBreakoutRoomId(roomIndex);
 		if (jitsiRoomId) {
-			console.log('[BREAKOUT] joinBreakoutRoom via Jitsi API, roomId:', jitsiRoomId);
-			console.log(
-				'[BREAKOUT] roomId type:',
-				typeof jitsiRoomId,
-				'value:',
-				JSON.stringify(jitsiRoomId)
-			);
 			jitsiApi?.executeCommand('joinBreakoutRoom', jitsiRoomId);
 		} else {
 			console.warn(
@@ -646,13 +587,11 @@
 	}
 
 	function handleLeaveBreakoutRoom() {
-		console.log('[BREAKOUT] handleLeaveBreakoutRoom → returning to main room');
 		roomContext = 'plenary';
 
 		// Use Jitsi API to return to main room (no iframe reload needed)
 		try {
 			jitsiApi?.executeCommand('joinBreakoutRoom');
-			console.log('[BREAKOUT] Sent joinBreakoutRoom command to return to main');
 		} catch (error) {
 			console.error('[BREAKOUT] Error returning to main room:', error);
 		}
@@ -697,11 +636,8 @@
 	}
 
 	async function handleEndBreakoutSession() {
-		console.log('[BREAKOUT] handleEndBreakoutSession - removing breakout rooms');
-
 		// Step 1: Ensure moderator is in main room before removing breakout rooms
 		if (typeof roomContext !== 'string') {
-			console.log('[BREAKOUT] Moderator in breakout room - returning to main first');
 			try {
 				jitsiApi?.executeCommand('joinBreakoutRoom');
 				// Wait a moment for the transition
@@ -715,7 +651,6 @@
 		let breakoutRoomsList: any[] = [];
 		try {
 			const rooms = await jitsiApi?.listBreakoutRooms?.();
-			console.log('[BREAKOUT] listBreakoutRooms() returned:', rooms);
 
 			if (rooms) {
 				breakoutRoomsList = Object.values(rooms).filter((r: any) => !r.isMainRoom);
@@ -726,23 +661,11 @@
 			breakoutRoomsList = Object.values(jitsiBreakoutRooms).filter((r: any) => !r.isMainRoom);
 		}
 
-		console.log('[BREAKOUT] Found', breakoutRoomsList.length, 'breakout rooms to remove');
-
 		// Step 3: Remove all breakout rooms - Jitsi should auto-return participants to main room
-		console.log('[BREAKOUT] Removing breakout rooms...');
 		for (const room of breakoutRoomsList) {
-			console.log('[BREAKOUT] Removing room:', {
-				id: room.id,
-				jid: room.jid,
-				name: room.name
-			});
 			try {
 				// Use room.jid for the removeBreakoutRoom command
 				jitsiApi?.executeCommand('closeBreakoutRoom', room.id);
-				console.log(
-					'[BREAKOUT] Successfully sent removeBreakoutRoom command for:',
-					room.jid
-				);
 			} catch (error) {
 				console.error('[BREAKOUT] Error removing breakout room:', error);
 			}
@@ -765,19 +688,14 @@
 	}
 
 	function handleGoBackToPlenary() {
-		console.log('[BREAKOUT] handleGoBackToPlenary called, isModerator:', isModerator);
 		roomContext = 'plenary';
 		if (isModerator) {
 			handleEndBreakoutSession();
 		} else {
 			// Participants return to main room by calling joinBreakoutRoom without arguments
-			console.log('[BREAKOUT] Participant returning to main room:', plenaryRoomName);
 			try {
 				// Calling joinBreakoutRoom without arguments moves user to main room
 				jitsiApi?.executeCommand('joinBreakoutRoom');
-				console.log(
-					'[BREAKOUT] Successfully sent joinBreakoutRoom command to return to main'
-				);
 			} catch (error) {
 				console.error('[BREAKOUT] Error returning to main room:', error);
 			}
@@ -789,14 +707,10 @@
 	}
 
 	function handleModeratorStatusChanged(isMod: boolean) {
-		console.log('[BREAKOUT] handleModeratorStatusChanged called with:', isMod);
-		console.log('[BREAKOUT] Previous jitsiModeratorStatus:', jitsiModeratorStatus);
 		jitsiModeratorStatus = isMod;
-		console.log('[BREAKOUT] New jitsiModeratorStatus:', jitsiModeratorStatus);
 	}
 
 	function handleVideoConferenceJoined(data: any) {
-		console.log('[BREAKOUT] Entered Jitsi room:', data.roomName);
 		currentJitsiRoomName = data.roomName;
 		localParticipantId = data.id ?? null;
 		// Tell the backend we're really in the video (rename-proof call presence) and
@@ -809,14 +723,12 @@
 	}
 
 	function handleVideoConferenceLeft(data: any) {
-		console.log('[BREAKOUT] Left Jitsi room:', data.roomName);
 		videoCallService.reportVideoLeft(eventId);
 	}
 
 	function handleDisplayNameChange(data: any) {
 		// Only re-report when OUR own display name changed.
 		if (data?.id && data.id === localParticipantId) {
-			console.log('[BREAKOUT] Local display name changed:', data.displayname);
 			videoCallService.reportVideoJoined(eventId, data.displayname ?? data.displayName);
 		}
 	}
@@ -1170,7 +1082,8 @@
 <!-- Dialogs -->
 <CreateBreakoutDialog
 	bind:open={showCreateBreakout}
-	participants={inCallParticipants}
+	participants={allParticipants}
+	breakoutRoomPlan={videoCallService.breakoutRooms}
 	defaultDuration={breakoutDialogItem?.durationMinutes}
 	defaultMaxPerRoom={breakoutDialogItem?.maxPerRoom}
 	onClose={() => (showCreateBreakout = false)}

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
@@ -230,6 +230,32 @@
 		return mockBreakoutRooms;
 	});
 
+	let preassignedBreakoutRooms = $derived.by(() => {
+		return renderPreassignedRooms(allParticipants, videoCallService.breakoutRooms);
+	});
+
+	function renderPreassignedRooms(
+		participants: VideoCallParticipant[],
+		preassignedRooms: { participants: string[] }[]
+	): VideoCallParticipant[][] {
+		const roomIndexByUserId = new Map<string, number>();
+		preassignedRooms.forEach((room, index) => {
+			room.participants.forEach((userId) => roomIndexByUserId.set(userId, index));
+		});
+
+		const roomAssignments: VideoCallParticipant[][] = preassignedRooms.map(() => []);
+
+		participants.forEach((p) => {
+			const roomIndex = roomIndexByUserId.get(p.user_id);
+
+			if (roomIndex !== undefined) {
+				roomAssignments[roomIndex].push(p);
+			}
+		});
+
+		return roomAssignments;
+	}
+
 	$effect(() => {
 		const session = breakoutSession;
 		if (session) {
@@ -1083,7 +1109,7 @@
 <CreateBreakoutDialog
 	bind:open={showCreateBreakout}
 	participants={allParticipants}
-	breakoutRoomPlan={videoCallService.breakoutRooms}
+	initialAssignments={preassignedBreakoutRooms}
 	defaultDuration={breakoutDialogItem?.durationMinutes}
 	defaultMaxPerRoom={breakoutDialogItem?.maxPerRoom}
 	onClose={() => (showCreateBreakout = false)}

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
@@ -231,10 +231,10 @@
 	});
 
 	let preassignedBreakoutRooms = $derived.by(() => {
-		return renderPreassignedRooms(allParticipants, videoCallService.breakoutRooms);
+		return transformPreassignedRooms(allParticipants, videoCallService.breakoutRooms);
 	});
 
-	function renderPreassignedRooms(
+	function transformPreassignedRooms(
 		participants: VideoCallParticipant[],
 		preassignedRooms: { participants: string[] }[]
 	): VideoCallParticipant[][] {


### PR DESCRIPTION
Motivation:

- ensure pre-assigned breakout rooms are maintained in live meetings
- fix bug where editing breakout rooms in admin resulted in empty list of rooms

Actions:

- expose pre-assigned breakout room plan as `initialAssignements` in `CreateBreakoutDialog` for live meetings
- expose attendees / participants to `CreateBreakoutDialog` in admin