### PR TITLE
Add frame-top alignment on step change to keep questions visible

### DIFF
--- a/ui/packages/comhairle/src/lib/tools/heyform/HeyFormEmbed.svelte
+++ b/ui/packages/comhairle/src/lib/tools/heyform/HeyFormEmbed.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { tick } from 'svelte';
 	import { fade } from 'svelte/transition';
 	import HeyFormEmbedSkeleton from './HeyFormEmbedSkeleton.svelte';
 	import { browser } from '$app/environment';
@@ -104,19 +105,51 @@
 
 	let measuredHeight = $state<number | null>(null);
 
-	// The iframe auto-sizes to each question, so the window (not the iframe) is what scrolls; after
-	// clicking Next the page would otherwise stay at the previous question's offset. FORM_STEP_CHANGE
-	// is the exact "new question" signal and always wins. Until a webapp build that emits it is
-	// deployed, we fall back to FORM_RESIZE: that build already re-emits on every question change, and
-	// a resize while the user is scrolled down almost always means a new question replaced the one they
-	// finished at the bottom of. The moment a FORM_STEP_CHANGE arrives we drop the fallback, since the
-	// exact signal avoids the fallback's false positives (textarea growth or validation reflow while
-	// scrolled down).
-	const SCROLL_TOP_THRESHOLD_PX = 80;
-	let stepChangeSupported = false;
+	/**
+	 * Keeping the active question in view. The iframe sizes itself to each question, so the page (not
+	 * the frame) is what scrolls: answer a tall question at the bottom and the next one renders above
+	 * the fold, or the page shrinks under you and strands you at the footer. The correction is to pull
+	 * the frame's top edge back up to the top of the viewport.
+	 *
+	 * Scrolling the window to 0 is a different thing and the wrong one: a step description can be many
+	 * paragraphs long, so top-of-page routinely leaves the question itself off screen.
+	 *
+	 * Two rules keep this from fighting the user:
+	 *   - FORM_STEP_CHANGE is the only trigger. FORM_RESIZE also covers the mount emit and every
+	 *     reflow (a textarea growing, validation, fonts settling), so acting on it hijacks someone who
+	 *     is reading or typing further down the page, or scrolling while the form is still a skeleton.
+	 *   - We only ever scroll up, and only when the frame's top is already above the viewport. If the
+	 *     new question starts on screen there is nothing to correct.
+	 */
+	const FRAME_TOP_MARGIN_PX = 16;
+	/**
+	 * The height for the new question arrives in a FORM_RESIZE just after the step change. Aligning
+	 * before it applies would scroll against the outgoing question's box and then be clamped when the
+	 * document resizes, so we wait for it; this bounds that wait.
+	 */
+	const ALIGN_AFTER_STEP_CHANGE_MS = 150;
 
-	function scrollPageToTop() {
-		window.scrollTo({ top: 0, behavior: 'smooth' });
+	let alignPending = false;
+	let alignTimer: ReturnType<typeof setTimeout> | undefined;
+
+	function alignFrameTop() {
+		alignPending = false;
+		clearTimeout(alignTimer);
+		alignTimer = undefined;
+		if (!iframeEl) return;
+
+		const frameTop = window.scrollY + iframeEl.getBoundingClientRect().top;
+		const target = Math.max(0, frameTop - FRAME_TOP_MARGIN_PX);
+		if (window.scrollY <= target) return;
+
+		const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+		window.scrollTo({ top: target, behavior: reduceMotion ? 'auto' : 'smooth' });
+	}
+
+	function requestFrameTopAlign() {
+		alignPending = true;
+		clearTimeout(alignTimer);
+		alignTimer = setTimeout(alignFrameTop, ALIGN_AFTER_STEP_CHANGE_MS);
 	}
 
 	function onFrameMessage(e: MessageEvent) {
@@ -131,14 +164,12 @@
 			case 'FORM_RESIZE':
 				if (typeof data.height === 'number' && Number.isFinite(data.height)) {
 					measuredHeight = Math.min(Math.max(data.height, MIN_FRAME_PX), MAX_FRAME_PX);
-					if (!stepChangeSupported && window.scrollY > SCROLL_TOP_THRESHOLD_PX) {
-						scrollPageToTop();
-					}
+					// The new question's box is in the DOM after the flush, so measure then.
+					if (alignPending) tick().then(alignFrameTop);
 				}
 				break;
 			case 'FORM_STEP_CHANGE':
-				stepChangeSupported = true;
-				scrollPageToTop();
+				requestFrameTopAlign();
 				break;
 		}
 	}
@@ -149,6 +180,7 @@
 		return () => {
 			window.removeEventListener('message', onFrameMessage);
 			stopResizePing();
+			clearTimeout(alignTimer);
 		};
 	});
 


### PR DESCRIPTION
Actions:

- replace scroll-to-top logic with scroll-to-frame-top alignment
- trigger alignment only on FORM_STEP_CHANGE, not FORM_RESIZE
- wait up to 150ms for new question's height before measuring frame position
- only scroll up when frame top is above viewport
- respect prefers-reduced-motion for scroll behavior
- import tick from svelte for post-render measurement
- clear alignment timer on component cleanup