### PR TITLE
1027 apply credential rate limit per-route instead of router-wide

### DIFF
--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -74,7 +74,7 @@ uuid = { workspace = true, features = ["serde", "v4"] }
 argon2 = "0.5.3"
 rand_core = { version = "0.6", features = ["std"] }
 redis = { version = "1.3.0", features = ["aio", "tokio-comp", "connection-manager"] }
-tower = "0.5.2"
+tower = { version = "0.5.2", features = ["util"] }
 serde_json = { workspace = true }
 http-body-util = "0.1.2"
 headers = "0.4.0"

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -189,14 +189,10 @@ pub async fn build_app_and_spec(state: Arc<ComhairleState>) -> (Router, OpenApi)
         ])
         .allow_origin(allowed_origins);
 
+    // Rate limiting is applied per route inside the auth router: the strict
+    // limiter belongs on the credential endpoints, not on session reads.
     // Added `.await` here to resolve the opaque Future issue
     let auth_router = routes::auth::router(state.clone()).await;
-
-    let auth_router = if state.config.enable_rate_limiting {
-        auth_router.layer(middleware::rate_limit::auth_rate_limiter())
-    } else {
-        auth_router
-    };
 
     let router = ApiRouter::new()
         .route("/health", axum::routing::get(health_check))

--- a/api/src/middleware/rate_limit_tests.rs
+++ b/api/src/middleware/rate_limit_tests.rs
@@ -327,4 +327,102 @@ mod tests {
 
         Ok(())
     }
+
+    /// Helper to read the current user with a custom IP address
+    async fn current_user_request_with_ip(
+        app: &axum::Router,
+        ip: &str,
+    ) -> Result<axum::response::Response, Box<dyn Error>> {
+        let request = Request::builder()
+            .uri("/auth/current_user")
+            .method("GET")
+            .header("X-Forwarded-For", ip)
+            .body(Body::empty())
+            .unwrap();
+
+        Ok(app.clone().oneshot(request).await?)
+    }
+
+    /// Regression test for #1027. `current_user` runs on every page render, so
+    /// putting it behind the credential limiter signed people out at random.
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
+    async fn test_current_user_survives_exhausted_credential_limit(
+        pool: PgPool,
+    ) -> Result<(), Box<dyn Error>> {
+        let state = test_state_with_rate_limiting(pool)?;
+        let app = setup_rate_limited_server(state).await?;
+
+        let ip = "192.168.1.107";
+
+        // Burn the credential budget for this IP
+        for i in 0..6 {
+            signup_request_with_ip(
+                &app,
+                ip,
+                &format!("burn{}", i),
+                &format!("burn{}@test.com", i),
+            )
+            .await?;
+        }
+
+        let response = signup_request_with_ip(&app, ip, "burned", "burned@test.com").await?;
+        assert_eq!(
+            response.status(),
+            StatusCode::TOO_MANY_REQUESTS,
+            "Credential limit should be exhausted for this IP"
+        );
+
+        // Page renders keep working from the same IP
+        for i in 0..10 {
+            let response = current_user_request_with_ip(&app, ip).await?;
+            assert_eq!(
+                response.status(),
+                StatusCode::UNAUTHORIZED,
+                "current_user request {} should answer normally, not 429",
+                i + 1
+            );
+        }
+
+        Ok(())
+    }
+
+    /// The credential endpoints share one bucket, so rotating between them does
+    /// not buy an attacker extra attempts.
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
+    async fn test_credential_endpoints_share_one_bucket(
+        pool: PgPool,
+    ) -> Result<(), Box<dyn Error>> {
+        let state = test_state_with_rate_limiting(pool)?;
+        let app = setup_rate_limited_server(state).await?;
+
+        let email = "sharedbucket@test.com";
+        let _ = signup_request_with_ip(&app, "192.168.1.200", "sharedbucket", email).await?;
+
+        let ip = "192.168.1.108";
+        for i in 0..3 {
+            let response = signup_request_with_ip(
+                &app,
+                ip,
+                &format!("shared{}", i),
+                &format!("shared{}@test.com", i),
+            )
+            .await?;
+
+            assert_eq!(
+                response.status(),
+                StatusCode::CREATED,
+                "Signup {} should sit within the burst",
+                i + 1
+            );
+        }
+
+        let response = login_request_with_ip(&app, ip, email, TEST_PASSWORD).await?;
+        assert_eq!(
+            response.status(),
+            StatusCode::TOO_MANY_REQUESTS,
+            "Login should draw on the same bucket the signups exhausted"
+        );
+
+        Ok(())
+    }
 }

--- a/api/src/routes/auth.rs
+++ b/api/src/routes/auth.rs
@@ -53,11 +53,13 @@ use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use serde_json::json;
 use std::marker::PhantomData;
 use std::{collections::HashMap, sync::Arc};
+use tower::util::option_layer;
 use tracing::{instrument, warn};
 use uuid::Uuid;
 
 use crate::ComhairleState;
 use crate::error::ComhairleError;
