### PR TITLE
1056/learning assistant reading level

### DIFF
--- a/adaptors/ragflow/src/agent/session.rs
+++ b/adaptors/ragflow/src/agent/session.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use bytes::Bytes;
 use futures::{Stream, TryStreamExt};
 use reqwest::StatusCode;
@@ -7,7 +9,7 @@ use tracing::instrument;
 
 use crate::client::RagflowClient;
 use crate::error::Result;
-use crate::{ConvoQuestion, DeleteResources, GetQueryParams, RagflowError, SessionMessage};
+use crate::{DeleteResources, GetQueryParams, RagflowError, SessionMessage};
 
 pub async fn create(client: &RagflowClient, agent_id: &str) -> Result<(StatusCode, AgentSession)> {
     let path = format!("/agents/{agent_id}/sessions");
@@ -46,7 +48,7 @@ pub async fn list(
 pub async fn stream_agent_conversation(
     client: &RagflowClient,
     agent_id: &str,
-    body: ConvoQuestion,
+    body: AgentConvoRequest,
 ) -> Result<impl Stream<Item = Result<Bytes>> + use<>> {
     let url = format!("{}/agents/{agent_id}/completions", client.base_url);
 
@@ -116,6 +118,25 @@ pub struct SseData {
 pub struct SseOutputs {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub content: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Default, Debug)]
+pub struct AgentConvoRequest {
+    pub question: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stream: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub inputs: Option<HashMap<String, Input>>,
+}
+
+#[derive(Serialize, Deserialize, Default, Debug)]
+pub struct Input {
+    pub r#type: String,
+    pub value: String,
 }
 
 #[cfg(test)]
@@ -231,7 +252,7 @@ mod tests {
             .mount(&mock_server)
             .await;
 
-        let body = ConvoQuestion {
+        let body = AgentConvoRequest {
             question: "hello".to_string(),
             ..Default::default()
         };

--- a/adaptors/ragflow/src/chat/session.rs
+++ b/adaptors/ragflow/src/chat/session.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use bytes::Bytes;
 use futures::{Stream, TryStreamExt};
 use reqwest::StatusCode;
@@ -5,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::client::RagflowClient;
 use crate::error::Result;
-use crate::{ConvoQuestion, DeleteResources, GetQueryParams, RagflowError, SessionMessage};
+use crate::{DeleteResources, GetQueryParams, RagflowError, SessionMessage};
 
 pub async fn create(
     client: &RagflowClient,
@@ -60,7 +62,7 @@ pub async fn list(
 pub async fn stream_chat_conversation(
     client: &RagflowClient,
     chat_id: &str,
-    body: ConvoQuestion,
+    body: ChatConvoRequest,
 ) -> Result<impl Stream<Item = Result<Bytes>> + use<>> {
     let url = format!("{}/chats/{chat_id}/completions", client.base_url);
 
@@ -119,6 +121,19 @@ pub struct Reference {
 
 #[derive(Serialize, Deserialize)]
 pub struct Chunk;
+
+#[derive(Serialize, Deserialize, Default, Debug)]
+pub struct ChatConvoRequest {
+    pub question: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stream: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_id: Option<String>,
+    #[serde(flatten, skip_serializing_if = "Option::is_none")]
+    pub prompt_variables: Option<HashMap<String, String>>,
+}
 
 #[cfg(test)]
 mod tests {

--- a/adaptors/ragflow/src/lib.rs
+++ b/adaptors/ragflow/src/lib.rs
@@ -5,29 +5,8 @@ pub mod dataset;
 pub mod document;
 pub mod error;
 
-use std::collections::HashMap;
-
 pub use error::RagflowError;
 use serde::{Deserialize, Serialize};
-
-#[derive(Serialize, Deserialize, Default, Debug)]
-pub struct ConvoQuestion {
-    pub question: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub stream: Option<bool>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub session_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub user_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub inputs: Option<HashMap<String, Input>>,
-}
-
-#[derive(Serialize, Deserialize, Default, Debug)]
-pub struct Input {
-    pub r#type: String,
-    pub value: String,
-}
 
 #[derive(Serialize, Default, Debug)]
 pub struct GetQueryParams {

--- a/api/src/bot_service.rs
+++ b/api/src/bot_service.rs
@@ -311,11 +311,18 @@ pub struct ComhairlePrompt {
     pub opener: Option<String>,
     pub empty_response: Option<String>,
     pub cross_languages: Option<Vec<String>>,
+    pub variables: Option<Vec<Variable>>,
 }
 
 #[derive(Serialize, Deserialize, JsonSchema, Default, Debug, Clone, PartialEq)]
 pub struct ComhairleLlm {
     pub model_name: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, JsonSchema, Default, Clone, PartialEq)]
+pub struct Variable {
+    pub key: String,
+    pub optional: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, JsonSchema, Default, Debug, Clone)]

--- a/api/src/bot_service.rs
+++ b/api/src/bot_service.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::pin::Pin;
 
 use async_trait::async_trait;
@@ -25,17 +26,26 @@ You can ask me any question or ask me to explain something in simpler language.
 "#;
 pub const DEFAULT_CHAT_NOT_FOUND_RESPONSE: &str = "That one's outside what I can help with based on the materials I have available. If your question is about the topic, try asking in a different way. I'm happy to keep trying!";
 /// Default system prompt for conversation Q&A chatbots
-pub const DEFAULT_CHAT_PROMPT: &str = r#"You are a helpful assistant for a participatory democracy platform.
+pub const DEFAULT_CHAT_PROMPT: &str = r#"
+You are a helpful assistant for a participatory democracy platform.
 
 Your task is to answer the user's question using ONLY the information in the knowledge base below.
 
-Write your answer for a general public audience:
+The reader's exact reading age is: {target_reading_age}
+
+- Reading age 5–7: very short sentences (under 10 words), only the most common everyday words, no numbers beyond simple counting, no technical terms at all — explain any necessary concept using a simple story or comparison instead of a definition
+- Reading age 8–11: short sentences, everyday vocabulary, technical terms only when unavoidable and always explained in the same sentence
+- Reading age 12+: normal adult sentence complexity is fine; technical terms allowed with brief explanation
+
+  Do not include exact figures, units, or statistical ranges from the dataset if the reading age is under 8 — describe the general trend in words instead (e.g. "grew a lot" rather than "grew by 135%").
+
 - Use clear, simple language
 - Avoid technical terms, academic phrasing, and jargon
 - Use short sentences and plain explanations
 - Explain ideas as if speaking to an interested citizen with no prior expertise
 
 Structure your answer as follows:
+
 1. A short, direct answer (2–4 sentences)
 2. A clear explanation in bullet points or short paragraphs
 3. If helpful, include simple examples
@@ -45,6 +55,7 @@ If multiple viewpoints or pieces of information appear in the dataset, summarize
 If the question does not make clear what it refers to (for example "explain this" or "summarise this page" with no indication of which part of the material is meant), ask a short clarifying question about which part they mean instead of guessing.
 
 If ALL of the dataset content is irrelevant to the question, include this exact sentence:
+
 "The answer you are looking for is not found in the dataset!"
 
 Take prior chat history into account when answering.
@@ -384,6 +395,7 @@ pub struct UpdateChatSessionRequest {
 #[derive(Serialize, Deserialize, Debug, JsonSchema, Clone, PartialEq)]
 pub struct ChatConversationRequest {
     pub question: String,
+    pub variables: Option<HashMap<String, String>>,
 }
 
 #[derive(Serialize, Deserialize, JsonSchema, Debug, PartialEq, Clone, Default)]

--- a/api/src/bot_service/ragflow_bot.rs
+++ b/api/src/bot_service/ragflow_bot.rs
@@ -28,7 +28,7 @@ use crate::{
         ComhairlePrompt, ComhairleSessionMessage, CreateAgentRequest, CreateChatRequest,
         CreateChatSessionRequest, GetQueryParams as ApiGetQueryParams, UpdateAgentRequest,
         UpdateChatRequest, UpdateChatSessionRequest, UpdateDocumentRequest,
-        UpdateKnowledgeBaseRequest, UploadFileRequest,
+        UpdateKnowledgeBaseRequest, UploadFileRequest, Variable as ComhairleVariable,
     },
     error::ComhairleError,
 };
@@ -992,6 +992,9 @@ impl From<Prompt> for ComhairlePrompt {
             opener: input.opener,
             empty_response: input.empty_response,
             cross_languages: input.cross_languages,
+            variables: input
+                .variables
+                .map(|vars| vars.into_iter().map(Into::into).collect()),
         }
     }
 }
@@ -1003,6 +1006,10 @@ impl From<&Prompt> for ComhairlePrompt {
             opener: input.opener.clone(),
             empty_response: input.empty_response.clone(),
             cross_languages: input.cross_languages.clone(),
+            variables: input
+                .variables
+                .as_ref()
+                .map(|vars| vars.iter().map(Into::into).collect()),
         }
     }
 }
@@ -1014,7 +1021,37 @@ impl From<ComhairlePrompt> for Prompt {
             opener: input.opener,
             empty_response: input.empty_response,
             cross_languages: input.cross_languages,
+            variables: input
+                .variables
+                .map(|vars| vars.into_iter().map(Into::into).collect()),
             ..Default::default()
+        }
+    }
+}
+
+impl From<ComhairleVariable> for Variable {
+    fn from(input: ComhairleVariable) -> Self {
+        Self {
+            key: input.key,
+            optional: input.optional.unwrap_or(true),
+        }
+    }
+}
+
+impl From<Variable> for ComhairleVariable {
+    fn from(input: Variable) -> Self {
+        Self {
+            key: input.key,
+            optional: Some(input.optional),
+        }
+    }
+}
+
+impl From<&Variable> for ComhairleVariable {
+    fn from(input: &Variable) -> Self {
+        Self {
+            key: input.key.clone(),
+            optional: Some(input.optional),
         }
     }
 }

--- a/api/src/bot_service/ragflow_bot.rs
+++ b/api/src/bot_service/ragflow_bot.rs
@@ -8,8 +8,7 @@ use async_trait::async_trait;
 use axum::body::Bytes;
 use futures::stream::{self, Stream, StreamExt};
 use ragflow::{
-    ConvoQuestion, DeleteResources, GetQueryParams, Input, MessageReference, RagflowError,
-    SessionMessage,
+    DeleteResources, GetQueryParams, MessageReference, RagflowError, SessionMessage,
     agent::{session::*, *},
     chat::{session::*, *},
     client::RagflowClient,
@@ -539,7 +538,7 @@ impl ComhairleBotService for ComhairleRagBotService {
         Pin<Box<dyn Stream<Item = Result<Bytes, ComhairleError>> + Send + 'static>>,
         ComhairleError,
     > {
-        let mut body: ConvoQuestion = body.into();
+        let mut body: ChatConvoRequest = body.into();
         body.session_id = Some(session_id.to_string());
 
         let stream =
@@ -718,7 +717,7 @@ impl ComhairleBotService for ComhairleRagBotService {
         Pin<Box<dyn Stream<Item = Result<Bytes, ComhairleError>> + Send + 'static>>,
         ComhairleError,
     > {
-        let mut body: ConvoQuestion = body.into();
+        let mut body: AgentConvoRequest = body.into();
         body.session_id = session_id.map(|id| id.to_string());
 
         let stream =
@@ -1229,14 +1228,14 @@ impl From<UpdateChatSessionRequest> for UpdateChatSession {
     }
 }
 
-impl From<ChatConversationRequest> for ConvoQuestion {
+impl From<ChatConversationRequest> for ChatConvoRequest {
     fn from(input: ChatConversationRequest) -> Self {
         Self {
             question: input.question,
             session_id: None,
             user_id: None,
             stream: Some(true),
-            inputs: None,
+            prompt_variables: input.variables,
         }
     }
 }
@@ -1313,7 +1312,7 @@ impl From<&AgentSession> for ComhairleAgentSession {
     }
 }
 
-impl From<AgentConversationRequest> for ConvoQuestion {
+impl From<AgentConversationRequest> for AgentConvoRequest {
     fn from(a: AgentConversationRequest) -> Self {
         let mut inputs = HashMap::new();
         if let Some(topic) = a.topic {

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -254,6 +254,10 @@ pub async fn build_app_and_spec(state: Arc<ComhairleState>) -> (Router, OpenApi)
                     routes::chats::router(state.clone()),
                 )
                 .nest_api_service(
+                    "/{conversation_id}/chat_instructions",
+                    routes::chat_instructions::router(state.clone()),
+                )
+                .nest_api_service(
                     "/{conversation_id}/chat_sessions",
                     routes::chat_sessions::router(state.clone()),
                 )

--- a/api/src/models/chat_instructions.rs
+++ b/api/src/models/chat_instructions.rs
@@ -68,7 +68,7 @@ impl UpsertChatInstructions {
 pub async fn upsert_for_conversation(
     db: &PgPool,
     conversation_id: Uuid,
-    payload: UpsertChatInstructions,
+    payload: &UpsertChatInstructions,
 ) -> Result<ChatInstructions, ComhairleError> {
     let mut columns = payload.columns();
     let mut values = payload.values();
@@ -134,7 +134,7 @@ mod tests {
             max_length: Some(500),
         };
 
-        let instructions = upsert_for_conversation(&pool, conversation_id, payload).await?;
+        let instructions = upsert_for_conversation(&pool, conversation_id, &payload).await?;
 
         assert_eq!(
             instructions.conversation_id, conversation_id,
@@ -162,7 +162,7 @@ mod tests {
             max_length: Some(100),
         };
 
-        let new_instructions = upsert_for_conversation(&pool, conversation_id, payload).await?;
+        let new_instructions = upsert_for_conversation(&pool, conversation_id, &payload).await?;
 
         assert_eq!(
             new_instructions.conversation_id, conversation_id,
@@ -184,7 +184,8 @@ mod tests {
             max_length: Some(200),
         };
 
-        let updated_instructions = upsert_for_conversation(&pool, conversation_id, payload).await?;
+        let updated_instructions =
+            upsert_for_conversation(&pool, conversation_id, &payload).await?;
 
         assert_eq!(
             updated_instructions.conversation_id, conversation_id,
@@ -218,7 +219,7 @@ mod tests {
             max_length: Some(500),
         };
 
-        let new_instructions = upsert_for_conversation(&pool, conversation_id, payload).await?;
+        let new_instructions = upsert_for_conversation(&pool, conversation_id, &payload).await?;
 
         let fetched_instructions = get_by_conversation_id(&pool, conversation_id).await?;
 

--- a/api/src/models/chat_instructions.rs
+++ b/api/src/models/chat_instructions.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use chrono::{DateTime, Utc};
 use schemars::JsonSchema;
 use sea_query::{Expr, OnConflict, PostgresQueryBuilder, Query, SimpleExpr, enum_def};
@@ -29,6 +31,27 @@ const DEFAULT_COLUMNS: [ChatInstructionsIden; 6] = [
     ChatInstructionsIden::CreatedAt,
     ChatInstructionsIden::UpdatedAt,
 ];
+
+pub trait ChatInstructionsExt {
+    fn to_prompt_variables(&self) -> HashMap<String, String>;
+}
+
+impl ChatInstructionsExt for Option<ChatInstructions> {
+    fn to_prompt_variables(&self) -> HashMap<String, String> {
+        let mut var_map = HashMap::new();
+
+        // Extend with other fields as prompt requirements change
+        var_map.insert(
+            "target_reading_age".to_string(),
+            self.as_ref()
+                .and_then(|inst| inst.target_reading_age)
+                .unwrap_or(9)
+                .to_string(),
+        );
+
+        var_map
+    }
+}
 
 #[derive(Deserialize, Debug, JsonSchema)]
 pub struct UpsertChatInstructions {

--- a/api/src/models/conversation.rs
+++ b/api/src/models/conversation.rs
@@ -766,6 +766,7 @@ pub async fn create(
                 opener: Some(DEFAULT_CHAT_OPENER.to_string()),
                 empty_response: Some(DEFAULT_CHAT_NOT_FOUND_RESPONSE.to_string()),
                 cross_languages: None,
+                ..Default::default()
             }),
             ..Default::default()
         };

--- a/api/src/models/conversation.rs
+++ b/api/src/models/conversation.rs
@@ -9,7 +9,7 @@ use super::{
 use crate::ComhairleState;
 use crate::bot_service::{
     ComhairleBotService, ComhairlePrompt, CreateChatRequest, DEFAULT_CHAT_NOT_FOUND_RESPONSE,
-    DEFAULT_CHAT_OPENER, DEFAULT_CHAT_PROMPT,
+    DEFAULT_CHAT_OPENER, DEFAULT_CHAT_PROMPT, Variable,
 };
 use crate::config::ComhairleConfig;
 use crate::error::ComhairleError;
@@ -766,7 +766,16 @@ pub async fn create(
                 opener: Some(DEFAULT_CHAT_OPENER.to_string()),
                 empty_response: Some(DEFAULT_CHAT_NOT_FOUND_RESPONSE.to_string()),
                 cross_languages: None,
-                ..Default::default()
+                variables: Some(vec![
+                    Variable {
+                        key: "knowledge".to_string(),
+                        optional: Some(false),
+                    },
+                    Variable {
+                        key: "target_reading_age".to_string(),
+                        optional: Some(false),
+                    },
+                ]),
             }),
             ..Default::default()
         };

--- a/api/src/routes.rs
+++ b/api/src/routes.rs
@@ -1,6 +1,7 @@
 pub mod api_keys;
 pub mod audio_recordings;
 pub mod auth;
+pub mod chat_instructions;
 pub mod chat_sessions;
 pub mod chats;
 pub mod conversations;

--- a/api/src/routes/chat_instructions.rs
+++ b/api/src/routes/chat_instructions.rs
@@ -11,8 +11,14 @@ use axum::{
 use tracing::instrument;
 use uuid::Uuid;
 
-use crate::models::chat_instructions::{self, UpsertChatInstructions};
 use crate::{ComhairleError, ComhairleState};
+use crate::{
+    bot_service::{ComhairlePrompt, UpdateChatRequest, Variable},
+    models::{
+        chat_instructions::{self, UpsertChatInstructions},
+        conversation,
+    },
+};
 use dto::ChatInstructionsDto;
 
 pub mod dto;
@@ -34,8 +40,60 @@ async fn upsert_for_conversation(
     Path(conversation_id): Path<Uuid>,
     Json(payload): Json<UpsertChatInstructions>,
 ) -> Result<(StatusCode, Json<ChatInstructionsDto>), ComhairleError> {
+    let bot_service = state.required_bot_service()?;
+
+    let conversation = conversation::get_by_id(&state.db, &conversation_id).await?;
+    let chat_bot_id = conversation.chat_bot_id.ok_or_else(|| {
+        ComhairleError::CorruptedData(format!(
+            "Missing chat_bot_id on conversation {conversation_id}"
+        ))
+    })?;
+    // Retrieve chat data first as some data needs to be added to update request
+    // or it will be removed
+    let (_, chat) = bot_service.get_chat(&chat_bot_id).await?;
+
     let instructions =
-        chat_instructions::upsert_for_conversation(&state.db, conversation_id, payload).await?;
+        chat_instructions::upsert_for_conversation(&state.db, conversation_id, &payload).await?;
+
+    let mut variables = chat
+        .prompt
+        .and_then(|prompt| prompt.variables)
+        .unwrap_or(vec![Variable {
+            key: "knowledge".to_string(),
+            optional: Some(true),
+        }]);
+    let original_len = variables.len();
+
+    let payload_variables = [
+        (payload.target_reading_age.is_some(), "target_reading_age"),
+        (payload.max_length.is_some(), "max_length"),
+    ];
+
+    for (is_present, key) in payload_variables {
+        if is_present && !variables.iter().any(|var| var.key == key) {
+            variables.push(Variable {
+                key: key.to_string(),
+                optional: Some(true),
+            });
+        }
+    }
+
+    // Only update chat if variables has changed
+    if variables.len() != original_len {
+        let update_chat_payload = UpdateChatRequest {
+            // Include knowledge_base_ids or they will be stripped (Ragflow specific)
+            knowledge_base_ids: Some(chat.knowledge_base_ids),
+            prompt: Some(ComhairlePrompt {
+                variables: Some(variables),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        bot_service
+            .update_chat(&chat_bot_id, update_chat_payload)
+            .await?;
+    }
 
     Ok((StatusCode::OK, Json(instructions.into())))
 }

--- a/api/src/routes/chat_instructions.rs
+++ b/api/src/routes/chat_instructions.rs
@@ -1,0 +1,231 @@
+use std::sync::Arc;
+
+use aide::axum::{
+    ApiRouter,
+    routing::{get_with, post_with},
+};
+use axum::{
+    extract::{Json, Path, State},
+    http::StatusCode,
+};
+use tracing::instrument;
+use uuid::Uuid;
+
+use crate::models::chat_instructions::{self, UpsertChatInstructions};
+use crate::{ComhairleError, ComhairleState};
+use dto::ChatInstructionsDto;
+
+pub mod dto;
+
+#[instrument(err(Debug), skip(state))]
+async fn get_by_conversation(
+    State(state): State<Arc<ComhairleState>>,
+    Path(conversation_id): Path<Uuid>,
+) -> Result<(StatusCode, Json<ChatInstructionsDto>), ComhairleError> {
+    let instructions =
+        chat_instructions::get_by_conversation_id(&state.db, conversation_id).await?;
+
+    Ok((StatusCode::OK, Json(instructions.into())))
+}
+
+#[instrument(err(Debug), skip(state))]
+async fn upsert_for_conversation(
+    State(state): State<Arc<ComhairleState>>,
+    Path(conversation_id): Path<Uuid>,
+    Json(payload): Json<UpsertChatInstructions>,
+) -> Result<(StatusCode, Json<ChatInstructionsDto>), ComhairleError> {
+    let instructions =
+        chat_instructions::upsert_for_conversation(&state.db, conversation_id, payload).await?;
+
+    Ok((StatusCode::OK, Json(instructions.into())))
+}
+
+pub fn router(state: Arc<ComhairleState>) -> ApiRouter {
+    ApiRouter::new()
+        .api_route(
+            "/",
+            get_with(get_by_conversation, |op| {
+                op.id("GetConversationChatInstructions")
+                    .tag("ChatInstructions")
+                    .summary("Get chat instructions by conversation_id")
+                    .description("Get chat instructions by conversation_id")
+                    .security_requirement("JWT")
+                    .response::<200, Json<ChatInstructionsDto>>()
+            }),
+        )
+        .api_route(
+            "/",
+            post_with(upsert_for_conversation, |op| {
+                op.id("UpsertConversationChatInstructions")
+                    .tag("ChatInstructions")
+                    .summary("Upsert chat instructions ")
+                    .description(
+                        "Creates a new chat instructions record for \
+                        a conversation or updates and existing record",
+                    )
+                    .security_requirement("JWT")
+                    .response::<200, Json<ChatInstructionsDto>>()
+            }),
+        )
+        .with_state(state)
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+    use sqlx::PgPool;
+
+    use super::*;
+
+    use std::error::Error;
+
+    use crate::models::model_test_helpers::{
+        get_random_conversation_id, setup_default_app_and_session,
+    };
+
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
+    async fn should_create_new_instructions_for_conversation(
+        pool: PgPool,
+    ) -> Result<(), Box<dyn Error>> {
+        let (app, mut session) = setup_default_app_and_session(&pool).await?;
+        let conversation_id = get_random_conversation_id(&app, &mut session).await?;
+
+        let (_, res, _) = session
+            .post(
+                &app,
+                &format!("/conversation/{conversation_id}/chat_instructions"),
+                json!({
+                    "target_reading_age": 10,
+                })
+                .to_string()
+                .into(),
+            )
+            .await?;
+
+        let instructions: ChatInstructionsDto = serde_json::from_value(res)?;
+
+        assert_eq!(
+            instructions.conversation_id, conversation_id,
+            "incorrect conversation_id"
+        );
+        assert_eq!(
+            instructions.target_reading_age,
+            Some(10),
+            "incorrect target_reading_age"
+        );
+        assert!(instructions.max_length.is_none(), "incorrect max_length");
+
+        Ok(())
+    }
+
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
+    async fn should_update_existing_instructions_for_conversation(
+        pool: PgPool,
+    ) -> Result<(), Box<dyn Error>> {
+        let (app, mut session) = setup_default_app_and_session(&pool).await?;
+        let conversation_id = get_random_conversation_id(&app, &mut session).await?;
+
+        let (_, res, _) = session
+            .post(
+                &app,
+                &format!("/conversation/{conversation_id}/chat_instructions"),
+                json!({
+                    "target_reading_age": 10,
+                })
+                .to_string()
+                .into(),
+            )
+            .await?;
+        let new_instructions: ChatInstructionsDto = serde_json::from_value(res)?;
+
+        let (_, res, _) = session
+            .post(
+                &app,
+                &format!("/conversation/{conversation_id}/chat_instructions"),
+                json!({
+                    "target_reading_age": 15,
+                    "max_length": 1000
+                })
+                .to_string()
+                .into(),
+            )
+            .await?;
+        let updated_instructions: ChatInstructionsDto = serde_json::from_value(res)?;
+
+        assert_eq!(
+            updated_instructions.conversation_id, conversation_id,
+            "incorrect conversation_id"
+        );
+        assert_eq!(
+            updated_instructions.target_reading_age,
+            Some(15),
+            "incorrect target_reading_age"
+        );
+        assert_eq!(
+            updated_instructions.max_length,
+            Some(1000),
+            "incorrect max_length"
+        );
+        assert_eq!(
+            new_instructions.id, updated_instructions.id,
+            "ids don't match"
+        );
+
+        Ok(())
+    }
+
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
+    async fn should_get_instructions_for_conversation(pool: PgPool) -> Result<(), Box<dyn Error>> {
+        let (app, mut session) = setup_default_app_and_session(&pool).await?;
+        let conversation_id = get_random_conversation_id(&app, &mut session).await?;
+
+        let (_, res, _) = session
+            .post(
+                &app,
+                &format!("/conversation/{conversation_id}/chat_instructions"),
+                json!({
+                    "target_reading_age": 10,
+                })
+                .to_string()
+                .into(),
+            )
+            .await?;
+        let new_instructions: ChatInstructionsDto = serde_json::from_value(res)?;
+
+        let (_, res, _) = session
+            .get(
+                &app,
+                &format!("/conversation/{conversation_id}/chat_instructions"),
+            )
+            .await?;
+        let instructions: ChatInstructionsDto = serde_json::from_value(res)?;
+
+        assert_eq!(new_instructions.id, instructions.id, "ids don't match");
+
+        Ok(())
+    }
+
+    #[sqlx::test(migrator = "crate::SQLX_MIGRATOR")]
+    async fn should_404_if_no_instructions_for_conversation(
+        pool: PgPool,
+    ) -> Result<(), Box<dyn Error>> {
+        let (app, mut session) = setup_default_app_and_session(&pool).await?;
+        let conversation_id = get_random_conversation_id(&app, &mut session).await?;
+
+        let (status, res, _) = session
+            .get(
+                &app,
+                &format!("/conversation/{conversation_id}/chat_instructions"),
+            )
+            .await?;
+
+        assert_eq!(status, StatusCode::NOT_FOUND, "incorrect status code");
+        assert_eq!(
+            res.get("err").unwrap(),
+            "Chat Instructions not found",
+            "incorrect error message"
+        );
+
+        Ok(())
+    }
+}

--- a/api/src/routes/chat_instructions/dto.rs
+++ b/api/src/routes/chat_instructions/dto.rs
@@ -1,0 +1,36 @@
+use chrono::{DateTime, Utc};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::models::chat_instructions::ChatInstructions;
+
+/// Data transfer object (public API representation) for a ChatInstructions record.
+///
+/// This DTO is returned by chat_instructions related endpoints and is safe to expose
+/// to clients.
+///
+/// Serialized to JSON using camelCase field names for frontend (JavaScript) compatibility.
+#[derive(Serialize, Deserialize, JsonSchema, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct ChatInstructionsDto {
+    pub id: Uuid,
+    pub conversation_id: Uuid,
+    pub target_reading_age: Option<i32>,
+    pub max_length: Option<i32>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+impl From<ChatInstructions> for ChatInstructionsDto {
+    fn from(ci: ChatInstructions) -> Self {
+        Self {
+            id: ci.id,
+            conversation_id: ci.conversation_id,
+            target_reading_age: ci.target_reading_age,
+            max_length: ci.max_length,
+            created_at: ci.created_at,
+            updated_at: ci.updated_at,
+        }
+    }
+}

--- a/api/src/routes/chat_sessions.rs
+++ b/api/src/routes/chat_sessions.rs
@@ -16,16 +16,12 @@ use axum::{
 use tracing::instrument;
 use uuid::Uuid;
 
-use crate::{
-    ComhairleState,
-    bot_service::{ChatConversationRequest, ComhairleChatSession},
-    error::ComhairleError,
-    models::{
-        bot_service_user_session::{self, BotServiceSessionContext},
-        conversation,
-    },
-    routes::auth::RequiredUser,
-};
+use crate::bot_service::{ChatConversationRequest, ComhairleChatSession};
+use crate::models::bot_service_user_session::{self, BotServiceSessionContext};
+use crate::models::chat_instructions::{self, ChatInstructionsExt};
+use crate::models::conversation;
+use crate::routes::auth::RequiredUser;
+use crate::{ComhairleError, ComhairleState};
 
 #[instrument(err(Debug), skip(state))]
 pub async fn get_session(
@@ -77,11 +73,17 @@ async fn converse(
     State(state): State<Arc<ComhairleState>>,
     Path(conversation_id): Path<Uuid>,
     RequiredUser(user): RequiredUser,
-    Json(payload): Json<ChatConversationRequest>,
+    Json(mut payload): Json<ChatConversationRequest>,
 ) -> Result<StreamBody, ComhairleError> {
     let bot_service = state.required_bot_service()?;
 
     let conversation = conversation::get_by_id(&state.db, &conversation_id).await?;
+    let chat_instructions = chat_instructions::get_by_conversation_id(&state.db, conversation.id)
+        .await
+        .ok();
+
+    payload.variables = Some(chat_instructions.to_prompt_variables());
+
     let session = bot_service_user_session::get_or_create(
         &state,
         BotServiceSessionContext::QaBot,
@@ -140,6 +142,7 @@ mod tests {
         setup_server,
         test_helpers::{UserSession, test_state},
     };
+    use std::collections::HashMap;
     use std::error::Error;
     use std::{pin::Pin, sync::Arc};
 
@@ -251,6 +254,10 @@ mod tests {
     ) -> Result<(), Box<dyn Error>> {
         let converse_request = ChatConversationRequest {
             question: "Test question?".to_string(),
+            variables: Some(HashMap::from([(
+                "target_reading_age".to_string(),
+                "9".to_string(),
+            )])),
         };
         let chat_session = ComhairleChatSession {
             id: "456".to_string(),

--- a/ui/packages/api-client/src/api.ts
+++ b/ui/packages/api-client/src/api.ts
@@ -2236,6 +2236,25 @@ export const UpdateChatRequest = z
   .partial()
   .passthrough();
 export type UpdateChatRequest = z.infer<typeof UpdateChatRequest>;
+export const ChatInstructionsDto = z
+  .object({
+    conversationId: z.string().uuid(),
+    createdAt: z.string().datetime({ offset: true }),
+    id: z.string().uuid(),
+    maxLength: z.union([z.number(), z.null()]).optional(),
+    targetReadingAge: z.union([z.number(), z.null()]).optional(),
+    updatedAt: z.string().datetime({ offset: true }),
+  })
+  .passthrough();
+export type ChatInstructionsDto = z.infer<typeof ChatInstructionsDto>;
+export const UpsertChatInstructions = z
+  .object({
+    max_length: z.union([z.number(), z.null()]),
+    target_reading_age: z.union([z.number(), z.null()]),
+  })
+  .partial()
+  .passthrough();
+export type UpsertChatInstructions = z.infer<typeof UpsertChatInstructions>;
 export const ComhairleChatSession = z
   .object({
     chat_id: z.string(),
@@ -3392,6 +3411,8 @@ export const schemas: Record<string, z.ZodType<any>> = {
   ComhairlePrompt,
   ComhairleChat,
   UpdateChatRequest,
+  ChatInstructionsDto,
+  UpsertChatInstructions,
   ComhairleChatSession,
   ChatConversationRequest,
   page_size,
@@ -3837,6 +3858,29 @@ const endpoints = makeApi([
     description: `Delete the conversation and all related content`,
     requestFormat: "json",
     response: ConversationDto,
+  },
+  {
+    method: "get",
+    path: "/conversation/:conversation_id/chat_instructions",
+    alias: "GetConversationChatInstructions",
+    description: `Get chat instructions by conversation_id`,
+    requestFormat: "json",
+    response: ChatInstructionsDto,
+  },
+  {
+    method: "post",
+    path: "/conversation/:conversation_id/chat_instructions",
+    alias: "UpsertConversationChatInstructions",
+    description: `Creates a new chat instructions record for a conversation or updates and existing record`,
+    requestFormat: "json",
+    parameters: [
+      {
+        name: "body",
+        type: "Body",
+        schema: UpsertChatInstructions,
+      },
+    ],
+    response: ChatInstructionsDto,
   },
   {
     method: "get",

--- a/ui/packages/api-client/src/api.ts
+++ b/ui/packages/api-client/src/api.ts
@@ -2273,7 +2273,10 @@ export const ComhairleChatSession = z
   .passthrough();
 export type ComhairleChatSession = z.infer<typeof ComhairleChatSession>;
 export const ChatConversationRequest = z
-  .object({ question: z.string() })
+  .object({
+    question: z.string(),
+    variables: z.union([z.record(z.string()), z.null()]).optional(),
+  })
   .passthrough();
 export type ChatConversationRequest = z.infer<typeof ChatConversationRequest>;
 export const page_size = z
@@ -3912,7 +3915,7 @@ Use a raw HTTP request and process the response body incrementally.`,
       {
         name: "body",
         type: "Body",
-        schema: z.object({ question: z.string() }).passthrough(),
+        schema: ChatConversationRequest,
       },
     ],
     response: z.void(),

--- a/ui/packages/api-client/src/api.ts
+++ b/ui/packages/api-client/src/api.ts
@@ -2206,12 +2206,20 @@ export const ComhairleLlm = z
   .partial()
   .passthrough();
 export type ComhairleLlm = z.infer<typeof ComhairleLlm>;
+export const Variable = z
+  .object({
+    key: z.string(),
+    optional: z.union([z.boolean(), z.null()]).optional(),
+  })
+  .passthrough();
+export type Variable = z.infer<typeof Variable>;
 export const ComhairlePrompt = z
   .object({
     cross_languages: z.union([z.array(z.string()), z.null()]),
     empty_response: z.union([z.string(), z.null()]),
     llm_prompt: z.union([z.string(), z.null()]),
     opener: z.union([z.string(), z.null()]),
+    variables: z.union([z.array(Variable), z.null()]),
   })
   .partial()
   .passthrough();
@@ -3408,6 +3416,7 @@ export const schemas: Record<string, z.ZodType<any>> = {
   CreateFeedbackDTO,
   PartialFeedback,
   ComhairleLlm,
+  Variable,
   ComhairlePrompt,
   ComhairleChat,
   UpdateChatRequest,

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/learning-assistant/+page.svelte
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/learning-assistant/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type {
+		ChatInstructionsDto,
 		ComhairleChat,
 		ComhairleDocument,
 		ConversationWithTranslations
@@ -31,6 +32,8 @@
 	import type { Option } from '$lib/components/ui/mutli-select/multi-select.svelte';
 	import { locales } from '$lib/paraglide/runtime';
 	import { getLanguageName } from '$lib/config/languages';
+	import { Input } from '$lib/components/ui/input';
+	import { useDebounce } from 'runed';
 
 	const MAX_SIZE = 50 * MB;
 
@@ -39,6 +42,7 @@
 			documents: ComhairleDocument[];
 			conversation: ConversationWithTranslations;
 			chat: ComhairleChat;
+			chatInstructions: ChatInstructionsDto | null;
 		};
 	};
 
@@ -46,6 +50,7 @@
 	let conversation = $derived(data.conversation);
 	let chat = $derived(data.chat);
 	let documents = $derived(data.documents);
+	let targetReadingAge = $derived(data.chatInstructions?.targetReadingAge ?? 9);
 
 	// The synced learn-step content is a knowledge-base document like any other, but it is
 	// managed via Sync (not the uploader), so keep it out of the uploaded-files lists and
@@ -303,6 +308,34 @@
 	// 	urlInput = '';
 	// 	await invalidate('knowledge-base:documents');
 	// }
+
+	const updateChatInstructions = useDebounce(async (e: Event) => {
+		const target = e.target as HTMLInputElement;
+
+		const value = target.type === 'number' ? Number(target.value) : target.value;
+
+		const res = await tryCatchAsync(() =>
+			apiClient.UpsertConversationChatInstructions(
+				{ [target.name]: value },
+				{ params: { conversation_id: conversation.id } }
+			)
+		);
+
+		if (res.err !== null) {
+			console.error(res.err);
+			return notifications.send({
+				priority: 'ERROR',
+				message: 'Something went wrong updating chat instructions'
+			});
+		}
+
+		notifications.send({
+			priority: 'INFO',
+			message: 'Successfully updated chat instructions'
+		});
+
+		await invalidate('knowledge-base');
+	}, 500);
 </script>
 
 <svelte:head>
@@ -455,6 +488,31 @@
 					ariaLabel="Supported languages"
 					emptyMessage="No languages found"
 					class="w-full"
+				/>
+			</div>
+		</div>
+	</div>
+
+	<div
+		class="border-border flex flex-col gap-4 border-t py-6 lg:flex-row lg:items-start lg:gap-6"
+	>
+		<div class="lg:w-50 lg:shrink-0 lg:pt-1">
+			<p class="text-sm font-semibold">Target reading age</p>
+		</div>
+		<div class="flex-1 space-y-4">
+			<p class="text-muted-foreground text-base">
+				Sets the reading level the chatbot should aim for when phrasing its answers. The bot
+				will adjust vocabulary and sentence complexity to match this age. Choose an age
+				level between 5-18.
+			</p>
+			<div class="flex max-w-md flex-col gap-3">
+				<Input
+					name="target_reading_age"
+					type="number"
+					min="5"
+					max="18"
+					bind:value={targetReadingAge}
+					oninput={updateChatInstructions}
 				/>
 			</div>
 		</div>

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/learning-assistant/+page.ts
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/learning-assistant/+page.ts
@@ -1,9 +1,9 @@
 import { tryCatchAsync } from '$lib/utils/errorHandling';
 import type { LoadEvent } from '@sveltejs/kit';
 import type { PageLoad } from './$types';
-import { apiClient } from '@crownshy/api-client/client';
 
-export const load: PageLoad = async ({ depends, params }: LoadEvent) => {
+export const load: PageLoad = async ({ depends, params, parent }: LoadEvent) => {
+	const { api } = await parent();
 	depends('knowledge-base:documents');
 
 	const { conversation_id } = params;
@@ -12,7 +12,7 @@ export const load: PageLoad = async ({ depends, params }: LoadEvent) => {
 	}
 
 	const docsResponse = await tryCatchAsync(() =>
-		apiClient.ListDocuments({
+		api.ListDocuments({
 			params: { conversation_id }
 		})
 	);
@@ -23,7 +23,7 @@ export const load: PageLoad = async ({ depends, params }: LoadEvent) => {
 	}
 
 	const chatResponse = await tryCatchAsync(() =>
-		apiClient.GetChat({
+		api.GetChat({
 			params: { conversation_id }
 		})
 	);

--- a/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/learning-assistant/+page.ts
+++ b/ui/packages/comhairle/src/routes/(admin)/admin/conversations/[conversation_id]/learning-assistant/+page.ts
@@ -1,6 +1,7 @@
 import { tryCatchAsync } from '$lib/utils/errorHandling';
 import type { LoadEvent } from '@sveltejs/kit';
 import type { PageLoad } from './$types';
+import type { ChatInstructionsDto } from '@crownshy/api-client/api';
 
 export const load: PageLoad = async ({ depends, params, parent }: LoadEvent) => {
 	const { api } = await parent();
@@ -33,5 +34,20 @@ export const load: PageLoad = async ({ depends, params, parent }: LoadEvent) => 
 		return;
 	}
 
-	return { documents: docsResponse.ok, chat: chatResponse.ok };
+	let chatInstructions: ChatInstructionsDto | null = null;
+	const chatInstructionsResponse = await tryCatchAsync(() =>
+		api.GetConversationChatInstructions({ params: { conversation_id } })
+	);
+
+	if (chatInstructionsResponse.err !== null) {
+		console.error(chatResponse.err);
+	} else {
+		chatInstructions = chatInstructionsResponse.ok as ChatInstructionsDto;
+	}
+
+	return {
+		documents: docsResponse.ok,
+		chat: chatResponse.ok,
+		chatInstructions: chatInstructions
+	};
 };


### PR DESCRIPTION
Motivation:

- allow reading age level to be configured for learning assistant

Actions:

- router for chat_instructions model
- admin ui for setting target reading age on learning assistant
- bug fix for api client used within load functions on learning assistant page
- expose prompt variables on chat bots during updates and while conversing
- tweak chat prompt to respect reading age
- take reading age from chat_instructions with fallback values