### PR TITLE
Add pnpm to publish-api-client action image

### DIFF
--- a/.github/workflows/publish-api-client.yml
+++ b/.github/workflows/publish-api-client.yml
@@ -24,6 +24,9 @@ jobs:
           node-version: 22
           registry-url: https://registry.npmjs.org/
       -
+        name: Install pnpm
+        run: npm install -g pnpm
+      -
         name: Set version from tag
         run: |
           VERSION=${GITHUB_REF#refs/tags/v}


### PR DESCRIPTION
Motivations:

 - The publish-api-client action is currently failing due to a missing dependency on pnpm during the pre-publish stage.

Actions:

 - Add pnpm to the action image.