+use crate::middleware::rate_limit::auth_rate_limiter_if_enabled;
 use crate::middleware::request_logging::{ClientIp, ClientUserAgent};
 use crate::models::permissions::{
     Action, ConversationPath, ExtractResourceId, GrantRoleRequest, Role as PermissionRole,
@@ -1135,6 +1137,12 @@ pub fn create_session_cookie<'a>(user: &User, state: &Arc<ComhairleState>) -> Co
 
 /// Function to set up the auth routes
 pub async fn router(state: Arc<ComhairleState>) -> ApiRouter {
+    // One strict per-IP bucket, shared by every route that takes or issues
+    // credentials, so rotating between login and signup does not buy extra
+    // attempts. Session reads (`current_user`, `logout`) stay off it: they run
+    // on every page render, and limiting them signs people out at random.
+    let credential_limit = option_layer(auth_rate_limiter_if_enabled(&state.config));
+
     ApiRouter::new()
         .api_route(
             "/login_annon",
@@ -1143,7 +1151,8 @@ pub async fn router(state: Arc<ComhairleState>) -> ApiRouter {
                     .tag("Auth")
                     .summary("Login an annon user")
                     .response::<200, Json<UserDto>>()
-            }),
+            })
+            .layer(credential_limit.clone()),
         )
         .api_route(
             "/login",
@@ -1152,7 +1161,8 @@ pub async fn router(state: Arc<ComhairleState>) -> ApiRouter {
                     .tag("Auth")
                     .summary("Login a user")
                     .response::<200, Json<UserDto>>()
-            }),
+            })
+            .layer(credential_limit.clone()),
         )
         .api_route(
             "/login_otp",
@@ -1162,7 +1172,8 @@ pub async fn router(state: Arc<ComhairleState>) -> ApiRouter {
                     .summary("Login an otp user")
                     .description("Login a user with a one time passcode")
                     .response::<200, Json<UserDto>>()
-            }),
+            })
+            .layer(credential_limit.clone()),
         )
         .api_route(
             "/signup",
@@ -1171,7 +1182,8 @@ pub async fn router(state: Arc<ComhairleState>) -> ApiRouter {
                     .tag("Auth")
                     .summary("Signup a user with email and password")
                     .response::<201, Json<UserDto>>()
-            }),
+            })
+            .layer(credential_limit.clone()),
         )
         .api_route(
             "/signup_annon",
@@ -1180,7 +1192,8 @@ pub async fn router(state: Arc<ComhairleState>) -> ApiRouter {
                     .tag("Auth")
                     .summary("Signup and annon user")
                     .response::<201, Json<UserDto>>()
-            }),
+            })
+            .layer(credential_limit.clone()),
         )
         .api_route(
             "/signup_otp",
@@ -1189,7 +1202,8 @@ pub async fn router(state: Arc<ComhairleState>) -> ApiRouter {
                     .tag("Auth")
                     .summary("Signup a one-time-password user with an email")
                     .response::<201, Json<UserDto>>()
-            }),
+            })
+            .layer(credential_limit.clone()),
         )
         .api_route(
             "/create_otp",
@@ -1198,7 +1212,8 @@ pub async fn router(state: Arc<ComhairleState>) -> ApiRouter {
                     .tag("Auth")
                     .summary("Create and send a new one time passcode")
                     .response::<201, ()>()
-            }),
+            })
+            .layer(credential_limit.clone()),
         )
         .api_route(
             "/login_otp_token",
@@ -1207,7 +1222,8 @@ pub async fn router(state: Arc<ComhairleState>) -> ApiRouter {
                     .tag("Auth")
                     .summary("Verify one-time-passcode from a JWT")
                     .response::<200, Json<UserDto>>()
-            }),
+            })
+            .layer(credential_limit.clone()),
         )
         .api_route(
             "/logout",
@@ -1225,7 +1241,8 @@ pub async fn router(state: Arc<ComhairleState>) -> ApiRouter {
                     .tag("Auth")
                     .summary("Verify token from email verification link")
                     .response::<200, Json<UserDto>>()
-            }),
+            })
+            .layer(credential_limit.clone()),
         )
         .api_route(
             "/resend_verification_email",
@@ -1234,7 +1251,8 @@ pub async fn router(state: Arc<ComhairleState>) -> ApiRouter {
                     .tag("Auth")
                     .summary("Resend email verification link to user")
                     .response::<200, ()>()
-            }),
+            })
+            .layer(credential_limit.clone()),
         )
         .api_route(
             "/password_reset_create",
@@ -1243,7 +1261,8 @@ pub async fn router(state: Arc<ComhairleState>) -> ApiRouter {
                     .tag("Auth")
                     .summary("Create password reset flow by sending reset link to user email")
                     .response::<204, ()>()
-            }),
+            })
+            .layer(credential_limit.clone()),
         )
         .api_route(
             "/password_reset_update",
@@ -1252,7 +1271,8 @@ pub async fn router(state: Arc<ComhairleState>) -> ApiRouter {
                     .tag("Auth")
                     .summary("Update password of user in reset flow")
                     .response::<204, ()>()
-            }),
+            })
+            .layer(credential_limit.clone()),
         )
         .api_route(
             "/current_user",


### PR DESCRIPTION
Actions:

+ enable tower "util" feature for option_layer
+ move credential rate limiter from auth router to individual routes
+ apply strict limiter only to credential endpoints (login, signup, otp, password reset)
+ exclude current_user and logout from rate limiting
+ add test verifying current_user survives exhausted credential limit
+ add test verifying credential endpoints share one bucket

#1027
