### PR TITLE
Migrate demographics to own table

### DIFF
--- a/api/migrations/20260826093939_create_first_class_demographics.sql
+++ b/api/migrations/20260826093939_create_first_class_demographics.sql
@@ -1,0 +1,94 @@
+-- Demographics questions
+CREATE TYPE demographics_response_type AS ENUM ('string', 'number');
+
+CREATE TABLE demographics_question (
+    slug TEXT NOT NULL PRIMARY KEY,
+    response_type demographics_response_type NOT NULL
+);
+
+CREATE INDEX idx_demographics_question_slug ON demographics_question(slug);
+
+-- Demographics responses
+CREATE TABLE demographics_response (
+    id UUID NOT NULL PRIMARY KEY DEFAULT uuid_generate_v4(),
+    question_slug TEXT NOT NULL REFERENCES demographics_question(slug) ON DELETE CASCADE,
+    user_id UUID REFERENCES comhairle_user(id) ON DELETE SET NULL,
+    value TEXT NOT NULL,
+    CONSTRAINT chk_value_not_empty CHECK (value <> '')
+);
+
+CREATE INDEX idx_demographics_response_demographics_question ON demographics_response(question_slug);
+CREATE INDEX idx_demographics_response_user_id ON demographics_response(user_id);
+
+-- {question_slug, user_id} should be unique if user_id is not null (user account is not yet deleted)
+CREATE UNIQUE INDEX IF NOT EXISTS uq_demographics_response_question_slug_user_id ON demographics_response (question_slug, user_id) 
+WHERE user_id IS NOT NULL;
+
+-- Let's add the age, ethnicity, gender, location, and political party demographics questions.
+INSERT INTO demographics_question (slug, response_type) VALUES
+    ('age', 'number'),
+    ('ethnicity', 'string'),
+    ('gender', 'string'),
+    ('zipcode', 'string'),
+    ('political_party', 'string');
+
+-- Let's migrate the existing age, ethnicity, gender, and political party data from the user_profile table to the new demographics_response table.
+-- Migrate one field at a time
+-- Migrate age
+INSERT INTO demographics_response (question_slug, user_id, value)
+SELECT 'age', user_id, age::TEXT
+FROM user_profile
+WHERE age IS NOT NULL;
+
+-- Migrate ethnicity
+INSERT INTO demographics_response (question_slug, user_id, value)
+SELECT 'ethnicity', user_id, ethnicity
+FROM user_profile
+WHERE ethnicity IS NOT NULL;
+
+-- Migrate gender
+INSERT INTO demographics_response (question_slug, user_id, value)
+SELECT 'gender', user_id, gender
+FROM user_profile
+WHERE gender IS NOT NULL;
+
+-- Migrate zipcode
+INSERT INTO demographics_response (question_slug, user_id, value)
+SELECT 'zipcode', user_id, zipcode
+FROM user_profile
+WHERE zipcode IS NOT NULL;
+
+-- Migrate political_party
+INSERT INTO demographics_response (question_slug, user_id, value)
+SELECT 'political_party', user_id, political_party
+FROM user_profile
+WHERE political_party IS NOT NULL;
+
+-- Delete the migrated columns from the user_profile table.
+ALTER TABLE user_profile
+DROP COLUMN IF EXISTS age,
+DROP COLUMN IF EXISTS ethnicity,
+DROP COLUMN IF EXISTS gender,
+DROP COLUMN IF EXISTS zipcode,
+DROP COLUMN IF EXISTS political_party;
+
+-- Many-many relationship between conversations and demographics questions.
+CREATE TABLE conversation_demographics (
+    conversation_id UUID NOT NULL REFERENCES conversation(id) ON DELETE CASCADE,
+    question_slug TEXT NOT NULL REFERENCES demographics_question(slug) ON DELETE CASCADE,
+    CONSTRAINT pk_conversation_demographics PRIMARY KEY (conversation_id, question_slug)
+);
+
+CREATE INDEX idx_conversation_demographics_conversation_id ON conversation_demographics(conversation_id);
+CREATE INDEX idx_conversation_demographics_question_slug ON conversation_demographics(question_slug);
+
+-- Create demographics relationships from existing metadata
+INSERT INTO conversation_demographics (conversation_id, question_slug)
+SELECT c.id, q.slug
+FROM conversation c
+JOIN demographics_question q ON q.slug IN ('age', 'ethnicity', 'gender', 'zipcode', 'political_party')
+WHERE c.metadata->'demographics'->>q.slug = 'true';
+
+UPDATE conversation
+SET metadata = metadata - 'demographics'
+WHERE metadata ? 'demographics';

--- a/api/migrations/20260831093138_add_demographics_question_config.sql
+++ b/api/migrations/20260831093138_add_demographics_question_config.sql
@@ -1,0 +1,31 @@
+-- Add display_name and bucket_config columns to demographics_question table
+ALTER TABLE demographics_question
+    ADD COLUMN display_name TEXT,
+    ADD COLUMN bucket_config JSONB;
+
+-- Set display_name for existing demographics questions
+UPDATE demographics_question SET display_name = 'Age' WHERE slug = 'age';
+UPDATE demographics_question SET display_name = 'Ethnicity' WHERE slug = 'ethnicity';
+UPDATE demographics_question SET display_name = 'Gender' WHERE slug = 'gender';
+UPDATE demographics_question SET display_name = 'Zipcode' WHERE slug = 'zipcode';
+UPDATE demographics_question SET display_name = 'Political Party' WHERE slug = 'political_party';
+
+-- Set display name as not null
+ALTER TABLE demographics_question
+    ALTER COLUMN display_name SET NOT NULL;
+
+-- Set bucket_config for existing age question
+UPDATE demographics_question
+SET bucket_config = '{
+    "type": "numeric",
+    "buckets": [
+        {"label": "Under 18", "min": null, "max": 17},
+        {"label": "18-24", "min": 18, "max": 24},
+        {"label": "25-34", "min": 25, "max": 34},
+        {"label": "35-44", "min": 35, "max": 44},
+        {"label": "45-54", "min": 45, "max": 54},
+        {"label": "55-64", "min": 55, "max": 64},
+        {"label": "65+", "min": 65, "max": null}
+    ]
+}'::jsonb
+WHERE slug = 'age';

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -309,6 +309,7 @@ pub async fn build_app_and_spec(state: Arc<ComhairleState>) -> (Router, OpenApi)
         )
         .nest_api_service("/permissions", routes::permissions::router(state.clone()))
         .nest_api_service("/docs", docs_routes(state.clone()))
