### PR TITLE
1118/thinking space summary

### DIFF
--- a/adaptors/ragflow/src/agent/session.rs
+++ b/adaptors/ragflow/src/agent/session.rs
@@ -96,7 +96,7 @@ pub struct SseEvent {
     pub message_id: String,
     pub created_at: i64,
     pub task_id: String,
-    pub session_id: String,
+    pub session_id: Option<String>,
     pub data: SseData,
 }
 
@@ -108,6 +108,8 @@ pub struct SseData {
     pub outputs: Option<SseOutputs>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub component_type: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Default, Debug)]

--- a/api/src/bot_service/ragflow_bot.rs
+++ b/api/src/bot_service/ragflow_bot.rs
@@ -822,7 +822,20 @@ pub async fn parse_sse_stream(
         ComhairleError::CorruptedData("Invalid UTF-8 in bot service response".to_string())
     })?;
 
-    Ok(parse_sse_str(&raw_str))
+    let chunks = parse_sse_str(&raw_str);
+
+    if let Some(error) = chunks
+        .iter()
+        .find(|chunk| chunk.data.error.is_some())
+        .map(|chunk| chunk.data.error.as_ref())
+        .and_then(|error| error)
+    {
+        return Err(ComhairleError::StreamChunkError(format!(
+            "Chunk contains ragflow '**ERROR**:' message: {error}"
+        )));
+    }
+
+    Ok(chunks)
 }
 
 pub fn parse_sse_str(sse_str: &str) -> Vec<SseEvent> {
@@ -1359,6 +1372,26 @@ mod tests {
         Ok(())
     }
 
+    #[tokio::test]
+    async fn error_chunks_caught_during_parsing() -> Result<(), Box<dyn Error>> {
+        let chunks = stream::iter(vec![
+            Ok(sse_stream_chunk_ext("Some safe text")),
+            Ok(sse_stream_chunk_ext("Some safe text")),
+            Ok(sse_stream_error_chunk_ext("**ERROR**: (Some bad text)")),
+            Ok(sse_stream_chunk_ext("Some safe text")),
+        ]);
+        let boxed: Pin<Box<dyn Stream<Item = _> + Send>> = Box::pin(chunks);
+
+        let result = parse_sse_stream(boxed).await.unwrap_err();
+
+        assert!(
+            matches!(result, ComhairleError::StreamChunkError(_)),
+            "incorrect error type"
+        );
+
+        Ok(())
+    }
+
     fn msg(role: &str, id: &str, ref_ids: Option<Vec<&str>>) -> ComhairleSessionMessage {
         ComhairleSessionMessage {
             id: id.to_string(),
@@ -1422,6 +1455,22 @@ mod tests {
 
     fn sse_stream_chunk(answer: &str) -> Bytes {
         Bytes::from(format!(r#"data:{{"data": {{"answer": "{answer}"}}}}"#))
+    }
+
+    fn sse_stream_chunk_ext(content: &str) -> Bytes {
+        Bytes::from(
+            format!(
+                r#"data:{{"event":"1","message_id":"1","created_at":918273912,"task_id":"askdjha","session_id":"aksjdha","data": {{"content": "{content}"}}}}"#
+            ) + "\n\n",
+        )
+    }
+
+    fn sse_stream_error_chunk_ext(error: &str) -> Bytes {
+        Bytes::from(
+            format!(
+                r#"data:{{"event":"1","message_id":"1","created_at":918273912,"task_id":"askdjha","session_id":"aksjdha","data": {{"error": "{error}"}}}}"#
+            ) + "\n\n",
+        )
     }
 
     #[test]

--- a/api/src/tools/thinking_space.rs
+++ b/api/src/tools/thinking_space.rs
@@ -625,6 +625,11 @@ impl From<ThinkingSpaceAnswer> for ThinkingSpaceSummaryQa {
     }
 }
 
+#[derive(Deserialize)]
+struct ThinkingSpaceContentSummary {
+    summary: String,
+}
+
 #[instrument(err(Debug), skip(state))]
 async fn generate_thinking_space_summary(
     State(state): State<Arc<ComhairleState>>,
@@ -698,15 +703,19 @@ async fn generate_thinking_space_summary(
             ComhairleError::CorruptedData("Missing summary from bot service agent".to_string())
         })?;
 
-    let summary_content = final_event
-        .clone()
+    let summary_event = final_event
         .content
-        .ok_or(ComhairleError::CorruptedData(
-            "Missing summary from bot service agent".to_string(),
-        ))?;
+        .as_deref()
+        .ok_or_else(|| {
+            ComhairleError::CorruptedData("Missing summary from bot service agent".to_string())
+        })
+        .and_then(|content| {
+            serde_json::from_str::<ThinkingSpaceContentSummary>(content)
+                .map_err(|e| ComhairleError::CorruptedData(format!("Invalid summary payload: {e}")))
+        })?;
 
     let create_summary = CreateSummary {
-        summary: summary_content,
+        summary: summary_event.summary,
         is_ai_generated: Some(true),
     };
     let summary = thinking_space_summary::create(


### PR DESCRIPTION
Motivation:

- catch errors in summary agent streams
- parse summary as structured data due to model change

Actions:

- check for error events when parsing and collecting sse chunks in summary agent
- deserialize summary into structured json with `summary` field instead of simple text