### PR TITLE
Change string demographics to multiple choice

### DIFF
--- a/api/migrations/20260908120000_demographics_multiple_choice.sql
+++ b/api/migrations/20260908120000_demographics_multiple_choice.sql
@@ -1,0 +1,34 @@
+-- Derive multiple-choice options for existing data
+WITH bucket_value_options AS (
+    SELECT
+        dq.slug,
+        jsonb_build_object('value', v, 'label', bucket ->> 'label') AS option
+    FROM demographics_question dq,
+        jsonb_array_elements(dq.bucket_config -> 'buckets') AS bucket,
+        jsonb_array_elements_text(COALESCE(bucket -> 'values', '[]'::jsonb)) AS v
+    WHERE dq.response_type::text = 'string'
+      AND dq.bucket_config ->> 'type' = 'text'
+),
+bucket_options AS (
+    SELECT slug, jsonb_agg(DISTINCT option) AS options
+    FROM bucket_value_options
+    GROUP BY slug
+),
+value_options AS (
+    SELECT
+        dq.slug,
+        jsonb_agg(DISTINCT jsonb_build_object('value', dr.value, 'label', dr.value)) AS options
+    FROM demographics_question dq
+    JOIN demographics_response dr ON dr.question_slug = dq.slug
+    WHERE dq.response_type::text = 'string'
+    GROUP BY dq.slug
+)
+UPDATE demographics_question dq
+SET bucket_config = jsonb_build_object(
+    'type', 'string',
+    'options', COALESCE(bo.options, vo.options, '[]'::jsonb)
+)
+FROM (SELECT slug FROM demographics_question WHERE response_type::text = 'string') s
+LEFT JOIN bucket_options bo ON bo.slug = s.slug
+LEFT JOIN value_options vo ON vo.slug = s.slug
+WHERE dq.slug = s.slug;

--- a/api/src/models/demographics.rs
+++ b/api/src/models/demographics.rs
@@ -3,8 +3,8 @@
 // (
 //    slug TEXT PK,                               - Unique identifier for the demographics question
 //    display_name TEXT NOT NULL,                 - Human-readable name for the demographics question
-//    response_type 'string' | 'number' NOT NULL, - The type of response expected for the demographics question
-//    bucket_config JSONB                         - Configuration for how responses should be bucketed (e.g., age ranges)
+//    response_type 'number' | 'string' NOT NULL, - The type of response expected for the demographics question
+//    bucket_config JSONB                         - For 'number': bucket ranges (e.g. age ranges). For 'string': the configurable set of selectable options.
 // )
 // 2. `demographics_response`                     - Represents a user's response to a demographics question
 // (
@@ -30,6 +30,7 @@ use tracing::instrument;
 use uuid::Uuid;
 
 use crate::error::ComhairleError;
+use crate::models::SqlxResultExt;
 use crate::models::pagination::{PageOptions, PaginatedResults};
 
 // ============================================================================
@@ -97,13 +98,13 @@ impl ConversationDemographicsFilterOptions {
     }
 }
 
