### PR TITLE
612 moderator breakout room timer

### DIFF
--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
@@ -410,7 +410,6 @@
 	$effect(() => {
 		// Show countdown dialog to participants at 5 seconds
 		if (
-			!isModerator &&
 			breakoutTimeRemaining !== null &&
 			breakoutTimeRemaining <= 5000 &&
 			breakoutTimeRemaining > 0 &&


### PR DESCRIPTION
Actions:

+ remove isModerator check on showing 5 second warning on breakout room close

Motivation:

+ moderators should see this warning also