### PR TITLE
Allow listing of resources by action

### DIFF
--- a/api/src/models/permissions.rs
+++ b/api/src/models/permissions.rs
@@ -1080,6 +1080,47 @@ pub async fn list_organizations_with_permission(
     Ok(organizations_with_permission)
 }
 
+#[instrument(err(Debug))]
+pub async fn list_permissions_by_action(
+    db: &PgPool,
+    user_id: Uuid,
+    organization_id: Option<Uuid>,
+    action: &str,
+) -> Result<Vec<ResourcePermission>, ComhairleError> {
+    let Ok(action_enum) = action.parse::<Action>() else {
+        return Err(ComhairleError::BadRequest(format!(
+            "Invalid action: {}",
+            action
+        )));
+    };
+
+    let roles = Role::for_resource_type(action_enum.resource_type())
+        .filter(|role| role.actions().contains(&action_enum))
+        .map(|role| role.as_ref().to_string())
+        .collect::<Vec<String>>();
+
+    let mut query = Query::select();
+
+    query
+        .from(ResourcePermissionIden::Table)
+        .columns(DEFAULT_COLUMNS)
+        .and_where(Expr::col(ResourcePermissionIden::RoleName).is_in(roles))
+        .and_where(Expr::col(ResourcePermissionIden::UserId).eq(user_id.to_owned()));
+
+    if let Some(org_id) = organization_id {
+        query.and_where(Expr::col(ResourcePermissionIden::OrganizationId).eq(org_id.to_owned()));
+    }
+
+    let (sql, values) = query.build_sqlx(PostgresQueryBuilder);
+
+    let permissions = query_as_with(&sql, values)
+        .fetch_all(db)
+        .await
+        .map_err(ComhairleError::DatabaseError)?;
+
+    Ok(permissions)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1562,6 +1603,79 @@ mod tests {
             "role {} should appear exactly once across pages",
             OtherRole::name()
         );
+
+        Ok(())
+    }
+
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
+    fn test_list_permissions_by_action(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
+        let state = Arc::new(test_state().db(pool).call()?);
+        let (app, mut session) = setup_default_app_and_session(&state.db).await?;
+
+        let user_id = get_random_user_id(&app, &mut session).await?;
+        let resource_id = Uuid::new_v4();
+
+        // Create three test resources
+        let resource_1_id = Uuid::new_v4(); // Simulated conversation resource
+        let resource_2_id = Uuid::new_v4(); // Simulated conversation resource
+        let resource_3_id = Uuid::new_v4(); // Simulated organization resource
+
+        // Grant the conversation co host and conversation content editor roles to the user for resource_1 and resource_2
+        grant_role(
+            &state,
+            GrantRoleRequest {
+                actor_id: UserOrOrganizationId::User(user_id),
+                permission_triplet: Role::ConversationCoHost.triplet(&resource_1_id),
+                granted_by: &session.id.unwrap(),
+                grant_reason: "Testing",
+            },
+        )
+        .await?;
+
+        grant_role(
+            &state,
+            GrantRoleRequest {
+                actor_id: UserOrOrganizationId::User(user_id),
+                permission_triplet: Role::ConversationContentEditor.triplet(&resource_2_id),
+                granted_by: &session.id.unwrap(),
+                grant_reason: "Testing",
+            },
+        )
+        .await?;
+
+        // Grant the organization admin role to the user for resource_3
+        grant_role(
+            &state,
+            GrantRoleRequest {
+                actor_id: UserOrOrganizationId::User(user_id),
+                permission_triplet: Role::OrganizationAdmin.triplet(&resource_3_id),
+                granted_by: &session.id.unwrap(),
+                grant_reason: "Testing",
+            },
+        )
+        .await?;
+
+        // List permissions which permit the user to perform the "conversation_read" action
+        let permissions =
+            list_permissions_by_action(&state.db, user_id, None, "conversation_read").await?;
+
+        assert_eq!(permissions.len(), 2);
+        assert!(permissions.iter().any(|p| p.resource_id == resource_1_id));
+        assert!(permissions.iter().any(|p| p.resource_id == resource_2_id));
+
+        // List permissions which permit the user to perform the "conversation_update" action
+        let permissions =
+            list_permissions_by_action(&state.db, user_id, None, "conversation_update").await?;
+
+        assert_eq!(permissions.len(), 1);
+        assert_eq!(permissions[0].resource_id, resource_2_id);
+
+        // List permissions which permit the user to perform the "organization_update" action
+        let permissions =
+            list_permissions_by_action(&state.db, user_id, None, "organization_update").await?;
+
+        assert_eq!(permissions.len(), 1);
+        assert_eq!(permissions[0].resource_id, resource_3_id);
 
         Ok(())
     }

