### PR TITLE
990/update chat cross languages

### DIFF
--- a/api/src/bot_service.rs
+++ b/api/src/bot_service.rs
@@ -52,20 +52,6 @@ Take prior chat history into account when answering.
 Here is the knowledge base:
 {knowledge}"#;
 
-pub const COMHAIRLE_SUPPORTED_LANGUAGES: [&str; 11] = [
-    "Arabic",
-    "Welsh",
-    "English",
-    "Spanish",
-    "French",
-    "Scottish Gaelic",
-    "Dari",
-    "Pashto",
-    "Portuguese",
-    "Chinese",
-    "Farsi",
-];
-
 #[async_trait]
 #[cfg_attr(test, automock)]
 pub trait ComhairleBotService: Send + Sync {

--- a/api/src/bot_service/ragflow_bot.rs
+++ b/api/src/bot_service/ragflow_bot.rs
@@ -1034,10 +1034,7 @@ impl From<UpdateChatRequest> for UpdateChat {
             llm: input.llm_model.map(|model| Llm {
                 model_name: model.model_name,
             }),
-            prompt: input.prompt.map(|prompt| Prompt {
-                prompt: prompt.llm_prompt,
-                ..Default::default()
-            }),
+            prompt: input.prompt.map(|prompt| Prompt { ..prompt.into() }),
             ..Default::default()
         }
     }

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -254,6 +254,10 @@ pub async fn build_app_and_spec(state: Arc<ComhairleState>) -> (Router, OpenApi)
                     routes::feedback::router(state.clone()),
                 )
                 .nest_api_service(
+                    "/{conversation_id}/chats",
+                    routes::chats::router(state.clone()),
+                )
+                .nest_api_service(
                     "/{conversation_id}/chat_sessions",
                     routes::chat_sessions::router(state.clone()),
                 )

--- a/api/src/models/conversation.rs
+++ b/api/src/models/conversation.rs
@@ -6,6 +6,7 @@ use super::{
     user_participation::UserParticipationIden,
     workflow::WorkflowIden,
 };
+use crate::ComhairleState;
 use crate::bot_service::{
     ComhairleBotService, ComhairlePrompt, CreateChatRequest, DEFAULT_CHAT_NOT_FOUND_RESPONSE,
     DEFAULT_CHAT_OPENER, DEFAULT_CHAT_PROMPT,
@@ -14,7 +15,6 @@ use crate::config::ComhairleConfig;
 use crate::error::ComhairleError;
 use crate::models::permissions::{Action, ResourcePermissionIden, ResourceType, Role};
 use crate::models::{self, SqlxResultExt};
-use crate::{ComhairleState, bot_service::COMHAIRLE_SUPPORTED_LANGUAGES};
 use chrono::{DateTime, Utc};
 use comhairle_macros::Translatable;
 use partially::Partial;
@@ -761,12 +761,7 @@ pub async fn create(
                 llm_prompt: Some(DEFAULT_CHAT_PROMPT.to_string()),
                 opener: Some(DEFAULT_CHAT_OPENER.to_string()),
                 empty_response: Some(DEFAULT_CHAT_NOT_FOUND_RESPONSE.to_string()),
-                cross_languages: Some(
-                    COMHAIRLE_SUPPORTED_LANGUAGES
-                        .into_iter()
-                        .map(|lang| lang.to_string())
-                        .collect(),
-                ),
+                cross_languages: None,
             }),
             ..Default::default()
         };

--- a/api/src/routes.rs
+++ b/api/src/routes.rs
@@ -2,6 +2,7 @@ pub mod api_keys;
 pub mod audio_recordings;
 pub mod auth;
 pub mod chat_sessions;
+pub mod chats;
 pub mod conversations;
 pub mod documents;
 pub mod email_template_configs;

