### PR TITLE
Separate OpenAPI spec generation into new application

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,6 +208,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "api_spec_gen"
+version = "0.1.0"
+dependencies = [
+ "aide",
+ "async-trait",
+ "comhairle_api",
+ "lettre",
+ "minijinja",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
 name = "ar_archive_writer"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,18 @@
 [workspace]
 members = [
-    "api", "comhairle_macros","adaptors/heyform-rust-sdk", "adaptors/ragflow"]
+    "api", "comhairle_macros","adaptors/heyform-rust-sdk", "adaptors/ragflow", "api_spec_gen"]
 resolver="2"
 
 [workspace.package]
 rust-version = "1.95"
+
+[workspace.dependencies]
+aide = "0.14.0"
+async-trait = "0.1.83"
+lettre = "0.11.16"
+minijinja = "2.10.2"
+serde = "1.0.218"
+serde_json = "1.0.139"
+sqlx = "0.8.3"
+tokio = "1.43.0"
+uuid = "1.14.0"

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -21,7 +21,7 @@ path = "src/data_loader/main.rs"
 
 [dependencies]
 axum = { version = "0.8.3", features = ["ws", "multipart"] }
-async-trait = "0.1.83"
+async-trait = { workspace = true }
 config = "0.15.8"
 sea-query = { version = "0.32.3", features = [
     "attr",
@@ -42,9 +42,8 @@ sea-query-binder = { version = "0.7.0", features = [
     "runtime-async-std-native-tls",
 ] }
 rand = "0.8"
-serde = { version = "1.0.218", features = ["derive"] }
-# serde = {version="1.0.217", features=['derive']}
-sqlx = { version = "0.8.3", features = [
+serde = { workspace = true, features = ["derive"] }
+sqlx = { workspace = true, features = [
     "runtime-tokio-native-tls",
     "macros",
     "postgres",
@@ -57,7 +56,7 @@ sqlx-postgres = { version = "0.8.3", features = [
     "uuid",
 ] }
 thiserror = "2.0.11"
-tokio = { version = "1.43.0", features = ["full"] }
+tokio = { workspace = true, features = ["full"] }
 tower-http = { version = "0.6.2", features = ["trace", "cors", "auth"] }
 tower_governor = "0.8"
 governor = "0.10"
@@ -71,12 +70,12 @@ jsonwebtoken = "^9.3.1"
 openidconnect = "^4.0.0"
 chrono = { version = "0.4.39", features = ["serde"] }
 time = "0.3"
-uuid = { version = "1.14.0", features = ["serde", "v4"] }
+uuid = { workspace = true, features = ["serde", "v4"] }
 argon2 = "0.5.3"
 rand_core = { version = "0.6", features = ["std"] }
 redis = { version = "1.3.0", features = ["aio", "tokio-comp", "connection-manager"] }
 tower = "0.5.2"
-serde_json = "1.0.139"
+serde_json = { workspace = true }
 http-body-util = "0.1.2"
 headers = "0.4.0"
 tower-cookies = "0.11.0"
@@ -93,7 +92,7 @@ strum_macros = "0.28"
 #API documentation
 
 schemars = { version = "0.8.10", features = ["uuid1", "chrono"] }
-aide = { version = "0.14.0", features = [
+aide = { workspace = true, features = [
     "redoc",
     "swagger",
     "scalar",
@@ -113,9 +112,9 @@ reqwest = { version = "0.12.15", features = ["cookies", "json", "gzip"] }
 axum-proxy = { version = "0.4.1", features = ["http2", "https", "axum"] }
 regex = "1.11.1"
 fancy-regex = "0.14.0"
-lettre = "0.11.16"
+lettre = { workspace = true }
 zxcvbn = "3.1.0"
-minijinja = "2.10.2"
+minijinja = { workspace = true }
 fluent-bundle = "0.15.3"
 fluent = "0.16.1"
 unic-langid = "0.9.6"

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -140,12 +140,9 @@ pub struct Args {
 async fn health_check() -> &'static str {
     "OK"
 }
-
-pub async fn setup_server(state: Arc<ComhairleState>) -> Result<Router<()>, ComhairleError> {
-    let args = Args::try_parse().unwrap_or_default();
-
-    tracing::info!("Running with config {:#?}", state.config);
-
+/// Constructs the ApiRouter and extracts the OpenAPI spec.
+/// Note that sub-routers like `routes::auth::router` are async and must be `.await`ed.
+pub async fn build_app_and_spec(state: Arc<ComhairleState>) -> (Router, OpenApi) {
     aide::generate::on_error(|error| {
         println!("{error}");
     });
@@ -163,7 +160,6 @@ pub async fn setup_server(state: Arc<ComhairleState>) -> Result<Router<()>, Comh
             .unwrap(),
     ];
 
-    // Add whitelisted domains from config
     if let Some(whitelisted_domains) = &state.config.whitelisted_domains {
         for domain in whitelisted_domains {
             if let Ok(header_value) = domain.parse::<HeaderValue>() {
@@ -193,20 +189,16 @@ pub async fn setup_server(state: Arc<ComhairleState>) -> Result<Router<()>, Comh
         ])
         .allow_origin(allowed_origins);
 
-    // Run migrations
-    run_migrations(&state.db).await?;
-
+    // Added `.await` here to resolve the opaque Future issue
     let auth_router = routes::auth::router(state.clone()).await;
 
-    // Apply rate limiting if enabled in config
     let auth_router = if state.config.enable_rate_limiting {
         auth_router.layer(middleware::rate_limit::auth_rate_limiter())
     } else {
         auth_router
     };
 
-    // build our application with a route
-    let app = ApiRouter::new()
+    let router = ApiRouter::new()
         .route("/health", axum::routing::get(health_check))
         .nest_api_service("/auth", auth_router)
         .nest_api_service(
@@ -321,6 +313,18 @@ pub async fn setup_server(state: Arc<ComhairleState>) -> Result<Router<()>, Comh
         .layer(Extension(Arc::new(api.clone()))) // Arc is very important here or you will face massive memory and performance issues
         .layer(DefaultBodyLimit::max(10 * 1024 * 1024))
         .layer(cors);
+
+    (router, api)
+}
+
+pub async fn setup_server(state: Arc<ComhairleState>) -> Result<Router<()>, ComhairleError> {
+    let args = Args::try_parse().unwrap_or_default();
+
+    tracing::info!("Running with config {:#?}", state.config);
+
+    run_migrations(&state.db).await?;
+
+    let (app, api) = build_app_and_spec(state).await;
 
     if args.export_api_spec {
         let json = serde_json::to_string_pretty(&api).unwrap();

--- a/api_spec_gen/Cargo.toml
+++ b/api_spec_gen/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "api_spec_gen"
+version = "0.1.0"
+edition = "2024"
+rust-version = { workspace = true }
+
+[dependencies]
+aide = { workspace = true }
+async-trait = { workspace = true }
+lettre = { workspace = true }
+minijinja = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sqlx = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+uuid = { workspace = true }
+
+
+comhairle_api = { path = "../api" }

--- a/api_spec_gen/src/dummy.rs
+++ b/api_spec_gen/src/dummy.rs
@@ -1,0 +1,357 @@
+use std::{collections::HashMap, sync::Arc};
+
+use comhairle::config::{ComhairleConfig, MailerConfig};
+use comhairle::error::ComhairleError;
+use comhairle::models::{permissions::ResourcePermission, users::User};
+use comhairle::websockets::handlers::video_call::VideoCallMessageHandler;
+use comhairle::websockets::{
+    ConnectionId, WebSocketConnection, WebSocketMessageHandler, messages::WebSocketMessage,
+};
+use comhairle::wiki_poll_service::error::WikiPollServiceError;
+use comhairle::wiki_poll_service::polis_service::WikiPollReport;
+use comhairle::wiki_poll_service::{
+    ModerationStatus, PostedStatement, WikiPoll, WikiPollComment, WikiPollConfigUpdate,
+    WikiPollLogin, WikiPollXid,
+};
+use comhairle::{ComhairleState, mailer, websockets, wiki_poll_service};
+use lettre::message::SinglePart;
+use minijinja::Value;
+use uuid::Uuid;
+
+#[derive(Clone)]
+struct DummyMailer;
+#[async_trait::async_trait]
+impl mailer::ComhairleMailer for DummyMailer {
+    fn send_email(
+        &self,
+        _to: &str,
+        _subject: &str,
+        _template: &str,
+        _context: Value,
+        _attachment: Option<SinglePart>,
+    ) -> Result<(), ComhairleError> {
+        todo!()
+    }
+
+    async fn send_conversation_invite_email(
+        &self,
+        _state: &Arc<ComhairleState>,
+        _email: &str,
+        _conversation_id: Uuid,
+        _user_id: Uuid,
+        _invite_id: Uuid,
+        _locale: &str,
+    ) -> Result<(), ComhairleError> {
+        todo!()
+    }
+
+    fn send_welcome_email(&self, _user: &User, _verify_link: String) -> Result<(), ComhairleError> {
+        todo!()
+    }
+
+    fn send_password_reset_email(
+        &self,
+        _to: &Option<String>,
+        _username: &Option<String>,
+        _reset_link: String,
+    ) -> Result<(), ComhairleError> {
+        todo!()
+    }
+
+    fn send_user_account_created_email(
+        &self,
+        _to: &Option<String>,
+        _username: &Option<String>,
+        _set_password_link: String,
+    ) -> Result<(), ComhairleError> {
+        todo!()
+    }
+
+    fn send_verification_email(
+        &self,
+        _username: &Option<String>,
+        _email: &Option<String>,
+        _verify_link: String,
+    ) -> Result<(), ComhairleError> {
+        todo!()
+    }
+
+    fn send_otp_email(
+        &self,
+        _username: &Option<String>,
+        _email: &Option<String>,
+        _passcode: String,
+        _passcode_link: Option<String>,
+    ) -> Result<(), ComhairleError> {
+        todo!()
+    }
+
+    async fn send_event_registration_email(
+        &self,
+        _state: &Arc<ComhairleState>,
+        _email: &str,
+        _event_id: Uuid,
+        _user_id: Uuid,
+        _invite_id: Uuid,
+        _locale: &str,
+    ) -> Result<(), ComhairleError> {
+        todo!()
+    }
+
+    async fn send_event_confirmation_email(
+        &self,
+        _state: &Arc<ComhairleState>,
+        _email: &str,
+        _event_id: Uuid,
+        _user_id: Uuid,
+        _locale: &str,
+    ) -> Result<(), ComhairleError> {
+        todo!()
+    }
+
+    async fn send_event_reminder(
+        &self,
+        _state: &Arc<ComhairleState>,
+        _email: &str,
+        _event_id: Uuid,
+        _recipient_id: Uuid,
+        _sender_id: Uuid,
+        _locale: &str,
+    ) -> Result<(), ComhairleError> {
+        todo!()
+    }
+
+    fn send_conversation_broadcast_email(
+        &self,
+        _email: &str,
+        _subject: &str,
+        _html_body: &str,
+    ) -> Result<(), ComhairleError> {
+        todo!()
+    }
+
+    fn send_permission_notification_email(
+        &self,
+        _email: &str,
+        _permission: &ResourcePermission,
+        _action: &str,
+    ) -> Result<(), ComhairleError> {
+        todo!()
+    }
+
+    fn preview_email(
+        &self,
+        _template: &str,
+        _slots_map: HashMap<String, String>,
+        _variables_map: Option<HashMap<String, String>>,
+    ) -> Result<String, ComhairleError> {
+        todo!()
+    }
+}
+
+#[derive(Clone)]
+struct DummyWebSocketService;
+#[async_trait::async_trait]
+impl websockets::WebSocketService for DummyWebSocketService {
+    fn add_connection(&self, _connection: WebSocketConnection) {
+        todo!()
+    }
+
+    fn remove_connection(&self, _connection_id: &ConnectionId) -> Option<WebSocketConnection> {
+        todo!()
+    }
+
+    async fn broadcast_to_all(&self, _message: &WebSocketMessage) -> Result<usize, ComhairleError> {
+        todo!()
+    }
+
+    async fn broadcast_to_authenticated_users(
+        &self,
+        _message: &WebSocketMessage,
+    ) -> Result<usize, ComhairleError> {
+        todo!()
+    }
+
+    async fn send_to_user(
+        &self,
+        _user_id: &Uuid,
+        _message: &WebSocketMessage,
+    ) -> Result<usize, ComhairleError> {
+        todo!()
+    }
+
+    async fn send_to_connections(
+        &self,
+        _connection_ids: &[ConnectionId],
+        _message: &WebSocketMessage,
+    ) -> Result<usize, ComhairleError> {
+        todo!()
+    }
+
+    async fn broadcast_to_room(
+        &self,
+        _domain: &str,
+        _room_id: &Uuid,
+        _message: &WebSocketMessage,
+    ) -> Result<usize, ComhairleError> {
+        todo!()
+    }
+
+    fn get_connection_count(&self) -> usize {
+        todo!()
+    }
+
+    fn get_user_connection_count(&self, _user_id: &Uuid) -> usize {
+        todo!()
+    }
+
+    fn get_connected_user_ids(&self) -> Vec<Uuid> {
+        todo!()
+    }
+
+    fn register_handler(&self, _handler: Arc<dyn WebSocketMessageHandler>) {
+        todo!()
+    }
+
+    fn unregister_handler(&self, _domain: &str) -> Option<Arc<dyn WebSocketMessageHandler>> {
+        todo!()
+    }
+
+    fn get_handler(&self, _domain: &str) -> Option<Arc<dyn WebSocketMessageHandler>> {
+        todo!()
+    }
+}
+
+#[derive(Clone)]
+struct DummyWikiPollService;
+#[async_trait::async_trait]
+impl wiki_poll_service::WikiPollService for DummyWikiPollService {
+    async fn create_random_admin_user(&self) -> Result<(String, String), WikiPollServiceError> {
+        todo!()
+    }
+
+    async fn login(&self, _login: &WikiPollLogin) -> Result<String, WikiPollServiceError> {
+        todo!()
+    }
+
+    async fn create_poll(&self, _auth_cookies: &str) -> Result<String, WikiPollServiceError> {
+        todo!()
+    }
+
+    async fn post_seed_comment(
+        &self,
+        _comment: &str,
+        _poll_id: &str,
+        _auth_cookies: &str,
+    ) -> Result<String, WikiPollServiceError> {
+        todo!()
+    }
+
+    async fn post_statement(
+        &self,
+        _comment: &str,
+        _poll_id: &str,
+        _is_seed: bool,
+        _auth_cookies: &str,
+    ) -> Result<PostedStatement, WikiPollServiceError> {
+        todo!()
+    }
+
+    async fn get_comments(
+        &self,
+        _poll_id: &str,
+    ) -> Result<Vec<WikiPollComment>, WikiPollServiceError> {
+        todo!()
+    }
+
+    async fn get_xids(
+        &self,
+        _poll_id: &str,
+        _auth_cookies: &str,
+    ) -> Result<Vec<WikiPollXid>, WikiPollServiceError> {
+        todo!()
+    }
+
+    async fn get_report_data(
+        &self,
+        _poll_id: &str,
+    ) -> Result<WikiPollReport, WikiPollServiceError> {
+        todo!()
+    }
+
+    async fn moderate_comment(
+        &self,
+        _poll_id: &str,
+        _tid: i32,
+        _decision: ModerationStatus,
+        _auth_cookies: &str,
+    ) -> Result<(), WikiPollServiceError> {
+        todo!()
+    }
+
+    async fn delete_poll(
+        &self,
+        _poll_id: &str,
+        _auth_cookies: &str,
+    ) -> Result<WikiPoll, WikiPollServiceError> {
+        todo!()
+    }
+
+    async fn update_poll_config(
+        &self,
+        _poll_id: &str,
+        _auth_cookies: &str,
+        _config: &WikiPollConfigUpdate,
+    ) -> Result<WikiPoll, WikiPollServiceError> {
+        todo!()
+    }
+}
+
+pub(crate) unsafe fn create_dummy_state() -> ComhairleState {
+    unsafe {
+        ComhairleState {
+            db: sqlx::PgPool::connect_lazy("postgres://localhost/dummy").unwrap(),
+            config: ComhairleConfig {
+                enable_rate_limiting: true,
+                redis_cache_ttl_secs: 0,
+                mailer: MailerConfig {
+                    from_email: "".to_string(),
+                    host: "".to_string(),
+                    password: "".to_string(),
+                    user: "".to_string(),
+                },
+                database_url: "".to_string(),
+                default_conversation_image_url: "".to_string(),
+                domain: "".to_string(),
+                heyform_url: "".to_string(),
+                jwt_secret: "".to_string(),
+                polis_url: "".to_string(),
+                resource_bucket: "".to_string(),
+                admin_users: None,
+                bot_service: None,
+                bulk_storage_service: None,
+                categorization_service: None,
+                redis_cache_url: None,
+                transcription_service: None,
+                translator: None,
+                video_call_service: None,
+                websocket_service: None,
+                whitelisted_domains: None,
+                worker_service: None,
+            },
+            mailer: Arc::new(DummyMailer),
+            websockets: Arc::new(DummyWebSocketService),
+            video_call_handler: Arc::from_raw(
+                std::ptr::NonNull::dangling().as_ptr() as *const VideoCallMessageHandler
+            ),
+            translation_service: None,
+            bot_service: None,
+            wiki_poll_service: Arc::new(DummyWikiPollService),
+            bulk_storage_service: None,
+            transcription_service: None,
+            worker_service: None,
+            categorization_service: None,
+            redis_conn: None,
+        }
+    }
+}

--- a/api_spec_gen/src/main.rs
+++ b/api_spec_gen/src/main.rs
@@ -1,0 +1,29 @@
+use std::sync::Arc;
+
+use comhairle::error::ComhairleError;
+use aide::openapi::OpenApi;
+
+mod dummy;
+
+/// Generates the OpenAPI spec without connecting to a live database or instantiating real services.
+pub async fn generate_api_spec() -> Result<OpenApi, ComhairleError> {
+    // Construct a state populated with dummy zeroed values for schema inspection
+    // FIXME: GH 2026-08-19 - The API spec should not depend on runtime state.
+    let dummy_state = Arc::new(unsafe { dummy::create_dummy_state() });
+
+    let (_, api_spec) = comhairle::build_app_and_spec(dummy_state.clone()).await;
+
+    let json = serde_json::to_string_pretty(&api_spec).unwrap();
+    tokio::fs::write("open-api-spec.json", json.as_bytes()).await?;
+
+    // Prevent dropping dangling pointers from memory
+    std::mem::forget(dummy_state);
+
+    Ok(api_spec)
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    generate_api_spec().await?;
+    Ok(())
+}

--- a/justfile
+++ b/justfile
@@ -16,6 +16,9 @@ psql:
 load_saia:
     cargo run --bin comhairle_data_loader -- -f fixtures/saia.json -d true
 
+generate-api-spec:
+    cargo run --bin api_spec_gen --
+
 api-dev:
     cargo watch -q -c \
     -i open-api-spec.json \


### PR DESCRIPTION
Motivation:

 - We would like to be able to generate the open api spec without having to spin up the full server + database + redis stack.

Actions:

 - Create lightweight api_spec_gen application to generate OpenAPI spec.