-/// Represents demographics question response type (either 'string' or 'number').
+/// Represents demographics question response type (either 'number' or 'string').
 #[derive(Serialize, Deserialize, Debug, Clone, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 #[cfg_attr(test, derive(PartialEq))]
 pub enum DemographicsQuestionResponseType {
-    String,
     Number,
+    String,
 }
 
 impl Into<SimpleExpr> for DemographicsQuestionResponseType {
@@ -115,8 +116,8 @@ impl Into<SimpleExpr> for DemographicsQuestionResponseType {
 impl AsRef<str> for DemographicsQuestionResponseType {
     fn as_ref(&self) -> &str {
         match self {
-            Self::String => "string",
             Self::Number => "number",
+            Self::String => "string",
         }
     }
 }
@@ -127,8 +128,8 @@ impl Decode<'_, Postgres> for DemographicsQuestionResponseType {
     ) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
         let s = row.as_str()?;
         match s {
-            "string" => return Ok(DemographicsQuestionResponseType::String),
             "number" => return Ok(DemographicsQuestionResponseType::Number),
+            "string" => return Ok(DemographicsQuestionResponseType::String),
             _ => {
                 return Err(Box::new(std::io::Error::new(
                     std::io::ErrorKind::InvalidData,
@@ -153,10 +154,11 @@ pub struct NumericBucket {
     pub label: String,
 }
 
+/// A single selectable answer for a 'string' demographics question.
 #[derive(Debug, Deserialize, Serialize, Clone, JsonSchema)]
 #[cfg_attr(test, derive(PartialEq))]
-pub struct TextBucket {
-    pub values: Option<Vec<String>>,
+pub struct StringOption {
+    pub value: String,
     pub label: String,
 }
 
@@ -165,7 +167,18 @@ pub struct TextBucket {
 #[serde(tag = "type", rename_all = "camelCase")]
 pub enum ValueBuckets {
     Numeric { buckets: Vec<NumericBucket> },
-    Text { buckets: Vec<TextBucket> },
+    String { options: Vec<StringOption> },
+}
+
+impl ValueBuckets {
+    pub fn accepts_value(&self, value: &str) -> bool {
+        match self {
+            ValueBuckets::Numeric { .. } => value.parse::<i64>().is_ok(),
+            ValueBuckets::String { options } => {
+                options.is_empty() || options.iter().any(|option| option.value == value)
+            }
+        }
+    }
 }
 
 /// Safely maps a raw value into a defined category bucket label based on the provided bucket configuration.
@@ -184,15 +197,13 @@ pub fn resolve_category_bucket(value: &str, buckets: &ValueBuckets) -> String {
                 }
             }
         }
-        ValueBuckets::Text {
-            buckets: text_buckets,
-        } => {
-            for bucket in text_buckets {
-                if let Some(values) = &bucket.values {
-                    if values.contains(&value.to_string()) {
-                        return bucket.label.clone();
-                    }
-                }
+        ValueBuckets::String { options } => {
+            // No options configured yet: report the raw value rather than hiding it.
+            if options.is_empty() {
+                return value.to_string();
+            }
+            if let Some(option) = options.iter().find(|option| option.value == value) {
+                return option.label.clone();
             }
         }
     }
@@ -210,7 +221,7 @@ pub struct DemographicsQuestion {
     pub slug: String,
     pub display_name: String,
     pub response_type: DemographicsQuestionResponseType,
-    #[schemars(with = "Option<Vec<ValueBuckets>>")]
+    #[schemars(with = "Option<ValueBuckets>")]
     pub bucket_config: Option<sqlx::types::Json<ValueBuckets>>,
 }
 
@@ -227,7 +238,7 @@ pub struct CreateDemographicsQuestion {
     pub slug: String,
     pub display_name: String,
     pub response_type: DemographicsQuestionResponseType,
-    #[schemars(with = "Option<Vec<ValueBuckets>>")]
+    #[schemars(with = "Option<ValueBuckets>")]
     pub bucket_config: Option<sqlx::types::Json<ValueBuckets>>,
 }
 
@@ -260,9 +271,10 @@ impl PartialDemographicsQuestion {
         }
 
         if let Some(bucket_config) = self.bucket_config {
-            let json_expr = bucket_config
-                .map(|json| serde_json::to_value(json.0).unwrap())
-                .into();
+            let json_expr: SimpleExpr = match bucket_config {
+                Some(json) => Expr::val(serde_json::to_value(json.0).unwrap()).into(),
+                None => sea_query::Keyword::Null.into(),
+            };
 
             values.push((DemographicsQuestionIden::BucketConfig, json_expr));
         }
@@ -301,8 +313,18 @@ impl DemographicsQuestionsFilterOptions {
     }
 }
 
+/// A demographics response value is always a JSON number or string on the wire, never
+/// stored/parsed as arbitrary JSON. Schema-only type: response bodies still serialize
+/// `value` as a plain `String` internally.
+#[derive(Serialize, Deserialize, JsonSchema)]
+#[serde(untagged)]
+pub enum TypedValue {
+    Number(i64),
+    Text(String),
+}
+
 /// Represents a demographics response from a user to a specific demographics question.
-#[derive(Serialize, Deserialize, Partial, Debug, FromRow, Clone, JsonSchema)]
+#[derive(Deserialize, Partial, Debug, FromRow, Clone, JsonSchema)]
 #[enum_def(table_name = "demographics_response")]
 #[partially(derive(Serialize, Deserialize, Debug, JsonSchema, Default))]
 #[serde(rename_all = "camelCase")]
@@ -314,7 +336,38 @@ pub struct DemographicsResponse {
     pub question_slug: String,
     #[partially(omit)]
     pub user_id: Option<Uuid>,
+    #[schemars(with = "TypedValue")]
     pub value: String,
+}
+
+impl Serialize for DemographicsResponse {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::SerializeStruct;
+
+        let mut state = serializer.serialize_struct("DemographicsResponse", 4)?;
+        state.serialize_field("id", &self.id)?;
+        state.serialize_field("questionSlug", &self.question_slug)?;
+        state.serialize_field("userId", &self.user_id)?;
+        match self.value.parse::<i64>() {
+            Ok(number) => state.serialize_field("value", &number)?,
+            Err(_) => state.serialize_field("value", &self.value)?,
+        }
+        state.end()
+    }
+}
+
+/// Accepts either a JSON number or JSON string for a response value and stores it as text.
+fn deserialize_typed_value<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Ok(match TypedValue::deserialize(deserializer)? {
+        TypedValue::Number(number) => number.to_string(),
+        TypedValue::Text(text) => text,
+    })
 }
 
 const DEMOGRAPHICS_RESPONSE_COLUMNS: [DemographicsResponseIden; 4] = [
@@ -329,6 +382,8 @@ const DEMOGRAPHICS_RESPONSE_COLUMNS: [DemographicsResponseIden; 4] = [
 pub struct CreateDemographicsResponse {
     pub question_slug: String,
     pub user_id: Uuid,
+    #[serde(deserialize_with = "deserialize_typed_value")]
+    #[schemars(with = "TypedValue")]
     pub value: String,
 }
 
@@ -416,6 +471,7 @@ pub async fn get_conversation_demographics(
 ) -> Result<PaginatedResults<ConversationDemographics>, ComhairleError> {
     let mut query = sea_query::Query::select()
         .columns(CONVERSATION_DEMOGRAPHICS_COLUMNS)
+        .from(ConversationDemographicsIden::Table)
         .to_owned();
 
     query = filters.apply(query);
@@ -441,8 +497,7 @@ pub async fn create_conversation_demographics(
 
     let created = sqlx::query_as_with::<_, ConversationDemographics, _>(&sql, values)
         .fetch_one(db)
-        .await
-        .map_err(|e| ComhairleError::DatabaseError(e))?;
+        .await?;
 
     Ok(created)
 }
@@ -464,7 +519,7 @@ pub async fn delete_conversation_demographics(
     let deleted = sqlx::query_as_with::<_, ConversationDemographics, _>(&sql, values)
         .fetch_optional(db)
         .await
-        .map_err(|e| ComhairleError::DatabaseError(e))?;
+        .resolve_db_err("conversation_demographics")?;
 
     Ok(deleted)
 }
@@ -472,6 +527,26 @@ pub async fn delete_conversation_demographics(
 // ============================================================================
 // Demographics questions - CRUD
 // ============================================================================
+
+/// Get a single demographics question by its slug.
+#[instrument(err(Debug), skip(db))]
+pub async fn get_demographics_question_by_slug(
+    db: &PgPool,
+    slug: &str,
+) -> Result<DemographicsQuestion, ComhairleError> {
+    let (sql, values) = sea_query::Query::select()
+        .columns(DEMOGRAPHICS_QUESTION_COLUMNS)
+        .from(DemographicsQuestionIden::Table)
+        .and_where(Expr::col(DemographicsQuestionIden::Slug).eq(slug))
+        .build_sqlx(PostgresQueryBuilder);
+
+    let question = sqlx::query_as_with::<_, DemographicsQuestion, _>(&sql, values)
+        .fetch_one(db)
+        .await
+        .resolve_db_err("demographics_question")?;
+
+    Ok(question)
+}
 
 /// Get a demographics questions with optional filters.
 #[instrument(err(Debug), skip(db))]
@@ -509,7 +584,7 @@ pub async fn create_demographics_question(
     let question = sqlx::query_as_with::<_, DemographicsQuestion, _>(&sql, values)
         .fetch_one(db)
         .await
-        .map_err(|e| ComhairleError::DatabaseError(e))?;
+        .resolve_db_err("demographics_question")?;
 
     Ok(question)
 }
@@ -521,9 +596,15 @@ pub async fn update_demographics_question(
     slug: String,
     updated_demographics_question: PartialDemographicsQuestion,
 ) -> Result<DemographicsQuestion, ComhairleError> {
+    let update_values = updated_demographics_question.to_values();
+
+    if update_values.is_empty() {
+        return get_demographics_question_by_slug(db, &slug).await;
+    }
+
     let (sql, values) = sea_query::Query::update()
         .table(DemographicsQuestionIden::Table)
-        .values(updated_demographics_question.to_values())
+        .values(update_values)
         .and_where(Expr::col(DemographicsQuestionIden::Slug).eq(slug))
         .returning(sea_query::Query::returning().columns(DEMOGRAPHICS_QUESTION_COLUMNS))
         .build_sqlx(PostgresQueryBuilder);
@@ -531,7 +612,7 @@ pub async fn update_demographics_question(
     let question = sqlx::query_as_with::<_, DemographicsQuestion, _>(&sql, values)
         .fetch_one(db)
         .await
-        .map_err(|e| ComhairleError::DatabaseError(e))?;
+        .resolve_db_err("demographics_question")?;
 
     Ok(question)
 }
@@ -551,7 +632,7 @@ pub async fn delete_demographics_question(
     let deleted_question = sqlx::query_as_with::<_, DemographicsQuestion, _>(&sql, values)
         .fetch_optional(db)
         .await
-        .map_err(|e| ComhairleError::DatabaseError(e))?;
+        .resolve_db_err("demographics_question")?;
 
     Ok(deleted_question)
 }
@@ -586,12 +667,37 @@ pub async fn get_demographics_responses(
     Ok(responses)
 }
 
+async fn validate_response_value(
+    db: &PgPool,
+    question_slug: &str,
+    value: &str,
+) -> Result<(), ComhairleError> {
+    let question = get_demographics_question_by_slug(db, question_slug).await?;
+
+    if let Some(bucket_config) = &question.bucket_config {
+        if !bucket_config.0.accepts_value(value) {
+            return Err(ComhairleError::BadRequest(format!(
+                "'{value}' is not a valid answer for question '{question_slug}'"
+            )));
+        }
+    }
+
+    Ok(())
+}
+
 /// Add a new response for a specific demographics question and user.
 #[instrument(err(Debug), skip(db))]
 pub async fn create_demographics_response(
     db: &PgPool,
     new_demographics_response: CreateDemographicsResponse,
 ) -> Result<DemographicsResponse, ComhairleError> {
+    validate_response_value(
+        db,
+        &new_demographics_response.question_slug,
+        &new_demographics_response.value,
+    )
+    .await?;
+
     let (sql, values) = sea_query::Query::insert()
         .into_table(DemographicsResponseIden::Table)
         .columns(DEMOGRAPHICS_RESPONSE_COLUMNS)
@@ -602,7 +708,7 @@ pub async fn create_demographics_response(
     let response = sqlx::query_as_with::<_, DemographicsResponse, _>(&sql, values)
         .fetch_one(db)
         .await
-        .map_err(|e| ComhairleError::DatabaseError(e))?;
+        .resolve_db_err("demographics_response")?;
 
     Ok(response)
 }
@@ -615,9 +721,31 @@ pub async fn update_demographics_response(
     user_id: Uuid,
     updated_demographics_response: PartialDemographicsResponse,
 ) -> Result<DemographicsResponse, ComhairleError> {
+    if let Some(value) = &updated_demographics_response.value {
+        validate_response_value(db, &question_slug, value).await?;
+    }
+
+    let update_values = updated_demographics_response.to_values();
+
+    if update_values.is_empty() {
+        let (sql, query_values) = sea_query::Query::select()
+            .columns(DEMOGRAPHICS_RESPONSE_COLUMNS)
+            .from(DemographicsResponseIden::Table)
+            .and_where(Expr::col(DemographicsResponseIden::QuestionSlug).eq(question_slug))
+            .and_where(Expr::col(DemographicsResponseIden::UserId).eq(user_id))
+            .build_sqlx(PostgresQueryBuilder);
+
+        let response = sqlx::query_as_with::<_, DemographicsResponse, _>(&sql, query_values)
+            .fetch_one(db)
+            .await
+            .resolve_db_err("demographics_response")?;
+
+        return Ok(response);
+    }
+
     let (sql, values) = sea_query::Query::update()
         .table(DemographicsResponseIden::Table)
-        .values(updated_demographics_response.to_values())
+        .values(update_values)
         .and_where(Expr::col(DemographicsResponseIden::QuestionSlug).eq(question_slug))
         .and_where(Expr::col(DemographicsResponseIden::UserId).eq(user_id))
         .returning(sea_query::Query::returning().columns(DEMOGRAPHICS_RESPONSE_COLUMNS))
@@ -626,7 +754,7 @@ pub async fn update_demographics_response(
     let response = sqlx::query_as_with::<_, DemographicsResponse, _>(&sql, values)
         .fetch_one(db)
         .await
-        .map_err(|e| ComhairleError::DatabaseError(e))?;
+        .resolve_db_err("demographics_response")?;
 
     Ok(response)
 }
@@ -648,7 +776,7 @@ pub async fn delete_demographics_response(
     let deleted = sqlx::query_as_with::<_, DemographicsResponse, _>(&sql, values)
         .fetch_optional(db)
         .await
-        .map_err(|e| ComhairleError::DatabaseError(e))?;
+        .resolve_db_err("demographics_response")?;
 
     Ok(deleted)
 }
@@ -695,11 +823,17 @@ mod tests {
         assert_eq!(response.total, 1, "Question should exist after creation");
         assert_eq!(vec![question], response.records);
 
-        // Update the demographics question and ensure the changes are reflected
+        // Update the demographics question with bucket_config and ensure the changes are reflected
+        let string_options = ValueBuckets::String {
+            options: vec![StringOption {
+                value: "opt1".to_string(),
+                label: "Option 1".to_string(),
+            }],
+        };
         let update = PartialDemographicsQuestion {
             display_name: Some("Updated Display Name".to_string()),
             response_type: Some(DemographicsQuestionResponseType::String),
-            bucket_config: None,
+            bucket_config: Some(Some(sqlx::types::Json(string_options))),
         };
         let updated_question = update_demographics_question(&db, slug.clone(), update).await?;
         assert_eq!(
@@ -712,11 +846,28 @@ mod tests {
             "Updated Display Name".to_string(),
             "Question display name should be updated correctly"
         );
+        assert!(
+            updated_question.bucket_config.is_some(),
+            "Bucket config should be set"
+        );
+
+        // Update with bucket_config: Some(None) to clear all options (set bucket_config to NULL)
+        let clear_update = PartialDemographicsQuestion {
+            display_name: None,
+            response_type: None,
+            bucket_config: Some(None),
+        };
+        let cleared_question =
+            update_demographics_question(&db, slug.clone(), clear_update).await?;
+        assert!(
+            cleared_question.bucket_config.is_none(),
+            "Bucket config should be cleared to NULL"
+        );
 
         // Delete the demographics question and ensure it is removed successfully
         let response = delete_demographics_question(&db, slug.clone()).await?;
         assert_eq!(
-            Some(updated_question),
+            Some(cleared_question),
             response,
             "Question should be deleted successfully"
         );

--- a/api/src/routes/demographics.rs
+++ b/api/src/routes/demographics.rs
@@ -10,6 +10,7 @@ use uuid::Uuid;
 
 use crate::ComhairleState;
 use crate::error::ComhairleError;
+use crate::models::conversation;
 use crate::models::demographics::{
     self, ConversationDemographics, ConversationDemographicsFilterOptions,
     CreateConversationDemographics, CreateDemographicsQuestion, CreateDemographicsResponse,
@@ -17,18 +18,70 @@ use crate::models::demographics::{
     DemographicsResponsesFilterOptions, PartialDemographicsQuestion, PartialDemographicsResponse,
 };
 use crate::models::pagination::{PageOptions, PaginatedResults};
+use crate::models::permissions::{Action, can_perform_resource_action};
+use crate::models::users::User;
+use crate::routes::auth::{OptionalUser, RequiredAdminUser, RequiredUser, is_user_admin};
+
+/// Whether `user` is allowed to view `conversation_id`: admins, the owner, anyone
+/// with `ConversationRead`, or anyone at all once the conversation is live.
+async fn can_view_conversation(
+    state: &Arc<ComhairleState>,
+    user: Option<&User>,
+    conversation_id: Uuid,
+) -> Result<bool, ComhairleError> {
+    let conversation = conversation::get_by_id(&state.db, &conversation_id).await?;
+
+    if conversation.is_live {
+        return Ok(true);
+    }
+
+    let Some(user) = user else {
+        return Ok(false);
+    };
+
+    if user.id == conversation.owner_id {
+        return Ok(true);
+    }
+
+    can_perform_resource_action(
+        state,
+        &conversation.id,
+        Action::ConversationRead,
+        &user.id,
+        user.organization_id.as_ref(),
+        Some(&conversation.owner_id),
+    )
+    .await
+}
 
 // ============================================================================
 // Conversation-demographics associations - CR.D
 // ============================================================================
 
 /// Get all associations between conversations and demographics questions, with optional filters for conversation ID and question slug.
+/// A `conversation_id` filter is required for non-admins.
 #[instrument(err(Debug), skip(state))]
 pub async fn get_conversation_demographics(
     State(state): State<Arc<ComhairleState>>,
+    OptionalUser(user): OptionalUser,
     Query(filters): Query<ConversationDemographicsFilterOptions>,
     Query(page_options): Query<PageOptions>,
 ) -> Result<(StatusCode, Json<PaginatedResults<ConversationDemographics>>), ComhairleError> {
+    let is_admin = match &user {
+        Some(user) => is_user_admin(&state, user).await,
+        None => false,
+    };
+
+    if !is_admin {
+        let conversation_id = filters
+            .conversation_id
+            .ok_or(ComhairleError::UserNotAuthorized)?;
+
+        if !can_view_conversation(&state, user.as_ref(), conversation_id).await? {
+            return Err(ComhairleError::UserNotAuthorized);
+        }
+    }
+
     demographics::get_conversation_demographics(&state.db, filters, page_options)
         .await
         .map(|results| (StatusCode::OK, Json(results)))
@@ -38,6 +91,7 @@ pub async fn get_conversation_demographics(
 #[instrument(err(Debug), skip(state))]
 pub async fn create_conversation_demographics(
     State(state): State<Arc<ComhairleState>>,
+    RequiredAdminUser(_user): RequiredAdminUser,
     Json(payload): Json<CreateConversationDemographics>,
 ) -> Result<(StatusCode, Json<ConversationDemographics>), ComhairleError> {
     demographics::create_conversation_demographics(&state.db, payload)
@@ -49,7 +103,8 @@ pub async fn create_conversation_demographics(
 #[instrument(err(Debug), skip(state))]
 pub async fn delete_conversation_demographics(
     State(state): State<Arc<ComhairleState>>,
-    Json((conversation_id, question_slug)): Json<(Uuid, String)>,
+    RequiredAdminUser(_user): RequiredAdminUser,
+    Path((conversation_id, question_slug)): Path<(Uuid, String)>,
 ) -> Result<(StatusCode, Json<Option<ConversationDemographics>>), ComhairleError> {
     demographics::delete_conversation_demographics(&state.db, conversation_id, question_slug)
         .await
@@ -72,10 +127,11 @@ pub async fn get_demographics_questions(
         .map(|result| (StatusCode::OK, Json(result)))
 }
 
-/// Create a new demographics question.
+/// Create a new demographics question. Admin-only.
 #[instrument(err(Debug), skip(state))]
 pub async fn create_demographics_question(
     State(state): State<Arc<ComhairleState>>,
+    RequiredAdminUser(_user): RequiredAdminUser,
     Json(payload): Json<CreateDemographicsQuestion>,
 ) -> Result<(StatusCode, Json<DemographicsQuestion>), ComhairleError> {
     demographics::create_demographics_question(&state.db, payload)
@@ -83,10 +139,11 @@ pub async fn create_demographics_question(
         .map(|result| (StatusCode::CREATED, Json(result)))
 }
 
-/// Update a demographics question.
+/// Update a demographics question. Admin-only.
 #[instrument(err(Debug), skip(state))]
 pub async fn update_demographics_question(
     State(state): State<Arc<ComhairleState>>,
+    RequiredAdminUser(_user): RequiredAdminUser,
     Path(question_slug): Path<String>,
     Json(payload): Json<PartialDemographicsQuestion>,
 ) -> Result<(StatusCode, Json<DemographicsQuestion>), ComhairleError> {
@@ -95,10 +152,11 @@ pub async fn update_demographics_question(
         .map(|result| (StatusCode::OK, Json(result)))
 }
 
-/// Delete a demographics question.
+/// Delete a demographics question. Admin-only.
 #[instrument(err(Debug), skip(state))]
 pub async fn delete_demographics_question(
     State(state): State<Arc<ComhairleState>>,
+    RequiredAdminUser(_user): RequiredAdminUser,
     Path(question_slug): Path<String>,
 ) -> Result<(StatusCode, Json<Option<DemographicsQuestion>>), ComhairleError> {
     demographics::delete_demographics_question(&state.db, question_slug)
@@ -111,12 +169,23 @@ pub async fn delete_demographics_question(
 // ============================================================================
 
 /// Get all responses for a specific demographics question.
+///
+/// Non-admins get their `user_id` filter forced to themselves and cannot query
+/// for other users.
 #[instrument(err(Debug), skip(state))]
 pub async fn get_demographics_responses(
     State(state): State<Arc<ComhairleState>>,
-    Query(filters): Query<DemographicsResponsesFilterOptions>,
+    RequiredUser(user): RequiredUser,
+    Query(mut filters): Query<DemographicsResponsesFilterOptions>,
     Query(page_options): Query<PageOptions>,
 ) -> Result<(StatusCode, Json<PaginatedResults<DemographicsResponse>>), ComhairleError> {
+    if !is_user_admin(&state, &user).await {
+        if filters.user_id.is_some_and(|user_id| user_id != user.id) {
+            return Err(ComhairleError::UserNotAuthorized);
+        }
+        filters.user_id = Some(user.id);
+    }
+
     demographics::get_demographics_responses(&state.db, filters, page_options)
         .await
         .map(|result| (StatusCode::OK, Json(result)))
@@ -126,8 +195,13 @@ pub async fn get_demographics_responses(
 #[instrument(err(Debug), skip(state))]
 pub async fn create_demographics_response(
     State(state): State<Arc<ComhairleState>>,
+    RequiredUser(user): RequiredUser,
     Json(payload): Json<CreateDemographicsResponse>,
 ) -> Result<(StatusCode, Json<DemographicsResponse>), ComhairleError> {
+    if payload.user_id != user.id && !is_user_admin(&state, &user).await {
+        return Err(ComhairleError::UserNotAuthorized);
+    }
+
     demographics::create_demographics_response(&state.db, payload)
         .await
         .map(|result| (StatusCode::CREATED, Json(result)))
@@ -137,9 +211,14 @@ pub async fn create_demographics_response(
 #[instrument(err(Debug), skip(state))]
 pub async fn update_demographics_response(
     State(state): State<Arc<ComhairleState>>,
+    RequiredUser(user): RequiredUser,
     Path((question_slug, user_id)): Path<(String, Uuid)>,
     Json(payload): Json<PartialDemographicsResponse>,
 ) -> Result<(StatusCode, Json<DemographicsResponse>), ComhairleError> {
+    if user_id != user.id && !is_user_admin(&state, &user).await {
+        return Err(ComhairleError::UserNotAuthorized);
+    }
+
     demographics::update_demographics_response(&state.db, question_slug, user_id, payload)
         .await
         .map(|result| (StatusCode::OK, Json(result)))
@@ -149,8 +228,13 @@ pub async fn update_demographics_response(
 #[instrument(err(Debug), skip(state))]
 pub async fn delete_demographics_response(
     State(state): State<Arc<ComhairleState>>,
+    RequiredUser(user): RequiredUser,
     Path((question_slug, user_id)): Path<(String, Uuid)>,
 ) -> Result<(StatusCode, Json<Option<DemographicsResponse>>), ComhairleError> {
+    if user_id != user.id && !is_user_admin(&state, &user).await {
+        return Err(ComhairleError::UserNotAuthorized);
+    }
+
     demographics::delete_demographics_response(&state.db, question_slug, user_id)
         .await
         .map(|result| (StatusCode::OK, Json(result)))
@@ -187,7 +271,7 @@ pub fn router(state: Arc<ComhairleState>) -> ApiRouter {
                     .summary("Delete conversation demographics by question")
                     .description("Delete demographics responses for a specific conversation and question")
                     .security_requirement("JWT")
-                    .response::<200, Json<PaginatedResults<ConversationDemographics>>>()
+                    .response::<200, Json<Option<ConversationDemographics>>>()
             }))
             .with_state(state.clone())
     )

--- a/ui/packages/api-client/src/api.ts
+++ b/ui/packages/api-client/src/api.ts
@@ -3071,29 +3071,26 @@ export const NumericBucket = z
   })
   .passthrough();
 export type NumericBucket = z.infer<typeof NumericBucket>;
-export const TextBucket = z
-  .object({
-    label: z.string(),
-    values: z.union([z.array(z.string()), z.null()]).optional(),
-  })
+export const StringOption = z
+  .object({ label: z.string(), value: z.string() })
   .passthrough();
-export type TextBucket = z.infer<typeof TextBucket>;
+export type StringOption = z.infer<typeof StringOption>;
 export const ValueBuckets = z.union([
   z
     .object({ buckets: z.array(NumericBucket), type: z.literal("numeric") })
     .passthrough(),
   z
-    .object({ buckets: z.array(TextBucket), type: z.literal("text") })
+    .object({ options: z.array(StringOption), type: z.literal("string") })
     .passthrough(),
 ]);
 export type ValueBuckets = z.infer<typeof ValueBuckets>;
-export const DemographicsQuestionResponseType = z.enum(["string", "number"]);
+export const DemographicsQuestionResponseType = z.enum(["number", "string"]);
 export type DemographicsQuestionResponseType = z.infer<
   typeof DemographicsQuestionResponseType
 >;
 export const DemographicsQuestion = z
   .object({
-    bucketConfig: z.union([z.array(ValueBuckets), z.null()]).optional(),
+    bucketConfig: z.union([ValueBuckets, z.null()]).optional(),
     displayName: z.string(),
     responseType: DemographicsQuestionResponseType,
     slug: z.string(),
@@ -3108,7 +3105,7 @@ export type PaginatedResults_for_DemographicsQuestion = z.infer<
 >;
 export const CreateDemographicsQuestion = z
   .object({
-    bucketConfig: z.union([z.array(ValueBuckets), z.null()]).optional(),
+    bucketConfig: z.union([ValueBuckets, z.null()]).optional(),
     displayName: z.string(),
     responseType: DemographicsQuestionResponseType,
     slug: z.string(),
@@ -3119,7 +3116,7 @@ export type CreateDemographicsQuestion = z.infer<
 >;
 export const PartialDemographicsQuestion = z
   .object({
-    bucketConfig: z.union([z.array(ValueBuckets), z.null()]),
+    bucketConfig: z.union([ValueBuckets, z.null()]),
     displayName: z.union([z.string(), z.null()]),
     responseType: z.union([DemographicsQuestionResponseType, z.null()]),
   })
@@ -3128,12 +3125,14 @@ export const PartialDemographicsQuestion = z
 export type PartialDemographicsQuestion = z.infer<
   typeof PartialDemographicsQuestion
 >;
+export const TypedValue = z.union([z.number(), z.string()]);
+export type TypedValue = z.infer<typeof TypedValue>;
 export const DemographicsResponse = z
   .object({
     id: z.string().uuid(),
     questionSlug: z.string(),
     userId: z.union([z.string(), z.null()]).optional(),
-    value: z.string(),
+    value: TypedValue,
   })
   .passthrough();
 export type DemographicsResponse = z.infer<typeof DemographicsResponse>;
@@ -3147,15 +3146,14 @@ export const CreateDemographicsResponse = z
   .object({
     questionSlug: z.string(),
     userId: z.string().uuid(),
-    value: z.string(),
+    value: TypedValue,
   })
   .passthrough();
 export type CreateDemographicsResponse = z.infer<
   typeof CreateDemographicsResponse
 >;
 export const PartialDemographicsResponse = z
-  .object({ value: z.union([z.string(), z.null()]) })
-  .partial()
+  .object({ value: TypedValue })
   .passthrough();
 export type PartialDemographicsResponse = z.infer<
   typeof PartialDemographicsResponse
@@ -3499,13 +3497,14 @@ export const schemas: Record<string, z.ZodType<any>> = {
   PaginatedResults_for_ConversationDemographics,
   CreateConversationDemographics,
   NumericBucket,
-  TextBucket,
+  StringOption,
   ValueBuckets,
   DemographicsQuestionResponseType,
   DemographicsQuestion,
   PaginatedResults_for_DemographicsQuestion,
   CreateDemographicsQuestion,
   PartialDemographicsQuestion,
+  TypedValue,
   DemographicsResponse,
   PaginatedResults_for_DemographicsResponse,
   CreateDemographicsResponse,
@@ -5026,14 +5025,7 @@ Use query param withUserProgress&#x3D;true to get the active user&#x27;s progres
     alias: "DeleteConversationDemographicsByQuestion",
     description: `Delete demographics responses for a specific conversation and question`,
     requestFormat: "json",
-    parameters: [
-      {
-        name: "body",
-        type: "Body",
-        schema: z.array(z.unknown()).min(2).max(2),
-      },
-    ],
-    response: PaginatedResults_for_ConversationDemographics,
+    response: z.union([ConversationDemographics, z.null()]),
   },
   {
     method: "get",

--- a/ui/packages/comhairle/src/routes/(public)/settings/UserDemographicsForm/UserDemographicsForm.svelte
+++ b/ui/packages/comhairle/src/routes/(public)/settings/UserDemographicsForm/UserDemographicsForm.svelte
@@ -4,9 +4,12 @@
 	import { Input } from '$lib/components/ui/input';
 	import { Label } from '$lib/components/ui/label';
 	import { Button } from '$lib/components/ui/button';
+	import * as Select from '$lib/components/ui/select';
 	import { apiClient } from '@crownshy/api-client/client';
 	import { notifications } from '$lib/notifications.svelte';
 	import { superForm } from 'sveltekit-superforms';
+	import { zodClient } from 'sveltekit-superforms/adapters';
+	import { z } from 'zod';
 	import { tryCatchAsync } from '$lib/utils/errorHandling';
 	import type { DemographicsQuestion, DemographicsResponse } from '@crownshy/api-client/api';
 
@@ -33,11 +36,20 @@
 		return initialData;
 	};
 
+	const buildSchema = () => {
+		const shape: Record<string, z.ZodTypeAny> = {};
+		for (const q of questions) {
+			shape[q.slug] = z.string().optional();
+		}
+		return z.object(shape);
+	};
+
 	const form = untrack(() => {
 		const initialData = buildInitialData();
+		const schema = buildSchema();
 
 		return superForm(initialData, {
-			validators: false,
+			validators: zodClient(schema),
 			taintedMessage: false,
 			validationMethod: 'onsubmit'
 		});
@@ -139,12 +151,32 @@
 						{(question as any).label || (question as any).text || question.displayName}
 					</Label>
 
-					<Input
-						id={question.slug}
-						bind:value={$formData[question.slug]}
-						placeholder={`Enter ${question.displayName.toLowerCase()}`}
-						disabled={saving}
-					/>
+					{#if question.bucketConfig?.type === 'string' && question.bucketConfig?.options?.length > 0}
+						{@const options = question.bucketConfig.options}
+						<Select.Root
+							type="single"
+							value={$formData[question.slug]}
+							onValueChange={(v) => ($formData[question.slug] = v ?? '')}
+							disabled={saving}
+						>
+							<Select.Trigger id={question.slug} class="w-full">
+								{options.find((o) => o.value === $formData[question.slug])?.label ??
+									`Select ${question.displayName.toLowerCase()}`}
+							</Select.Trigger>
+							<Select.Content>
+								{#each options as option (option.value)}
+									<Select.Item value={option.value}>{option.label}</Select.Item>
+								{/each}
+							</Select.Content>
+						</Select.Root>
+					{:else}
+						<Input
+							id={question.slug}
+							bind:value={$formData[question.slug]}
+							placeholder={`Enter ${question.displayName.toLowerCase()}`}
+							disabled={saving}
+						/>
+					{/if}
 
 					{#if $errors[question.slug]}
 						<span class="text-destructive block text-xs">{$errors[question.slug]}</span>


### PR DESCRIPTION
Motivations:

 - Most of our demographics are multiple choice, and so should not accept any invalid string. Though, we do have some fields like postal codes which should still be able to.

Actions:

 - Allow an admin to define multiple_choice options that define what response values will be accepted.