--- a/api/src/routes/chats.rs
+++ b/api/src/routes/chats.rs
@@ -1,0 +1,91 @@
+use std::sync::Arc;
+
+use aide::axum::{
+    ApiRouter,
+    routing::{get_with, put_with},
+};
+use axum::{
+    extract::{Json, Path, State},
+    http::StatusCode,
+};
+use tracing::instrument;
+use uuid::Uuid;
+
+use crate::bot_service::{ComhairleChat, UpdateChatRequest};
+use crate::models::conversation;
+use crate::routes::auth::RequiredAdminUser;
+use crate::{ComhairleError, ComhairleState};
+
+#[instrument(err(Debug), skip(state))]
+async fn get(
+    State(state): State<Arc<ComhairleState>>,
+    Path(conversation_id): Path<Uuid>,
+    RequiredAdminUser(user): RequiredAdminUser,
+) -> Result<(StatusCode, Json<ComhairleChat>), ComhairleError> {
+    let bot_service = state.required_bot_service()?;
+
+    let conversation = conversation::get_by_id(&state.db, &conversation_id).await?;
+    let chat_bot_id = match conversation.chat_bot_id {
+        Some(id) => id,
+        None => {
+            return Err(ComhairleError::CorruptedData(
+                "Missing chat_bot_id on conversation: {conversation_id}".to_string(),
+            ));
+        }
+    };
+
+    let (_, chat) = bot_service.get_chat(&chat_bot_id).await?;
+
+    Ok((StatusCode::OK, Json(chat)))
+}
+
+#[instrument(err(Debug), skip(state))]
+async fn update(
+    State(state): State<Arc<ComhairleState>>,
+    Path(conversation_id): Path<Uuid>,
+    RequiredAdminUser(user): RequiredAdminUser,
+    Json(payload): Json<UpdateChatRequest>,
+) -> Result<(StatusCode, Json<ComhairleChat>), ComhairleError> {
+    let bot_service = state.required_bot_service()?;
+
+    let conversation = conversation::get_by_id(&state.db, &conversation_id).await?;
+    let chat_bot_id = match conversation.chat_bot_id {
+        Some(id) => id,
+        None => {
+            return Err(ComhairleError::CorruptedData(
+                "Missing chat_bot_id on conversation: {conversation_id}".to_string(),
+            ));
+        }
+    };
+
+    let (_, chat) = bot_service.update_chat(&chat_bot_id, payload).await?;
+
+    Ok((StatusCode::OK, Json(chat)))
+}
+
+pub fn router(state: Arc<ComhairleState>) -> ApiRouter {
+    ApiRouter::new()
+        .api_route(
+            "/",
+            get_with(get, |op| {
+                op.id("GetChat")
+                    .tag("Chats")
+                    .summary("Get chat bot")
+                    .description("Get a conversation's bot service chat")
+                    .security_requirement("JWT")
+                    .response::<200, Json<ComhairleChat>>()
+            }),
+        )
+        .api_route(
+            "/",
+            put_with(update, |op| {
+                op.id("UpdateChat")
+                    .tag("Chats")
+                    .summary("Update chat bot")
+                    .description("Update a conversation's bot service chat")
+                    .security_requirement("JWT")
+                    .response::<200, Json<ComhairleChat>>()
+            }),
+        )
+        .with_state(state)
+}

--- a/ui/packages/api-client/src/api.ts
+++ b/ui/packages/api-client/src/api.ts
@@ -2185,6 +2185,41 @@ export const PartialFeedback = z
   .partial()
   .passthrough();
 export type PartialFeedback = z.infer<typeof PartialFeedback>;
