### PR TITLE
Refactor: Live event page: move pure logic to $lib/utils with tests

### DIFF
--- a/ui/packages/comhairle/src/lib/utils/breakoutRoomAssignments.test.ts
+++ b/ui/packages/comhairle/src/lib/utils/breakoutRoomAssignments.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { groupParticipantsByRoom } from './breakoutRoomAssignments';
 import type { VideoCallParticipant } from '$lib/services/videoCallService.svelte';
+import { groupParticipantsByRoom } from './breakoutRoomAssignments';
 
 const participant = (user_id: string, role = 'participant'): VideoCallParticipant => ({
 	user_id,

--- a/ui/packages/comhairle/src/lib/utils/breakoutRoomAssignments.test.ts
+++ b/ui/packages/comhairle/src/lib/utils/breakoutRoomAssignments.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { groupParticipantsByRoom } from './breakoutRoomAssignments';
+import type { VideoCallParticipant } from '$lib/services/videoCallService.svelte';
+
+const participant = (user_id: string, role = 'participant'): VideoCallParticipant => ({
+	user_id,
+	username: user_id,
+	role
+});
+
+describe('groupParticipantsByRoom', () => {
+	it('buckets each participant into the room they are assigned to', () => {
+		const grouped = groupParticipantsByRoom(
+			[participant('a'), participant('b'), participant('c')],
+			[{ participants: ['a', 'c'] }, { participants: ['b'] }]
+		);
+
+		expect(grouped.map((room) => room.map((p) => p.user_id))).toEqual([['a', 'c'], ['b']]);
+	});
+
+	it('keeps rooms in room order, not in participant order', () => {
+		const grouped = groupParticipantsByRoom(
+			[participant('b'), participant('a')],
+			[{ participants: ['a'] }, { participants: ['b'] }]
+		);
+
+		expect(grouped.map((room) => room.map((p) => p.user_id))).toEqual([['a'], ['b']]);
+	});
+
+	it('returns an empty bucket for a room nobody is in, so indices stay aligned', () => {
+		const grouped = groupParticipantsByRoom(
+			[participant('a')],
+			[{ participants: [] }, { participants: ['a'] }]
+		);
+
+		expect(grouped).toEqual([[], [participant('a')]]);
+	});
+
+	it('drops participants with no room assignment', () => {
+		const grouped = groupParticipantsByRoom(
+			[participant('a'), participant('unassigned')],
+			[{ participants: ['a'] }]
+		);
+
+		expect(grouped).toEqual([[participant('a')]]);
+	});
+
+	it('puts a participant listed in two rooms in the last one that claims them', () => {
+		const grouped = groupParticipantsByRoom(
+			[participant('a')],
+			[{ participants: ['a'] }, { participants: ['a'] }]
+		);
+
+		expect(grouped.map((room) => room.length)).toEqual([0, 1]);
+	});
+
+	it('returns no rooms when there is no breakout plan', () => {
+		expect(groupParticipantsByRoom([participant('a')], [])).toEqual([]);
+	});
+});

--- a/ui/packages/comhairle/src/lib/utils/breakoutRoomAssignments.ts
+++ b/ui/packages/comhairle/src/lib/utils/breakoutRoomAssignments.ts
@@ -1,0 +1,33 @@
+import type {
+	BreakoutRoomAssignments,
+	VideoCallParticipant
+} from '$lib/services/videoCallService.svelte';
+
+/**
+ * Group participants by the breakout room they are assigned to.
+ *
+ * Returns one bucket per room, in room order, so the caller can index by room number.
+ * Participants with no assignment are dropped; a room with no participants stays as an
+ * empty bucket, which keeps the room indices lined up with Jitsi's.
+ */
+export function groupParticipantsByRoom(
+	participants: VideoCallParticipant[],
+	rooms: BreakoutRoomAssignments[]
+): VideoCallParticipant[][] {
+	const roomIndexByUserId = new Map<string, number>();
+	rooms.forEach((room, index) => {
+		room.participants.forEach((userId) => roomIndexByUserId.set(userId, index));
+	});
+
+	const roomAssignments: VideoCallParticipant[][] = rooms.map(() => []);
+
+	participants.forEach((p) => {
+		const roomIndex = roomIndexByUserId.get(p.user_id);
+
+		if (roomIndex !== undefined) {
+			roomAssignments[roomIndex].push(p);
+		}
+	});
+
+	return roomAssignments;
+}

--- a/ui/packages/comhairle/src/lib/utils/formatCountdown.test.ts
+++ b/ui/packages/comhairle/src/lib/utils/formatCountdown.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { formatCountdown } from './formatCountdown';
+
+describe('formatCountdown', () => {
+	it('formats whole minutes', () => {
+		expect(formatCountdown(5 * 60 * 1000)).toBe('5:00');
+	});
+
+	it('zero-pads the seconds', () => {
+		expect(formatCountdown(61_000)).toBe('1:01');
+	});
+
+	it('rounds down to the second', () => {
+		expect(formatCountdown(1999)).toBe('0:01');
+	});
+
+	it('does not roll minutes over at 60', () => {
+		expect(formatCountdown(90 * 60 * 1000)).toBe('90:00');
+	});
+
+	it('reads 0:00 once time is up', () => {
+		expect(formatCountdown(0)).toBe('0:00');
+		expect(formatCountdown(-1000)).toBe('0:00');
+	});
+
+	it('reads 0:00 when there is no session', () => {
+		expect(formatCountdown(null)).toBe('0:00');
+	});
+});

--- a/ui/packages/comhairle/src/lib/utils/formatCountdown.ts
+++ b/ui/packages/comhairle/src/lib/utils/formatCountdown.ts
@@ -1,0 +1,8 @@
+/** Format a millisecond countdown as `m:ss`. Anything at or below zero reads `0:00`. */
+export function formatCountdown(msRemaining: number | null): string {
+	if (msRemaining === null || msRemaining <= 0) return '0:00';
+	const totalSecs = Math.floor(msRemaining / 1000);
+	const min = Math.floor(totalSecs / 60);
+	const sec = totalSecs % 60;
+	return `${min}:${sec.toString().padStart(2, '0')}`;
+}

--- a/ui/packages/comhairle/src/lib/utils/formatCountdown.ts
+++ b/ui/packages/comhairle/src/lib/utils/formatCountdown.ts
@@ -1,8 +1,8 @@
 /** Format a millisecond countdown as `m:ss`. Anything at or below zero reads `0:00`. */
 export function formatCountdown(msRemaining: number | null): string {
 	if (msRemaining === null || msRemaining <= 0) return '0:00';
-	const totalSecs = Math.floor(msRemaining / 1000);
-	const min = Math.floor(totalSecs / 60);
-	const sec = totalSecs % 60;
-	return `${min}:${sec.toString().padStart(2, '0')}`;
+	const totalSeconds = Math.floor(msRemaining / 1000);
+	const minutes = Math.floor(totalSeconds / 60);
+	const seconds = totalSeconds % 60;
+	return `${minutes}:${seconds.toString().padStart(2, '0')}`;
 }

--- a/ui/packages/comhairle/src/lib/utils/jitsiBreakoutRooms.test.ts
+++ b/ui/packages/comhairle/src/lib/utils/jitsiBreakoutRooms.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { getJitsiBreakoutRoomId, type JitsiBreakoutRoom } from './jitsiBreakoutRooms';
+
+const rooms = (...entries: JitsiBreakoutRoom[]): Record<string, JitsiBreakoutRoom> =>
+	Object.fromEntries(entries.map((room, i) => [`key-${i}`, room]));
+
+describe('getJitsiBreakoutRoomId', () => {
+	it('maps a room index to the jid of the nth non-main room, in name order', () => {
+		const all = rooms(
+			{ jid: 'main@conf', name: 'Main room', isMainRoom: true },
+			{ jid: 'two@breakout', name: 'Breakout room #2' },
+			{ jid: 'one@breakout', name: 'Breakout room #1' }
+		);
+
+		expect(getJitsiBreakoutRoomId(all, 0)).toBe('one@breakout');
+		expect(getJitsiBreakoutRoomId(all, 1)).toBe('two@breakout');
+	});
+
+	it('returns null for an index past the last room', () => {
+		expect(getJitsiBreakoutRoomId(rooms({ jid: 'one@breakout', name: 'A' }), 3)).toBeNull();
+	});
+
+	it('returns null when Jitsi has not reported any rooms yet', () => {
+		expect(getJitsiBreakoutRoomId({}, 0)).toBeNull();
+	});
+
+	it('returns null when a room has no jid', () => {
+		expect(getJitsiBreakoutRoomId(rooms({ name: 'A' }), 0)).toBeNull();
+	});
+
+	it('sorts unnamed rooms first rather than dropping them', () => {
+		const all = rooms({ jid: 'named@breakout', name: 'A' }, { jid: 'unnamed@breakout' });
+
+		expect(getJitsiBreakoutRoomId(all, 0)).toBe('unnamed@breakout');
+	});
+
+	// Current behaviour, not desired behaviour: the sort is lexicographic, so once there
+	// are ten or more rooms "#10" lands before "#2" and every index past it points at the
+	// wrong room. Part of #752; this test is here to fail loudly when that gets fixed.
+	it('orders room names lexicographically, so #10 sorts before #2', () => {
+		const all = rooms(
+			{ jid: 'ten@breakout', name: 'Breakout room #10' },
+			{ jid: 'two@breakout', name: 'Breakout room #2' }
+		);
+
+		expect(getJitsiBreakoutRoomId(all, 0)).toBe('ten@breakout');
+	});
+});

--- a/ui/packages/comhairle/src/lib/utils/jitsiBreakoutRooms.ts
+++ b/ui/packages/comhairle/src/lib/utils/jitsiBreakoutRooms.ts
@@ -1,0 +1,23 @@
+/** The subset of Jitsi's breakout room payload we read. */
+export interface JitsiBreakoutRoom {
+	jid?: string;
+	name?: string;
+	isMainRoom?: boolean;
+}
+
+/**
+ * Translate a 0-based breakout room index into the Jitsi room jid to join.
+ *
+ * Jitsi hands us the rooms as an object keyed by an internal id, with the main room mixed
+ * in, so the ordering our room numbers rely on comes from sorting the non-main rooms by
+ * name.
+ */
+export function getJitsiBreakoutRoomId(
+	rooms: Record<string, JitsiBreakoutRoom>,
+	roomIndex: number
+): string | null {
+	const nonMainRooms = Object.values(rooms)
+		.filter((r) => !r.isMainRoom)
+		.sort((a, b) => (a.name ?? '').localeCompare(b.name ?? ''));
+	return nonMainRooms[roomIndex]?.jid ?? null;
+}

--- a/ui/packages/comhairle/src/lib/utils/jitsiBreakoutRooms.ts
+++ b/ui/packages/comhairle/src/lib/utils/jitsiBreakoutRooms.ts
@@ -1,5 +1,6 @@
 /** The subset of Jitsi's breakout room payload we read. */
 export interface JitsiBreakoutRoom {
+	// jid: the XMPP address Jitsi identifies a room by, and what you pass to join it.
 	jid?: string;
 	name?: string;
 	isMainRoom?: boolean;

--- a/ui/packages/comhairle/src/lib/utils/liveEventAgenda.test.ts
+++ b/ui/packages/comhairle/src/lib/utils/liveEventAgenda.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import { mapApiAgenda } from './liveEventAgenda';
+
+describe('mapApiAgenda', () => {
+	it('maps a basic item to a plenary agenda item', () => {
+		expect(
+			mapApiAgenda([{ Basic: { title: 'Welcome', description: 'Intro', estimated_time: 5 } }])
+		).toEqual([{ id: '1', title: 'Welcome', type: 'plenary' }]);
+	});
+
+	it('maps a breakout item, titling it from the prompt', () => {
+		expect(
+			mapApiAgenda([
+				{
+					BreakoutRoom: {
+						prompt: 'What matters most to you?',
+						instructions: 'Talk it through',
+						estimated_time: 15,
+						max_per_room: 4
+					}
+				}
+			])
+		).toEqual([
+			{
+				id: '1',
+				title: 'What matters most to you?',
+				type: 'breakout',
+				breakoutQuestion: 'What matters most to you?',
+				breakoutDescription: 'Talk it through',
+				durationMinutes: 15,
+				maxPerRoom: 4
+			}
+		]);
+	});
+
+	it('falls back to a generic title when a breakout has no prompt', () => {
+		const [item] = mapApiAgenda([
+			{ BreakoutRoom: { prompt: '', instructions: '', estimated_time: 10 } }
+		]);
+
+		expect(item.title).toBe('Breakout session');
+	});
+
+	it('leaves maxPerRoom undefined when the API sends null', () => {
+		const [item] = mapApiAgenda([
+			{
+				BreakoutRoom: {
+					prompt: 'Q',
+					instructions: '',
+					estimated_time: 10,
+					max_per_room: null
+				}
+			}
+		]);
+
+		expect(item.maxPerRoom).toBeUndefined();
+	});
+
+	it('numbers ids from one, in agenda order', () => {
+		const items = mapApiAgenda([
+			{ Basic: { title: 'One', description: '', estimated_time: 5 } },
+			{ BreakoutRoom: { prompt: 'Two', instructions: '', estimated_time: 5 } },
+			{ Basic: { title: 'Three', description: '', estimated_time: 5 } }
+		]);
+
+		expect(items.map((i) => i.id)).toEqual(['1', '2', '3']);
+	});
+
+	it('maps an empty agenda to an empty list', () => {
+		expect(mapApiAgenda([])).toEqual([]);
+	});
+});

--- a/ui/packages/comhairle/src/lib/utils/liveEventAgenda.ts
+++ b/ui/packages/comhairle/src/lib/utils/liveEventAgenda.ts
@@ -1,0 +1,25 @@
+import type { EventAgendaItem } from '@crownshy/api-client/api';
+import type { AgendaItem } from '$lib/components/LiveEvent/types';
+
+/** Map API agenda items to the shape the live event UI renders. */
+export function mapApiAgenda(items: EventAgendaItem[]): AgendaItem[] {
+	return items.map((item, index) => {
+		if ('Basic' in item) {
+			return {
+				id: String(index + 1),
+				title: item.Basic.title,
+				type: 'plenary' as const
+			};
+		} else {
+			return {
+				id: String(index + 1),
+				title: item.BreakoutRoom.prompt || 'Breakout session',
+				type: 'breakout' as const,
+				breakoutQuestion: item.BreakoutRoom.prompt,
+				breakoutDescription: item.BreakoutRoom.instructions,
+				durationMinutes: item.BreakoutRoom.estimated_time,
+				maxPerRoom: item.BreakoutRoom.max_per_room ?? undefined
+			};
+		}
+	});
+}

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
@@ -5,6 +5,10 @@
 	import { dev } from '$app/environment';
 	import JitsiMeet from '$lib/components/JitsiMeet/JitsiMeet.svelte';
 	import { formatDateShort, formatTime } from '$lib/utils';
+	import { formatCountdown } from '$lib/utils/formatCountdown';
+	import { getJitsiBreakoutRoomId } from '$lib/utils/jitsiBreakoutRooms';
+	import { groupParticipantsByRoom } from '$lib/utils/breakoutRoomAssignments';
+	import { mapApiAgenda } from '$lib/utils/liveEventAgenda';
 	import { videoCallService } from '$lib/services/videoCallService.svelte';
 	import MeetingLobby from '$lib/components/LiveEvent/MeetingLobby.svelte';
 	import AgendaPanel from '$lib/components/LiveEvent/AgendaPanel.svelte';
@@ -37,7 +41,6 @@
 	} from 'lucide-svelte';
 	import Button from '$lib/components/ui/button/button.svelte';
 	import type { PageProps } from './$types';
-	import type { EventAgendaItem } from '@crownshy/api-client/api';
 
 	let { data }: PageProps = $props();
 
@@ -124,43 +127,12 @@
 	/** Flag to track if Jitsi breakout rooms have been created and are ready */
 	let breakoutRoomsReady = $state(false);
 
-	/** Get the Jitsi room ID for a given room index (0-based) */
-	function getJitsiBreakoutRoomId(roomIndex: number): string | null {
-		const nonMainRooms = Object.values(jitsiBreakoutRooms)
-			.filter((r: any) => !r.isMainRoom)
-			.sort((a: any, b: any) => (a.name ?? '').localeCompare(b.name ?? ''));
-		return nonMainRooms[roomIndex]?.jid ?? null;
-	}
-
 	/** Lightweight toast for admin confirmations */
 	let toastMessage = $state<string | null>(null);
 	let toastTimeout: ReturnType<typeof setTimeout> | null = null;
 
 	let breakoutTimeRemaining = $state<number | null>(null);
 	let countdownInterval: ReturnType<typeof setInterval> | null = null;
-
-	/** Map API agenda items to live event format */
-	function mapApiAgenda(items: EventAgendaItem[]): AgendaItem[] {
-		return items.map((item, index) => {
-			if ('Basic' in item) {
-				return {
-					id: String(index + 1),
-					title: item.Basic.title,
-					type: 'plenary' as const
-				};
-			} else {
-				return {
-					id: String(index + 1),
-					title: item.BreakoutRoom.prompt || 'Breakout session',
-					type: 'breakout' as const,
-					breakoutQuestion: item.BreakoutRoom.prompt,
-					breakoutDescription: item.BreakoutRoom.instructions,
-					durationMinutes: item.BreakoutRoom.estimated_time,
-					maxPerRoom: item.BreakoutRoom.max_per_room ?? undefined
-				};
-			}
-		});
-	}
 
 	// Prefer the agenda pushed over WS (live edits) over the SSR-loaded one, which can go stale.
 	let agendaItems = $derived(mapApiAgenda(videoCallService.agenda ?? event?.agenda ?? []));
@@ -206,13 +178,7 @@
 		return roomContext.roomName;
 	});
 