+        .nest_api_service("/demographics", routes::demographics::router(state.clone()))
         .finish_api_with(&mut api, api_docs)
         .layer(axum::middleware::from_fn_with_state(
             state.clone(),

--- a/api/src/models.rs
+++ b/api/src/models.rs
@@ -8,6 +8,7 @@ pub mod bot_service_user_session;
 pub mod breakout_plan;
 pub mod conversation;
 pub mod conversation_email_notification_recipients;
+pub mod demographics;
 pub mod email_template_config;
 pub mod event;
 pub mod event_attendance;

--- a/api/src/models/demographics.rs
+++ b/api/src/models/demographics.rs
@@ -1,0 +1,1131 @@
+// Context: We migrated user profile demographics to an EAV key-value schema using three tables:
+// 1. `demographics_question`                     - Represents a demographics question
+// (
+//    slug TEXT PK,                               - Unique identifier for the demographics question
+//    display_name TEXT NOT NULL,                 - Human-readable name for the demographics question
+//    response_type 'string' | 'number' NOT NULL, - The type of response expected for the demographics question
+//    bucket_config JSONB                         - Configuration for how responses should be bucketed (e.g., age ranges)
+// )
+// 2. `demographics_response`                     - Represents a user's response to a demographics question
+// (
+//    question_slug FK,                           - Foreign key referencing the demographics question
+//    user_id FK,                                 - Foreign key referencing the user
+//    value NOT NULL                              - The response value provided by the user
+// )
+// 3. `conversation_demographics`                 - Represents which demographics questions are associated with a conversation
+// (
+//    conversation_id FK,                         - Foreign key referencing the conversation
+//    question_slug FK                            - Foreign key referencing the demographics question
+// )
+
+use partially::Partial;
+use schemars::JsonSchema;
+use sea_query::{Alias, Expr, PostgresQueryBuilder, SimpleExpr, enum_def};
+use sea_query_binder::SqlxBinder;
+use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
+use sqlx::prelude::FromRow;
+use sqlx::{Decode, Postgres, Type};
+use tracing::instrument;
+use uuid::Uuid;
+
+use crate::error::ComhairleError;
+use crate::models::pagination::{PageOptions, PaginatedResults};
+
+// ============================================================================
+// Conversation Demographics Models
+// ============================================================================
+
+/// Represents an association between a conversation and a demographics question.
+#[derive(Serialize, Deserialize, Debug, FromRow, Clone, JsonSchema)]
+#[enum_def(table_name = "conversation_demographics")]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(test, derive(PartialEq))]
+pub struct ConversationDemographics {
+    pub conversation_id: Uuid,
+    pub question_slug: String,
+}
+
+const CONVERSATION_DEMOGRAPHICS_COLUMNS: [ConversationDemographicsIden; 2] = [
+    ConversationDemographicsIden::ConversationId,
+    ConversationDemographicsIden::QuestionSlug,
+];
+
+#[derive(Serialize, Deserialize, JsonSchema, Debug, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateConversationDemographics {
+    pub conversation_id: Uuid,
+    pub question_slug: String,
+}
+
+impl CreateConversationDemographics {
+    fn columns() -> [ConversationDemographicsIden; 2] {
+        CONVERSATION_DEMOGRAPHICS_COLUMNS
+    }
+
+    fn values(self) -> [SimpleExpr; 2] {
+        [
+            self.conversation_id.into(),
+            self.question_slug.clone().into(),
+        ]
+    }
+}
+
+#[derive(Debug, Default, Deserialize, Serialize, Clone, JsonSchema)]
+pub struct ConversationDemographicsFilterOptions {
+    pub conversation_id: Option<Uuid>,
+    pub question_slug: Option<String>,
+}
+
+impl ConversationDemographicsFilterOptions {
+    pub fn apply(&self, mut query: sea_query::SelectStatement) -> sea_query::SelectStatement {
+        if let Some(conversation_id) = self.conversation_id {
+            query = query
+                .and_where(
+                    Expr::col(ConversationDemographicsIden::ConversationId).eq(conversation_id),
+                )
+                .to_owned();
+        }
+
+        if let Some(question_slug) = self.question_slug.clone() {
+            query = query
+                .and_where(Expr::col(ConversationDemographicsIden::QuestionSlug).eq(question_slug))
+                .to_owned();
+        }
+
+        query
+    }
+}
+
+/// Represents demographics question response type (either 'string' or 'number').
+#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(test, derive(PartialEq))]
+pub enum DemographicsQuestionResponseType {
+    String,
+    Number,
+}
+
+impl Into<SimpleExpr> for DemographicsQuestionResponseType {
+    fn into(self) -> SimpleExpr {
+        Expr::val(self.as_ref()).cast_as(Alias::new("demographics_response_type"))
+    }
+}
+
+impl AsRef<str> for DemographicsQuestionResponseType {
+    fn as_ref(&self) -> &str {
+        match self {
+            Self::String => "string",
+            Self::Number => "number",
+        }
+    }
+}
+
+impl Decode<'_, Postgres> for DemographicsQuestionResponseType {
+    fn decode(
+        row: <Postgres as sqlx::Database>::ValueRef<'_>,
+    ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        let s = row.as_str()?;
+        match s {
+            "string" => return Ok(DemographicsQuestionResponseType::String),
+            "number" => return Ok(DemographicsQuestionResponseType::Number),
+            _ => {
+                return Err(Box::new(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("Invalid demographics question response type: {s}"),
+                )));
+            }
+        }
+    }
+}
+
+impl Type<Postgres> for DemographicsQuestionResponseType {
+    fn type_info() -> <Postgres as sqlx::Database>::TypeInfo {
+        <Postgres as sqlx::Database>::TypeInfo::with_name("demographics_response_type").into()
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, JsonSchema)]
+#[cfg_attr(test, derive(PartialEq))]
+pub struct NumericBucket {
+    pub min: Option<i64>,
+    pub max: Option<i64>,
+    pub label: String,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, JsonSchema)]
+#[cfg_attr(test, derive(PartialEq))]
+pub struct TextBucket {
+    pub values: Option<Vec<String>>,
+    pub label: String,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone, JsonSchema)]
+#[cfg_attr(test, derive(PartialEq))]
+#[serde(tag = "type", rename_all = "camelCase")]
+pub enum ValueBuckets {
+    Numeric { buckets: Vec<NumericBucket> },
+    Text { buckets: Vec<TextBucket> },
+}
+
+/// Safely maps a raw value into a defined category bucket label based on the provided bucket configuration.
+pub fn resolve_category_bucket(value: &str, buckets: &ValueBuckets) -> String {
+    match buckets {
+        ValueBuckets::Numeric {
+            buckets: numeric_buckets,
+        } => {
+            if let Ok(num) = value.parse::<i64>() {
+                for bucket in numeric_buckets {
+                    let greater_than_or_equal_to_min = bucket.min.map_or(true, |m| num >= m);
+                    let less_than_or_equal_to_max = bucket.max.map_or(true, |m| num <= m);
+                    if greater_than_or_equal_to_min && less_than_or_equal_to_max {
+                        return bucket.label.clone();
+                    }
+                }
+            }
+        }
+        ValueBuckets::Text {
+            buckets: text_buckets,
+        } => {
+            for bucket in text_buckets {
+                if let Some(values) = &bucket.values {
+                    if values.contains(&value.to_string()) {
+                        return bucket.label.clone();
+                    }
+                }
+            }
+        }
+    }
+    "Uncategorized".to_string()
+}
+
+/// Represents a demographics question.
+#[derive(Serialize, Deserialize, Partial, Debug, FromRow, Clone, JsonSchema)]
+#[enum_def(table_name = "demographics_question")]
+#[partially(derive(Serialize, Deserialize, Debug, JsonSchema))]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(test, derive(PartialEq))]
+pub struct DemographicsQuestion {
+    #[partially(omit)]
+    pub slug: String,
+    pub display_name: String,
+    pub response_type: DemographicsQuestionResponseType,
+    #[schemars(with = "Option<Vec<ValueBuckets>>")]
+    pub bucket_config: Option<sqlx::types::Json<ValueBuckets>>,
+}
+
+const DEMOGRAPHICS_QUESTION_COLUMNS: [DemographicsQuestionIden; 4] = [
+    DemographicsQuestionIden::Slug,
+    DemographicsQuestionIden::DisplayName,
+    DemographicsQuestionIden::ResponseType,
+    DemographicsQuestionIden::BucketConfig,
+];
+
+#[derive(Serialize, Deserialize, JsonSchema, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateDemographicsQuestion {
+    pub slug: String,
+    pub display_name: String,
+    pub response_type: DemographicsQuestionResponseType,
+    #[schemars(with = "Option<Vec<ValueBuckets>>")]
+    pub bucket_config: Option<sqlx::types::Json<ValueBuckets>>,
+}
+
+impl CreateDemographicsQuestion {
+    fn columns() -> [DemographicsQuestionIden; 4] {
+        DEMOGRAPHICS_QUESTION_COLUMNS
+    }
+
+    fn values(self) -> [SimpleExpr; 4] {
+        [
+            self.slug.into(),
+            self.display_name.into(),
+            self.response_type.into(),
+            self.bucket_config
+                .map(|json| serde_json::to_value(json.0).unwrap())
+                .into(),
+        ]
+    }
+}
+
+impl PartialDemographicsQuestion {
+    fn to_values(self) -> Vec<(DemographicsQuestionIden, SimpleExpr)> {
+        let mut values = Vec::new();
+        if let Some(display_name) = self.display_name {
+            values.push((DemographicsQuestionIden::DisplayName, display_name.into()));
+        }
+
+        if let Some(response_type) = self.response_type {
+            values.push((DemographicsQuestionIden::ResponseType, response_type.into()));
+        }
+
+        if let Some(bucket_config) = self.bucket_config {
+            let json_expr = bucket_config
+                .map(|json| serde_json::to_value(json.0).unwrap())
+                .into();
+
+            values.push((DemographicsQuestionIden::BucketConfig, json_expr));
+        }
+        values
+    }
+}
+
+#[derive(Debug, Default, Deserialize, Serialize, Clone, JsonSchema)]
+pub struct DemographicsQuestionsFilterOptions {
+    pub conversation_id: Option<Uuid>,
+    pub question_slug: Option<String>,
+}
+
+impl DemographicsQuestionsFilterOptions {
+    pub fn apply(&self, mut query: sea_query::SelectStatement) -> sea_query::SelectStatement {
+        if let Some(conversation_id) = self.conversation_id {
+            query = query
+                .inner_join(
+                    ConversationDemographicsIden::Table,
+                    sea_query::Expr::col(DemographicsQuestionIden::Slug)
+                        .equals(ConversationDemographicsIden::QuestionSlug),
+                )
+                .and_where(
+                    Expr::col(ConversationDemographicsIden::ConversationId).eq(conversation_id),
+                )
+                .to_owned();
+        }
+
+        if let Some(question_slug) = self.question_slug.clone() {
+            query = query
+                .and_where(Expr::col(DemographicsQuestionIden::Slug).eq(question_slug))
+                .to_owned();
+        }
+
+        query
+    }
+}
+
+/// Represents a demographics response from a user to a specific demographics question.
+#[derive(Serialize, Deserialize, Partial, Debug, FromRow, Clone, JsonSchema)]
+#[enum_def(table_name = "demographics_response")]
+#[partially(derive(Serialize, Deserialize, Debug, JsonSchema, Default))]
+#[serde(rename_all = "camelCase")]
+#[cfg_attr(test, derive(PartialEq))]
+pub struct DemographicsResponse {
+    #[partially(omit)]
+    pub id: Uuid,
+    #[partially(omit)]
+    pub question_slug: String,
+    #[partially(omit)]
+    pub user_id: Option<Uuid>,
+    pub value: String,
+}
+
+const DEMOGRAPHICS_RESPONSE_COLUMNS: [DemographicsResponseIden; 4] = [
+    DemographicsResponseIden::Id,
+    DemographicsResponseIden::QuestionSlug,
+    DemographicsResponseIden::UserId,
+    DemographicsResponseIden::Value,
+];
+
+#[derive(Serialize, Deserialize, JsonSchema, Debug, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct CreateDemographicsResponse {
+    pub question_slug: String,
+    pub user_id: Uuid,
+    pub value: String,
+}
+
+impl CreateDemographicsResponse {
+    fn values(self, id: Uuid) -> [SimpleExpr; 4] {
+        [
+            id.into(),
+            self.question_slug.into(),
+            self.user_id.into(),
+            self.value.into(),
+        ]
+    }
+}
+
+impl PartialDemographicsResponse {
+    fn to_values(&self) -> Vec<(DemographicsResponseIden, SimpleExpr)> {
+        let mut values = Vec::new();
+        if let Some(value) = &self.value {
+            values.push((DemographicsResponseIden::Value, value.clone().into()));
+        }
+        values
+    }
+}
+
+#[derive(Debug, Default, Deserialize, Serialize, Clone, JsonSchema)]
+pub struct DemographicsResponsesFilterOptions {
+    pub conversation_id: Option<Uuid>,
+    pub question_slug: Option<String>,
+    pub user_id: Option<Uuid>,
+}
+
+impl DemographicsResponsesFilterOptions {
+    pub fn apply(&self, mut query: sea_query::SelectStatement) -> sea_query::SelectStatement {
+        if let Some(conversation_id) = self.conversation_id {
+            query = query
+                .inner_join(
+                    ConversationDemographicsIden::Table,
+                    sea_query::Expr::col((
+                        DemographicsResponseIden::Table,
+                        DemographicsResponseIden::QuestionSlug,
+                    ))
+                    .equals((
+                        ConversationDemographicsIden::Table,
+                        ConversationDemographicsIden::QuestionSlug,
+                    )),
+                )
+                .and_where(
+                    Expr::col(ConversationDemographicsIden::ConversationId).eq(conversation_id),
+                )
+                .to_owned();
+        }
+
+        if let Some(question_slug) = self.question_slug.clone() {
+            query = query
+                .and_where(
+                    Expr::col((
+                        DemographicsResponseIden::Table,
+                        DemographicsResponseIden::QuestionSlug,
+                    ))
+                    .eq(question_slug),
+                )
+                .to_owned();
+        }
+
+        if let Some(user_id) = self.user_id {
+            query = query
+                .and_where(Expr::col(DemographicsResponseIden::UserId).eq(user_id))
+                .to_owned();
+        }
+
+        query
+    }
+}
+
+// ============================================================================
+// Conversation-demographics associations - CR.D
+// ============================================================================
+
+/// Get all associations between conversations and demographics questions, with optional filters for conversation ID and question slug.
+#[instrument(err(Debug), skip(db))]
+pub async fn get_conversation_demographics(
+    db: &PgPool,
+    filters: ConversationDemographicsFilterOptions,
+    page_options: PageOptions,
+) -> Result<PaginatedResults<ConversationDemographics>, ComhairleError> {
+    let mut query = sea_query::Query::select()
+        .columns(CONVERSATION_DEMOGRAPHICS_COLUMNS)
+        .to_owned();
+
+    query = filters.apply(query);
+
+    let fetched: PaginatedResults<ConversationDemographics> =
+        page_options.fetch_paginated_results(db, query).await?;
+
+    Ok(fetched)
+}
+
+/// Create a new association between a conversation and a demographics question.
+#[instrument(err(Debug), skip(db))]
+pub async fn create_conversation_demographics(
+    db: &PgPool,
+    new_conversation_demographics: CreateConversationDemographics,
+) -> Result<ConversationDemographics, ComhairleError> {
+    let (sql, values) = sea_query::Query::insert()
+        .into_table(ConversationDemographicsIden::Table)
+        .columns(CreateConversationDemographics::columns())
+        .values(new_conversation_demographics.values())?
+        .returning(sea_query::Query::returning().columns(CONVERSATION_DEMOGRAPHICS_COLUMNS))
+        .build_sqlx(PostgresQueryBuilder);
+
+    let created = sqlx::query_as_with::<_, ConversationDemographics, _>(&sql, values)
+        .fetch_one(db)
+        .await
+        .map_err(|e| ComhairleError::DatabaseError(e))?;
+
+    Ok(created)
+}
+
+/// Remove an association between a conversation and a demographics question.
+#[instrument(err(Debug), skip(db))]
+pub async fn delete_conversation_demographics(
+    db: &PgPool,
+    conversation_id: Uuid,
+    question_slug: String,
+) -> Result<Option<ConversationDemographics>, ComhairleError> {
+    let (sql, values) = sea_query::Query::delete()
+        .from_table(ConversationDemographicsIden::Table)
+        .and_where(Expr::col(ConversationDemographicsIden::ConversationId).eq(conversation_id))
+        .and_where(Expr::col(ConversationDemographicsIden::QuestionSlug).eq(question_slug))
+        .returning(sea_query::Query::returning().columns(CONVERSATION_DEMOGRAPHICS_COLUMNS))
+        .build_sqlx(PostgresQueryBuilder);
+
+    let deleted = sqlx::query_as_with::<_, ConversationDemographics, _>(&sql, values)
+        .fetch_optional(db)
+        .await
+        .map_err(|e| ComhairleError::DatabaseError(e))?;
+
+    Ok(deleted)
+}
+
+// ============================================================================
+// Demographics questions - CRUD
+// ============================================================================
+
+/// Get a demographics questions with optional filters.
+#[instrument(err(Debug), skip(db))]
+pub async fn get_demographics_questions(
+    db: &PgPool,
+    filters: DemographicsQuestionsFilterOptions,
+    page_options: PageOptions,
+) -> Result<PaginatedResults<DemographicsQuestion>, ComhairleError> {
+    let mut query = sea_query::Query::select()
+        .columns(DEMOGRAPHICS_QUESTION_COLUMNS)
+        .from(DemographicsQuestionIden::Table)
+        .to_owned();
+
+    query = filters.apply(query);
+
+    let questions: PaginatedResults<DemographicsQuestion> =
+        page_options.fetch_paginated_results(db, query).await?;
+
+    Ok(questions)
+}
+
+/// Create a new demographics question.
+#[instrument(err(Debug), skip(db))]
+pub async fn create_demographics_question(
+    db: &PgPool,
+    new_demographics_question: CreateDemographicsQuestion,
+) -> Result<DemographicsQuestion, ComhairleError> {
+    let (sql, values) = sea_query::Query::insert()
+        .into_table(DemographicsQuestionIden::Table)
+        .columns(CreateDemographicsQuestion::columns())
+        .values(new_demographics_question.values())?
+        .returning(sea_query::Query::returning().columns(DEMOGRAPHICS_QUESTION_COLUMNS))
+        .build_sqlx(PostgresQueryBuilder);
+
+    let question = sqlx::query_as_with::<_, DemographicsQuestion, _>(&sql, values)
+        .fetch_one(db)
+        .await
+        .map_err(|e| ComhairleError::DatabaseError(e))?;
+
+    Ok(question)
+}
+
+/// Update a demographics question.
+#[instrument(err(Debug), skip(db))]
+pub async fn update_demographics_question(
+    db: &PgPool,
+    slug: String,
+    updated_demographics_question: PartialDemographicsQuestion,
+) -> Result<DemographicsQuestion, ComhairleError> {
+    let (sql, values) = sea_query::Query::update()
+        .table(DemographicsQuestionIden::Table)
+        .values(updated_demographics_question.to_values())
+        .and_where(Expr::col(DemographicsQuestionIden::Slug).eq(slug))
+        .returning(sea_query::Query::returning().columns(DEMOGRAPHICS_QUESTION_COLUMNS))
+        .build_sqlx(PostgresQueryBuilder);
+
+    let question = sqlx::query_as_with::<_, DemographicsQuestion, _>(&sql, values)
+        .fetch_one(db)
+        .await
+        .map_err(|e| ComhairleError::DatabaseError(e))?;
+
+    Ok(question)
+}
+
+/// Delete a demographics question.
+#[instrument(err(Debug), skip(db))]
+pub async fn delete_demographics_question(
+    db: &PgPool,
+    slug: String,
+) -> Result<Option<DemographicsQuestion>, ComhairleError> {
+    let (sql, values) = sea_query::Query::delete()
+        .from_table(DemographicsQuestionIden::Table)
+        .and_where(Expr::col(DemographicsQuestionIden::Slug).eq(slug))
+        .returning(sea_query::Query::returning().columns(DEMOGRAPHICS_QUESTION_COLUMNS))
+        .build_sqlx(PostgresQueryBuilder);
+
+    let deleted_question = sqlx::query_as_with::<_, DemographicsQuestion, _>(&sql, values)
+        .fetch_optional(db)
+        .await
+        .map_err(|e| ComhairleError::DatabaseError(e))?;
+
+    Ok(deleted_question)
+}
+
+// ============================================================================
+// Demographics responses - CRUD
+// ============================================================================
+
+/// Get responses with optional filters.
+#[instrument(err(Debug), skip(db))]
+pub async fn get_demographics_responses(
+    db: &PgPool,
+    filters: DemographicsResponsesFilterOptions,
+    page_options: PageOptions,
+) -> Result<PaginatedResults<DemographicsResponse>, ComhairleError> {
+    let mut query = sea_query::Query::select();
+
+    query = query
+        .columns(
+            DEMOGRAPHICS_RESPONSE_COLUMNS
+                .into_iter()
+                .map(|col| (DemographicsResponseIden::Table, col)),
+        )
+        .from(DemographicsResponseIden::Table)
+        .to_owned();
+
+    query = filters.apply(query);
+
+    let responses: PaginatedResults<DemographicsResponse> =
+        page_options.fetch_paginated_results(db, query).await?;
+
+    Ok(responses)
+}
+
+/// Add a new response for a specific demographics question and user.
+#[instrument(err(Debug), skip(db))]
+pub async fn create_demographics_response(
+    db: &PgPool,
+    new_demographics_response: CreateDemographicsResponse,
+) -> Result<DemographicsResponse, ComhairleError> {
+    let (sql, values) = sea_query::Query::insert()
+        .into_table(DemographicsResponseIden::Table)
+        .columns(DEMOGRAPHICS_RESPONSE_COLUMNS)
+        .values(new_demographics_response.values(Uuid::new_v4()))?
+        .returning(sea_query::Query::returning().columns(DEMOGRAPHICS_RESPONSE_COLUMNS))
+        .build_sqlx(PostgresQueryBuilder);
+
+    let response = sqlx::query_as_with::<_, DemographicsResponse, _>(&sql, values)
+        .fetch_one(db)
+        .await
+        .map_err(|e| ComhairleError::DatabaseError(e))?;
+
+    Ok(response)
+}
+
+/// Update a response for a specific demographics question and user.
+#[instrument(err(Debug), skip(db))]
+pub async fn update_demographics_response(
+    db: &PgPool,
+    question_slug: String,
+    user_id: Uuid,
+    updated_demographics_response: PartialDemographicsResponse,
+) -> Result<DemographicsResponse, ComhairleError> {
+    let (sql, values) = sea_query::Query::update()
+        .table(DemographicsResponseIden::Table)
+        .values(updated_demographics_response.to_values())
+        .and_where(Expr::col(DemographicsResponseIden::QuestionSlug).eq(question_slug))
+        .and_where(Expr::col(DemographicsResponseIden::UserId).eq(user_id))
+        .returning(sea_query::Query::returning().columns(DEMOGRAPHICS_RESPONSE_COLUMNS))
+        .build_sqlx(PostgresQueryBuilder);
+
+    let response = sqlx::query_as_with::<_, DemographicsResponse, _>(&sql, values)
+        .fetch_one(db)
+        .await
+        .map_err(|e| ComhairleError::DatabaseError(e))?;
+
+    Ok(response)
+}
+
+/// Delete a response for a specific demographics question and user.
+#[instrument(err(Debug), skip(db))]
+pub async fn delete_demographics_response(
+    db: &PgPool,
+    question_slug: String,
+    user_id: Uuid,
+) -> Result<Option<DemographicsResponse>, ComhairleError> {
+    let (sql, values) = sea_query::Query::delete()
+        .from_table(DemographicsResponseIden::Table)
+        .and_where(Expr::col(DemographicsResponseIden::QuestionSlug).eq(question_slug))
+        .and_where(Expr::col(DemographicsResponseIden::UserId).eq(user_id))
+        .returning(sea_query::Query::returning().columns(DEMOGRAPHICS_RESPONSE_COLUMNS))
+        .build_sqlx(PostgresQueryBuilder);
+
+    let deleted = sqlx::query_as_with::<_, DemographicsResponse, _>(&sql, values)
+        .fetch_optional(db)
+        .await
+        .map_err(|e| ComhairleError::DatabaseError(e))?;
+
+    Ok(deleted)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::models::model_test_helpers::setup_default_app_and_session;
+    use crate::test_helpers::UserSession;
+
+    use super::*;
+
+    // Test can create, get, update and delete a demographics question.
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
+    async fn test_create_get_update_delete_demographics_question(
+        db: PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let slug = "example_slug".to_string();
+        let response_type = DemographicsQuestionResponseType::Number;
+
+        // Ensure the question does not exist before creation
+        let filters = DemographicsQuestionsFilterOptions {
+            question_slug: Some(slug.clone()),
+            ..Default::default()
+        };
+        let response = get_demographics_questions(&db, filters, PageOptions::default()).await?;
+        assert_eq!(
+            response.total, 0,
+            "Question should not exist before creation"
+        );
+
+        // Create the demographics question and ensure it can be retrieved successfully
+        let new_demographics_question = CreateDemographicsQuestion {
+            slug: slug.clone(),
+            display_name: "Example Display Name".to_string(),
+            response_type: response_type.clone(),
+            bucket_config: None,
+        };
+        let question = create_demographics_question(&db, new_demographics_question).await?;
+        let filters = DemographicsQuestionsFilterOptions {
+            question_slug: Some(slug.clone()),
+            ..Default::default()
+        };
+        let response = get_demographics_questions(&db, filters, PageOptions::default()).await?;
+        assert_eq!(response.total, 1, "Question should exist after creation");
+        assert_eq!(vec![question], response.records);
+
+        // Update the demographics question and ensure the changes are reflected
+        let update = PartialDemographicsQuestion {
+            display_name: Some("Updated Display Name".to_string()),
+            response_type: Some(DemographicsQuestionResponseType::String),
+            bucket_config: None,
+        };
+        let updated_question = update_demographics_question(&db, slug.clone(), update).await?;
+        assert_eq!(
+            updated_question.response_type,
+            DemographicsQuestionResponseType::String,
+            "Question response type should be updated correctly"
+        );
+        assert_eq!(
+            updated_question.display_name,
+            "Updated Display Name".to_string(),
+            "Question display name should be updated correctly"
+        );
+
+        // Delete the demographics question and ensure it is removed successfully
+        let response = delete_demographics_question(&db, slug.clone()).await?;
+        assert_eq!(
+            Some(updated_question),
+            response,
+            "Question should be deleted successfully"
+        );
+
+        // Ensure the question is actually deleted
+        let filters = DemographicsQuestionsFilterOptions {
+            question_slug: Some(slug.clone()),
+            ..Default::default()
+        };
+        let response = get_demographics_questions(&db, filters, PageOptions::default()).await?;
+        assert_eq!(
+            response.total, 0,
+            "Question should not exist after deletion"
+        );
+
+        Ok(())
+    }
+
+    // Test can create a demographics question, associate it with a conversation, and then delete it.
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
+    async fn test_create_associate_delete_demographics_question(
+        db: PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let slug = "example_slug".to_string();
+        let response_type = DemographicsQuestionResponseType::Number;
+
+        // Create the demographics question
+        let payload = CreateDemographicsQuestion {
+            slug: slug.clone(),
+            display_name: "Example Display Name".to_string(),
+            response_type,
+            bucket_config: None,
+        };
+        let question = create_demographics_question(&db, payload).await?;
+
+        // Create a conversation
+        let (app, mut session) = setup_default_app_and_session(&db).await?;
+        let (status, response, _) = session.create_random_conversation(&app).await?;
+        let conversation_id: Uuid = serde_json::from_value(
+            response
+                .get("id")
+                .cloned()
+                .ok_or("Failed to get conversation id")?,
+        )?;
+
+        assert!(status.is_success(), "Failed to create random conversation");
+
+        // Ensure the question is initially absent
+        let filters = DemographicsQuestionsFilterOptions {
+            conversation_id: Some(conversation_id),
+            ..Default::default()
+        };
+        let questions = get_demographics_questions(&db, filters, PageOptions::default()).await?;
+        assert_eq!(
+            questions.total, 0,
+            "Question should not be initially associated with the conversation"
+        );
+
+        // Associate the demographics question with the conversation
+        let payload = CreateConversationDemographics {
+            conversation_id: conversation_id,
+            question_slug: question.slug.clone(),
+        };
+        let response = create_conversation_demographics(&db, payload).await?;
+
+        assert_eq!(
+            conversation_id, response.conversation_id,
+            "Conversation ID should match after associating demographics question"
+        );
+        assert_eq!(
+            question.slug, response.question_slug,
+            "Question slug should match after associating demographics question"
+        );
+
+        // Ensure the question is now associated with the conversation
+        let filters = DemographicsQuestionsFilterOptions {
+            conversation_id: Some(conversation_id),
+            ..Default::default()
+        };
+        let questions = get_demographics_questions(&db, filters, PageOptions::default()).await?;
+        assert_eq!(
+            questions.total, 1,
+            "Question should be associated with the conversation after creation"
+        );
+        assert_eq!(
+            questions.records[0].slug, question.slug,
+            "The associated question slug should match the created question slug"
+        );
+
+        // Delete the demographics question and ensure it is removed successfully
+        let response = delete_demographics_question(&db, question.slug.clone()).await?;
+        assert_eq!(
+            Some(question.slug.clone()),
+            response.map(|r| r.slug),
+            "Deleted question slug should match the original question slug"
+        );
+
+        // Ensure the question is actually deleted
+        let filters = DemographicsQuestionsFilterOptions {
+            conversation_id: Some(conversation_id),
+            ..Default::default()
+        };
+        let questions = get_demographics_questions(&db, filters, PageOptions::default()).await?;
+        assert_eq!(
+            questions.total, 0,
+            "Question should not be associated with the conversation after deletion"
+        );
+
+        Ok(())
+    }
+
+    // Test can create, get, update and delete a demographics response.
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
+    async fn test_create_get_update_delete_demographics_response(
+        db: sqlx::PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let (app, mut session) = setup_default_app_and_session(&db).await?;
+
+        // Get the session user
+        let (status, response, _) = session.current_user(&app).await?;
+        assert!(status.is_success(), "Failed to get current user");
+        let user_id = response.id;
+
+        // Create a demographics question
+        let slug = "test_question_slug".to_string();
+        let response_type = DemographicsQuestionResponseType::String;
+        let payload = CreateDemographicsQuestion {
+            slug: slug.clone(),
+            display_name: "Example Display Name".to_string(),
+            response_type: response_type.clone(),
+            bucket_config: None,
+        };
+        let question = create_demographics_question(&db, payload).await?;
+
+        // Create a demographics response
+        let response_value = "test_response".to_string();
+        let payload = CreateDemographicsResponse {
+            question_slug: question.slug.clone(),
+            user_id,
+            value: response_value.clone(),
+        };
+        let demographics_response = create_demographics_response(&db, payload).await?;
+        assert_eq!(
+            demographics_response.value, response_value,
+            "Demographics response value should match the provided response"
+        );
+
+        // Get the demographics response by question slug and user ID
+        let filters = DemographicsResponsesFilterOptions {
+            question_slug: Some(question.slug.clone()),
+            user_id: Some(user_id),
+            conversation_id: None,
+        };
+        let fetched_responses =
+            get_demographics_responses(&db, filters, PageOptions::default()).await?;
+        assert_eq!(
+            fetched_responses.total, 1,
+            "Fetched demographics responses should not be empty"
+        );
+        assert_eq!(
+            demographics_response, fetched_responses.records[0],
+            "Fetched demographics response should match the created response"
+        );
+
+        // Update the demographics response
+        let new_response_value = "updated_test_response".to_string();
+        let payload = PartialDemographicsResponse {
+            value: Some(new_response_value.clone()),
+        };
+        let updated_demographics_response =
+            update_demographics_response(&db, question.slug.clone(), user_id, payload).await?;
+        assert_eq!(
+            new_response_value, updated_demographics_response.value,
+            "Updated demographics response value should match the new response"
+        );
+
+        // Delete the demographics response
+        let deleted_response =
+            delete_demographics_response(&db, question.slug.clone(), user_id).await?;
+        assert_eq!(
+            Some(updated_demographics_response),
+            deleted_response,
+            "Demographics response should be successfully deleted"
+        );
+
+        // Verify the demographics response has been deleted
+        let filters = DemographicsResponsesFilterOptions {
+            question_slug: Some(question.slug.clone()),
+            user_id: Some(user_id),
+            conversation_id: None,
+        };
+        let fetched_responses_after_deletion =
+            get_demographics_responses(&db, filters, PageOptions::default()).await?;
+        assert_eq!(
+            fetched_responses_after_deletion.total, 0,
+            "Demographics response should be deleted"
+        );
+
+        Ok(())
+    }
+
+    // Test can create a demographics response for a specific demographics question, associated with a conversation, and list the response by question, conversation and user.
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
+    async fn test_list_response_by_conversation_question_and_user(
+        db: sqlx::PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let (app, mut session) = setup_default_app_and_session(&db).await?;
+
+        // Get the session user
+        let (status, user_dto, _) = session.current_user(&app).await?;
+        assert!(status.is_success(), "Failed to get current user");
+        let user_id = user_dto.id;
+
+        // Create a conversation
+        let (status, response, _) = session.create_random_conversation(&app).await?;
+        assert!(status.is_success(), "Failed to create random conversation");
+        let conversation_id: Uuid = serde_json::from_value(
+            response
+                .get("id")
+                .cloned()
+                .ok_or("Failed to get conversation id")?,
+        )?;
+
+        // Create another conversation
+        let (status, response, _) = session.create_random_conversation(&app).await?;
+        assert!(status.is_success(), "Failed to create random conversation");
+        let other_conversation_id: Uuid = serde_json::from_value(
+            response
+                .get("id")
+                .cloned()
+                .ok_or("Failed to get other conversation id")?,
+        )?;
+
+        // Create a second user for testing
+        let mut other_session = UserSession::new_anon();
+        let (status, other_user_dto, _) = other_session.signup_annon(&app).await?;
+        assert!(status.is_success(), "Failed to create random user");
+        let other_user_id: Uuid = serde_json::from_value(
+            other_user_dto
+                .get("id")
+                .cloned()
+                .flatten()
+                .ok_or("Failed to get other user id")?,
+        )?;
+
+        // Create a demographics question
+        let question_slug = "test_question".to_string();
+        let response_type = DemographicsQuestionResponseType::String;
+        let payload = CreateDemographicsQuestion {
+            slug: question_slug.clone(),
+            display_name: "Test Question".to_string(),
+            response_type: response_type.clone(),
+            bucket_config: None,
+        };
+        let question = create_demographics_question(&db, payload).await?;
+
+        // Create another demographics question
+        let other_question_slug = "other_test_question".to_string();
+        let other_response_type = DemographicsQuestionResponseType::Number;
+        let other_payload = CreateDemographicsQuestion {
+            slug: other_question_slug.clone(),
+            display_name: "Other Test Question".to_string(),
+            response_type: other_response_type.clone(),
+            bucket_config: None,
+        };
+        let other_question = create_demographics_question(&db, other_payload).await?;
+
+        // Associate the demographics questions with the conversations
+        let _ = create_conversation_demographics(
+            &db,
+            CreateConversationDemographics {
+                conversation_id: conversation_id,
+                question_slug: question.slug.clone(),
+            },
+        )
+        .await?;
+        let _ = create_conversation_demographics(
+            &db,
+            CreateConversationDemographics {
+                conversation_id: conversation_id,
+                question_slug: other_question.slug.clone(),
+            },
+        )
+        .await?;
+        let _ = create_conversation_demographics(
+            &db,
+            CreateConversationDemographics {
+                conversation_id: other_conversation_id,
+                question_slug: other_question.slug.clone(),
+            },
+        )
+        .await?;
+
+        // Create several demographics responses associated with the question and user
+        let response_value = "test_response".to_string();
+        let other_response_value = "15".to_string();
+        let _ = create_demographics_response(
+            &db,
+            CreateDemographicsResponse {
+                question_slug: question.slug.clone(),
+                user_id,
+                value: response_value.clone(),
+            },
+        )
+        .await?;
+        let _ = create_demographics_response(
+            &db,
+            CreateDemographicsResponse {
+                question_slug: other_question.slug.clone(),
+                user_id,
+                value: other_response_value.clone(),
+            },
+        )
+        .await?;
+        let _ = create_demographics_response(
+            &db,
+            CreateDemographicsResponse {
+                question_slug: question.slug.clone(),
+                user_id: other_user_id,
+                value: response_value.clone(),
+            },
+        )
+        .await?;
+
+        // List demographics responses by conversation
+        let conversation_responses_filters = DemographicsResponsesFilterOptions {
+            conversation_id: Some(conversation_id),
+            ..Default::default()
+        };
+        let conversation_responses =
+            get_demographics_responses(&db, conversation_responses_filters, PageOptions::default())
+                .await?;
+        assert_eq!(
+            conversation_responses.total, 3,
+            "Expected 3 demographics responses for the conversation"
+        );
+
+        let other_conversation_responses_filters = DemographicsResponsesFilterOptions {
+            conversation_id: Some(other_conversation_id),
+            ..Default::default()
+        };
+        let other_conversation_responses = get_demographics_responses(
+            &db,
+            other_conversation_responses_filters,
+            PageOptions::default(),
+        )
+        .await?;
+        assert_eq!(
+            other_conversation_responses.total, 1,
+            "Expected 1 demographics response for the other conversation"
+        );
+
+        // List demographics responses by question
+        let question_responses_filters = DemographicsResponsesFilterOptions {
+            question_slug: Some(question.slug.clone()),
+            ..Default::default()
+        };
+        let question_responses =
+            get_demographics_responses(&db, question_responses_filters, PageOptions::default())
+                .await?;
+        assert_eq!(
+            question_responses.total, 2,
+            "Expected 2 demographics responses for the question"
+        );
+
+        let other_question_responses_filters = DemographicsResponsesFilterOptions {
+            question_slug: Some(other_question.slug.clone()),
+            ..Default::default()
+        };
+        let other_question_responses = get_demographics_responses(
+            &db,
+            other_question_responses_filters,
+            PageOptions::default(),
+        )
+        .await?;
+        assert_eq!(
+            other_question_responses.total, 1,
+            "Expected 1 demographics response for the other question"
+        );
+
+        // List demographics responses by user
+        let user_responses_filters = DemographicsResponsesFilterOptions {
+            user_id: Some(user_id),
+            ..Default::default()
+        };
+        let user_responses =
+            get_demographics_responses(&db, user_responses_filters, PageOptions::default()).await?;
+        assert_eq!(
+            user_responses.total, 2,
+            "Expected 2 demographics responses for the user"
+        );
+
+        let other_user_responses_filters = DemographicsResponsesFilterOptions {
+            user_id: Some(other_user_id),
+            ..Default::default()
+        };
+        let other_user_responses =
+            get_demographics_responses(&db, other_user_responses_filters, PageOptions::default())
+                .await?;
+        assert_eq!(
+            other_user_responses.total, 1,
+            "Expected 1 demographics response for the other user"
+        );
+
+        assert_ne!(
+            user_responses.total, other_user_responses.total,
+            "Expected the user responses and other user responses to be different"
+        );
+
+        Ok(())
+    }
+}