--- a/api/src/routes/permissions.rs
+++ b/api/src/routes/permissions.rs
@@ -55,12 +55,20 @@ pub struct RevokePermissionQuery {
     pub role_name: String,
 }
 
-/// Represents a request query for listing permissions with optional filters.
+/// Represents a request query for listing permissions, with optional filters.
 #[derive(Debug, Deserialize, Serialize, JsonSchema)]
 pub struct ListPermissionsQuery {
     pub user_id: Option<Uuid>,
     pub organization_id: Option<Uuid>,
     pub role_name: Option<String>,
+    pub offset: Option<u64>,
+    pub limit: Option<u64>,
+}
+
+/// Represents a request query for listing permissions by action, with optional filters.
+#[derive(Debug, Deserialize, Serialize, JsonSchema)]
+pub struct ListPermissionsByActionQuery {
+    pub user_id: Option<Uuid>,
     pub offset: Option<u64>,
     pub limit: Option<u64>,
 }
@@ -223,6 +231,38 @@ async fn list(
     Ok((StatusCode::OK, Json(page)))
 }
 
+/// Lists the resources of the specified type that the caller can perform the specified action on.
+///
+/// # Errors
+///
+/// * Returns [`ComhairleError::BadRequest`] if the action is not provided or invalid.
+/// * Returns [`ComhairleError::DatabaseError`] if there is an error querying the database.
+#[instrument(err(Debug), skip(state))]
+async fn list_permissions_by_action(
+    State(state): State<Arc<ComhairleState>>,
+    RequiredUser(caller): RequiredUser,
+    system: SystemResource,
+    Path(action): Path<String>,
+    Query(query): Query<ListPermissionsByActionQuery>,
+) -> Result<(StatusCode, Json<Vec<permissions::ResourcePermission>>), ComhairleError> {
+    if let Err(err) = authorize(&state, &caller, Action::ListPermission, &system).await
+        && (!matches!(err, ComhairleError::UserNotAuthorized)
+            || caller.id != query.user_id.unwrap_or(caller.id))
+    {
+        return Err(err);
+    };
+
+    let permissions = permissions::list_permissions_by_action(
+        &state.db,
+        caller.id,
+        caller.organization_id,
+        &action,
+    )
+    .await?;
+
+    Ok((StatusCode::OK, Json(permissions)))
+}
+
 /// Lists permissions for a specific resource with optional filtering. Supports pagination via offset and limit query parameters.
 ///
 /// # Errors
@@ -301,6 +341,21 @@ pub fn router(state: Arc<ComhairleState>) -> ApiRouter {
                     )
                     .security_requirement("JWT")
                     .response::<200, Json<PaginatedResults<permissions::ResourcePermission>>>()
+            }),
+        )
+        .api_route(
+            "/by-action/{action}",
+            get_with(list_permissions_by_action, |op| {
+                op.id("ListPermissionsByAction")
+                    .tag("Permissions")
+                    .summary("List resources by action")
+                    .description(
+                        "Returns resources of the specified type that the caller can perform \
+                        the specified action on. Optionally filter by user_id. Use the `offset` \
+                        and `limit` query params to page through results.",
+                    )
+                    .security_requirement("JWT")
+                    .response::<200, Json<Vec<permissions::ResourcePermission>>>()
             }),
         )
         .api_route(

--- a/ui/packages/api-client/src/api.ts
+++ b/ui/packages/api-client/src/api.ts
@@ -5466,6 +5466,31 @@ curl -X POST \
   },
   {
     method: "get",
+    path: "/permissions/by-action/:action",
+    alias: "ListPermissionsByAction",
+    description: `Returns resources of the specified type that the caller can perform the specified action on. Optionally filter by user_id. Use the &#x60;offset&#x60; and &#x60;limit&#x60; query params to page through results.`,
+    requestFormat: "json",
+    parameters: [
+      {
+        name: "limit",
+        type: "Query",
+        schema: limit,
+      },
+      {
+        name: "offset",
+        type: "Query",
+        schema: limit,
+      },
+      {
+        name: "user_id",
+        type: "Query",
+        schema: created_after,
+      },
+    ],
+    response: z.array(ResourcePermission),
+  },
+  {
+    method: "get",
     path: "/region_areas",
     alias: "ListRegionAreas",
     requestFormat: "json",


### PR DESCRIPTION
Motivations:

 - With the introduction and further use of the new permissions system, it would be useful for us to be able to list resources and permissions by what actions can be performed on them.

Actions:

 - Add an endpoint that allows the user to list what resources a given user_id can perform a given action on. If no user_id is provided, it defaults to the current user.