+export const ComhairleLlm = z
+  .object({ model_name: z.union([z.string(), z.null()]) })
+  .partial()
+  .passthrough();
+export type ComhairleLlm = z.infer<typeof ComhairleLlm>;
+export const ComhairlePrompt = z
+  .object({
+    cross_languages: z.union([z.array(z.string()), z.null()]),
+    empty_response: z.union([z.string(), z.null()]),
+    llm_prompt: z.union([z.string(), z.null()]),
+    opener: z.union([z.string(), z.null()]),
+  })
+  .partial()
+  .passthrough();
+export type ComhairlePrompt = z.infer<typeof ComhairlePrompt>;
+export const ComhairleChat = z
+  .object({
+    id: z.string(),
+    knowledge_base_ids: z.array(z.string()),
+    llm_model: z.union([ComhairleLlm, z.null()]).optional(),
+    name: z.string(),
+    prompt: z.union([ComhairlePrompt, z.null()]).optional(),
+  })
+  .passthrough();
+export type ComhairleChat = z.infer<typeof ComhairleChat>;
+export const UpdateChatRequest = z
+  .object({
+    knowledge_base_ids: z.union([z.array(z.string()), z.null()]),
+    llm_model: z.union([ComhairleLlm, z.null()]),
+    name: z.union([z.string(), z.null()]),
+    prompt: z.union([ComhairlePrompt, z.null()]),
+  })
+  .partial()
+  .passthrough();
+export type UpdateChatRequest = z.infer<typeof UpdateChatRequest>;
 export const ComhairleChatSession = z
   .object({
     chat_id: z.string(),
@@ -3209,6 +3244,10 @@ export const schemas: Record<string, z.ZodType<any>> = {
   FeedbackDto,
   CreateFeedbackDTO,
   PartialFeedback,
+  ComhairleLlm,
+  ComhairlePrompt,
+  ComhairleChat,
+  UpdateChatRequest,
   ComhairleChatSession,
   ChatConversationRequest,
   page_size,
@@ -3665,6 +3704,29 @@ Use a raw HTTP request and process the response body incrementally.`,
       },
     ],
     response: z.void(),
+  },
+  {
+    method: "get",
+    path: "/conversation/:conversation_id/chats",
+    alias: "GetChat",
+    description: `Get a conversation&#x27;s bot service chat`,
+    requestFormat: "json",
+    response: ComhairleChat,
+  },
+  {
+    method: "put",
+    path: "/conversation/:conversation_id/chats",
+    alias: "UpdateChat",
+    description: `Update a conversation&#x27;s bot service chat`,
+    requestFormat: "json",
+    parameters: [
+      {
+        name: "body",
+        type: "Body",
+        schema: UpdateChatRequest,
+      },
+    ],
+    response: ComhairleChat,
   },
   {
     method: "get",

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/learning-assistant/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/learning-assistant/+page.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-	import type { ComhairleDocument, ConversationWithTranslations } from '@crownshy/api-client/api';
+	import type {
+		ComhairleChat,
+		ComhairleDocument,
+		ConversationWithTranslations
+	} from '@crownshy/api-client/api';
 	import { apiClient } from '@crownshy/api-client/client';
 	import { invalidate } from '$app/navigation';
 	import PageHeader from '$lib/components/PageHeader.svelte';
@@ -23,6 +27,9 @@
 		type ImageMap
 	} from '$lib/learn/tiptapToPdf';
 	import LearnSyncStatus from './LearnSyncStatus.svelte';
+	import { allLanguages } from '$lib/config/languages';
+	import MultiSelect from '$lib/components/ui/mutli-select/multi-select.svelte';
+	import type { Option } from '$lib/components/ui/mutli-select/multi-select.svelte';
 
 	const MAX_SIZE = 50 * MB;
 
@@ -30,11 +37,13 @@
 		data: {
 			documents: ComhairleDocument[];
 			conversation: ConversationWithTranslations;
+			chat: ComhairleChat;
 		};
 	};
 
 	let { data }: Props = $props();
 	let conversation = $derived(data.conversation);
+	let chat = $derived(data.chat);
 	let documents = $derived(data.documents);
 
 	// The synced learn-step content is a knowledge-base document like any other, but it is
@@ -219,6 +228,41 @@
 		await invalidate('knowledge-base:documents');
 	}
 