--- a/api/src/models/user_profile.rs
+++ b/api/src/models/user_profile.rs
@@ -1,11 +1,17 @@
-use crate::{error::ComhairleError, models::SqlxResultExt};
+use crate::{
+    error::ComhairleError,
+    models::{
+        SqlxResultExt,
+        demographics::{self, ValueBuckets},
+    },
+};
 use chrono::{DateTime, Utc};
 use partially::Partial;
 use schemars::JsonSchema;
 use sea_query::{Expr, PostgresQueryBuilder, Query, enum_def};
 use sea_query_binder::SqlxBinder;
 use serde::{Deserialize, Serialize};
-use sqlx::{PgPool, prelude::FromRow};
+use sqlx::{PgPool, prelude::FromRow, types::Json};
 use std::collections::HashMap;
 use uuid::Uuid;
 
@@ -18,16 +24,6 @@ pub struct UserProfile {
     #[partially(omit)]
     pub user_id: Uuid,
     pub consented: bool,
-    #[partially(transparent)]
-    pub ethnicity: Option<String>,
-    #[partially(transparent)]
-    pub age: Option<i32>,
-    #[partially(transparent)]
-    pub gender: Option<String>,
-    #[partially(transparent)]
-    pub zipcode: Option<String>,
-    #[partially(transparent)]
-    pub political_party: Option<String>,
     #[partially(omit)]
     pub created_at: DateTime<Utc>,
     #[partially(omit)]
@@ -38,70 +34,28 @@ pub struct UserProfile {
 pub struct CreateUserProfile {
     pub user_id: Uuid,
     pub consented: bool,
-    pub ethnicity: Option<String>,
     pub age: Option<i32>,
+    pub ethnicity: Option<String>,
     pub gender: Option<String>,
     pub zipcode: Option<String>,
     pub political_party: Option<String>,
 }
 
-const DEFAULT_COLUMNS: [UserProfileIden; 10] = [
+const DEFAULT_COLUMNS: [UserProfileIden; 5] = [
     UserProfileIden::Id,
     UserProfileIden::UserId,
     UserProfileIden::Consented,
-    UserProfileIden::Ethnicity,
-    UserProfileIden::Age,
-    UserProfileIden::Gender,
-    UserProfileIden::Zipcode,
-    UserProfileIden::PoliticalParty,
     UserProfileIden::CreatedAt,
     UserProfileIden::UpdatedAt,
 ];
 
 impl CreateUserProfile {
     pub fn columns(&self) -> Vec<UserProfileIden> {
-        let mut columns = vec![UserProfileIden::UserId, UserProfileIden::Consented];
-
-        if self.ethnicity.is_some() {
-            columns.push(UserProfileIden::Ethnicity);
-        }
-        if self.age.is_some() {
-            columns.push(UserProfileIden::Age);
-        }
-        if self.gender.is_some() {
-            columns.push(UserProfileIden::Gender);
-        }
-        if self.zipcode.is_some() {
-            columns.push(UserProfileIden::Zipcode);
-        }
-        if self.political_party.is_some() {
-            columns.push(UserProfileIden::PoliticalParty);
-        }
-
-        columns
+        vec![UserProfileIden::UserId, UserProfileIden::Consented]
     }
 
     pub fn values(&self) -> Vec<sea_query::SimpleExpr> {
-        let mut values: Vec<sea_query::SimpleExpr> =
-            vec![self.user_id.into(), self.consented.into()];
-
-        if let Some(ref ethnicity) = self.ethnicity {
-            values.push(ethnicity.clone().into());
-        }
-        if let Some(age) = self.age {
-            values.push(age.into());
-        }
-        if let Some(ref gender) = self.gender {
-            values.push(gender.clone().into());
-        }
-        if let Some(ref zipcode) = self.zipcode {
-            values.push(zipcode.clone().into());
-        }
-        if let Some(ref political_party) = self.political_party {
-            values.push(political_party.clone().into());
-        }
-
-        values
+        vec![self.user_id.into(), self.consented.into()]
     }
 }
 
@@ -120,11 +74,22 @@ pub async fn create(
         .returning(Query::returning().columns(DEFAULT_COLUMNS))
         .build_sqlx(PostgresQueryBuilder);
 
-    let profile = sqlx::query_as_with::<_, UserProfile, _>(&sql, values)
+    let new_profile = sqlx::query_as_with::<_, UserProfile, _>(&sql, values)
         .fetch_one(db)
         .await?;
 
-    Ok(profile)
+    let _ = create_default_user_profile_demographics(
+        db,
+        new_profile.user_id,
+        profile.age.to_owned(),
+        profile.ethnicity.to_owned(),
+        profile.gender.to_owned(),
+        profile.zipcode.to_owned(),
+        profile.political_party.to_owned(),
+    )
+    .await?;
+
+    Ok(new_profile)
 }
 
 pub async fn get_by_id(db: &PgPool, id: &Uuid) -> Result<UserProfile, ComhairleError> {
@@ -173,28 +138,6 @@ pub async fn update(
         query = query.value(UserProfileIden::Consented, *value).to_owned();
         has_updates = true;
     }
-    if let Some(value) = &update.ethnicity {
-        query = query.value(UserProfileIden::Ethnicity, value).to_owned();
-        has_updates = true;
-    }
-    if let Some(value) = &update.age {
-        query = query.value(UserProfileIden::Age, *value).to_owned();
-        has_updates = true;
-    }
-    if let Some(value) = &update.gender {
-        query = query.value(UserProfileIden::Gender, value).to_owned();
-        has_updates = true;
-    }
-    if let Some(value) = &update.zipcode {
-        query = query.value(UserProfileIden::Zipcode, value).to_owned();
-        has_updates = true;
-    }
-    if let Some(value) = &update.political_party {
-        query = query
-            .value(UserProfileIden::PoliticalParty, value)
-            .to_owned();
-        has_updates = true;
-    }
 
     if !has_updates {
         return get_by_id(db, id).await;
@@ -231,11 +174,45 @@ pub async fn delete(db: &PgPool, id: &Uuid) -> Result<UserProfile, ComhairleErro
     Ok(profile)
 }
 
+pub async fn create_default_user_profile_demographics(
+    db: &PgPool,
+    user_id: Uuid,
+    age: Option<i32>,
+    ethnicity: Option<String>,
+    gender: Option<String>,
+    zipcode: Option<String>,
+    political_party: Option<String>,
+) -> Result<Vec<demographics::DemographicsResponse>, ComhairleError> {
+    let demographics = std::iter::once(("age", age.map(|v| v.to_string())))
+        .chain(std::iter::once(("ethnicity", ethnicity)))
+        .chain(std::iter::once(("gender", gender)))
+        .chain(std::iter::once(("zipcode", zipcode)))
+        .chain(std::iter::once(("political_party", political_party)));
+
+    let mut responses = Vec::new();
+    for (question_slug, value) in demographics {
+        if let Some(value) = value {
+            let response = demographics::create_demographics_response(
+                db,
+                demographics::CreateDemographicsResponse {
+                    question_slug: question_slug.to_string(),
+                    user_id,
+                    value,
+                },
+            )
+            .await?;
+            responses.push(response);
+        }
+    }
+
+    Ok(responses)
+}
+
 #[derive(Debug, Serialize, Deserialize, FromRow, JsonSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct DemographicCategory {
-    pub category: String,
-    pub value: Option<String>,
+pub struct DemographicCount {
+    pub display_name: String,
+    pub value: String,
     pub count: i64,
 }
 
@@ -243,44 +220,55 @@ pub struct DemographicCategory {
 #[serde(rename_all = "camelCase")]
 pub struct DemographicReport {
     pub total_participants: i64,
-    pub ethnicity: Vec<DemographicCategory>,
-    pub age_ranges: Vec<DemographicCategory>,
-    pub gender: Vec<DemographicCategory>,
-    pub political_party: Vec<DemographicCategory>,
-    pub zipcode_counts: HashMap<String, i64>,
+    pub categories: HashMap<String, Vec<DemographicCount>>,
 }
 
 /// Generate a demographic report for users participating in a workflow
 #[derive(Debug, Serialize, Deserialize, FromRow)]
+pub struct UserProfileDemographicsExport {
+    pub question_slug: String,
+    pub display_name: String,
+    pub value: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, FromRow)]
 pub struct UserProfileExport {
     pub user_id: Uuid,
-    pub ethnicity: Option<String>,
-    pub age: Option<i32>,
-    pub gender: Option<String>,
-    pub zipcode: Option<String>,
-    pub political_party: Option<String>,
     pub created_at: DateTime<Utc>,
+    pub demographics: Json<HashMap<String, UserProfileDemographicsExport>>,
 }
 
 pub async fn get_demographics_for_export(
     db: &PgPool,
     conversation_id: &Uuid,
 ) -> Result<Vec<UserProfileExport>, ComhairleError> {
+    // We join conversation_demographics to ensure we only get required questions,
+    // and use jsonb_object_agg to map question_slug -> value dynamically.
     let query = r#"
-        SELECT DISTINCT
+        SELECT
             up.user_id,
-            up.ethnicity,
-            up.age,
-            up.gender,
-            up.zipcode,
-            up.political_party,
-            up.created_at
+            up.created_at,
+            COALESCE(
+                jsonb_object_agg(
+                    cd.question_slug,
+                    jsonb_build_object(
+                        'question_slug', cd.question_slug,
+                        'display_name', dq.display_name,
+                        'value', dr.value
+                    )
+                ), 
+                '{}'::jsonb
+            ) as demographics
         FROM user_profile up
         INNER JOIN comhairle_user u ON u.id = up.user_id
         INNER JOIN user_participation upart ON upart.user_id = u.id
         INNER JOIN workflow w ON w.id = upart.workflow_id
+        LEFT JOIN conversation_demographics cd ON cd.conversation_id = w.conversation_id
+        LEFT JOIN demographics_question dq ON dq.slug = cd.question_slug
+        LEFT JOIN demographics_response dr ON dr.user_id = up.user_id AND dr.question_slug = cd.question_slug
         WHERE w.conversation_id = $1
-          AND up.consented = true
+        AND up.consented = true
+        GROUP BY up.user_id, up.created_at
         ORDER BY up.created_at DESC
     "#;
 
@@ -296,7 +284,7 @@ pub async fn get_demographic_report(
     db: &PgPool,
     workflow_id: &Uuid,
 ) -> Result<DemographicReport, ComhairleError> {
-    // Get total participants
+    // 1. Get total participants (unchanged)
     let total_query = r#"
         SELECT COUNT(DISTINCT up.user_id)::BIGINT as count
         FROM user_participation up
@@ -307,143 +295,147 @@ pub async fn get_demographic_report(
         .fetch_one(db)
         .await?;
 
-    // Get ethnicity breakdown (only consented users)
-    let ethnicity_query = r#"
+    // 2. Get dynamically grouped counts for ALL string-based demographics
+    let dynamic_report_query = r#"
         SELECT
-            'ethnicity'::TEXT as category,
-            prof.ethnicity as value,
-            COUNT(*)::BIGINT as count
+            dq.slug as category_name,
+            dq.display_name as display_name,
+            dq.bucket_config as bucket_config,
+            dr.value as value,
+            COUNT(up.user_id)::BIGINT as count
         FROM user_participation up
-        INNER JOIN user_profile prof ON prof.user_id = up.user_id
-        WHERE up.workflow_id = $1 AND prof.consented = true
-        GROUP BY prof.ethnicity
-        ORDER BY count DESC
-    "#;
-    let ethnicity: Vec<DemographicCategory> = sqlx::query_as(ethnicity_query)
-        .bind(workflow_id)
-        .fetch_all(db)
-        .await?;
-
-    // Get age ranges breakdown (only consented users)
-    let age_query = r#"
-        WITH age_categories AS (
-            SELECT
-                'age_range'::TEXT as category,
-                CASE
-                    WHEN prof.age IS NULL THEN NULL
-                    WHEN prof.age < 18 THEN 'Under 18'
-                    WHEN prof.age >= 18 AND prof.age < 25 THEN '18-24'
-                    WHEN prof.age >= 25 AND prof.age < 35 THEN '25-34'
-                    WHEN prof.age >= 35 AND prof.age < 45 THEN '35-44'
-                    WHEN prof.age >= 45 AND prof.age < 55 THEN '45-54'
-                    WHEN prof.age >= 55 AND prof.age < 65 THEN '55-64'
-                    ELSE '65+'
-                END as value
-            FROM user_participation up
-            INNER JOIN user_profile prof ON prof.user_id = up.user_id
-            WHERE up.workflow_id = $1 AND prof.consented = true
-        )
-        SELECT
-            category,
-            value,
-            COUNT(*)::BIGINT as count
-        FROM age_categories
-        GROUP BY category, value
-        ORDER BY
-            CASE value
-                WHEN 'Under 18' THEN 1
-                WHEN '18-24' THEN 2
-                WHEN '25-34' THEN 3
-                WHEN '35-44' THEN 4
-                WHEN '45-54' THEN 5
-                WHEN '55-64' THEN 6
-                WHEN '65+' THEN 7
-                ELSE 8
-            END
-    "#;
-    let age_ranges: Vec<DemographicCategory> = sqlx::query_as(age_query)
-        .bind(workflow_id)
-        .fetch_all(db)
-        .await?;
-
-    // Get gender breakdown (only consented users)
-    let gender_query = r#"
-        SELECT
-            'gender'::TEXT as category,
-            prof.gender as value,
-            COUNT(*)::BIGINT as count
-        FROM user_participation up
-        INNER JOIN user_profile prof ON prof.user_id = up.user_id
-        WHERE up.workflow_id = $1 AND prof.consented = true
-        GROUP BY prof.gender
-        ORDER BY count DESC
-    "#;
-    let gender: Vec<DemographicCategory> = sqlx::query_as(gender_query)
-        .bind(workflow_id)
-        .fetch_all(db)
-        .await?;
-
-    // Get political party breakdown (only consented users)
-    let political_party_query = r#"
-        SELECT
-            'political_party'::TEXT as category,
-            prof.political_party as value,
-            COUNT(*)::BIGINT as count
-        FROM user_participation up
-        INNER JOIN user_profile prof ON prof.user_id = up.user_id
-        WHERE up.workflow_id = $1 AND prof.consented = true
-        GROUP BY prof.political_party
-        ORDER BY count DESC
-    "#;
-    let political_party: Vec<DemographicCategory> = sqlx::query_as(political_party_query)
-        .bind(workflow_id)
-        .fetch_all(db)
-        .await?;
-
-    // Get zipcode counts (only non-null zipcodes from consented users)
-    let zipcode_query = r#"
-        SELECT
-            prof.zipcode as zipcode,
-            COUNT(*)::BIGINT as count
-        FROM user_participation up
-        INNER JOIN user_profile prof ON prof.user_id = up.user_id
-        WHERE up.workflow_id = $1 AND prof.consented = true AND prof.zipcode IS NOT NULL
-        GROUP BY prof.zipcode
-        ORDER BY count DESC
+        INNER JOIN workflow w ON w.id = up.workflow_id
+        INNER JOIN conversation_demographics cd ON cd.conversation_id = w.conversation_id
+        INNER JOIN demographics_question dq ON dq.slug = cd.question_slug
+        INNER JOIN user_profile prof ON prof.user_id = up.user_id AND prof.consented = true
+        LEFT JOIN demographics_response dr ON dr.user_id = up.user_id AND dr.question_slug = cd.question_slug
+        WHERE up.workflow_id = $1
+        GROUP BY dq.slug, dq.bucket_config, dr.value
+        ORDER BY dq.slug, count DESC
     "#;
 
-    #[derive(FromRow)]
-    struct ZipcodeCount {
-        zipcode: String,
+    // Use a temporary struct to hold the flat DB rows
+    #[derive(sqlx::FromRow)]
+    struct FlatDemographicRow {
+        category_name: String,
+        display_name: String,
+        bucket_config: Option<sqlx::types::Json<ValueBuckets>>,
+        value: String,
         count: i64,
     }
 
-    let zipcode_results: Vec<ZipcodeCount> = sqlx::query_as(zipcode_query)
+    let flat_rows: Vec<FlatDemographicRow> = sqlx::query_as(dynamic_report_query)
         .bind(workflow_id)
         .fetch_all(db)
         .await?;
 
-    let zipcode_counts: HashMap<String, i64> = zipcode_results
-        .into_iter()
-        .map(|z| (z.zipcode, z.count))
-        .collect();
+    // 3. Transform the flat rows into a nested HashMap for the UI
+    let mut categories: HashMap<String, Vec<DemographicCount>> = HashMap::new();
+
+    for row in flat_rows {
+        if let Some(bucket_config) = &row.bucket_config {
+            let bucket_value = demographics::resolve_category_bucket(&row.value, &bucket_config.0);
+            let category_counts = categories.entry(row.category_name).or_insert_with(Vec::new);
+
+            if let Some(category_count) =
+                category_counts.iter_mut().find(|c| c.value == bucket_value)
+            {
+                category_count.count += row.count;
+            } else {
+                category_counts.push(DemographicCount {
+                    display_name: row.display_name,
+                    value: bucket_value,
+                    count: row.count,
+                });
+            }
+        } else {
+            categories
+                .entry(row.category_name)
+                .or_insert_with(Vec::new)
+                .push(DemographicCount {
+                    display_name: row.display_name,
+                    value: row.value,
+                    count: row.count,
+                });
+        };
+    }
 
     Ok(DemographicReport {
         total_participants,
-        ethnicity,
-        age_ranges,
-        gender,
-        political_party,
-        zipcode_counts,
+        categories,
     })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::routes::auth::SignupRequest;
+
     use sqlx::PgPool;
     use std::error::Error;
+
+    use crate::models::demographics::{
+        DemographicsResponse, DemographicsResponsesFilterOptions, get_demographics_responses,
+    };
+    use crate::routes::auth::SignupRequest;
+
+    async fn get_demographic(
+        pool: &PgPool,
+        question_slug: String,
+        user_id: Uuid,
+    ) -> Result<Option<DemographicsResponse>, Box<dyn Error>> {
+        let record = get_demographics_responses(
+            &pool,
+            DemographicsResponsesFilterOptions {
+                question_slug: Some(question_slug),
+                user_id: Some(user_id),
+                ..Default::default()
+            },
+            Default::default(),
+        )
+        .await?
+        .records
+        .drain(..)
+        .next();
+        Ok(record)
+    }
+
+    async fn update_demographic(
+        pool: &PgPool,
+        question_slug: String,
+        user_id: Uuid,
+        value: Option<String>,
+    ) -> Result<(), Box<dyn Error>> {
+        crate::models::demographics::update_demographics_response(
+            &pool,
+            question_slug,
+            user_id,
+            crate::models::demographics::PartialDemographicsResponse { value: value },
+        )
+        .await?;
+        Ok(())
+    }
+
+    async fn add_default_demographics_to_conversation(
+        pool: &PgPool,
+        conversation_id: Uuid,
+    ) -> Result<(), Box<dyn Error>> {
+        use crate::models::demographics::{
+            CreateConversationDemographics, create_conversation_demographics,
+        };
+
+        let default_questions = vec!["age", "ethnicity", "gender", "zipcode", "political_party"];
+        for question_slug in default_questions {
+            let _ = create_conversation_demographics(
+                &pool,
+                CreateConversationDemographics {
+                    conversation_id,
+                    question_slug: question_slug.to_string(),
+                },
+            )
+            .await?;
+        }
+        Ok(())
+    }
 
     #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
     async fn should_create_user_profile(pool: PgPool) -> Result<(), Box<dyn Error>> {
@@ -472,23 +464,32 @@ mod tests {
 
         assert_eq!(profile.user_id, user.id, "incorrect user_id");
         assert!(profile.consented, "incorrect consented");
+
+        let age = get_demographic(&pool, "age".to_string(), user.id).await?;
+        let ethnicity = get_demographic(&pool, "ethnicity".to_string(), user.id).await?;
+        let gender = get_demographic(&pool, "gender".to_string(), user.id).await?;
+        let zipcode = get_demographic(&pool, "zipcode".to_string(), user.id).await?;
+
         assert_eq!(
-            profile.ethnicity,
+            age.map(|r| r.value),
+            Some("25".to_string()),
+            "incorrect age"
+        );
+        assert_eq!(
+            ethnicity.map(|r| r.value),
             Some("Asian".to_string()),
             "incorrect ethnicity"
         );
-        assert_eq!(profile.age, Some(25), "incorrect age");
         assert_eq!(
-            profile.gender,
+            gender.map(|r| r.value),
             Some("Female".to_string()),
             "incorrect gender"
         );
         assert_eq!(
-            profile.zipcode,
+            zipcode.map(|r| r.value),
             Some("12345".to_string()),
             "incorrect zipcode"
         );
-
         Ok(())
     }
 
@@ -545,10 +546,10 @@ mod tests {
         let create_profile = CreateUserProfile {
             user_id: user.id,
             consented: false,
-            ethnicity: None,
+            ethnicity: Some("Hispanic".to_string()),
             age: None,
             gender: None,
-            zipcode: None,
+            zipcode: Some("67890".to_string()),
             political_party: None,
         };
 
@@ -563,35 +564,54 @@ mod tests {
             &profile.id,
             &PartialUserProfile {
                 consented: Some(true),
-                ethnicity: Some("Black".to_string()),
-                age: Some(35),
-                gender: Some("Non-binary".to_string()),
-                zipcode: Some("54321".to_string()),
                 ..PartialUserProfile::default()
             },
         )
         .await?;
 
-        assert!(updated_profile.consented, "consented not updated");
-        assert_eq!(
-            updated_profile.ethnicity,
+        update_demographic(
+            &pool,
+            "ethnicity".to_string(),
+            user.id,
             Some("Black".to_string()),
-            "ethnicity not updated"
-        );
-        assert_eq!(updated_profile.age, Some(35), "age not updated");
-        assert_eq!(
-            updated_profile.gender,
-            Some("Non-binary".to_string()),
-            "gender not updated"
-        );
-        assert_eq!(
-            updated_profile.zipcode,
+        )
+        .await?;
+        update_demographic(
+            &pool,
+            "zipcode".to_string(),
+            user.id,
             Some("54321".to_string()),
-            "zipcode not updated"
-        );
+        )
+        .await?;
+
+        assert!(updated_profile.consented, "consented not updated");
         assert!(
             updated_profile.updated_at > original_updated_at,
             "updated_at should be updated"
+        );
+
+        let age = get_demographic(&pool, "age".to_string(), user.id).await?;
+        let ethnicity = get_demographic(&pool, "ethnicity".to_string(), user.id).await?;
+        let gender = get_demographic(&pool, "gender".to_string(), user.id).await?;
+        let zipcode = get_demographic(&pool, "zipcode".to_string(), user.id).await?;
+        let political_party =
+            get_demographic(&pool, "political_party".to_string(), user.id).await?;
+
+        assert_eq!(age, None, "age updated unexpectedly");
+        assert_eq!(
+            ethnicity.map(|r| r.value),
+            Some("Black".to_string()),
+            "ethnicity not updated"
+        );
+        assert_eq!(gender, None, "gender updated unexpectedly");
+        assert_eq!(
+            zipcode.map(|r| r.value),
+            Some("54321".to_string()),
+            "zipcode not updated"
+        );
+        assert_eq!(
+            political_party, None,
+            "political_party updated unexpectedly"
         );
 
         Ok(())
@@ -661,6 +681,38 @@ mod tests {
 
         let profile = create(&pool, &create_profile).await?;
 
+        let age = get_demographic(&pool, "age".to_string(), user.id).await?;
+        let ethnicity = get_demographic(&pool, "ethnicity".to_string(), user.id).await?;
+        let gender = get_demographic(&pool, "gender".to_string(), user.id).await?;
+        let zipcode = get_demographic(&pool, "zipcode".to_string(), user.id).await?;
+        let political_party =
+            get_demographic(&pool, "political_party".to_string(), user.id).await?;
+
+        assert_eq!(
+            age.map(|r| r.value),
+            Some("40".to_string()),
+            "age should be correctly set"
+        );
+        assert_eq!(
+            ethnicity.map(|r| r.value),
+            Some("White".to_string()),
+            "ethnicity should be correctly set"
+        );
+        assert_eq!(
+            gender.map(|r| r.value),
+            Some("Male".to_string()),
+            "gender should be correctly set"
+        );
+        assert_eq!(
+            zipcode.map(|r| r.value),
+            Some("11111".to_string()),
+            "zipcode should be correctly set"
+        );
+        assert_eq!(
+            political_party, None,
+            "political_party should be correctly set"
+        );
+
         // Delete the user
         sqlx::query("DELETE FROM comhairle_user WHERE id = $1")
             .bind(user.id)
@@ -673,6 +725,97 @@ mod tests {
         assert!(
             result.is_err(),
             "profile should be deleted when user is deleted"
+        );
+
+        // We should keep demographics and simply set the user to null on delete.
+        let age = get_demographics_responses(
+            &pool,
+            DemographicsResponsesFilterOptions {
+                question_slug: Some("age".to_string()),
+                ..Default::default()
+            },
+            Default::default(),
+        )
+        .await?
+        .records
+        .drain(..)
+        .next();
+
+        let ethnicity = get_demographics_responses(
+            &pool,
+            DemographicsResponsesFilterOptions {
+                question_slug: Some("ethnicity".to_string()),
+                ..Default::default()
+            },
+            Default::default(),
+        )
+        .await?
+        .records
+        .drain(..)
+        .next();
+
+        let gender = get_demographics_responses(
+            &pool,
+            DemographicsResponsesFilterOptions {
+                question_slug: Some("gender".to_string()),
+                ..Default::default()
+            },
+            Default::default(),
+        )
+        .await?
+        .records
+        .drain(..)
+        .next();
+
+        let zipcode = get_demographics_responses(
+            &pool,
+            DemographicsResponsesFilterOptions {
+                question_slug: Some("zipcode".to_string()),
+                ..Default::default()
+            },
+            Default::default(),
+        )
+        .await?
+        .records
+        .drain(..)
+        .next();
+
+        let political_party = get_demographics_responses(
+            &pool,
+            DemographicsResponsesFilterOptions {
+                question_slug: Some("political_party".to_string()),
+                ..Default::default()
+            },
+            Default::default(),
+        )
+        .await?
+        .records
+        .drain(..)
+        .next();
+
+        assert_eq!(
+            age.map(|r| r.value),
+            Some("40".to_string()),
+            "age should not be deleted via cascade"
+        );
+        assert_eq!(
+            ethnicity.map(|r| r.value),
+            Some("White".to_string()),
+            "ethnicity should not be deleted via cascade"
+        );
+        assert_eq!(
+            gender.map(|r| r.value),
+            Some("Male".to_string()),
+            "gender should not be deleted via cascade"
+        );
+        assert_eq!(
+            zipcode.map(|r| r.value),
+            Some("11111".to_string()),
+            "zipcode should not be deleted via cascade"
+        );
+        assert_eq!(
+            political_party, None,
+            "political_party should be not be set"
         );
 
         Ok(())
@@ -699,6 +842,9 @@ mod tests {
         let workflow: crate::routes::workflows::dto::WorkflowDto =
             serde_json::from_value(workflow)?;
         let workflow_id = workflow.id;
+
+        // Add demographics questions to conversation
+        add_default_demographics_to_conversation(&pool, conversation.id).await?;
 
         // Create users with different demographics
         let user1 = crate::models::users::create_user(
@@ -788,69 +934,85 @@ mod tests {
         assert_eq!(report.total_participants, 3, "incorrect total participants");
 
         // Verify ethnicity breakdown
-        assert_eq!(report.ethnicity.len(), 2, "incorrect ethnicity count");
-        let asian_count = report
-            .ethnicity
+        assert_eq!(report.categories.len(), 5, "incorrect number of categories");
+
+        let ethnicity = report.categories.get("ethnicity");
+        let age = report.categories.get("age");
+        let gender = report.categories.get("gender");
+        let political_party = report.categories.get("political_party");
+        let zipcode = report.categories.get("zipcode");
+
+        assert!(ethnicity.is_some(), "ethnicity category should exist");
+        assert!(age.is_some(), "age category should exist");
+        assert!(gender.is_some(), "gender category should exist");
+        assert!(
+            political_party.is_some(),
+            "political party category should exist"
+        );
+        assert!(zipcode.is_some(), "zipcode category should exist");
+
+        let ethnicities = ethnicity.unwrap();
+        let ages = age.unwrap();
+        let genders = gender.unwrap();
+        let political_parties = political_party.unwrap();
+        let zipcodes = zipcode.unwrap();
+
+        assert_eq!(ethnicities.len(), 2, "incorrect ethnicity count");
+        let asian_count = ethnicities
             .iter()
-            .find(|e| e.value == Some("Asian".to_string()))
+            .find(|e| e.value == "Asian".to_string())
             .map(|e| e.count)
             .unwrap_or(0);
         assert_eq!(asian_count, 2, "incorrect Asian count");
 
-        let hispanic_count = report
-            .ethnicity
+        let hispanic_count = ethnicities
             .iter()
-            .find(|e| e.value == Some("Hispanic".to_string()))
+            .find(|e| e.value == "Hispanic".to_string())
             .map(|e| e.count)
             .unwrap_or(0);
         assert_eq!(hispanic_count, 1, "incorrect Hispanic count");
 
         // Verify age ranges (user1=25, user2=30, user3=45)
-        let age_25_34 = report
-            .age_ranges
+        let age_25_34 = ages
             .iter()
-            .find(|a| a.value == Some("25-34".to_string()))
+            .find(|a| a.value == "25-34".to_string())
             .map(|a| a.count)
             .unwrap_or(0);
         assert_eq!(age_25_34, 2, "incorrect 25-34 age range count");
 
-        let age_45_54 = report
-            .age_ranges
+        let age_45_54 = ages
             .iter()
-            .find(|a| a.value == Some("45-54".to_string()))
+            .find(|a| a.value == "45-54".to_string())
             .map(|a| a.count)
             .unwrap_or(0);
         assert_eq!(age_45_54, 1, "incorrect 45-54 age range count");
 
         // Verify gender breakdown
-        assert_eq!(report.gender.len(), 3, "incorrect gender count");
+        assert_eq!(genders.len(), 3, "incorrect gender count");
 
         // Verify political party breakdown
         assert_eq!(
-            report.political_party.len(),
+            political_parties.len(),
             3,
             "incorrect political party count"
         );
 
         // Verify zipcode counts
+        assert_eq!(zipcodes.len(), 3, "should have 3 unique zipcodes");
         assert_eq!(
-            report.zipcode_counts.len(),
-            3,
-            "should have 3 unique zipcodes"
-        );
-        assert_eq!(
-            report.zipcode_counts.get("12345"),
-            Some(&1),
+            // Count of users in zipcode 12345
+            zipcodes.iter().find(|dc| dc.value == "12345").iter().len(),
+            1,
             "zipcode 12345 should have 1 user"
         );
         assert_eq!(
-            report.zipcode_counts.get("67890"),
-            Some(&1),
+            zipcodes.iter().find(|dc| dc.value == "67890").iter().len(),
+            1,
             "zipcode 67890 should have 1 user"
         );
         assert_eq!(
-            report.zipcode_counts.get("11111"),
-            Some(&1),
+            zipcodes.iter().find(|dc| dc.value == "11111").iter().len(),
+            1,
             "zipcode 11111 should have 1 user"
         );
 
@@ -878,6 +1040,9 @@ mod tests {
         let workflow: crate::routes::workflows::dto::WorkflowDto =
             serde_json::from_value(workflow)?;
         let workflow_id = workflow.id;
+
+        // Add default demographics to the conversation
+        add_default_demographics_to_conversation(&pool, conversation.id).await?;
 
         // Create consented user
         let consented_user = crate::models::users::create_user(
@@ -941,34 +1106,42 @@ mod tests {
         // Both users should count in total
         assert_eq!(report.total_participants, 2, "incorrect total participants");
 
+        let ethnicities = report.categories.get("ethnicity");
+        let genders = report.categories.get("gender");
+        let zipcodes = report.categories.get("zipcode");
+
+        assert!(ethnicities.is_some(), "ethnicity category should exist");
+        assert!(genders.is_some(), "gender category should exist");
+        assert!(zipcodes.is_some(), "zipcode category should exist");
+
+        let ethnicities = ethnicities.unwrap();
+        let genders = genders.unwrap();
+        let zipcodes = zipcodes.unwrap();
+
+        assert_eq!(ethnicities.len(), 1, "should only have one ethnicity");
+        assert_eq!(genders.len(), 1, "should only have one gender");
+        assert_eq!(zipcodes.len(), 1, "should only have one zipcode");
+
         // Only consented user should appear in demographics
-        assert_eq!(report.ethnicity.len(), 1, "should only have one ethnicity");
         assert_eq!(
-            report.ethnicity[0].value,
-            Some("Asian".to_string()),
+            ethnicities[0].value,
+            "Asian".to_string(),
             "should only show consented user's ethnicity"
         );
-        assert_eq!(
-            report.ethnicity[0].count, 1,
-            "should only count consented user"
-        );
+        assert_eq!(ethnicities[0].count, 1, "should only count consented user");
 
-        assert_eq!(report.gender.len(), 1, "should only have one gender");
+        assert_eq!(genders.len(), 1, "should only have one gender");
         assert_eq!(
-            report.gender[0].value,
-            Some("Female".to_string()),
+            genders[0].value,
+            "Female".to_string(),
             "should only show consented user's gender"
         );
 
         // Verify zipcode counts only include consented user
+        assert_eq!(zipcodes.len(), 1, "should only have one zipcode");
         assert_eq!(
-            report.zipcode_counts.len(),
-            1,
-            "should only have one zipcode"
-        );
-        assert_eq!(
-            report.zipcode_counts.get("12345"),
-            Some(&1),
+            zipcodes[0].value,
+            "12345".to_string(),
             "should only show consented user's zipcode"
         );
 
@@ -1029,34 +1202,10 @@ mod tests {
         // Generate report
         let report = get_demographic_report(&pool, &workflow_id).await?;
 
-        // Should show None for null values
-        assert_eq!(report.ethnicity.len(), 1, "should have one ethnicity entry");
         assert_eq!(
-            report.ethnicity[0].value, None,
-            "should show None for null ethnicity"
-        );
-
-        assert_eq!(
-            report.age_ranges.len(),
-            1,
-            "should have one age range entry"
-        );
-        assert_eq!(
-            report.age_ranges[0].value, None,
-            "should show None for null age"
-        );
-
-        assert_eq!(report.gender.len(), 1, "should have one gender entry");
-        assert_eq!(
-            report.gender[0].value, None,
-            "should show None for null gender"
-        );
-
-        // Verify zipcode counts (user has null zipcode, so map should be empty)
-        assert_eq!(
-            report.zipcode_counts.len(),
+            report.categories.len(),
             0,
-            "should have no zipcodes for user with null zipcode"
+            "should have no demographics entries for user with null values"
         );
 
         Ok(())

--- a/api/src/routes.rs
+++ b/api/src/routes.rs
@@ -4,6 +4,7 @@ pub mod auth;
 pub mod chat_sessions;
 pub mod chats;
 pub mod conversations;
+pub mod demographics;
 pub mod documents;
 pub mod email_template_configs;
 pub mod event_attendances;

--- a/api/src/routes/conversations.rs
+++ b/api/src/routes/conversations.rs
@@ -836,11 +836,31 @@ async fn export_conversation_demographics(
         for profile in demographics {
             writer.write_record(&[
                 profile.user_id.to_string(),
-                profile.ethnicity.unwrap_or_default(),
-                profile.age.map(|a| a.to_string()).unwrap_or_default(),
-                profile.gender.unwrap_or_default(),
-                profile.zipcode.unwrap_or_default(),
-                profile.political_party.unwrap_or_default(),
+                profile
+                    .demographics
+                    .get("ethnicity")
+                    .map(|d| d.value.clone())
+                    .unwrap_or_default(),
+                profile
+                    .demographics
+                    .get("age")
+                    .map(|d| d.value.clone())
+                    .unwrap_or_default(),
+                profile
+                    .demographics
+                    .get("gender")
+                    .map(|d| d.value.clone())
+                    .unwrap_or_default(),
+                profile
+                    .demographics
+                    .get("zipcode")
+                    .map(|d| d.value.clone())
+                    .unwrap_or_default(),
+                profile
+                    .demographics
+                    .get("political_party")
+                    .map(|d| d.value.clone())
+                    .unwrap_or_default(),
                 profile.created_at.to_rfc3339(),
             ])?;
         }
@@ -1041,6 +1061,9 @@ mod tests {
     use crate::bulk_storage_service::{MockBulkStorageService, UploadResult};
     use crate::config::BotServiceConfig;
     use crate::models::conversation::PartialConversation;
+    use crate::models::demographics::{
+        CreateConversationDemographics, create_conversation_demographics,
+    };
     use crate::models::permissions::{
         GrantRoleRequest, OrganizationWithPermissionDto, Role, UserOrOrganizationId, grant_role,
     };
@@ -2057,6 +2080,19 @@ mod tests {
         let workflow: crate::routes::workflows::dto::WorkflowDto =
             serde_json::from_value(workflow)?;
 
+        // Add default demographics to conversation
+        let default_questions = vec!["age", "ethnicity", "gender", "zipcode", "political_party"];
+        for question_slug in default_questions {
+            let _ = create_conversation_demographics(
+                &pool,
+                CreateConversationDemographics {
+                    conversation_id: conversation.id,
+                    question_slug: question_slug.to_string(),
+                },
+            )
+            .await?;
+        }
+
         // Create test users with profiles
         let user1 = crate::models::users::create_user(
             &SignupRequest {
@@ -2129,9 +2165,9 @@ mod tests {
         let response = app.clone().oneshot(request).await?;
         let status = response.status();
 
+        let body = response.into_body().collect().await?.to_bytes();
         assert_eq!(status, StatusCode::OK, "Should export successfully");
 
-        let body = response.into_body().collect().await?.to_bytes();
         let csv_string = String::from_utf8(body.to_vec())?;
 
         // Verify CSV contains expected headers

--- a/api/src/routes/demographics.rs
+++ b/api/src/routes/demographics.rs
@@ -267,9 +267,3 @@ pub fn router(state: Arc<ComhairleState>) -> ApiRouter {
         )
         .with_state(state.clone())
 }
-
-#[cfg(test)]
-mod tests {
-    // GH TODO: Tests for the demographics routes would go here.
-    // There isn't much to test here yet, as the routes are primarily thin wrappers around the model functions.
-}

--- a/api/src/routes/demographics.rs
+++ b/api/src/routes/demographics.rs
@@ -1,0 +1,275 @@
+use std::sync::Arc;
+
+use aide::axum::ApiRouter;
+use aide::axum::routing::{delete_with, get_with, post_with, put_with};
+use axum::Json;
+use axum::extract::{Path, Query, State};
+use hyper::StatusCode;
+use tracing::instrument;
+use uuid::Uuid;
+
+use crate::ComhairleState;
+use crate::error::ComhairleError;
+use crate::models::demographics::{
+    self, ConversationDemographics, ConversationDemographicsFilterOptions,
+    CreateConversationDemographics, CreateDemographicsQuestion, CreateDemographicsResponse,
+    DemographicsQuestion, DemographicsQuestionsFilterOptions, DemographicsResponse,
+    DemographicsResponsesFilterOptions, PartialDemographicsQuestion, PartialDemographicsResponse,
+};
+use crate::models::pagination::{PageOptions, PaginatedResults};
+
+// ============================================================================
+// Conversation-demographics associations - CR.D
+// ============================================================================
+
+/// Get all associations between conversations and demographics questions, with optional filters for conversation ID and question slug.
+#[instrument(err(Debug), skip(state))]
+pub async fn get_conversation_demographics(
+    State(state): State<Arc<ComhairleState>>,
+    Query(filters): Query<ConversationDemographicsFilterOptions>,
+    Query(page_options): Query<PageOptions>,
+) -> Result<(StatusCode, Json<PaginatedResults<ConversationDemographics>>), ComhairleError> {
+    demographics::get_conversation_demographics(&state.db, filters, page_options)
+        .await
+        .map(|results| (StatusCode::OK, Json(results)))
+}
+
+/// Create a new association between a conversation and a demographics question.
+#[instrument(err(Debug), skip(state))]
+pub async fn create_conversation_demographics(
+    State(state): State<Arc<ComhairleState>>,
+    Json(payload): Json<CreateConversationDemographics>,
+) -> Result<(StatusCode, Json<ConversationDemographics>), ComhairleError> {
+    demographics::create_conversation_demographics(&state.db, payload)
+        .await
+        .map(|result| (StatusCode::CREATED, Json(result)))
+}
+
+/// Remove an association between a conversation and a demographics question.
+#[instrument(err(Debug), skip(state))]
+pub async fn delete_conversation_demographics(
+    State(state): State<Arc<ComhairleState>>,
+    Json((conversation_id, question_slug)): Json<(Uuid, String)>,
+) -> Result<(StatusCode, Json<Option<ConversationDemographics>>), ComhairleError> {
+    demographics::delete_conversation_demographics(&state.db, conversation_id, question_slug)
+        .await
+        .map(|result| (StatusCode::OK, Json(result)))
+}
+
+// ============================================================================
+// Demographics questions - CRUD
+// ============================================================================
+
+/// Get a demographics question by its slug.
+#[instrument(err(Debug), skip(state))]
+pub async fn get_demographics_questions(
+    State(state): State<Arc<ComhairleState>>,
+    Query(filters): Query<DemographicsQuestionsFilterOptions>,
+    Query(page_options): Query<PageOptions>,
+) -> Result<(StatusCode, Json<PaginatedResults<DemographicsQuestion>>), ComhairleError> {
+    demographics::get_demographics_questions(&state.db, filters, page_options)
+        .await
+        .map(|result| (StatusCode::OK, Json(result)))
+}
+
+/// Create a new demographics question.
+#[instrument(err(Debug), skip(state))]
+pub async fn create_demographics_question(
+    State(state): State<Arc<ComhairleState>>,
+    Json(payload): Json<CreateDemographicsQuestion>,
+) -> Result<(StatusCode, Json<DemographicsQuestion>), ComhairleError> {
+    demographics::create_demographics_question(&state.db, payload)
+        .await
+        .map(|result| (StatusCode::CREATED, Json(result)))
+}
+
+/// Update a demographics question.
+#[instrument(err(Debug), skip(state))]
+pub async fn update_demographics_question(
+    State(state): State<Arc<ComhairleState>>,
+    Path(question_slug): Path<String>,
+    Json(payload): Json<PartialDemographicsQuestion>,
+) -> Result<(StatusCode, Json<DemographicsQuestion>), ComhairleError> {
+    demographics::update_demographics_question(&state.db, question_slug, payload)
+        .await
+        .map(|result| (StatusCode::OK, Json(result)))
+}
+
+/// Delete a demographics question.
+#[instrument(err(Debug), skip(state))]
+pub async fn delete_demographics_question(
+    State(state): State<Arc<ComhairleState>>,
+    Path(question_slug): Path<String>,
+) -> Result<(StatusCode, Json<Option<DemographicsQuestion>>), ComhairleError> {
+    demographics::delete_demographics_question(&state.db, question_slug)
+        .await
+        .map(|result| (StatusCode::OK, Json(result)))
+}
+
+// ============================================================================
+// Demographics responses - CRUD
+// ============================================================================
+
+/// Get all responses for a specific demographics question.
+#[instrument(err(Debug), skip(state))]
+pub async fn get_demographics_responses(
+    State(state): State<Arc<ComhairleState>>,
+    Query(filters): Query<DemographicsResponsesFilterOptions>,
+    Query(page_options): Query<PageOptions>,
+) -> Result<(StatusCode, Json<PaginatedResults<DemographicsResponse>>), ComhairleError> {
+    demographics::get_demographics_responses(&state.db, filters, page_options)
+        .await
+        .map(|result| (StatusCode::OK, Json(result)))
+}
+
+/// Add a new response for a specific demographics question and user.
+#[instrument(err(Debug), skip(state))]
+pub async fn create_demographics_response(
+    State(state): State<Arc<ComhairleState>>,
+    Json(payload): Json<CreateDemographicsResponse>,
+) -> Result<(StatusCode, Json<DemographicsResponse>), ComhairleError> {
+    demographics::create_demographics_response(&state.db, payload)
+        .await
+        .map(|result| (StatusCode::CREATED, Json(result)))
+}
+
+/// Update a response for a specific demographics question and user.
+#[instrument(err(Debug), skip(state))]
+pub async fn update_demographics_response(
+    State(state): State<Arc<ComhairleState>>,
+    Path((question_slug, user_id)): Path<(String, Uuid)>,
+    Json(payload): Json<PartialDemographicsResponse>,
+) -> Result<(StatusCode, Json<DemographicsResponse>), ComhairleError> {
+    demographics::update_demographics_response(&state.db, question_slug, user_id, payload)
+        .await
+        .map(|result| (StatusCode::OK, Json(result)))
+}
+
+/// Delete a response for a specific demographics question and user.
+#[instrument(err(Debug), skip(state))]
+pub async fn delete_demographics_response(
+    State(state): State<Arc<ComhairleState>>,
+    Path((question_slug, user_id)): Path<(String, Uuid)>,
+) -> Result<(StatusCode, Json<Option<DemographicsResponse>>), ComhairleError> {
+    demographics::delete_demographics_response(&state.db, question_slug, user_id)
+        .await
+        .map(|result| (StatusCode::OK, Json(result)))
+}
+
+// ============================================================================
+// Routes for demographics
+// ============================================================================
+
+pub fn router(state: Arc<ComhairleState>) -> ApiRouter {
+    ApiRouter::new()
+    .nest_api_service(
+        "/conversations_questions",
+        ApiRouter::new()
+            .api_route("/", get_with(get_conversation_demographics, |op| {
+                op.id("GetConversationDemographics")
+                    .tag("Demographics")
+                    .summary("Get conversation demographics")
+                    .description("Retrieve demographics responses for a specific conversation and question")
+                    .security_requirement("JWT")
+                    .response::<200, Json<PaginatedResults<ConversationDemographics>>>()
+            }))
+            .api_route("/", post_with(create_conversation_demographics, |op| {
+                op.id("CreateConversationDemographics")
+                    .tag("Demographics")
+                    .summary("Create a conversation demographics response")
+                    .description("Create a new demographics response for a specific conversation and question")
+                    .security_requirement("JWT")
+                    .response::<201, Json<ConversationDemographics>>()
+            }))
+            .api_route("/{conversation_id}/{question_slug}/", delete_with(delete_conversation_demographics, |op| {
+                op.id("DeleteConversationDemographicsByQuestion")
+                    .tag("Demographics")
+                    .summary("Delete conversation demographics by question")
+                    .description("Delete demographics responses for a specific conversation and question")
+                    .security_requirement("JWT")
+                    .response::<200, Json<PaginatedResults<ConversationDemographics>>>()
+            }))
+            .with_state(state.clone())
+    )
+    .nest_api_service(
+        "/questions",
+        ApiRouter::new()
+            .api_route("/", get_with(get_demographics_questions, |op| {
+                op.id("GetDemographicsQuestions")
+                    .tag("Demographics")
+                    .summary("List of demographics questions")
+                    .description("Paginated list of demographics questions with optional filtering and ordering")
+                    .security_requirement("JWT")
+                    .response::<200, Json<PaginatedResults<DemographicsQuestion>>>()
+            }))
+            .api_route("/", post_with(create_demographics_question, |op| {
+                op.id("CreateDemographicsQuestion")
+                    .tag("Demographics")
+                    .summary("Create a demographics question")
+                    .description("Create a new demographics question")
+                    .security_requirement("JWT")
+                    .response::<201, Json<DemographicsQuestion>>()
+            }))
+            .api_route("/{question_slug}", put_with(update_demographics_question, |op| {
+                op.id("UpdateDemographicsQuestion")
+                    .tag("Demographics")
+                    .summary("Update a demographics question")
+                    .description("Update a specific demographics question")
+                    .security_requirement("JWT")
+                    .response::<200, Json<DemographicsQuestion>>()
+            }))
+            .api_route("/{question_slug}", delete_with(delete_demographics_question, |op| {
+                op.id("DeleteDemographicsQuestion")
+                    .tag("Demographics")
+                    .summary("Delete a demographics question")
+                    .description("Delete a specific demographics question")
+                    .security_requirement("JWT")
+                    .response::<200, Json<Option<DemographicsQuestion>>>()
+            }))
+            .with_state(state.clone())
+        )
+        .nest_api_service(
+            "/responses",
+            ApiRouter::new()
+                .api_route("/", get_with(get_demographics_responses, |op| {
+                    op.id("GetDemographicsResponses")
+                        .tag("Demographics")
+                        .summary("List of demographics responses")
+                        .description("Paginated list of demographics responses with optional filtering and ordering")
+                        .security_requirement("JWT")
+                        .response::<200, Json<PaginatedResults<DemographicsResponse>>>()
+                }))
+                .api_route("/", post_with(create_demographics_response, |op| {
+                    op.id("CreateDemographicsResponse")
+                        .tag("Demographics")
+                        .summary("Create a demographics response")
+                        .description("Create a new response for a specific demographics question and user")
+                        .security_requirement("JWT")
+                        .response::<201, Json<DemographicsResponse>>()
+                }))
+                .api_route("/{question_slug}/{user_id}", put_with(update_demographics_response, |op| {
+                    op.id("UpdateDemographicsResponse")
+                        .tag("Demographics")
+                        .summary("Update a demographics response")
+                        .description("Update a response for a specific demographics question and user")
+                        .security_requirement("JWT")
+                        .response::<200, Json<DemographicsResponse>>()
+                }))
+                .api_route("/{question_slug}/{user_id}", delete_with(delete_demographics_response, |op| {
+                    op.id("DeleteDemographicsResponse")
+                        .tag("Demographics")
+                        .summary("Delete a demographics response")
+                        .description("Delete a response for a specific demographics question and user")
+                        .security_requirement("JWT")
+                        .response::<200, Json<Option<DemographicsResponse>>>()
+                }))
+                .with_state(state.clone())
+        )
+        .with_state(state.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    // GH TODO: Tests for the demographics routes would go here.
+    // There isn't much to test here yet, as the routes are primarily thin wrappers around the model functions.
+}

--- a/api/src/routes/user_profile.rs
+++ b/api/src/routes/user_profile.rs
@@ -46,11 +46,6 @@ pub async fn upsert_profile(
                 &existing.id,
                 &PartialUserProfile {
                     consented: request.consented,
-                    ethnicity: request.ethnicity,
-                    age: request.age,
-                    gender: request.gender,
-                    zipcode: request.zipcode,
-                    political_party: request.political_party,
                 },
             )
             .await?
@@ -131,22 +126,6 @@ mod tests {
 
         let profile: UserProfileDto = serde_json::from_value(response)?;
         assert!(profile.consented, "incorrect consented");
-        assert_eq!(
-            profile.ethnicity,
-            Some("Asian".to_string()),
-            "incorrect ethnicity"
-        );
-        assert_eq!(profile.age, Some(28), "incorrect age");
-        assert_eq!(
-            profile.gender,
-            Some("Female".to_string()),
-            "incorrect gender"
-        );
-        assert_eq!(
-            profile.zipcode,
-            Some("12345".to_string()),
-            "incorrect zipcode"
-        );
         assert_eq!(profile.user_id, session.id.unwrap(), "incorrect user_id");
 
         Ok(())
@@ -175,12 +154,6 @@ mod tests {
 
         let profile: UserProfileDto = serde_json::from_value(response)?;
         assert!(profile.consented, "incorrect consented");
-        assert_eq!(
-            profile.ethnicity,
-            Some("Hispanic".to_string()),
-            "incorrect ethnicity"
-        );
-        assert_eq!(profile.age, Some(30), "incorrect age");
 
         Ok(())
     }
@@ -222,22 +195,6 @@ mod tests {
             "should be same profile"
         );
         assert!(updated_profile.consented, "consented not updated");
-        assert_eq!(
-            updated_profile.ethnicity,
-            Some("Black".to_string()),
-            "ethnicity not updated"
-        );
-        assert_eq!(updated_profile.age, Some(35), "age not updated");
-        assert_eq!(
-            updated_profile.gender,
-            Some("Non-binary".to_string()),
-            "gender not updated"
-        );
-        assert_eq!(
-            updated_profile.zipcode,
-            Some("54321".to_string()),
-            "zipcode not updated"
-        );
 
         Ok(())
     }
@@ -293,22 +250,9 @@ mod tests {
         let (_, response, _) = session2.put(&app, "/user/profile", body.into()).await?;
         let profile2: UserProfileDto = serde_json::from_value(response)?;
 
-        // Verify user 2's profile has different data than user 1's
-        assert_eq!(
-            profile2.ethnicity,
-            Some("Hispanic".to_string()),
-            "user 2 should have their own profile data"
-        );
-        assert_eq!(profile2.age, Some(30), "user 2 should have their own age");
-
         // Get user 1's profile again to ensure it's unchanged
         let (_, response, _) = session1.get(&app, "/user/profile").await?;
         let profile1: UserProfileDto = serde_json::from_value(response)?;
-        assert_eq!(
-            profile1.ethnicity,
-            Some("Asian".to_string()),
-            "user 1 profile should be unchanged"
-        );
         assert_eq!(
             profile1.user_id,
             session1.id.unwrap(),

--- a/api/src/routes/user_profile/dto.rs
+++ b/api/src/routes/user_profile/dto.rs
@@ -11,11 +11,6 @@ pub struct UserProfileDto {
     pub id: Uuid,
     pub user_id: Uuid,
     pub consented: bool,
-    pub ethnicity: Option<String>,
-    pub age: Option<i32>,
-    pub gender: Option<String>,
-    pub zipcode: Option<String>,
-    pub political_party: Option<String>,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -26,11 +21,6 @@ impl From<UserProfile> for UserProfileDto {
             id: profile.id,
             user_id: profile.user_id,
             consented: profile.consented,
-            ethnicity: profile.ethnicity,
-            age: profile.age,
-            gender: profile.gender,
-            zipcode: profile.zipcode,
-            political_party: profile.political_party,
             created_at: profile.created_at,
             updated_at: profile.updated_at,
         }

--- a/api/src/test_helpers.rs
+++ b/api/src/test_helpers.rs
@@ -652,7 +652,8 @@ impl UserSession {
     ) -> Result<(StatusCode, UserDto, Option<HeaderValue>), Box<dyn Error>> {
         let (status, value, cookie) = self.get(app, "/auth/current_user").await?;
 
-        let user: UserDto = serde_json::from_value(value).unwrap();
+        let user: UserDto = serde_json::from_value(value.clone())
+            .map_err(|err| format!("Failed to parse current user: {value:?} - Error: {err}"))?;
         Ok((status, user, cookie))
     }
 

--- a/ui/packages/api-client/src/api.ts
+++ b/ui/packages/api-client/src/api.ts
@@ -1456,7 +1456,11 @@ export const WorkflowStats = z
   .passthrough();
 export type WorkflowStats = z.infer<typeof WorkflowStats>;
 export const DemographicCount = z
-  .object({ count: z.number().int(), value: z.string() })
+  .object({
+    count: z.number().int(),
+    displayName: z.string(),
+    value: z.string(),
+  })
   .passthrough();
 export type DemographicCount = z.infer<typeof DemographicCount>;
 export const DemographicReport = z
@@ -3061,7 +3065,7 @@ export type DemographicsQuestionResponseType = z.infer<
 export const DemographicsQuestion = z
   .object({
     bucketConfig: z.union([z.array(ValueBuckets), z.null()]).optional(),
-    displayName: z.union([z.string(), z.null()]).optional(),
+    displayName: z.string(),
     responseType: DemographicsQuestionResponseType,
     slug: z.string(),
   })
@@ -3075,8 +3079,8 @@ export type PaginatedResults_for_DemographicsQuestion = z.infer<
 >;
 export const CreateDemographicsQuestion = z
   .object({
-    bucketConfig: z.unknown().optional(),
-    displayName: z.union([z.string(), z.null()]).optional(),
+    bucketConfig: z.union([z.array(ValueBuckets), z.null()]).optional(),
+    displayName: z.string(),
     responseType: DemographicsQuestionResponseType,
     slug: z.string(),
   })

--- a/ui/packages/api-client/src/api.ts
+++ b/ui/packages/api-client/src/api.ts
@@ -231,16 +231,11 @@ export type UpdateUserConversationPreferences = z.infer<
 >;
 export const UserProfileDto = z
   .object({
-    age: z.union([z.number(), z.null()]).optional(),
     consented: z.boolean(),
     createdAt: z.string().datetime({ offset: true }),
-    ethnicity: z.union([z.string(), z.null()]).optional(),
-    gender: z.union([z.string(), z.null()]).optional(),
     id: z.string().uuid(),
-    politicalParty: z.union([z.string(), z.null()]).optional(),
     updatedAt: z.string().datetime({ offset: true }),
     userId: z.string().uuid(),
-    zipcode: z.union([z.string(), z.null()]).optional(),
   })
   .passthrough();
 export type UserProfileDto = z.infer<typeof UserProfileDto>;
@@ -1460,22 +1455,14 @@ export const WorkflowStats = z
   })
   .passthrough();
 export type WorkflowStats = z.infer<typeof WorkflowStats>;
-export const DemographicCategory = z
-  .object({
-    category: z.string(),
-    count: z.number().int(),
-    value: z.union([z.string(), z.null()]).optional(),
-  })
+export const DemographicCount = z
+  .object({ count: z.number().int(), value: z.string() })
   .passthrough();
-export type DemographicCategory = z.infer<typeof DemographicCategory>;
+export type DemographicCount = z.infer<typeof DemographicCount>;
 export const DemographicReport = z
   .object({
-    ageRanges: z.array(DemographicCategory),
-    ethnicity: z.array(DemographicCategory),
-    gender: z.array(DemographicCategory),
-    politicalParty: z.array(DemographicCategory),
+    categories: z.record(z.array(DemographicCount)),
     totalParticipants: z.number().int(),
-    zipcodeCounts: z.record(z.number().int()),
   })
   .passthrough();
 export type DemographicReport = z.infer<typeof DemographicReport>;
@@ -3024,6 +3011,122 @@ export const UserWithPermissionDto = z
   })
   .passthrough();
 export type UserWithPermissionDto = z.infer<typeof UserWithPermissionDto>;
+export const ConversationDemographics = z
+  .object({ conversationId: z.string().uuid(), questionSlug: z.string() })
+  .passthrough();
+export type ConversationDemographics = z.infer<typeof ConversationDemographics>;
+export const PaginatedResults_for_ConversationDemographics = z
+  .object({
+    records: z.array(ConversationDemographics),
+    total: z.number().int(),
+  })
+  .passthrough();
+export type PaginatedResults_for_ConversationDemographics = z.infer<
+  typeof PaginatedResults_for_ConversationDemographics
+>;
+export const CreateConversationDemographics = z
+  .object({ conversationId: z.string().uuid(), questionSlug: z.string() })
+  .passthrough();
+export type CreateConversationDemographics = z.infer<
+  typeof CreateConversationDemographics
+>;
+export const NumericBucket = z
+  .object({
+    label: z.string(),
+    max: z.union([z.number(), z.null()]).optional(),
+    min: z.union([z.number(), z.null()]).optional(),
+  })
+  .passthrough();
+export type NumericBucket = z.infer<typeof NumericBucket>;
+export const TextBucket = z
+  .object({
+    label: z.string(),
+    values: z.union([z.array(z.string()), z.null()]).optional(),
+  })
+  .passthrough();
+export type TextBucket = z.infer<typeof TextBucket>;
+export const ValueBuckets = z.union([
+  z
+    .object({ buckets: z.array(NumericBucket), type: z.literal("numeric") })
+    .passthrough(),
+  z
+    .object({ buckets: z.array(TextBucket), type: z.literal("text") })
+    .passthrough(),
+]);
+export type ValueBuckets = z.infer<typeof ValueBuckets>;
+export const DemographicsQuestionResponseType = z.enum(["string", "number"]);
+export type DemographicsQuestionResponseType = z.infer<
+  typeof DemographicsQuestionResponseType
+>;
+export const DemographicsQuestion = z
+  .object({
+    bucketConfig: z.union([z.array(ValueBuckets), z.null()]).optional(),
+    displayName: z.union([z.string(), z.null()]).optional(),
+    responseType: DemographicsQuestionResponseType,
+    slug: z.string(),
+  })
+  .passthrough();
+export type DemographicsQuestion = z.infer<typeof DemographicsQuestion>;
+export const PaginatedResults_for_DemographicsQuestion = z
+  .object({ records: z.array(DemographicsQuestion), total: z.number().int() })
+  .passthrough();
+export type PaginatedResults_for_DemographicsQuestion = z.infer<
+  typeof PaginatedResults_for_DemographicsQuestion
+>;
+export const CreateDemographicsQuestion = z
+  .object({
+    bucketConfig: z.unknown().optional(),
+    displayName: z.union([z.string(), z.null()]).optional(),
+    responseType: DemographicsQuestionResponseType,
+    slug: z.string(),
+  })
+  .passthrough();
+export type CreateDemographicsQuestion = z.infer<
+  typeof CreateDemographicsQuestion
+>;
+export const PartialDemographicsQuestion = z
+  .object({
+    bucketConfig: z.union([z.array(ValueBuckets), z.null()]),
+    displayName: z.union([z.string(), z.null()]),
+    responseType: z.union([DemographicsQuestionResponseType, z.null()]),
+  })
+  .partial()
+  .passthrough();
+export type PartialDemographicsQuestion = z.infer<
+  typeof PartialDemographicsQuestion
+>;
+export const DemographicsResponse = z
+  .object({
+    id: z.string().uuid(),
+    questionSlug: z.string(),
+    userId: z.union([z.string(), z.null()]).optional(),
+    value: z.string(),
+  })
+  .passthrough();
+export type DemographicsResponse = z.infer<typeof DemographicsResponse>;
+export const PaginatedResults_for_DemographicsResponse = z
+  .object({ records: z.array(DemographicsResponse), total: z.number().int() })
+  .passthrough();
+export type PaginatedResults_for_DemographicsResponse = z.infer<
+  typeof PaginatedResults_for_DemographicsResponse
+>;
+export const CreateDemographicsResponse = z
+  .object({
+    questionSlug: z.string(),
+    userId: z.string().uuid(),
+    value: z.string(),
+  })
+  .passthrough();
+export type CreateDemographicsResponse = z.infer<
+  typeof CreateDemographicsResponse
+>;
+export const PartialDemographicsResponse = z
+  .object({ value: z.union([z.string(), z.null()]) })
+  .partial()
+  .passthrough();
+export type PartialDemographicsResponse = z.infer<
+  typeof PartialDemographicsResponse
+>;
 
 export const schemas: Record<string, z.ZodType<any>> = {
   AnnonLoginRequest,
@@ -3185,7 +3288,7 @@ export const schemas: Record<string, z.ZodType<any>> = {
   DailySignupStats,
   WorkflowStepStats,
   WorkflowStats,
-  DemographicCategory,
+  DemographicCount,
   DemographicReport,
   UserParticipation,
   UserParticipationDto,
@@ -3356,6 +3459,21 @@ export const schemas: Record<string, z.ZodType<any>> = {
   PaginatedResults_for_ResourcePermission,
   GrantPermissionBody,
   UserWithPermissionDto,
+  ConversationDemographics,
+  PaginatedResults_for_ConversationDemographics,
+  CreateConversationDemographics,
+  NumericBucket,
+  TextBucket,
+  ValueBuckets,
+  DemographicsQuestionResponseType,
+  DemographicsQuestion,
+  PaginatedResults_for_DemographicsQuestion,
+  CreateDemographicsQuestion,
+  PartialDemographicsQuestion,
+  DemographicsResponse,
+  PaginatedResults_for_DemographicsResponse,
+  CreateDemographicsResponse,
+  PartialDemographicsResponse,
 };
 
 const endpoints = makeApi([
@@ -4820,6 +4938,209 @@ Use query param withUserProgress&#x3D;true to get the active user&#x27;s progres
     alias: "DeleteConversationWorkflowStep",
     requestFormat: "json",
     response: WorkflowStepDto,
+  },
+  {
+    method: "get",
+    path: "/demographics/conversations_questions",
+    alias: "GetConversationDemographics",
+    description: `Retrieve demographics responses for a specific conversation and question`,
+    requestFormat: "json",
+    parameters: [
+      {
+        name: "conversation_id",
+        type: "Query",
+        schema: created_after,
+      },
+      {
+        name: "question_slug",
+        type: "Query",
+        schema: created_after,
+      },
+      {
+        name: "limit",
+        type: "Query",
+        schema: limit,
+      },
+      {
+        name: "offset",
+        type: "Query",
+        schema: limit,
+      },
+    ],
+    response: PaginatedResults_for_ConversationDemographics,
+  },
+  {
+    method: "post",
+    path: "/demographics/conversations_questions",
+    alias: "CreateConversationDemographics",
+    description: `Create a new demographics response for a specific conversation and question`,
+    requestFormat: "json",
+    parameters: [
+      {
+        name: "body",
+        type: "Body",
+        schema: CreateConversationDemographics,
+      },
+    ],
+    response: ConversationDemographics,
+  },
+  {
+    method: "delete",
+    path: "/demographics/conversations_questions/:conversation_id/:question_slug/",
+    alias: "DeleteConversationDemographicsByQuestion",
+    description: `Delete demographics responses for a specific conversation and question`,
+    requestFormat: "json",
+    parameters: [
+      {
+        name: "body",
+        type: "Body",
+        schema: z.array(z.unknown()).min(2).max(2),
+      },
+    ],
+    response: PaginatedResults_for_ConversationDemographics,
+  },
+  {
+    method: "get",
+    path: "/demographics/questions",
+    alias: "GetDemographicsQuestions",
+    description: `Paginated list of demographics questions with optional filtering and ordering`,
+    requestFormat: "json",
+    parameters: [
+      {
+        name: "conversation_id",
+        type: "Query",
+        schema: created_after,
+      },
+      {
+        name: "question_slug",
+        type: "Query",
+        schema: created_after,
+      },
+      {
+        name: "limit",
+        type: "Query",
+        schema: limit,
+      },
+      {
+        name: "offset",
+        type: "Query",
+        schema: limit,
+      },
+    ],
+    response: PaginatedResults_for_DemographicsQuestion,
+  },
+  {
+    method: "post",
+    path: "/demographics/questions",
+    alias: "CreateDemographicsQuestion",
+    description: `Create a new demographics question`,
+    requestFormat: "json",
+    parameters: [
+      {
+        name: "body",
+        type: "Body",
+        schema: CreateDemographicsQuestion,
+      },
+    ],
+    response: DemographicsQuestion,
+  },
+  {
+    method: "put",
+    path: "/demographics/questions/:question_slug",
+    alias: "UpdateDemographicsQuestion",
+    description: `Update a specific demographics question`,
+    requestFormat: "json",
+    parameters: [
+      {
+        name: "body",
+        description: `Represents a demographics question.`,
+        type: "Body",
+        schema: PartialDemographicsQuestion,
+      },
+    ],
+    response: DemographicsQuestion,
+  },
+  {
+    method: "delete",
+    path: "/demographics/questions/:question_slug",
+    alias: "DeleteDemographicsQuestion",
+    description: `Delete a specific demographics question`,
+    requestFormat: "json",
+    response: z.union([DemographicsQuestion, z.null()]),
+  },
+  {
+    method: "get",
+    path: "/demographics/responses",
+    alias: "GetDemographicsResponses",
+    description: `Paginated list of demographics responses with optional filtering and ordering`,
+    requestFormat: "json",
+    parameters: [
+      {
+        name: "conversation_id",
+        type: "Query",
+        schema: created_after,
+      },
+      {
+        name: "question_slug",
+        type: "Query",
+        schema: created_after,
+      },
+      {
+        name: "user_id",
+        type: "Query",
+        schema: created_after,
+      },
+      {
+        name: "limit",
+        type: "Query",
+        schema: limit,
+      },
+      {
+        name: "offset",
+        type: "Query",
+        schema: limit,
+      },
+    ],
+    response: PaginatedResults_for_DemographicsResponse,
+  },
+  {
+    method: "post",
+    path: "/demographics/responses",
+    alias: "CreateDemographicsResponse",
+    description: `Create a new response for a specific demographics question and user`,
+    requestFormat: "json",
+    parameters: [
+      {
+        name: "body",
+        type: "Body",
+        schema: CreateDemographicsResponse,
+      },
+    ],
+    response: DemographicsResponse,
+  },
+  {
+    method: "put",
+    path: "/demographics/responses/:question_slug/:user_id",
+    alias: "UpdateDemographicsResponse",
+    description: `Update a response for a specific demographics question and user`,
+    requestFormat: "json",
+    parameters: [
+      {
+        name: "body",
+        description: `Represents a demographics response from a user to a specific demographics question.`,
+        type: "Body",
+        schema: PartialDemographicsResponse,
+      },
+    ],
+    response: DemographicsResponse,
+  },
+  {
+    method: "delete",
+    path: "/demographics/responses/:question_slug/:user_id",
+    alias: "DeleteDemographicsResponse",
+    description: `Delete a response for a specific demographics question and user`,
+    requestFormat: "json",
+    response: z.union([DemographicsResponse, z.null()]),
   },
   {
     method: "get",

--- a/ui/packages/comhairle/src/lib/components/UserDemographicsForm/UserDemographicsForm.svelte
+++ b/ui/packages/comhairle/src/lib/components/UserDemographicsForm/UserDemographicsForm.svelte
@@ -1,0 +1,175 @@
+<!-- src/lib/components/UserDemographicsForm/UserDemographicsForm.svelte -->
+<script lang="ts">
+	import { Input } from '$lib/components/ui/input';
+	import { Label } from '$lib/components/ui/label';
+	import { Button } from '$lib/components/ui/button';
+	import { apiClient } from '@crownshy/api-client/client';
+	import { notifications } from '$lib/notifications.svelte';
+	import { superForm } from 'sveltekit-superforms';
+	import { zodClient } from 'sveltekit-superforms/adapters';
+	import { z } from 'zod';
+	import type { DemographicsQuestion, DemographicsResponse } from '@crownshy/api-client/api';
+	import { invalidateAll } from '$app/navigation';
+
+	let {
+		questions,
+		responses,
+		userId
+	}: {
+		questions: DemographicsQuestion[];
+		responses: DemographicsResponse[];
+		userId: string;
+	} = $props();
+
+	let saving = $state(false);
+
+	// 1. Build initial data and dynamic Zod schema based on the provided questions
+	const buildFormConfig = () => {
+		const initialData: Record<string, string> = {};
+		const schemaShape: Record<string, z.ZodTypeAny> = {};
+
+		for (const q of questions) {
+			// Find existing answer if it exists
+			const existingResponse = responses.find((r) => r.questionSlug === q.slug);
+			initialData[q.slug] = existingResponse ? existingResponse.value : '';
+
+			// Require strings but allow empty values to represent deletion
+			schemaShape[q.slug] = z.string().nullable().optional();
+		}
+
+		return {
+			initialData,
+			schema: z.object(schemaShape)
+		};
+	};
+
+	const config = buildFormConfig();
+
+	const form = superForm(config.initialData, {
+		validators: zodClient(config.schema),
+		taintedMessage: false,
+		validationMethod: 'onsubmit'
+	});
+
+	const { form: formData, validateForm, errors } = form;
+
+	// Helper to format slugs like "political_party" into "Political Party"
+	const formatSlugLabel = (slug: string) => {
+		return slug
+			.split('_')
+			.map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+			.join(' ');
+	};
+
+	async function saveDemographics(e: Event) {
+		e.preventDefault();
+		const result = await validateForm({ update: false });
+
+		if (!result.valid) {
+			$errors = result.errors;
+			return;
+		}
+
+		try {
+			saving = true;
+
+			// 2. Iterate dynamically over the available questions to dispatch API calls
+			const apiCalls = questions.map(async (q) => {
+				const slug = q.slug;
+				const val = result.data[slug];
+				const existing = responses.find((r) => r.questionSlug === slug);
+
+				const hasNewValue = val !== null && val !== '' && val !== undefined;
+				const stringVal = hasNewValue ? String(val).trim() : '';
+
+				if (hasNewValue && !existing) {
+					// Create
+					return apiClient.CreateDemographicsResponse({
+						questionSlug: slug,
+						userId: userId,
+						value: stringVal
+					});
+				} else if (hasNewValue && existing && existing.value !== stringVal) {
+					// Update
+					return apiClient.UpdateDemographicsResponse(slug, userId, {
+						value: stringVal
+					});
+				} else if (!hasNewValue && existing) {
+					// Delete (user cleared the field)
+					return apiClient.DeleteDemographicsResponse(slug, userId);
+				}
+
+				return Promise.resolve();
+			});
+
+			await Promise.all(apiCalls);
+
+			notifications.send({
+				message: 'Demographics updated successfully',
+				priority: 'INFO'
+			});
+			$errors = {};
+
+			// Re-run the page load function to sync fresh responses into the UI state
+			await invalidateAll();
+		} catch (error: any) {
+			console.error('Demographics Save Error:', error?.response?.data || error); // <-- Add this to see the exact backend rejection
+
+			notifications.send({
+				message:
+					error?.response?.data?.err ||
+					error?.response?.data?.message ||
+					'Failed to update demographics. Please try again.',
+				priority: 'ERROR'
+			});
+		} finally {
+			saving = false;
+		}
+	}
+</script>
+
+<div class="space-y-6 border-t pt-8">
+	<div>
+		<h3 class="text-lg font-medium">Demographics</h3>
+		<p class="text-muted-foreground text-sm">
+			Update your demographic information here. This helps us contextualize conversation
+			results.
+		</p>
+	</div>
+
+	{#if questions.length === 0}
+		<p class="text-muted-foreground mt-4 text-sm italic">
+			No demographic questions are currently available.
+		</p>
+	{:else}
+		<form method="POST" class="grid gap-4 md:grid-cols-2" onsubmit={saveDemographics}>
+			{#each questions as question (question.slug)}
+				<div class="space-y-2">
+					<!-- Use question.label or question.text if your backend provides it, otherwise format the slug -->
+					<Label for={question.slug}>
+						{(question as any).label ||
+							(question as any).text ||
+							formatSlugLabel(question.slug)}
+					</Label>
+
+					<Input
+						id={question.slug}
+						bind:value={$formData[question.slug]}
+						placeholder={`Enter ${formatSlugLabel(question.slug).toLowerCase()}`}
+						disabled={saving}
+					/>
+
+					{#if $errors[question.slug]}
+						<span class="text-destructive block text-xs">{$errors[question.slug]}</span>
+					{/if}
+				</div>
+			{/each}
+
+			<div class="mt-4 flex justify-end md:col-span-2">
+				<Button type="submit" disabled={saving}>
+					{saving ? 'Saving...' : 'Save Demographics'}
+				</Button>
+			</div>
+		</form>
+	{/if}
+</div>

--- a/ui/packages/comhairle/src/lib/components/UserDetailsForm/UserDetailsForm.svelte
+++ b/ui/packages/comhairle/src/lib/components/UserDetailsForm/UserDetailsForm.svelte
@@ -92,7 +92,7 @@
 	}
 </script>
 
-<div class="space-y-6">
+<div class="space-y-6 border-b py-5">
 	<div>
 		<h3 class="text-lg font-medium">Account Details</h3>
 		<p class="text-muted-foreground text-sm">Update your username and password here.</p>

--- a/ui/packages/comhairle/src/routes/(public)/settings/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/settings/+page.svelte
@@ -3,12 +3,15 @@
 	import type { PageProps } from './$types';
 	import UserConversationPreferencesForm from '$lib/components/UserConversationPreferencesForm/UserConversationPreferencesForm.svelte';
 	import UserDetailsForm from '$lib/components/UserDetailsForm/UserDetailsForm.svelte';
+	import UserDemographicsForm from '$lib/components/UserDemographicsForm/UserDemographicsForm.svelte';
 	import UpgradeAccountModal from '$lib/components/UpgradeAccountModal/UpgradeAccountModal.svelte';
 	import type { UserDto } from '@crownshy/api-client/api';
 
 	let { data }: PageProps = $props();
 	let participation = $derived(data.participation);
 	let user = $state(data.user) as UserDto;
+	let demographicQuestions = $derived(data.demographicQuestions);
+	let demographicResponses = $derived(data.demographicResponses);
 
 	function handleUpgradeSuccess(upgradedUser: UserDto) {
 		user = upgradedUser;
@@ -55,6 +58,11 @@
 				</div>
 			{:else}
 				<UserDetailsForm {user} />
+				<UserDemographicsForm
+					questions={demographicQuestions}
+					responses={demographicResponses}
+					userId={user.id}
+				/>
 			{/if}
 		</section>
 

--- a/ui/packages/comhairle/src/routes/(public)/settings/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/settings/+page.svelte
@@ -1,20 +1,27 @@
 <script lang="ts">
 	import { Settings } from 'lucide-svelte';
+	import { invalidate } from '$app/navigation';
 	import type { PageProps } from './$types';
 	import UserConversationPreferencesForm from '$lib/components/UserConversationPreferencesForm/UserConversationPreferencesForm.svelte';
 	import UserDetailsForm from '$lib/components/UserDetailsForm/UserDetailsForm.svelte';
-	import UserDemographicsForm from '$lib/components/UserDemographicsForm/UserDemographicsForm.svelte';
+	import UserDemographicsForm from './UserDemographicsForm/UserDemographicsForm.svelte';
 	import UpgradeAccountModal from '$lib/components/UpgradeAccountModal/UpgradeAccountModal.svelte';
 	import type { UserDto } from '@crownshy/api-client/api';
 
 	let { data }: PageProps = $props();
-	let participation = $derived(data.participation);
-	let user = $state(data.user) as UserDto;
-	let demographicQuestions = $derived(data.demographicQuestions);
-	let demographicResponses = $derived(data.demographicResponses);
+	let {
+		participation,
+		user,
+		demographicQuestions = [],
+		demographicResponses = []
+	} = $derived(data);
 
 	function handleUpgradeSuccess(upgradedUser: UserDto) {
 		user = upgradedUser;
+	}
+
+	async function refreshDemographics() {
+		await invalidate('settings:demographics');
 	}
 </script>
 
@@ -30,7 +37,7 @@
 		</div>
 	</div>
 	<div class="mt-1 flex flex-col gap-y-10">
-		<section id="your_details" class="border-border border-b py-5">
+		<section id="your_details">
 			<h2 class="mb-6 text-3xl">Your Details</h2>
 			{#if user.authType === 'annon'}
 				<div class="space-y-6">
@@ -58,11 +65,14 @@
 				</div>
 			{:else}
 				<UserDetailsForm {user} />
-				<UserDemographicsForm
-					questions={demographicQuestions}
-					responses={demographicResponses}
-					userId={user.id}
-				/>
+				{#key demographicResponses}
+					<UserDemographicsForm
+						questions={demographicQuestions}
+						responses={demographicResponses}
+						userId={user.id}
+						onSaved={refreshDemographics}
+					/>
+				{/key}
 			{/if}
 		</section>
 

--- a/ui/packages/comhairle/src/routes/(public)/settings/+page.ts
+++ b/ui/packages/comhairle/src/routes/(public)/settings/+page.ts
@@ -1,7 +1,8 @@
 import { redirect } from '@sveltejs/kit';
 import type { PageLoad } from './$types';
 
-export const load: PageLoad = async ({ parent }) => {
+export const load: PageLoad = async ({ parent, depends }) => {
+	depends('settings:demographics');
 	const { user, api } = await parent();
 
 	if (!user) {
@@ -26,7 +27,7 @@ export const load: PageLoad = async ({ parent }) => {
 			demographicQuestions: questionsRes.records || [],
 			demographicResponses: responsesRes.records || []
 		};
-	} catch (e) {
-		return { error: e };
+	} catch (error) {
+		throw error;
 	}
 };

--- a/ui/packages/comhairle/src/routes/(public)/settings/+page.ts
+++ b/ui/packages/comhairle/src/routes/(public)/settings/+page.ts
@@ -10,8 +10,22 @@ export const load: PageLoad = async ({ parent }) => {
 	try {
 		const participation = await api.GetConversationsUserIsParticipatingIn();
 		const conversation_settings = await api.GetAllUserConversationPreferences();
+		const [questionsRes, responsesRes] = await Promise.all([
+			api
+				.GetDemographicsQuestions({ queries: { limit: 100 } })
+				.catch(() => ({ records: [] })),
+			api
+				.GetDemographicsResponses({ queries: { user_id: user.id, limit: 100 } })
+				.catch(() => ({ records: [] }))
+		]);
 
-		return { participation, conversation_settings, user };
+		return {
+			participation,
+			conversation_settings,
+			user,
+			demographicQuestions: questionsRes.records || [],
+			demographicResponses: responsesRes.records || []
+		};
 	} catch (e) {
 		return { error: e };
 	}

--- a/ui/packages/comhairle/src/routes/(public)/settings/UserDemographicsForm/UserDemographicsForm.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/settings/UserDemographicsForm/UserDemographicsForm.svelte
@@ -1,54 +1,46 @@
 <!-- src/lib/components/UserDemographicsForm/UserDemographicsForm.svelte -->
 <script lang="ts">
+	import { untrack } from 'svelte';
 	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';
 	import { Button } from '$lib/components/ui/button';
 	import { apiClient } from '@crownshy/api-client/client';
 	import { notifications } from '$lib/notifications.svelte';
 	import { superForm } from 'sveltekit-superforms';
-	import { zodClient } from 'sveltekit-superforms/adapters';
-	import { z } from 'zod';
+	import { tryCatchAsync } from '$lib/utils/errorHandling';
 	import type { DemographicsQuestion, DemographicsResponse } from '@crownshy/api-client/api';
-	import { invalidateAll } from '$app/navigation';
 
-	let {
-		questions,
-		responses,
-		userId
-	}: {
+	type Props = {
 		questions: DemographicsQuestion[];
 		responses: DemographicsResponse[];
 		userId: string;
-	} = $props();
+		onSaved: () => Promise<void>;
+	};
+
+	let { questions, responses, userId, onSaved }: Props = $props();
 
 	let saving = $state(false);
 
-	// 1. Build initial data and dynamic Zod schema based on the provided questions
-	const buildFormConfig = () => {
+	const buildInitialData = () => {
 		const initialData: Record<string, string> = {};
-		const schemaShape: Record<string, z.ZodTypeAny> = {};
 
 		for (const q of questions) {
 			// Find existing answer if it exists
 			const existingResponse = responses.find((r) => r.questionSlug === q.slug);
 			initialData[q.slug] = existingResponse ? existingResponse.value : '';
-
-			// Require strings but allow empty values to represent deletion
-			schemaShape[q.slug] = z.string().nullable().optional();
 		}
 
-		return {
-			initialData,
-			schema: z.object(schemaShape)
-		};
+		return initialData;
 	};
 
-	const config = buildFormConfig();
+	const form = untrack(() => {
+		const initialData = buildInitialData();
 
-	const form = superForm(config.initialData, {
-		validators: zodClient(config.schema),
-		taintedMessage: false,
-		validationMethod: 'onsubmit'
+		return superForm(initialData, {
+			validators: false,
+			taintedMessage: false,
+			validationMethod: 'onsubmit'
+		});
 	});
 
 	const { form: formData, validateForm, errors } = form;
@@ -70,7 +62,7 @@
 			return;
 		}
 
-		try {
+		let apiCalls = await tryCatchAsync(async () => {
 			saving = true;
 
 			// 2. Iterate dynamically over the available questions to dispatch API calls
@@ -91,12 +83,15 @@
 					});
 				} else if (hasNewValue && existing && existing.value !== stringVal) {
 					// Update
-					return apiClient.UpdateDemographicsResponse(slug, userId, {
-						value: stringVal
-					});
+					return apiClient.UpdateDemographicsResponse(
+						{ value: stringVal },
+						{ params: { question_slug: slug, user_id: userId } }
+					);
 				} else if (!hasNewValue && existing) {
 					// Delete (user cleared the field)
-					return apiClient.DeleteDemographicsResponse(slug, userId);
+					return apiClient.DeleteDemographicsResponse(undefined, {
+						params: { question_slug: slug, user_id: userId }
+					});
 				}
 
 				return Promise.resolve();
@@ -110,25 +105,27 @@
 			});
 			$errors = {};
 
-			// Re-run the page load function to sync fresh responses into the UI state
-			await invalidateAll();
-		} catch (error: any) {
-			console.error('Demographics Save Error:', error?.response?.data || error); // <-- Add this to see the exact backend rejection
+			await onSaved();
+		});
+
+		if (apiCalls.err !== null) {
+			const error = apiCalls.err;
+			const errorMessage =
+				error instanceof Error
+					? error.message
+					: 'Failed to update demographics. Please try again.';
 
 			notifications.send({
-				message:
-					error?.response?.data?.err ||
-					error?.response?.data?.message ||
-					'Failed to update demographics. Please try again.',
+				message: errorMessage,
 				priority: 'ERROR'
 			});
-		} finally {
-			saving = false;
 		}
+
+		saving = false;
 	}
 </script>
 
-<div class="space-y-6 border-t pt-8">
+<div class="space-y-6 border-b py-5">
 	<div>
 		<h3 class="text-lg font-medium">Demographics</h3>
 		<p class="text-muted-foreground text-sm">
@@ -147,15 +144,13 @@
 				<div class="space-y-2">
 					<!-- Use question.label or question.text if your backend provides it, otherwise format the slug -->
 					<Label for={question.slug}>
-						{(question as any).label ||
-							(question as any).text ||
-							formatSlugLabel(question.slug)}
+						{(question as any).label || (question as any).text || question.displayName}
 					</Label>
 
 					<Input
 						id={question.slug}
 						bind:value={$formData[question.slug]}
-						placeholder={`Enter ${formatSlugLabel(question.slug).toLowerCase()}`}
+						placeholder={`Enter ${question.displayName.toLowerCase()}`}
 						disabled={saving}
 					/>
 

--- a/ui/packages/comhairle/src/routes/(public)/settings/UserDemographicsForm/UserDemographicsForm.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/settings/UserDemographicsForm/UserDemographicsForm.svelte
@@ -45,14 +45,6 @@
 
 	const { form: formData, validateForm, errors } = form;
 
-	// Helper to format slugs like "political_party" into "Political Party"
-	const formatSlugLabel = (slug: string) => {
-		return slug
-			.split('_')
-			.map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-			.join(' ');
-	};
-
 	async function saveDemographics(e: Event) {
 		e.preventDefault();
 		const result = await validateForm({ update: false });


### PR DESCRIPTION
Motivations:

 - We currently have a fixed set of demographics associated with a user profile.
 - We would like to be able to set these demographics for arbitrary categories.

Actions:

 - Add user settings section for user demographics.
 - Migrate the demographics data out of user_profile into new demographics tables.
 - Modify user profile to use new demographics tables.
 - Modify participant report generation to use new demographics tables.