### PR TITLE
Build spec during API client publish

### DIFF
--- a/.github/workflows/publish-api-client.yml
+++ b/.github/workflows/publish-api-client.yml
@@ -17,6 +17,15 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@v4
+      - 
+        name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - 
+        name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
+      - 
+        name: Generate OpenAPI Spec
+        run: cargo run --package api_spec_gen --bin api_spec_gen
       -
         name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -32,6 +41,10 @@ jobs:
         name: Install pnpm
         run: pnpm install
         working-directory: ui
+      -
+        name: Build API Client
+        run: pnpm build
+        working-directory: ui/packages/api-client
       -
         name: Set version from tag
         run: |


### PR DESCRIPTION
Motivations:

 - In order to publish the API client, we need to be able to build the api spec for said client.

Actions:

 - Use new spec generation to generate the open api spec for use in the api client.