+	let allLanguageOptions = $derived<Option[]>(
+		allLanguages.map((lang) => ({ value: lang.name, label: lang.name }))
+	);
+
+	let selectedCrossLanguages = $derived<Option[]>(
+		chat?.prompt?.cross_languages && chat.prompt.cross_languages.length
+			? allLanguageOptions.filter(
+					(langOption) =>
+						!!chat?.prompt?.cross_languages?.find((lang) => lang === langOption.value)
+				)
+			: []
+	);
+
+	async function handleCrossLanguagesChange(options: Option[]) {
+		const result = await tryCatchAsync(() =>
+			apiClient.UpdateChat(
+				{ prompt: { cross_languages: [...options.map((o) => o.value)] } },
+				{ params: { conversation_id: conversation.id } }
+			)
+		);
+
+		if (result.err !== null) {
+			return notifications.send({
+				priority: 'ERROR',
+				message: 'Failed to update learning assistant cross languages'
+			});
+		}
+
+		notifications.send({
+			priority: 'INFO',
+			message: 'Successfully updated learning assistant cross languages'
+		});
+		invalidate('knowledge-base:documents');
+	}
+
 	// FIX: Upload from Url functionality
 	// async function uploadFromUrl() {
 	// 	if (!urlInput.trim()) {
@@ -383,6 +427,32 @@
 			{#if parsedDocuments?.length}
 				<ParsedFileList documents={parsedDocuments} {conversation} />
 			{/if}
+		</div>
+	</div>
+
+	<div
+		class="border-border flex flex-col gap-4 border-t py-6 lg:flex-row lg:items-start lg:gap-6"
+	>
+		<div class="lg:w-50 lg:shrink-0 lg:pt-1">
+			<p class="text-sm font-semibold">Cross-language Search</p>
+		</div>
+		<div class="flex-1 space-y-4">
+			<p class="text-muted-foreground text-base">
+				Lets users ask questions in one language and still get answers from documents
+				written in another. Before searching, your question is translated into the
+				document's language(s), so nothing gets missed just because of a language mismatch.
+			</p>
+			<div class="flex max-w-md flex-col gap-3">
+				<MultiSelect
+					defaultOptions={allLanguageOptions}
+					selected={selectedCrossLanguages}
+					onSelectedChange={handleCrossLanguagesChange}
+					placeholder="Select languages..."
+					ariaLabel="Supported languages"
+					emptyMessage="No languages found"
+					class="w-full"
+				/>
+			</div>
 		</div>
 	</div>
 </div>

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/learning-assistant/+page.ts
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/learning-assistant/+page.ts
@@ -11,16 +11,27 @@ export const load: PageLoad = async ({ depends, params }: LoadEvent) => {
 		return;
 	}
 
-	const response = await tryCatchAsync(() =>
+	const docsResponse = await tryCatchAsync(() =>
 		apiClient.ListDocuments({
 			params: { conversation_id }
 		})
 	);
 
-	if (response.err !== null) {
-		console.error(response.err);
+	if (docsResponse.err !== null) {
+		console.error(docsResponse.err);
 		return;
 	}
 
-	return { documents: response.ok };
+	const chatResponse = await tryCatchAsync(() =>
+		apiClient.GetChat({
+			params: { conversation_id }
+		})
+	);
+
+	if (chatResponse.err !== null) {
+		console.error(chatResponse.err);
+		return;
+	}
+
+	return { documents: docsResponse.ok, chat: chatResponse.ok };
 };


### PR DESCRIPTION
Motivation:

- improve slow server response times by ragflow chat bots caused by supporting full list of cross languages, which requires translating question into each language before running vector search

Actions:

- remove code to create chat bots with full list of supported cross languages
- add router for conversation chat bots with get and update endpoints
- admin UI to update chat bot's cross languages