### PR TITLE
367 Jitsi - remove breakout session panel text truncation

### DIFF
--- a/ui/packages/comhairle/src/lib/components/LiveEvent/BreakoutSessionPanel.svelte
+++ b/ui/packages/comhairle/src/lib/components/LiveEvent/BreakoutSessionPanel.svelte
@@ -28,7 +28,7 @@
 	class="bg-muted flex h-full flex-col overflow-hidden rounded-3xl shadow-[0px_2px_4px_0px_rgba(0,0,0,0.12)]"
 >
 	<!-- Header -->
-	<div class="flex flex-col items-start gap-6 px-5">
+	<div class="flex shrink-0 flex-col items-start gap-6 px-5">
 		<div class="flex w-full max-w-[1304px] items-center justify-center">
 			<h2 class="text-muted-foreground text-center text-xl leading-7 font-semibold">
 				Breakout session
@@ -40,14 +40,14 @@
 	<div class="flex flex-1 flex-col items-center gap-6 overflow-y-auto px-3 py-5">
 		{#if question}
 			<div
-				class="bg-background flex w-full flex-col items-center gap-4 overflow-hidden rounded-xl p-6"
+				class="bg-background flex w-full shrink-0 flex-col items-center gap-4 rounded-xl p-6"
 			>
 				<div class="flex flex-col items-center gap-1">
 					<span class="text-primary text-xs leading-4 font-medium uppercase"
 						>Question</span
 					>
 					<p
-						class="text-foreground line-clamp-2 text-center text-lg leading-7 font-semibold"
+						class="text-foreground text-center text-lg leading-7 font-semibold break-words"
 					>
 						{question}
 					</p>
@@ -55,7 +55,7 @@
 
 				{#if description}
 					<div class="h-0 w-full border-t"></div>
-					<div class="text-foreground w-full text-sm leading-5 font-normal">
+					<div class="text-foreground w-full text-base leading-6 font-normal">
 						<ContentRenderer content={description} />
 					</div>
 				{/if}
@@ -64,7 +64,7 @@
 	</div>
 
 	<!-- Footer -->
-	<div class="flex flex-col items-center gap-6 border-t p-5">
+	<div class="flex shrink-0 flex-col items-center gap-6 border-t p-5">
 		{#if isModerator}
 			<Button
 				variant="destructive"

--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/events/[event_id]/live/+page.svelte
@@ -914,21 +914,21 @@
 					>
 						{#if currentAgendaItem?.breakoutQuestion}
 							<div
-								class="bg-background flex flex-col items-center gap-4 rounded-2xl px-5 py-5"
+								class="bg-background flex shrink-0 flex-col items-center gap-4 rounded-2xl px-5 py-5"
 							>
 								<div class="flex flex-col items-center gap-2">
 									<span class="text-primary text-xs font-medium uppercase">
 										Question
 									</span>
 									<p
-										class="text-foreground text-center text-lg leading-tight font-semibold"
+										class="text-foreground text-center text-lg leading-tight font-semibold break-words"
 									>
 										{currentAgendaItem.breakoutQuestion}
 									</p>
 								</div>
 								{#if currentAgendaItem.breakoutDescription}
 									<div class="bg-border h-px w-full"></div>
-									<div class="text-muted-foreground w-full text-sm">
+									<div class="text-muted-foreground w-full text-base">
 										<ContentRenderer
 											content={currentAgendaItem.breakoutDescription}
 										/>


### PR DESCRIPTION
Actions:

+ add shrink-0 to header and footer to prevent flex compression
+ remove overflow-hidden and line-clamp-2 from question text
+ add break-words to question text for better wrapping
+ increase description text size from text-sm to text-base

Motivation:

+ prevent header/footer from being compressed when content overflows
+ allow full question text to display without truncation
+ improve text wrapping and readability

Before

<img width="410" height="216" alt="2026-08-27_09-24-08" src="https://github.com/user-attachments/assets/2bf24e3f-16ad-49c7-b84e-aad2034d4f04" />


After

<img width="446" height="315" alt="2026-08-27_09-22-15" src="https://github.com/user-attachments/assets/562c94e9-8fe7-47ca-945a-2842ffd4bc8d" />