-	let timeLeftFormatted = $derived.by(() => {
-		if (breakoutTimeRemaining === null || breakoutTimeRemaining <= 0) return '0:00';
-		const totalSecs = Math.floor(breakoutTimeRemaining / 1000);
-		const min = Math.floor(totalSecs / 60);
-		const sec = totalSecs % 60;
-		return `${min}:${sec.toString().padStart(2, '0')}`;
-	});
+	let timeLeftFormatted = $derived(formatCountdown(breakoutTimeRemaining));
 
 	let breakoutRoomDisplays = $derived.by((): BreakoutRoomDisplay[] => {
 		// Use real rooms from backend if available, otherwise use mock rooms
@@ -230,31 +196,9 @@
 		return mockBreakoutRooms;
 	});
 
-	let preassignedBreakoutRooms = $derived.by(() => {
-		return transformPreassignedRooms(allParticipants, videoCallService.breakoutRooms);
-	});
-
-	function transformPreassignedRooms(
-		participants: VideoCallParticipant[],
-		preassignedRooms: { participants: string[] }[]
-	): VideoCallParticipant[][] {
-		const roomIndexByUserId = new Map<string, number>();
-		preassignedRooms.forEach((room, index) => {
-			room.participants.forEach((userId) => roomIndexByUserId.set(userId, index));
-		});
-
-		const roomAssignments: VideoCallParticipant[][] = preassignedRooms.map(() => []);
-
-		participants.forEach((p) => {
-			const roomIndex = roomIndexByUserId.get(p.user_id);
-
-			if (roomIndex !== undefined) {
-				roomAssignments[roomIndex].push(p);
-			}
-		});
-
-		return roomAssignments;
-	}
+	let preassignedBreakoutRooms = $derived(
+		groupParticipantsByRoom(allParticipants, videoCallService.breakoutRooms)
+	);
 
 	$effect(() => {
 		const session = breakoutSession;
@@ -591,7 +535,7 @@
 		};
 
 		// Use Jitsi's native breakout room API to switch rooms
-		const jitsiRoomId = getJitsiBreakoutRoomId(roomIndex);
+		const jitsiRoomId = getJitsiBreakoutRoomId(jitsiBreakoutRooms, roomIndex);
 		if (jitsiRoomId) {
 			jitsiApi?.executeCommand('joinBreakoutRoom', jitsiRoomId);
 		} else {


### PR DESCRIPTION
Moves four pure functions out of the live event page into `$lib/utils`, each with tests. No behaviour change.

| new file | was |
|---|---|
| `liveEventAgenda.ts` | `mapApiAgenda` |
| `breakoutRoomAssignments.ts` | `transformPreassignedRooms` |
| `formatCountdown.ts` | the `mm:ss` body of `timeLeftFormatted` |
| `jitsiBreakoutRooms.ts` | `getJitsiBreakoutRoomId` |

Two things that aren't a straight copy and paste:

- `transformPreassignedRooms` is now `groupParticipantsByRoom`. It groups by whatever rooms it's handed, and nothing about it is specific to pre-assignment.
- `getJitsiBreakoutRoomId` takes the rooms record as an argument instead of reading the rune, and is typed against a small `JitsiBreakoutRoom` interface rather than `any`. The full Jitsi adapter is #934; this is just enough to make the function testable.


**One to look at.** The room id sort is lexicographic on the room name, so with ten or more rooms `#10` sorts ahead of `#2` and every index past it points at the wrong room. That's the #752 path and out of scope here, so kept the behaviour and pinned it with a test that says in a comment it should fail when someone fixes it. Happy to drop that test if you'd rather not have a bug written down as expected.