### PR TITLE
1011 conversation entry

### DIFF
--- a/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/invite/[invite_id]/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/conversations/[conversation_id]/[[preview]]/invite/[invite_id]/+page.svelte
@@ -58,9 +58,14 @@
 		try {
 			if (loginType === 'automatic') {
 				await apiClient.SignupAnnonUser(undefined, {});
+				await acceptInvite();
+				await goto(firstWorkflowPath + url.search, {
+					invalidate: ['user', 'app:participation']
+				});
+			} else {
+				await acceptInvite();
+				await goto(firstWorkflowPath + url.search, { invalidate: ['app:participation'] });
 			}
-			await acceptInvite();
-			await goto(firstWorkflowPath + url.search, { invalidateAll: true });
 		} catch (e) {
 			console.error(e);
 		}

--- a/ui/packages/comhairle/src/routes/+layout.server.ts
+++ b/ui/packages/comhairle/src/routes/+layout.server.ts
@@ -3,6 +3,8 @@ import { env } from '$env/dynamic/public';
 import { resolveThemeName } from '$lib/types/theme';
 
 export const load: LayoutServerLoad = async (event) => {
+	event.depends('user');
+
 	const tk = event.cookies.get('auth-token');
 	const common = {
 		themeName: resolveThemeName(env.PUBLIC_THEME),


### PR DESCRIPTION
Actions:

+ separate auto signup flow from other flows when accepting privacy policy on invite page

Motivation:

+ all flows re-fetching user data unnecessarily which could be causing timing issues when entering conversation